### PR TITLE
2016: various fixes

### DIFF
--- a/2016/20161108__sd__general__precinct.csv
+++ b/2016/20161108__sd__general__precinct.csv
@@ -4848,17 +4848,17 @@ Hutchinson,5,State Representative,19,Melissa R. Mentele,DEM,158
 Hutchinson,6,State Representative,19,Melissa R. Mentele,DEM,76
 Hutchinson,7,State Representative,19,Melissa R. Mentele,DEM,38
 Hutchinson,TOTAL,State Representative,19,Melissa R. Mentele,DEM,686
-Hyde,Hyde County Memorial Auditorium - Main Arena,President,,Republican,Donald J. Trump,543
-Hyde,Hyde County Memorial Auditorium - Main Arena,President,,Libertarian,Gary Johnson,17
-Hyde,Hyde County Memorial Auditorium - Main Arena,President,,Democratic,Hillary Clinton,125
-Hyde,Hyde County Memorial Auditorium - Main Arena,President,,,Darrell L. Castle,5
-Hyde,Hyde County Memorial Auditorium - Main Arena,U.S. House,1,Republican,Kristi Noem,518
-Hyde,Hyde County Memorial Auditorium - Main Arena,U.S. House,1,Democratic,Paula Hawks,176
-Hyde,Hyde County Memorial Auditorium - Main Arena,Public Utilities Commissioner,,Republican,Chris Nelson,580
-Hyde,Hyde County Memorial Auditorium - Main Arena,Public Utilities Commissioner,,Democratic,Henry Red Cloud,95
-Hyde,Hyde County Memorial Auditorium - Main Arena,State Senate,24,Republican,Jeff Monroe,532
-Hyde,Hyde County Memorial Auditorium - Main Arena,State House,24,Republican,Mary Duvall,409
-Hyde,Hyde County Memorial Auditorium - Main Arena,State House,24,Republican,Tim Rounds,451
+Hyde,Hyde County Memorial Auditorium - Main Arena,President,,Donald J. Trump,REP,543
+Hyde,Hyde County Memorial Auditorium - Main Arena,President,,Gary Johnson,LIB,17
+Hyde,Hyde County Memorial Auditorium - Main Arena,President,,Hillary Clinton,DEM,125
+Hyde,Hyde County Memorial Auditorium - Main Arena,President,,Darrell L. Castle,CON,5
+Hyde,Hyde County Memorial Auditorium - Main Arena,U.S. House,1,Kristi Noem,REP,518
+Hyde,Hyde County Memorial Auditorium - Main Arena,U.S. House,1,Paula Hawks,DEM,176
+Hyde,Hyde County Memorial Auditorium - Main Arena,Public Utilities Commissioner,,Chris Nelson,REP,580
+Hyde,Hyde County Memorial Auditorium - Main Arena,Public Utilities Commissioner,,Henry Red Cloud,DEM,95
+Hyde,Hyde County Memorial Auditorium - Main Arena,State Senate,24,Jeff Monroe,REP,532
+Hyde,Hyde County Memorial Auditorium - Main Arena,State House,24,Mary Duvall,REP,409
+Hyde,Hyde County Memorial Auditorium - Main Arena,State House,24,Tim Rounds,REP,451
 Jackson,1,President,,Donald J. Trump,REP,39
 Jackson,2,President,,Donald J. Trump,REP,94
 Jackson,3,President,,Donald J. Trump,REP,219

--- a/2016/20161108__sd__general__precinct.csv
+++ b/2016/20161108__sd__general__precinct.csv
@@ -3544,7 +3544,7 @@ Fall River,Hot Springs 3,State Senate,30,Lance Russell,REP,259
 Fall River,Hot Springs 4,State Senate,30,Lance Russell,REP,196
 Fall River,Jackson,State Senate,30,Lance Russell,REP,552
 Fall River,Oelrichs Area,State Senate,30,Lance Russell,REP,160
-Fall River,Total,State Senate,30,Lance Russell,REP,"2,271"
+Fall River,Total,State Senate,30,Lance Russell,REP,2271
 Fall River,Beaver,State Senate,30,Karla R. LaRive,DEM,32
 Fall River,Cascade,State Senate,30,Karla R. LaRive,DEM,49
 Fall River,Edgemont Area,State Senate,30,Karla R. LaRive,DEM,144
@@ -3554,7 +3554,7 @@ Fall River,Hot Springs 3,State Senate,30,Karla R. LaRive,DEM,165
 Fall River,Hot Springs 4,State Senate,30,Karla R. LaRive,DEM,124
 Fall River,Jackson,State Senate,30,Karla R. LaRive,DEM,312
 Fall River,Oelrichs Area,State Senate,30,Karla R. LaRive,DEM,37
-Fall River,Total,State Senate,30,Karla R. LaRive,DEM,"1,193"
+Fall River,Total,State Senate,30,Karla R. LaRive,DEM,1193
 Fall River,Beaver,State House,30,Julie Frye-Mueller,REP,102
 Fall River,Cascade,State House,30,Julie Frye-Mueller,REP,99
 Fall River,Edgemont Area,State House,30,Julie Frye-Mueller,REP,329
@@ -3564,7 +3564,7 @@ Fall River,Hot Springs 3,State House,30,Julie Frye-Mueller,REP,234
 Fall River,Hot Springs 4,State House,30,Julie Frye-Mueller,REP,169
 Fall River,Jackson,State House,30,Julie Frye-Mueller,REP,539
 Fall River,Oelrichs Area,State House,30,Julie Frye-Mueller,REP,151
-Fall River,Total,State House,30,Julie Frye-Mueller,REP,"2,083"
+Fall River,Total,State House,30,Julie Frye-Mueller,REP,2083
 Fall River,Beaver,State House,30,Tim R. Goodwin,REP,106
 Fall River,Cascade,State House,30,Tim R. Goodwin,REP,108
 Fall River,Edgemont Area,State House,30,Tim R. Goodwin,REP,328
@@ -3574,7 +3574,7 @@ Fall River,Hot Springs 3,State House,30,Tim R. Goodwin,REP,208
 Fall River,Hot Springs 4,State House,30,Tim R. Goodwin,REP,166
 Fall River,Jackson,State House,30,Tim R. Goodwin,REP,545
 Fall River,Oelrichs Area,State House,30,Tim R. Goodwin,REP,144
-Fall River,Total,State House,30,Tim R. Goodwin,REP,"2,073"
+Fall River,Total,State House,30,Tim R. Goodwin,REP,2073
 Fall River,Beaver,State House,30,Kristine Ina Winter,DEM,15
 Fall River,Cascade,State House,30,Kristine Ina Winter,DEM,36
 Fall River,Edgemont Area,State House,30,Kristine Ina Winter,DEM,106
@@ -9667,7 +9667,7 @@ Potter,Total,Public Utilities Commissioner,,Henry Red Cloud,DEM,139
 Potter,Absentee Precinct,State Senate,23,Justin R. Cronin,REP,214
 Potter,Gettysburg Legion Annex,State Senate,23,Justin R. Cronin,REP,636
 Potter,Hoven American Legion,State Senate,23,Justin R. Cronin,REP,272
-Potter,Total,State Senate,23,Justin R. Cronin,REP,"1,122"
+Potter,Total,State Senate,23,Justin R. Cronin,REP,1122
 Potter,Absentee Precinct,State House,23,Spencer Gosch,REP,106
 Potter,Gettysburg Legion Annex,State House,23,Spencer Gosch,REP,291
 Potter,Hoven American Legion,State House,23,Spencer Gosch,REP,150
@@ -9675,7 +9675,7 @@ Potter,Total,State House,23,Spencer Gosch,REP,547
 Potter,Absentee Precinct,State House,23,John A. Lake,REP,229
 Potter,Gettysburg Legion Annex,State House,23,John A. Lake,REP,682
 Potter,Hoven American Legion,State House,23,John A. Lake,REP,250
-Potter,Total,State House,23,John A. Lake,REP,"1,161county"
+Potter,Total,State House,23,John A. Lake,REP,1161
 Roberts,1,President,,Donald J. Trump,REP,113
 Roberts,2,President,,Donald J. Trump,REP,303
 Roberts,3,President,,Donald J. Trump,REP,104

--- a/2016/20161108__sd__general__precinct.csv
+++ b/2016/20161108__sd__general__precinct.csv
@@ -2522,7 +2522,7 @@ Custer,7,State House,30,DEM,Sandy Arseneault,87
 Custer,8,State House,30,DEM,Sandy Arseneault,173
 Custer,9,State House,30,DEM,Sandy Arseneault,402
 Custer,10,State House,30,DEM,Sandy Arseneault,30
-Custer,Total,State House,30,DEM,Sandy Arseneault,1466county
+Custer,Total,State House,30,DEM,Sandy Arseneault,1466
 Davison,1,President,,Donald J. Trump,REP,219
 Davison,2,President,,Donald J. Trump,REP,311
 Davison,3,President,,Donald J. Trump,REP,472
@@ -3109,7 +3109,7 @@ Deuel,8,State House,4,DEM,Peggy Schuelke,109
 Deuel,9,State House,4,DEM,Peggy Schuelke,86
 Deuel,10,State House,4,DEM,Peggy Schuelke,43
 Deuel,11,State House,4,DEM,Peggy Schuelke,85
-Deuel,Total,State House,4,DEM,Peggy Schuelke,796county
+Deuel,Total,State House,4,DEM,Peggy Schuelke,796
 Dewey,Precinct 02 Trail City,President,,Donald J. Trump,REP,37
 Dewey,Precinct-04 Timber Lake,President,,Donald J. Trump,REP,238
 Dewey,Precinct-05 Firesteel,President,,Donald J. Trump,REP,39
@@ -3594,7 +3594,7 @@ Fall River,Hot Springs 3,State House,30,DEM,Sandy Arseneault,135
 Fall River,Hot Springs 4,State House,30,DEM,Sandy Arseneault,104
 Fall River,Jackson,State House,30,DEM,Sandy Arseneault,224
 Fall River,Oelrichs Area,State House,30,DEM,Sandy Arseneault,21
-Fall River,Total,State House,30,DEM,Sandy Arseneault,950county
+Fall River,Total,State House,30,DEM,Sandy Arseneault,950
 Faulk,1,President,,Donald J. Trump,REP,139
 Faulk,2,President,,Donald J. Trump,REP,81
 Faulk,3,President,,Donald J. Trump,REP,109
@@ -4058,7 +4058,7 @@ Gregory,Total,State House,21,DEM,Gary Burrus,874
 Gregory,1,State House,21,DEM,Julie Bartling,644
 Gregory,2,State House,21,DEM,Julie Bartling,515
 Gregory,3,State House,21,DEM,Julie Bartling,190
-Gregory,Total,State House,21,DEM,Julie Bartling,1349county
+Gregory,Total,State House,21,DEM,Julie Bartling,1349
 Haakon,1,President,,Donald J. Trump,REP,96
 Haakon,4,President,,Donald J. Trump,REP,129
 Haakon,16,President,,Donald J. Trump,REP,188
@@ -4502,7 +4502,7 @@ Hanson,2,State House,19,DEM,Melissa R. Mentele,110
 Hanson,3,State House,19,DEM,Melissa R. Mentele,90
 Hanson,4,State House,19,DEM,Melissa R. Mentele,76
 Hanson,5,State House,19,DEM,Melissa R. Mentele,29
-Hanson,Total,State House,19,DEM,Melissa R. Mentele,543county
+Hanson,Total,State House,19,DEM,Melissa R. Mentele,543
 Harding,1,President,,REP,Donald J. Trump,140
 Harding,2,President,,REP,Donald J. Trump,110
 Harding,3,President,,REP,Donald J. Trump,48
@@ -4610,7 +4610,7 @@ Harding,5,State Representative,28B,REP,Sam Marty,42
 Harding,6,State Representative,28B,REP,Sam Marty,83
 Harding,7,State Representative,28B,REP,Sam Marty,54
 Harding,8,State Representative,28B,REP,Sam Marty,116
-Harding,Total,State Representative,28B,REP,Sam Marty,689county
+Harding,Total,State Representative,28B,REP,Sam Marty,689
 Hughes,Absentee,President,,Donald J. Trump,REP,1140
 Hughes,Blunt City Hall,President,,Donald J. Trump,REP,151
 Hughes,Faith Lutheran Church,President,,Donald J. Trump,REP,1164
@@ -4858,7 +4858,7 @@ Hyde,Hyde County Memorial Auditorium - Main Arena,Public Utilities Commissioner,
 Hyde,Hyde County Memorial Auditorium - Main Arena,Public Utilities Commissioner,,Democratic,Henry Red Cloud,95
 Hyde,Hyde County Memorial Auditorium - Main Arena,State Senate,24,Republican,Jeff Monroe,532
 Hyde,Hyde County Memorial Auditorium - Main Arena,State House,24,Republican,Mary Duvall,409
-Hyde,Hyde County Memorial Auditorium - Main Arena,State House,24,Republican,Tim Rounds,451county
+Hyde,Hyde County Memorial Auditorium - Main Arena,State House,24,Republican,Tim Rounds,451
 Jackson,1,President,,Donald J. Trump,REP,39
 Jackson,2,President,,Donald J. Trump,REP,94
 Jackson,3,President,,Donald J. Trump,REP,219
@@ -5591,7 +5591,7 @@ Lawrence,Whitewood,State House,31,REP,Charles M. Turbiville,342
 Lawrence,Rural #2,State House,31,REP,Charles M. Turbiville,811
 Lawrence,Absentee,State House,31,REP,Charles M. Turbiville,2392
 Lawrence,Provisional,State House,31,REP,Charles M. Turbiville,
-Lawrence,TOTALS,State House,31,REP,Charles M. Turbiville,6136county
+Lawrence,TOTALS,State House,31,REP,Charles M. Turbiville,6136
 Lincoln,02-Norway & Fairview,President,,Donald J. Trump,REP,187
 Lincoln,06-Highland & Canton,President,,Donald J. Trump,REP,315
 Lincoln,08-Lincoln & Delaware,President,,Donald J. Trump,REP,145
@@ -6225,7 +6225,7 @@ Lyman,Reliance,State Representative,26B,REP,James Schaefer,116
 Lyman,Lower Brule,State Representative,26B,REP,James Schaefer,63
 Lyman,Kennebec,State Representative,26B,REP,James Schaefer,214
 Lyman,Presho,State Representative,26B,REP,James Schaefer,319
-Lyman,Vivian,State Representative,26B,REP,James Schaefer,86county
+Lyman,Vivian,State Representative,26B,REP,James Schaefer,86
 Marshall,A1,President,,Donald J. Trump,REP,122
 Marshall,A2,President,,Donald J. Trump,REP,78
 Marshall,A3,President,,Donald J. Trump,REP,156
@@ -6460,7 +6460,7 @@ McCook,3,State House,19,DEM,Melissa Mentele,137
 McCook,4,State House,19,DEM,Melissa Mentele,82
 McCook,5,State House,19,DEM,Melissa Mentele,191
 McCook,6,State House,19,DEM,Melissa Mentele,81
-McCook,Total,State House,19,DEM,Melissa Mentele,729county
+McCook,Total,State House,19,DEM,Melissa Mentele,729
 McPherson,1,President,,REP,Donald J. Trump,149
 McPherson,2,President,,REP,Donald J. Trump,135
 McPherson,3,President,,REP,Donald J. Trump,56
@@ -6551,7 +6551,7 @@ McPherson,3,State Representative,23,REP,John A. Lake,27
 McPherson,4,State Representative,23,REP,John A. Lake,119
 McPherson,5,State Representative,23,REP,John A. Lake,120
 McPherson,6,State Representative,23,REP,John A. Lake,97
-McPherson,Total,State Representative,23,REP,John A. Lake,557county
+McPherson,Total,State Representative,23,REP,John A. Lake,557
 Meade,ALKALI #6A,President,,Donald J. Trump,REP,104
 Meade,BASE #23,President,,Donald J. Trump,REP,274
 Meade,BEAR BUTTE #9,President,,Donald J. Trump,REP,121
@@ -7167,7 +7167,7 @@ Mellette,,U.S. House,1,DEM,Paula Hawks,274
 Mellette,,Public Utilities Commissioner,,REP,Chris Nelson,449
 Mellette,,Public Utilities Commissioner,,DEM,Henry Red Cloud,232
 Mellette,,State Senate,26,REP,Troy Heinert,433
-Mellette,,State House,26A,REP,Shawn Bourdeaux,371county
+Mellette,,State House,26A,REP,Shawn Bourdeaux,371
 Miner,HOWARD WARD 1,President,,REP,Trump & Pence,76
 Miner,HOWARD WARD 2,President,,REP,Trump & Pence,75
 Miner,HOWARD WARD 3,President,,REP,Trump & Pence,62
@@ -7311,7 +7311,7 @@ Miner,BEAVER-CLINTON-MINER,State House,8,DEM,Kory Rawstern,17
 Miner,CLEARWATER-HOWARD-ROSWELL,State House,8,DEM,Kory Rawstern,28
 Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,State House,8,DEM,Kory Rawstern,43
 Miner,GREEN VALLEY-CARTHAGE-REDSTONE,State House,8,DEM,Kory Rawstern,23
-Miner,TOTAL,State House,8,DEM,Kory Rawstern,247county
+Miner,TOTAL,State House,8,DEM,Kory Rawstern,247
 Minnehaha,Precinct-VP01,President,,Donald Trump,REP,528
 Minnehaha,Precinct-VP02,President,,Donald Trump,REP,1274
 Minnehaha,Precinct-VP03,President,,Donald Trump,REP,1500
@@ -8504,7 +8504,7 @@ Minnehaha,Precinct-VP21,State Representative,25,Dan Ahlers,DEM,740
 Minnehaha,Precinct-0207,State Representative,25,Dan Ahlers,DEM,735
 Minnehaha,Precinct-0410,State Representative,25,Dan Ahlers,DEM,410
 Minnehaha,Precinct-0412,State Representative,25,Dan Ahlers,DEM,508
-Minnehaha,Total,State Representative,25,Dan Ahlers,DEM,5432county
+Minnehaha,Total,State Representative,25,Dan Ahlers,DEM,5432
 Moody,1,President,,Donald J. Trump,REP,226
 Moody,2,President,,Donald J. Trump,REP,207
 Moody,3,President,,Donald J. Trump,REP,357
@@ -9491,7 +9491,7 @@ Pennington,2-Apr,State House,35,DEM,Michael T. Hanson,392
 Pennington,BE,State House,35,DEM,Michael T. Hanson,271
 Pennington,RV,State House,35,DEM,Michael T. Hanson,245
 Pennington,VF,State House,35,DEM,Michael T. Hanson,287
-Pennington,VV,State House,35,DEM,Michael T. Hanson,239county
+Pennington,VV,State House,35,DEM,Michael T. Hanson,239
 Perkins,1,President,,Donald J. Trump,REP,219
 Perkins,2,President,,Donald J. Trump,REP,88
 Perkins,3,President,,Donald J. Trump,REP,230
@@ -9924,7 +9924,7 @@ Sanborn,1,State Representative,8,DEM,Kory Rawstern,41
 Sanborn,2,State Representative,8,DEM,Kory Rawstern,62
 Sanborn,4,State Representative,8,DEM,Kory Rawstern,62
 Sanborn,5,State Representative,8,DEM,Kory Rawstern,47
-Sanborn,Total,State Representative,8,DEM,Kory Rawstern,212county
+Sanborn,Total,State Representative,8,DEM,Kory Rawstern,212
 Spink,1,President,,Donald J. Trump,REP,276
 Spink,3,President,,Donald J. Trump,REP,232
 Spink,4,President,,Donald J. Trump,REP,222
@@ -10180,7 +10180,7 @@ Sully,Absentee Precinct,State House,24,REP,Tim Rounds,106
 Sully,Agar Fire Hall,State House,24,REP,Tim Rounds,61
 Sully,Bill Floyd Shop,State House,24,REP,Tim Rounds,68
 Sully,Phoenix Center,State House,24,REP,Tim Rounds,331
-Sully,Total,State House,24,REP,Tim Rounds,566county
+Sully,Total,State House,24,REP,Tim Rounds,566
 Todd,Bordeaux,President,,Donald J. Trump,REP,12
 Todd,Jeanette,President,,Donald J. Trump,REP,68
 Todd,Lakeview,President,,Donald J. Trump,REP,90
@@ -10640,7 +10640,7 @@ Turner,5,State Representative,17,Ray Ring,DEM,193
 Turner,6,State Representative,17,Ray Ring,DEM,206
 Turner,7,State Representative,17,Ray Ring,DEM,74
 Turner,8,State Representative,17,Ray Ring,DEM,181
-Turner,TOTAL,State Representative,17,Ray Ring,DEM,1325county
+Turner,TOTAL,State Representative,17,Ray Ring,DEM,1325
 Union,1,President,,Donald J. Trump,REP,238
 Union,2,President,,Donald J. Trump,REP,238
 Union,3,President,,Donald J. Trump,REP,456

--- a/2016/20161108__sd__general__precinct.csv
+++ b/2016/20161108__sd__general__precinct.csv
@@ -1,82 +1,82 @@
-county,precinct,office,district,party,candidate,votes
-Aurora,1,President,,REP,Donald J. Trump,230
-Aurora,2,President,,REP,Donald J. Trump,120
-Aurora,3,President,,REP,Donald J. Trump,290
-Aurora,5,President,,REP,Donald J. Trump,128
-Aurora,7,President,,REP,Donald J. Trump,206
-Aurora,1,President,,LIB,Gary Johnson,11
-Aurora,2,President,,LIB,Gary Johnson,7
-Aurora,3,President,,LIB,Gary Johnson,19
-Aurora,5,President,,LIB,Gary Johnson,11
-Aurora,7,President,,LIB,Gary Johnson,26
-Aurora,1,President,,DEM,Hillary Clinton,62
-Aurora,2,President,,DEM,Hillary Clinton,23
-Aurora,3,President,,DEM,Hillary Clinton,101
-Aurora,5,President,,DEM,Hillary Clinton,61
-Aurora,7,President,,DEM,Hillary Clinton,93
-Aurora,1,President,,CON,Darrell L. Castle,4
-Aurora,2,President,,CON,Darrell L. Castle,3
-Aurora,3,President,,CON,Darrell L. Castle,6
-Aurora,5,President,,CON,Darrell L. Castle,1
-Aurora,7,President,,CON,Darrell L. Castle,5
-Aurora,1,U.S. Senate,,REP,John R. Thune,254
-Aurora,2,U.S. Senate,,REP,John R. Thune,121
-Aurora,3,U.S. Senate,,REP,John R. Thune,314
-Aurora,5,U.S. Senate,,REP,John R. Thune,135
-Aurora,7,U.S. Senate,,REP,John R. Thune,249
-Aurora,1,U.S. Senate,,DEM,Jay Williams,60
-Aurora,2,U.S. Senate,,DEM,Jay Williams,32
-Aurora,3,U.S. Senate,,DEM,Jay Williams,107
-Aurora,5,U.S. Senate,,DEM,Jay Williams,62
-Aurora,7,U.S. Senate,,DEM,Jay Williams,82
-Aurora,1,U.S. House,1,REP,Kristi Noem,229
-Aurora,2,U.S. House,1,REP,Kristi Noem,107
-Aurora,3,U.S. House,1,REP,Kristi Noem,262
-Aurora,5,U.S. House,1,REP,Kristi Noem,128
-Aurora,7,U.S. House,1,REP,Kristi Noem,203
-Aurora,1,U.S. House,1,DEM,Paula Hawks,85
-Aurora,2,U.S. House,1,DEM,Paula Hawks,50
-Aurora,3,U.S. House,1,DEM,Paula Hawks,159
-Aurora,5,U.S. House,1,DEM,Paula Hawks,74
-Aurora,7,U.S. House,1,DEM,Paula Hawks,124
-Aurora,1,Public Utilities Commissioner,,REP,Chris Nelson,270
-Aurora,2,Public Utilities Commissioner,,REP,Chris Nelson,145
-Aurora,3,Public Utilities Commissioner,,REP,Chris Nelson,362
-Aurora,5,Public Utilities Commissioner,,REP,Chris Nelson,153
-Aurora,7,Public Utilities Commissioner,,REP,Chris Nelson,271
-Aurora,1,Public Utilities Commissioner,,DEM,Henry Red Cloud,40
-Aurora,2,Public Utilities Commissioner,,DEM,Henry Red Cloud,10
-Aurora,3,Public Utilities Commissioner,,DEM,Henry Red Cloud,61
-Aurora,5,Public Utilities Commissioner,,DEM,Henry Red Cloud,44
-Aurora,7,Public Utilities Commissioner,,DEM,Henry Red Cloud,53
-Aurora,1,State Senate,20,REP,Joshua Klumb,221
-Aurora,2,State Senate,20,REP,Joshua Klumb,109
-Aurora,3,State Senate,20,REP,Joshua Klumb,232
-Aurora,5,State Senate,20,REP,Joshua Klumb,91
-Aurora,7,State Senate,20,REP,Joshua Klumb,181
-Aurora,1,State Senate,20,DEM,Quinten L. Burg,93
-Aurora,2,State Senate,20,DEM,Quinten L. Burg,49
-Aurora,3,State Senate,20,DEM,Quinten L. Burg,186
-Aurora,5,State Senate,20,DEM,Quinten L. Burg,109
-Aurora,7,State Senate,20,DEM,Quinten L. Burg,144
-Aurora,1,State House,20,REP,Tona Rozum,202
-Aurora,2,State House,20,REP,Tona Rozum,108
-Aurora,3,State House,20,REP,Tona Rozum,247
-Aurora,5,State House,20,REP,Tona Rozum,109
-Aurora,7,State House,20,REP,Tona Rozum,215
-Aurora,1,State House,20,REP,Lance Carson,190
-Aurora,2,State House,20,REP,Lance Carson,80
-Aurora,3,State House,20,REP,Lance Carson,199
-Aurora,5,State House,20,REP,Lance Carson,101
-Aurora,7,State House,20,REP,Lance Carson,174
-Aurora,2,County Commissioner,3,REP,Clyde Dethlefsen,116
-Aurora,3,County Commissioner,3,REP,Clyde Dethlefsen,18
-Aurora,5,County Commissioner,3,REP,Clyde Dethlefsen,8
-Aurora,7,County Commissioner,3,REP,Clyde Dethlefsen,22
-Aurora,2,County Commissioner,3,IND,Karl Swanson,40
-Aurora,3,County Commissioner,3,IND,Karl Swanson,5
-Aurora,5,County Commissioner,3,IND,Karl Swanson,27
-Aurora,7,County Commissioner,3,IND,Karl Swanson,46
+county,precinct,office,district,candidate,party,votes
+Aurora,1,President,,Donald J. Trump,REP,230
+Aurora,2,President,,Donald J. Trump,REP,120
+Aurora,3,President,,Donald J. Trump,REP,290
+Aurora,5,President,,Donald J. Trump,REP,128
+Aurora,7,President,,Donald J. Trump,REP,206
+Aurora,1,President,,Gary Johnson,LIB,11
+Aurora,2,President,,Gary Johnson,LIB,7
+Aurora,3,President,,Gary Johnson,LIB,19
+Aurora,5,President,,Gary Johnson,LIB,11
+Aurora,7,President,,Gary Johnson,LIB,26
+Aurora,1,President,,Hillary Clinton,DEM,62
+Aurora,2,President,,Hillary Clinton,DEM,23
+Aurora,3,President,,Hillary Clinton,DEM,101
+Aurora,5,President,,Hillary Clinton,DEM,61
+Aurora,7,President,,Hillary Clinton,DEM,93
+Aurora,1,President,,Darrell L. Castle,CON,4
+Aurora,2,President,,Darrell L. Castle,CON,3
+Aurora,3,President,,Darrell L. Castle,CON,6
+Aurora,5,President,,Darrell L. Castle,CON,1
+Aurora,7,President,,Darrell L. Castle,CON,5
+Aurora,1,U.S. Senate,,John R. Thune,REP,254
+Aurora,2,U.S. Senate,,John R. Thune,REP,121
+Aurora,3,U.S. Senate,,John R. Thune,REP,314
+Aurora,5,U.S. Senate,,John R. Thune,REP,135
+Aurora,7,U.S. Senate,,John R. Thune,REP,249
+Aurora,1,U.S. Senate,,Jay Williams,DEM,60
+Aurora,2,U.S. Senate,,Jay Williams,DEM,32
+Aurora,3,U.S. Senate,,Jay Williams,DEM,107
+Aurora,5,U.S. Senate,,Jay Williams,DEM,62
+Aurora,7,U.S. Senate,,Jay Williams,DEM,82
+Aurora,1,U.S. House,1,Kristi Noem,REP,229
+Aurora,2,U.S. House,1,Kristi Noem,REP,107
+Aurora,3,U.S. House,1,Kristi Noem,REP,262
+Aurora,5,U.S. House,1,Kristi Noem,REP,128
+Aurora,7,U.S. House,1,Kristi Noem,REP,203
+Aurora,1,U.S. House,1,Paula Hawks,DEM,85
+Aurora,2,U.S. House,1,Paula Hawks,DEM,50
+Aurora,3,U.S. House,1,Paula Hawks,DEM,159
+Aurora,5,U.S. House,1,Paula Hawks,DEM,74
+Aurora,7,U.S. House,1,Paula Hawks,DEM,124
+Aurora,1,Public Utilities Commissioner,,Chris Nelson,REP,270
+Aurora,2,Public Utilities Commissioner,,Chris Nelson,REP,145
+Aurora,3,Public Utilities Commissioner,,Chris Nelson,REP,362
+Aurora,5,Public Utilities Commissioner,,Chris Nelson,REP,153
+Aurora,7,Public Utilities Commissioner,,Chris Nelson,REP,271
+Aurora,1,Public Utilities Commissioner,,Henry Red Cloud,DEM,40
+Aurora,2,Public Utilities Commissioner,,Henry Red Cloud,DEM,10
+Aurora,3,Public Utilities Commissioner,,Henry Red Cloud,DEM,61
+Aurora,5,Public Utilities Commissioner,,Henry Red Cloud,DEM,44
+Aurora,7,Public Utilities Commissioner,,Henry Red Cloud,DEM,53
+Aurora,1,State Senate,20,Joshua Klumb,REP,221
+Aurora,2,State Senate,20,Joshua Klumb,REP,109
+Aurora,3,State Senate,20,Joshua Klumb,REP,232
+Aurora,5,State Senate,20,Joshua Klumb,REP,91
+Aurora,7,State Senate,20,Joshua Klumb,REP,181
+Aurora,1,State Senate,20,Quinten L. Burg,DEM,93
+Aurora,2,State Senate,20,Quinten L. Burg,DEM,49
+Aurora,3,State Senate,20,Quinten L. Burg,DEM,186
+Aurora,5,State Senate,20,Quinten L. Burg,DEM,109
+Aurora,7,State Senate,20,Quinten L. Burg,DEM,144
+Aurora,1,State House,20,Tona Rozum,REP,202
+Aurora,2,State House,20,Tona Rozum,REP,108
+Aurora,3,State House,20,Tona Rozum,REP,247
+Aurora,5,State House,20,Tona Rozum,REP,109
+Aurora,7,State House,20,Tona Rozum,REP,215
+Aurora,1,State House,20,Lance Carson,REP,190
+Aurora,2,State House,20,Lance Carson,REP,80
+Aurora,3,State House,20,Lance Carson,REP,199
+Aurora,5,State House,20,Lance Carson,REP,101
+Aurora,7,State House,20,Lance Carson,REP,174
+Aurora,2,County Commissioner,3,Clyde Dethlefsen,REP,116
+Aurora,3,County Commissioner,3,Clyde Dethlefsen,REP,18
+Aurora,5,County Commissioner,3,Clyde Dethlefsen,REP,8
+Aurora,7,County Commissioner,3,Clyde Dethlefsen,REP,22
+Aurora,2,County Commissioner,3,Karl Swanson,IND,40
+Aurora,3,County Commissioner,3,Karl Swanson,IND,5
+Aurora,5,County Commissioner,3,Karl Swanson,IND,27
+Aurora,7,County Commissioner,3,Karl Swanson,IND,46
 Beadle,12,President,,Donald J. Trump,REP,616
 Beadle,15,President,,Donald J. Trump,REP,223
 Beadle,17,President,,Donald J. Trump,REP,202
@@ -997,108 +997,108 @@ Brown,Stratford Community Center,State Representative,3,Nikki Bootz,DEM,2
 Brown,Warner Community Center,State Representative,3,Nikki Bootz,DEM,6
 Brown,Westport Community Center,State Representative,3,Nikki Bootz,DEM,2
 Brown,Total,State Representative,3,Nikki Bootz,DEM,2784
-Brule,1,President,,REP,Donald J. Trump,765
-Brule,2,President,,REP,Donald J. Trump,388
-Brule,3,President,,REP,Donald J. Trump,266
-Brule,4,President,,REP,Donald J. Trump,59
-Brule,5,President,,REP,Donald J. Trump,87
-Brule,1,President,,LIB,Gary Johnson,76
-Brule,2,President,,LIB,Gary Johnson,26
-Brule,3,President,,LIB,Gary Johnson,20
-Brule,4,President,,LIB,Gary Johnson,2
-Brule,5,President,,LIB,Gary Johnson,1
-Brule,1,President,,DEM,Hillary Clinton,363
-Brule,2,President,,DEM,Hillary Clinton,98
-Brule,3,President,,DEM,Hillary Clinton,81
-Brule,4,President,,DEM,Hillary Clinton,11
-Brule,5,President,,DEM,Hillary Clinton,18
-Brule,1,President,,CON,Darrell L. Castle,12
-Brule,2,President,,CON,Darrell L. Castle,5
-Brule,3,President,,CON,Darrell L. Castle,4
-Brule,4,President,,CON,Darrell L. Castle,4
-Brule,5,President,,CON,Darrell L. Castle,2
-Brule,1,U.S. Senate,,REP,John R. Thune,894
-Brule,2,U.S. Senate,,REP,John R. Thune,413
-Brule,3,U.S. Senate,,REP,John R. Thune,289
-Brule,4,U.S. Senate,,REP,John R. Thune,56
-Brule,5,U.S. Senate,,REP,John R. Thune,94
-Brule,1,U.S. Senate,,DEM,Jay Williams,324
-Brule,2,U.S. Senate,,DEM,Jay Williams,109
-Brule,3,U.S. Senate,,DEM,Jay Williams,88
-Brule,4,U.S. Senate,,DEM,Jay Williams,18
-Brule,5,U.S. Senate,,DEM,Jay Williams,15
-Brule,1,U.S. House,1,REP,Kristi Noem,800
-Brule,2,U.S. House,1,REP,Kristi Noem,381
-Brule,3,U.S. House,1,REP,Kristi Noem,262
-Brule,4,U.S. House,1,REP,Kristi Noem,59
-Brule,5,U.S. House,1,REP,Kristi Noem,83
-Brule,1,U.S. House,1,DEM,Paula Hawks,414
-Brule,2,U.S. House,1,DEM,Paula Hawks,141
-Brule,3,U.S. House,1,DEM,Paula Hawks,114
-Brule,4,U.S. House,1,DEM,Paula Hawks,17
-Brule,5,U.S. House,1,DEM,Paula Hawks,27
-Brule,1,Public Utilities Commissioner,,REP,Chris Nelson,947
-Brule,2,Public Utilities Commissioner,,REP,Chris Nelson,441
-Brule,3,Public Utilities Commissioner,,REP,Chris Nelson,307
-Brule,4,Public Utilities Commissioner,,REP,Chris Nelson,65
-Brule,5,Public Utilities Commissioner,,REP,Chris Nelson,102
-Brule,1,Public Utilities Commissioner,,DEM,Henry Red Cloud,229
-Brule,2,Public Utilities Commissioner,,DEM,Henry Red Cloud,68
-Brule,3,Public Utilities Commissioner,,DEM,Henry Red Cloud,62
-Brule,4,Public Utilities Commissioner,,DEM,Henry Red Cloud,8
-Brule,5,Public Utilities Commissioner,,DEM,Henry Red Cloud,8
-Brule,1,State Senate,26,DEM,Troy Heinert,679
-Brule,2,State Senate,26,DEM,Troy Heinert,263
-Brule,3,State Senate,26,DEM,Troy Heinert,202
-Brule,4,State Senate,26,DEM,Troy Heinert,32
-Brule,5,State Senate,26,DEM,Troy Heinert,60
-Brule,1,State House,26B,REP,James Schaefer,874
-Brule,2,State House,26B,REP,James Schaefer,345
-Brule,3,State House,26B,REP,James Schaefer,272
-Brule,4,State House,26B,REP,James Schaefer,53
-Brule,5,State House,26B,REP,James Schaefer,89
-Brule,1,State Attorney,,REP,David V Natvig,604
-Brule,2,State Attorney,,REP,David V Natvig,365
-Brule,3,State Attorney,,REP,David V Natvig,187
-Brule,4,State Attorney,,REP,David V Natvig,48
-Brule,5,State Attorney,,REP,David V Natvig,54
-Brule,1,State Attorney,,IND,Theresa Maule Rossow,591
-Brule,2,State Attorney,,IND,Theresa Maule Rossow,150
-Brule,3,State Attorney,,IND,Theresa Maule Rossow,183
-Brule,4,State Attorney,,IND,Theresa Maule Rossow,25
-Brule,5,State Attorney,,IND,Theresa Maule Rossow,55
-Buffalo,1,President,,REP,Donald J. Trump,92
-Buffalo,2,President,,REP,Donald J. Trump,42
-Buffalo,3,President,,REP,Donald J. Trump,37
-Buffalo,Total,President,,REP,Donald J. Trump,171
-Buffalo,1,President,,LIB,Gary Johnson,3
-Buffalo,2,President,,LIB,Gary Johnson,0
-Buffalo,3,President,,LIB,Gary Johnson,15
-Buffalo,Total,President,,LIB,Gary Johnson,18
-Buffalo,1,President,,DEM,Hillary Clinton,21
-Buffalo,2,President,,DEM,Hillary Clinton,38
-Buffalo,3,President,,DEM,Hillary Clinton,237
-Buffalo,Total,President,,DEM,Hillary Clinton,296
-Buffalo,1,President,,CON,Darrell L. Castle,0
-Buffalo,2,President,,CON,Darrell L. Castle,1
-Buffalo,3,President,,CON,Darrell L. Castle,4
-Buffalo,Total,President,,CON,Darrell L. Castle,5
-Buffalo,1,U.S. Senate,,REP,John R. Thune,91
-Buffalo,2,U.S. Senate,,REP,John R. Thune,50
-Buffalo,3,U.S. Senate,,REP,John R. Thune,91
-Buffalo,Total,U.S. Senate,,REP,John R. Thune,232
-Buffalo,1,U.S. Senate,,DEM,Jay Williams,26
-Buffalo,2,U.S. Senate,,DEM,Jay Williams,32
-Buffalo,3,U.S. Senate,,DEM,Jay Williams,199
-Buffalo,Total,U.S. Senate,,DEM,Jay Williams,257
-Buffalo,1,U.S. House,1,REP,Kristi Noem,90
-Buffalo,2,U.S. House,1,REP,Kristi Noem,43
-Buffalo,3,U.S. House,1,REP,Kristi Noem,67
-Buffalo,Total,U.S. House,1,REP,Kristi Noem,200
-Buffalo,1,U.S. House,1,DEM,Paula Hawks,26
-Buffalo,2,U.S. House,1,DEM,Paula Hawks,40
-Buffalo,3,U.S. House,1,DEM,Paula Hawks,224
-Buffalo,Total,U.S. House,1,DEM,Paula Hawks,290
+Brule,1,President,,Donald J. Trump,REP,765
+Brule,2,President,,Donald J. Trump,REP,388
+Brule,3,President,,Donald J. Trump,REP,266
+Brule,4,President,,Donald J. Trump,REP,59
+Brule,5,President,,Donald J. Trump,REP,87
+Brule,1,President,,Gary Johnson,LIB,76
+Brule,2,President,,Gary Johnson,LIB,26
+Brule,3,President,,Gary Johnson,LIB,20
+Brule,4,President,,Gary Johnson,LIB,2
+Brule,5,President,,Gary Johnson,LIB,1
+Brule,1,President,,Hillary Clinton,DEM,363
+Brule,2,President,,Hillary Clinton,DEM,98
+Brule,3,President,,Hillary Clinton,DEM,81
+Brule,4,President,,Hillary Clinton,DEM,11
+Brule,5,President,,Hillary Clinton,DEM,18
+Brule,1,President,,Darrell L. Castle,CON,12
+Brule,2,President,,Darrell L. Castle,CON,5
+Brule,3,President,,Darrell L. Castle,CON,4
+Brule,4,President,,Darrell L. Castle,CON,4
+Brule,5,President,,Darrell L. Castle,CON,2
+Brule,1,U.S. Senate,,John R. Thune,REP,894
+Brule,2,U.S. Senate,,John R. Thune,REP,413
+Brule,3,U.S. Senate,,John R. Thune,REP,289
+Brule,4,U.S. Senate,,John R. Thune,REP,56
+Brule,5,U.S. Senate,,John R. Thune,REP,94
+Brule,1,U.S. Senate,,Jay Williams,DEM,324
+Brule,2,U.S. Senate,,Jay Williams,DEM,109
+Brule,3,U.S. Senate,,Jay Williams,DEM,88
+Brule,4,U.S. Senate,,Jay Williams,DEM,18
+Brule,5,U.S. Senate,,Jay Williams,DEM,15
+Brule,1,U.S. House,1,Kristi Noem,REP,800
+Brule,2,U.S. House,1,Kristi Noem,REP,381
+Brule,3,U.S. House,1,Kristi Noem,REP,262
+Brule,4,U.S. House,1,Kristi Noem,REP,59
+Brule,5,U.S. House,1,Kristi Noem,REP,83
+Brule,1,U.S. House,1,Paula Hawks,DEM,414
+Brule,2,U.S. House,1,Paula Hawks,DEM,141
+Brule,3,U.S. House,1,Paula Hawks,DEM,114
+Brule,4,U.S. House,1,Paula Hawks,DEM,17
+Brule,5,U.S. House,1,Paula Hawks,DEM,27
+Brule,1,Public Utilities Commissioner,,Chris Nelson,REP,947
+Brule,2,Public Utilities Commissioner,,Chris Nelson,REP,441
+Brule,3,Public Utilities Commissioner,,Chris Nelson,REP,307
+Brule,4,Public Utilities Commissioner,,Chris Nelson,REP,65
+Brule,5,Public Utilities Commissioner,,Chris Nelson,REP,102
+Brule,1,Public Utilities Commissioner,,Henry Red Cloud,DEM,229
+Brule,2,Public Utilities Commissioner,,Henry Red Cloud,DEM,68
+Brule,3,Public Utilities Commissioner,,Henry Red Cloud,DEM,62
+Brule,4,Public Utilities Commissioner,,Henry Red Cloud,DEM,8
+Brule,5,Public Utilities Commissioner,,Henry Red Cloud,DEM,8
+Brule,1,State Senate,26,Troy Heinert,DEM,679
+Brule,2,State Senate,26,Troy Heinert,DEM,263
+Brule,3,State Senate,26,Troy Heinert,DEM,202
+Brule,4,State Senate,26,Troy Heinert,DEM,32
+Brule,5,State Senate,26,Troy Heinert,DEM,60
+Brule,1,State House,26B,James Schaefer,REP,874
+Brule,2,State House,26B,James Schaefer,REP,345
+Brule,3,State House,26B,James Schaefer,REP,272
+Brule,4,State House,26B,James Schaefer,REP,53
+Brule,5,State House,26B,James Schaefer,REP,89
+Brule,1,State Attorney,,David V Natvig,REP,604
+Brule,2,State Attorney,,David V Natvig,REP,365
+Brule,3,State Attorney,,David V Natvig,REP,187
+Brule,4,State Attorney,,David V Natvig,REP,48
+Brule,5,State Attorney,,David V Natvig,REP,54
+Brule,1,State Attorney,,Theresa Maule Rossow,IND,591
+Brule,2,State Attorney,,Theresa Maule Rossow,IND,150
+Brule,3,State Attorney,,Theresa Maule Rossow,IND,183
+Brule,4,State Attorney,,Theresa Maule Rossow,IND,25
+Brule,5,State Attorney,,Theresa Maule Rossow,IND,55
+Buffalo,1,President,,Donald J. Trump,REP,92
+Buffalo,2,President,,Donald J. Trump,REP,42
+Buffalo,3,President,,Donald J. Trump,REP,37
+Buffalo,Total,President,,Donald J. Trump,REP,171
+Buffalo,1,President,,Gary Johnson,LIB,3
+Buffalo,2,President,,Gary Johnson,LIB,0
+Buffalo,3,President,,Gary Johnson,LIB,15
+Buffalo,Total,President,,Gary Johnson,LIB,18
+Buffalo,1,President,,Hillary Clinton,DEM,21
+Buffalo,2,President,,Hillary Clinton,DEM,38
+Buffalo,3,President,,Hillary Clinton,DEM,237
+Buffalo,Total,President,,Hillary Clinton,DEM,296
+Buffalo,1,President,,Darrell L. Castle,CON,0
+Buffalo,2,President,,Darrell L. Castle,CON,1
+Buffalo,3,President,,Darrell L. Castle,CON,4
+Buffalo,Total,President,,Darrell L. Castle,CON,5
+Buffalo,1,U.S. Senate,,John R. Thune,REP,91
+Buffalo,2,U.S. Senate,,John R. Thune,REP,50
+Buffalo,3,U.S. Senate,,John R. Thune,REP,91
+Buffalo,Total,U.S. Senate,,John R. Thune,REP,232
+Buffalo,1,U.S. Senate,,Jay Williams,DEM,26
+Buffalo,2,U.S. Senate,,Jay Williams,DEM,32
+Buffalo,3,U.S. Senate,,Jay Williams,DEM,199
+Buffalo,Total,U.S. Senate,,Jay Williams,DEM,257
+Buffalo,1,U.S. House,1,Kristi Noem,REP,90
+Buffalo,2,U.S. House,1,Kristi Noem,REP,43
+Buffalo,3,U.S. House,1,Kristi Noem,REP,67
+Buffalo,Total,U.S. House,1,Kristi Noem,REP,200
+Buffalo,1,U.S. House,1,Paula Hawks,DEM,26
+Buffalo,2,U.S. House,1,Paula Hawks,DEM,40
+Buffalo,3,U.S. House,1,Paula Hawks,DEM,224
+Buffalo,Total,U.S. House,1,Paula Hawks,DEM,290
 Campbell,1,President,,Donald J. Trump,REP,115
 Campbell,2,President,,Donald J. Trump,REP,136
 Campbell,3,President,,Donald J. Trump,REP,152
@@ -1373,374 +1373,374 @@ Charles Mix,11,State Representative,21,julie Bartling,DEM,341
 Charles Mix,12,State Representative,21,julie Bartling,DEM,72
 Charles Mix,13,State Representative,21,julie Bartling,DEM,43
 Charles Mix,TOTAL,State Representative,21,julie Bartling,DEM,1944
-Clark,1,President,,REP,Donald J. Trump,107
-Clark,2,President,,REP,Donald J. Trump,95
-Clark,3,President,,REP,Donald J. Trump,76
-Clark,4,President,,REP,Donald J. Trump,81
-Clark,5,President,,REP,Donald J. Trump,82
-Clark,6,President,,REP,Donald J. Trump,42
-Clark,7,President,,REP,Donald J. Trump,85
-Clark,8,President,,REP,Donald J. Trump,97
-Clark,9,President,,REP,Donald J. Trump,55
-Clark,10,President,,REP,Donald J. Trump,67
-Clark,11,President,,REP,Donald J. Trump,101
-Clark,12,President,,REP,Donald J. Trump,107
-Clark,13,President,,REP,Donald J. Trump,144
-Clark,1,President,,LIB,Gary Johnson,8
-Clark,2,President,,LIB,Gary Johnson,6
-Clark,3,President,,LIB,Gary Johnson,4
-Clark,4,President,,LIB,Gary Johnson,7
-Clark,5,President,,LIB,Gary Johnson,6
-Clark,6,President,,LIB,Gary Johnson,4
-Clark,7,President,,LIB,Gary Johnson,8
-Clark,8,President,,LIB,Gary Johnson,10
-Clark,9,President,,LIB,Gary Johnson,3
-Clark,10,President,,LIB,Gary Johnson,11
-Clark,11,President,,LIB,Gary Johnson,19
-Clark,12,President,,LIB,Gary Johnson,6
-Clark,13,President,,LIB,Gary Johnson,11
-Clark,1,President,,DEM,Hillary Clinton,42
-Clark,2,President,,DEM,Hillary Clinton,37
-Clark,3,President,,DEM,Hillary Clinton,25
-Clark,4,President,,DEM,Hillary Clinton,26
-Clark,5,President,,DEM,Hillary Clinton,18
-Clark,6,President,,DEM,Hillary Clinton,16
-Clark,7,President,,DEM,Hillary Clinton,24
-Clark,8,President,,DEM,Hillary Clinton,29
-Clark,9,President,,DEM,Hillary Clinton,6
-Clark,10,President,,DEM,Hillary Clinton,26
-Clark,11,President,,DEM,Hillary Clinton,39
-Clark,12,President,,DEM,Hillary Clinton,46
-Clark,13,President,,DEM,Hillary Clinton,64
-Clark,1,President,,CON,Darrell L. Castle,1
-Clark,2,President,,CON,Darrell L. Castle,0
-Clark,3,President,,CON,Darrell L. Castle,1
-Clark,4,President,,CON,Darrell L. Castle,0
-Clark,5,President,,CON,Darrell L. Castle,0
-Clark,6,President,,CON,Darrell L. Castle,1
-Clark,7,President,,CON,Darrell L. Castle,1
-Clark,8,President,,CON,Darrell L. Castle,2
-Clark,9,President,,CON,Darrell L. Castle,1
-Clark,10,President,,CON,Darrell L. Castle,0
-Clark,11,President,,CON,Darrell L. Castle,2
-Clark,12,President,,CON,Darrell L. Castle,2
-Clark,13,President,,CON,Darrell L. Castle,6
-Clark,1,U.S. Senate,,REP,John R. Thune,111
-Clark,2,U.S. Senate,,REP,John R. Thune,106
-Clark,3,U.S. Senate,,REP,John R. Thune,88
-Clark,4,U.S. Senate,,REP,John R. Thune,83
-Clark,5,U.S. Senate,,REP,John R. Thune,84
-Clark,6,U.S. Senate,,REP,John R. Thune,50
-Clark,7,U.S. Senate,,REP,John R. Thune,95
-Clark,8,U.S. Senate,,REP,John R. Thune,111
-Clark,9,U.S. Senate,,REP,John R. Thune,63
-Clark,10,U.S. Senate,,REP,John R. Thune,72
-Clark,11,U.S. Senate,,REP,John R. Thune,108
-Clark,12,U.S. Senate,,REP,John R. Thune,122
-Clark,13,U.S. Senate,,REP,John R. Thune,176
-Clark,1,U.S. Senate,,DEM,Jay Williams,48
-Clark,2,U.S. Senate,,DEM,Jay Williams,31
-Clark,3,U.S. Senate,,DEM,Jay Williams,19
-Clark,4,U.S. Senate,,DEM,Jay Williams,32
-Clark,5,U.S. Senate,,DEM,Jay Williams,24
-Clark,6,U.S. Senate,,DEM,Jay Williams,16
-Clark,7,U.S. Senate,,DEM,Jay Williams,23
-Clark,8,U.S. Senate,,DEM,Jay Williams,28
-Clark,9,U.S. Senate,,DEM,Jay Williams,5
-Clark,10,U.S. Senate,,DEM,Jay Williams,33
-Clark,11,U.S. Senate,,DEM,Jay Williams,55
-Clark,12,U.S. Senate,,DEM,Jay Williams,38
-Clark,13,U.S. Senate,,DEM,Jay Williams,56
-Clark,1,U.S. House,1,REP,Kristi Noem,106
-Clark,2,U.S. House,1,REP,Kristi Noem,92
-Clark,3,U.S. House,1,REP,Kristi Noem,76
-Clark,4,U.S. House,1,REP,Kristi Noem,76
-Clark,5,U.S. House,1,REP,Kristi Noem,79
-Clark,6,U.S. House,1,REP,Kristi Noem,34
-Clark,7,U.S. House,1,REP,Kristi Noem,83
-Clark,8,U.S. House,1,REP,Kristi Noem,90
-Clark,9,U.S. House,1,REP,Kristi Noem,63
-Clark,10,U.S. House,1,REP,Kristi Noem,58
-Clark,11,U.S. House,1,REP,Kristi Noem,95
-Clark,12,U.S. House,1,REP,Kristi Noem,102
-Clark,13,U.S. House,1,REP,Kristi Noem,145
-Clark,1,U.S. House,1,DEM,Paula Hawks,56
-Clark,2,U.S. House,1,DEM,Paula Hawks,47
-Clark,3,U.S. House,1,DEM,Paula Hawks,32
-Clark,4,U.S. House,1,DEM,Paula Hawks,39
-Clark,5,U.S. House,1,DEM,Paula Hawks,30
-Clark,6,U.S. House,1,DEM,Paula Hawks,32
-Clark,7,U.S. House,1,DEM,Paula Hawks,36
-Clark,8,U.S. House,1,DEM,Paula Hawks,45
-Clark,9,U.S. House,1,DEM,Paula Hawks,5
-Clark,10,U.S. House,1,DEM,Paula Hawks,47
-Clark,11,U.S. House,1,DEM,Paula Hawks,71
-Clark,12,U.S. House,1,DEM,Paula Hawks,57
-Clark,13,U.S. House,1,DEM,Paula Hawks,87
-Clark,1,Public Utilities Commissioner,,REP,Chris Nelson,124
-Clark,2,Public Utilities Commissioner,,REP,Chris Nelson,116
-Clark,3,Public Utilities Commissioner,,REP,Chris Nelson,83
-Clark,4,Public Utilities Commissioner,,REP,Chris Nelson,93
-Clark,5,Public Utilities Commissioner,,REP,Chris Nelson,92
-Clark,6,Public Utilities Commissioner,,REP,Chris Nelson,54
-Clark,7,Public Utilities Commissioner,,REP,Chris Nelson,100
-Clark,8,Public Utilities Commissioner,,REP,Chris Nelson,114
-Clark,9,Public Utilities Commissioner,,REP,Chris Nelson,61
-Clark,10,Public Utilities Commissioner,,REP,Chris Nelson,91
-Clark,11,Public Utilities Commissioner,,REP,Chris Nelson,121
-Clark,12,Public Utilities Commissioner,,REP,Chris Nelson,131
-Clark,13,Public Utilities Commissioner,,REP,Chris Nelson,189
-Clark,1,Public Utilities Commissioner,,DEM,Henry Red Cloud,29
-Clark,2,Public Utilities Commissioner,,DEM,Henry Red Cloud,15
-Clark,3,Public Utilities Commissioner,,DEM,Henry Red Cloud,19
-Clark,4,Public Utilities Commissioner,,DEM,Henry Red Cloud,16
-Clark,5,Public Utilities Commissioner,,DEM,Henry Red Cloud,13
-Clark,6,Public Utilities Commissioner,,DEM,Henry Red Cloud,10
-Clark,7,Public Utilities Commissioner,,DEM,Henry Red Cloud,17
-Clark,8,Public Utilities Commissioner,,DEM,Henry Red Cloud,19
-Clark,9,Public Utilities Commissioner,,DEM,Henry Red Cloud,6
-Clark,10,Public Utilities Commissioner,,DEM,Henry Red Cloud,11
-Clark,11,Public Utilities Commissioner,,DEM,Henry Red Cloud,37
-Clark,12,Public Utilities Commissioner,,DEM,Henry Red Cloud,24
-Clark,13,Public Utilities Commissioner,,DEM,Henry Red Cloud,29
-Clark,1,State Senate,2,REP,Brock L. Greenfield,118
-Clark,2,State Senate,2,REP,Brock L. Greenfield,104
-Clark,3,State Senate,2,REP,Brock L. Greenfield,86
-Clark,4,State Senate,2,REP,Brock L. Greenfield,85
-Clark,5,State Senate,2,REP,Brock L. Greenfield,75
-Clark,6,State Senate,2,REP,Brock L. Greenfield,47
-Clark,7,State Senate,2,REP,Brock L. Greenfield,89
-Clark,8,State Senate,2,REP,Brock L. Greenfield,110
-Clark,9,State Senate,2,REP,Brock L. Greenfield,56
-Clark,10,State Senate,2,REP,Brock L. Greenfield,76
-Clark,11,State Senate,2,REP,Brock L. Greenfield,112
-Clark,12,State Senate,2,REP,Brock L. Greenfield,121
-Clark,13,State Senate,2,REP,Brock L. Greenfield,160
-Clark,1,State House,2,REP,Burt Tulson,87
-Clark,2,State House,2,REP,Burt Tulson,82
-Clark,3,State House,2,REP,Burt Tulson,62
-Clark,4,State House,2,REP,Burt Tulson,65
-Clark,5,State House,2,REP,Burt Tulson,63
-Clark,6,State House,2,REP,Burt Tulson,41
-Clark,7,State House,2,REP,Burt Tulson,83
-Clark,8,State House,2,REP,Burt Tulson,82
-Clark,9,State House,2,REP,Burt Tulson,55
-Clark,10,State House,2,REP,Burt Tulson,63
-Clark,11,State House,2,REP,Burt Tulson,88
-Clark,12,State House,2,REP,Burt Tulson,109
-Clark,13,State House,2,REP,Burt Tulson,135
-Clark,1,State House,2,REP,Lana Greenfield,98
-Clark,2,State House,2,REP,Lana Greenfield,90
-Clark,3,State House,2,REP,Lana Greenfield,73
-Clark,4,State House,2,REP,Lana Greenfield,72
-Clark,5,State House,2,REP,Lana Greenfield,60
-Clark,6,State House,2,REP,Lana Greenfield,43
-Clark,7,State House,2,REP,Lana Greenfield,75
-Clark,8,State House,2,REP,Lana Greenfield,81
-Clark,9,State House,2,REP,Lana Greenfield,40
-Clark,10,State House,2,REP,Lana Greenfield,66
-Clark,11,State House,2,REP,Lana Greenfield,91
-Clark,12,State House,2,REP,Lana Greenfield,84
-Clark,13,State House,2,REP,Lana Greenfield,134
-Clark,1,State House,2,DEM,John Graham,58
-Clark,2,State House,2,DEM,John Graham,36
-Clark,3,State House,2,DEM,John Graham,29
-Clark,4,State House,2,DEM,John Graham,39
-Clark,5,State House,2,DEM,John Graham,33
-Clark,6,State House,2,DEM,John Graham,20
-Clark,7,State House,2,DEM,John Graham,36
-Clark,8,State House,2,DEM,John Graham,42
-Clark,9,State House,2,DEM,John Graham,6
-Clark,10,State House,2,DEM,John Graham,37
-Clark,11,State House,2,DEM,John Graham,62
-Clark,12,State House,2,DEM,John Graham,49
-Clark,13,State House,2,DEM,John Graham,82
-Clark,1,County Commissioner,2,IND,Chris Sass,78
-Clark,2,County Commissioner,2,IND,Chris Sass,65
-Clark,4,County Commissioner,2,IND,Chris Sass,46
-Clark,1,County Commissioner,2,IND,Eric J Caulfield,80
-Clark,2,County Commissioner,2,IND,Eric J Caulfield,48
-Clark,4,County Commissioner,2,IND,Eric J Caulfield,46
-Clay,1913 Vermillion SE Ward 2,President,,REP,Trump & Pence,189
-Clay,1913 Vermillion SE Ward 2,President,,LIB,Johnson & Weld,31
-Clay,1913 Vermillion SE Ward 2,President,,DEM,Clinton & Kaine,345
-Clay,1913 Vermillion SE Ward 2,President,,CON,Castle & Bradley,8
-Clay,1913 Vermillion SE Ward 2,U.S. Senate,,REP,John R. Thune,320
-Clay,1913 Vermillion SE Ward 2,U.S. Senate,,DEM,Jay Williams,258
-Clay,1913 Vermillion SE Ward 2,U.S. House,1,REP,Kristi Noem,252
-Clay,1913 Vermillion SE Ward 2,U.S. House,1,DEM,Paula Hawks,320
-Clay,1913 Vermillion SE Ward 2,Public Utilities Commissioner,,REP,Chris Nelson,303
-Clay,1913 Vermillion SE Ward 2,Public Utilities Commissioner,,DEM,Henry Red Cloud,248
-Clay,1913 Vermillion SE Ward 2,State Senate,17,REP,Arthur Rusch,345
-Clay,1913 Vermillion SE Ward 2,State Senate,17,DEM,Shane Merrill,212
-Clay,1913 Vermillion SE Ward 2,State House,17,REP,Debbie Pease,154
-Clay,1913 Vermillion SE Ward 2,State House,17,REP,Nancy Rasmussen,200
-Clay,1913 Vermillion SE Ward 2,State House,17,DEM,Mark Winegar,312
-Clay,1913 Vermillion SE Ward 2,State House,17,DEM,Ray Ring,358
-Clay,1913 Vermillion SE Ward 2,States Attorney,,REP,Alexis A. Tracy,273
-Clay,1913 Vermillion SE Ward 2,States Attorney,,DEM,Teddi J Gertsma,277
-Clay,1912 Vermillion SE Ward 1,President,,REP,Trump & Pence,265
-Clay,1912 Vermillion SE Ward 1,President,,LIB,Johnson & Weld,43
-Clay,1912 Vermillion SE Ward 1,President,,DEM,Clinton & Kaine,412
-Clay,1912 Vermillion SE Ward 1,President,,CON,Castle & Bradley,9
-Clay,1912 Vermillion SE Ward 1,U.S. Senate,,REP,John R. Thune,416
-Clay,1912 Vermillion SE Ward 1,U.S. Senate,,DEM,Jay Williams,327
-Clay,1912 Vermillion SE Ward 1,U.S. House,1,REP,Kristi Noem,340
-Clay,1912 Vermillion SE Ward 1,U.S. House,1,DEM,Paula Hawks,399
-Clay,1912 Vermillion SE Ward 1,Public Utilities Commissioner,,REP,Chris Nelson,416
-Clay,1912 Vermillion SE Ward 1,Public Utilities Commissioner,,DEM,Henry Red Cloud,292
-Clay,1912 Vermillion SE Ward 1,State Senate,17,REP,Arthur Rusch,481
-Clay,1912 Vermillion SE Ward 1,State Senate,17,DEM,Shane Merrill,255
-Clay,1912 Vermillion SE Ward 1,State House,17,REP,Debbie Pease,195
-Clay,1912 Vermillion SE Ward 1,State House,17,REP,Nancy Rasmussen,245
-Clay,1912 Vermillion SE Ward 1,State House,17,DEM,Mark Winegar,377
-Clay,1912 Vermillion SE Ward 1,State House,17,DEM,Ray Ring,512
-Clay,1912 Vermillion SE Ward 1,States Attorney,,REP,Alexis A. Tracy,359
-Clay,1912 Vermillion SE Ward 1,States Attorney,,DEM,Teddi J Gertsma,359
-Clay,1911 Vermillion NW Ward 2,President,,REP,Trump & Pence,156
-Clay,1911 Vermillion NW Ward 2,President,,LIB,Johnson & Weld,17
-Clay,1911 Vermillion NW Ward 2,President,,DEM,Clinton & Kaine,187
-Clay,1911 Vermillion NW Ward 2,President,,CON,Castle & Bradley,3
-Clay,1911 Vermillion NW Ward 2,U.S. Senate,,REP,John R. Thune,209
-Clay,1911 Vermillion NW Ward 2,U.S. Senate,,DEM,Jay Williams,156
-Clay,1911 Vermillion NW Ward 2,U.S. House,1,REP,Kristi Noem,181
-Clay,1911 Vermillion NW Ward 2,U.S. House,1,DEM,Paula Hawks,182
-Clay,1911 Vermillion NW Ward 2,Public Utilities Commissioner,,REP,Chris Nelson,212
-Clay,1911 Vermillion NW Ward 2,Public Utilities Commissioner,,DEM,Henry Red Cloud,144
-Clay,1911 Vermillion NW Ward 2,State Senate,17,REP,Arthur Rusch,214
-Clay,1911 Vermillion NW Ward 2,State Senate,17,DEM,Shane Merrill,147
-Clay,1911 Vermillion NW Ward 2,State House,17,REP,Debbie Pease,107
-Clay,1911 Vermillion NW Ward 2,State House,17,REP,Nancy Rasmussen,146
-Clay,1911 Vermillion NW Ward 2,State House,17,DEM,Mark Winegar,170
-Clay,1911 Vermillion NW Ward 2,State House,17,DEM,Ray Ring,211
-Clay,1911 Vermillion NW Ward 2,States Attorney,,REP,Alexis A. Tracy,197
-Clay,1911 Vermillion NW Ward 2,States Attorney,,DEM,Teddi J Gertsma,161
-Clay,1909 Vermillion NE Ward 2,President,,REP,Trump & Pence,46
-Clay,1909 Vermillion NE Ward 2,President,,LIB,Johnson & Weld,16
-Clay,1909 Vermillion NE Ward 2,President,,DEM,Clinton & Kaine,99
-Clay,1909 Vermillion NE Ward 2,President,,CON,Castle & Bradley,0
-Clay,1909 Vermillion NE Ward 2,U.S. Senate,,REP,John R. Thune,74
-Clay,1909 Vermillion NE Ward 2,U.S. Senate,,DEM,Jay Williams,86
-Clay,1909 Vermillion NE Ward 2,U.S. House,1,REP,Kristi Noem,61
-Clay,1909 Vermillion NE Ward 2,U.S. House,1,DEM,Paula Hawks,99
-Clay,1909 Vermillion NE Ward 2,Public Utilities Commissioner,,REP,Chris Nelson,57
-Clay,1909 Vermillion NE Ward 2,Public Utilities Commissioner,,DEM,Henry Red Cloud,88
-Clay,1909 Vermillion NE Ward 2,State Senate,17,REP,Arthur Rusch,63
-Clay,1909 Vermillion NE Ward 2,State Senate,17,DEM,Shane Merrill,84
-Clay,1909 Vermillion NE Ward 2,State House,17,REP,Debbie Pease,36
-Clay,1909 Vermillion NE Ward 2,State House,17,REP,Nancy Rasmussen,60
-Clay,1909 Vermillion NE Ward 2,State House,17,DEM,Mark Winegar,89
-Clay,1909 Vermillion NE Ward 2,State House,17,DEM,Ray Ring,74
-Clay,1909 Vermillion NE Ward 2,States Attorney,,REP,Alexis A. Tracy,58
-Clay,1909 Vermillion NE Ward 2,States Attorney,,DEM,Teddi J Gertsma,87
-Clay,1908 Vermillion NE Ward 1,President,,REP,Trump & Pence,135
-Clay,1908 Vermillion NE Ward 1,President,,LIB,Johnson & Weld,28
-Clay,1908 Vermillion NE Ward 1,President,,DEM,Clinton & Kaine,150
-Clay,1908 Vermillion NE Ward 1,President,,CON,Castle & Bradley,5
-Clay,1908 Vermillion NE Ward 1,U.S. Senate,,REP,John R. Thune,192
-Clay,1908 Vermillion NE Ward 1,U.S. Senate,,DEM,Jay Williams,125
-Clay,1908 Vermillion NE Ward 1,U.S. House,1,REP,Kristi Noem,161
-Clay,1908 Vermillion NE Ward 1,U.S. House,1,DEM,Paula Hawks,153
-Clay,1908 Vermillion NE Ward 1,Public Utilities Commissioner,,REP,Chris Nelson,160
-Clay,1908 Vermillion NE Ward 1,Public Utilities Commissioner,,DEM,Henry Red Cloud,132
-Clay,1908 Vermillion NE Ward 1,State Senate,17,REP,Arthur Rusch,179
-Clay,1908 Vermillion NE Ward 1,State Senate,17,DEM,Shane Merrill,119
-Clay,1908 Vermillion NE Ward 1,State House,17,REP,Debbie Pease,107
-Clay,1908 Vermillion NE Ward 1,State House,17,REP,Nancy Rasmussen,129
-Clay,1908 Vermillion NE Ward 1,State House,17,DEM,Mark Winegar,143
-Clay,1908 Vermillion NE Ward 1,State House,17,DEM,Ray Ring,141
-Clay,1908 Vermillion NE Ward 1,States Attorney,,REP,Alexis A. Tracy,162
-Clay,1908 Vermillion NE Ward 1,States Attorney,,DEM,Teddi J Gertsma,133
-Clay,1902 Rural Ward 2,President,,REP,Trump & Pence,204
-Clay,1902 Rural Ward 2,President,,LIB,Johnson & Weld,22
-Clay,1902 Rural Ward 2,President,,DEM,Clinton & Kaine,143
-Clay,1902 Rural Ward 2,President,,CON,Castle & Bradley,6
-Clay,1902 Rural Ward 2,U.S. Senate,,REP,John R. Thune,262
-Clay,1902 Rural Ward 2,U.S. Senate,,DEM,Jay Williams,111
-Clay,1902 Rural Ward 2,U.S. House,1,REP,Kristi Noem,221
-Clay,1902 Rural Ward 2,U.S. House,1,DEM,Paula Hawks,157
-Clay,1902 Rural Ward 2,Public Utilities Commissioner,,REP,Chris Nelson,269
-Clay,1902 Rural Ward 2,Public Utilities Commissioner,,DEM,Henry Red Cloud,90
-Clay,1902 Rural Ward 2,State Senate,17,REP,Arthur Rusch,211
-Clay,1902 Rural Ward 2,State Senate,17,DEM,Shane Merrill,154
-Clay,1902 Rural Ward 2,State House,17,REP,Debbie Pease,158
-Clay,1902 Rural Ward 2,State House,17,REP,Nancy Rasmussen,198
-Clay,1902 Rural Ward 2,State House,17,DEM,Mark Winegar,116
-Clay,1902 Rural Ward 2,State House,17,DEM,Ray Ring,159
-Clay,1902 Rural Ward 2,States Attorney,,REP,Alexis A. Tracy,223
-Clay,1902 Rural Ward 2,States Attorney,,DEM,Teddi J Gertsma,120
-Clay,1903 Rural Ward 3,President,,REP,Trump & Pence,472
-Clay,1903 Rural Ward 3,President,,LIB,Johnson & Weld,53
-Clay,1903 Rural Ward 3,President,,DEM,Clinton & Kaine,412
-Clay,1903 Rural Ward 3,President,,CON,Castle & Bradley,6
-Clay,1903 Rural Ward 3,U.S. Senate,,REP,John R. Thune,603
-Clay,1903 Rural Ward 3,U.S. Senate,,DEM,Jay Williams,350
-Clay,1903 Rural Ward 3,U.S. House,1,REP,Kristi Noem,496
-Clay,1903 Rural Ward 3,U.S. House,1,DEM,Paula Hawks,453
-Clay,1903 Rural Ward 3,Public Utilities Commissioner,,REP,Chris Nelson,615
-Clay,1903 Rural Ward 3,Public Utilities Commissioner,,DEM,Henry Red Cloud,299
-Clay,1903 Rural Ward 3,State Senate,17,REP,Arthur Rusch,626
-Clay,1903 Rural Ward 3,State Senate,17,DEM,Shane Merrill,308
-Clay,1903 Rural Ward 3,State House,17,REP,Debbie Pease,324
-Clay,1903 Rural Ward 3,State House,17,REP,Nancy Rasmussen,399
-Clay,1903 Rural Ward 3,State House,17,DEM,Mark Winegar,399
-Clay,1903 Rural Ward 3,State House,17,DEM,Ray Ring,525
-Clay,1903 Rural Ward 3,States Attorney,,REP,Alexis A. Tracy,564
-Clay,1903 Rural Ward 3,States Attorney,,DEM,Teddi J Gertsma,358
-Clay,1901 Rural Ward 1,President,,REP,Trump & Pence,271
-Clay,1901 Rural Ward 1,President,,LIB,Johnson & Weld,12
-Clay,1901 Rural Ward 1,President,,DEM,Clinton & Kaine,121
-Clay,1901 Rural Ward 1,President,,CON,Castle & Bradley,6
-Clay,1901 Rural Ward 1,U.S. Senate,,REP,John R. Thune,309
-Clay,1901 Rural Ward 1,U.S. Senate,,DEM,Jay Williams,102
-Clay,1901 Rural Ward 1,U.S. House,1,REP,Kristi Noem,278
-Clay,1901 Rural Ward 1,U.S. House,1,DEM,Paula Hawks,138
-Clay,1901 Rural Ward 1,Public Utilities Commissioner,,REP,Chris Nelson,320
-Clay,1901 Rural Ward 1,Public Utilities Commissioner,,DEM,Henry Red Cloud,82
-Clay,1901 Rural Ward 1,State Senate,17,REP,Arthur Rusch,268
-Clay,1901 Rural Ward 1,State Senate,17,DEM,Shane Merrill,130
-Clay,1901 Rural Ward 1,State House,17,REP,Debbie Pease,213
-Clay,1901 Rural Ward 1,State House,17,REP,Nancy Rasmussen,245
-Clay,1901 Rural Ward 1,State House,17,DEM,Mark Winegar,108
-Clay,1901 Rural Ward 1,State House,17,DEM,Ray Ring,147
-Clay,1901 Rural Ward 1,States Attorney,,REP,Alexis A. Tracy,267
-Clay,1901 Rural Ward 1,States Attorney,,DEM,Teddi J Gertsma,118
-Clay,1907 Vermillion Central Ward 2,President,,REP,Trump & Pence,74
-Clay,1907 Vermillion Central Ward 2,President,,LIB,Johnson & Weld,13
-Clay,1907 Vermillion Central Ward 2,President,,DEM,Clinton & Kaine,165
-Clay,1907 Vermillion Central Ward 2,President,,CON,Castle & Bradley,4
-Clay,1907 Vermillion Central Ward 2,U.S. Senate,,REP,John R. Thune,103
-Clay,1907 Vermillion Central Ward 2,U.S. Senate,,DEM,Jay Williams,155
-Clay,1907 Vermillion Central Ward 2,U.S. House,1,REP,Kristi Noem,98
-Clay,1907 Vermillion Central Ward 2,U.S. House,1,DEM,Paula Hawks,159
-Clay,1907 Vermillion Central Ward 2,Public Utilities Commissioner,,REP,Chris Nelson,89
-Clay,1907 Vermillion Central Ward 2,Public Utilities Commissioner,,DEM,Henry Red Cloud,150
-Clay,1907 Vermillion Central Ward 2,State Senate,17,REP,Arthur Rusch,96
-Clay,1907 Vermillion Central Ward 2,State Senate,17,DEM,Shane Merrill,143
-Clay,1907 Vermillion Central Ward 2,State House,17,REP,Debbie Pease,64
-Clay,1907 Vermillion Central Ward 2,State House,17,REP,Nancy Rasmussen,82
-Clay,1907 Vermillion Central Ward 2,State House,17,DEM,Mark Winegar,154
-Clay,1907 Vermillion Central Ward 2,State House,17,DEM,Ray Ring,138
-Clay,1907 Vermillion Central Ward 2,States Attorney,,REP,Alexis A. Tracy,104
-Clay,1907 Vermillion Central Ward 2,States Attorney,,DEM,Teddi J Gertsma,135
-Clay,1906 Vermillion Central Ward 1,President,,REP,Trump & Pence,78
-Clay,1906 Vermillion Central Ward 1,President,,LIB,Johnson & Weld,23
-Clay,1906 Vermillion Central Ward 1,President,,DEM,Clinton & Kaine,259
-Clay,1906 Vermillion Central Ward 1,President,,CON,Castle & Bradley,3
-Clay,1906 Vermillion Central Ward 1,U.S. Senate,,REP,John R. Thune,138
-Clay,1906 Vermillion Central Ward 1,U.S. Senate,,DEM,Jay Williams,222
-Clay,1906 Vermillion Central Ward 1,U.S. House,1,REP,Kristi Noem,95
-Clay,1906 Vermillion Central Ward 1,U.S. House,1,DEM,Paula Hawks,261
-Clay,1906 Vermillion Central Ward 1,Public Utilities Commissioner,,REP,Chris Nelson,136
-Clay,1906 Vermillion Central Ward 1,Public Utilities Commissioner,,DEM,Henry Red Cloud,208
-Clay,1906 Vermillion Central Ward 1,State Senate,17,REP,Arthur Rusch,164
-Clay,1906 Vermillion Central Ward 1,State Senate,17,DEM,Shane Merrill,188
-Clay,1906 Vermillion Central Ward 1,State House,17,REP,Debbie Pease,62
-Clay,1906 Vermillion Central Ward 1,State House,17,REP,Nancy Rasmussen,83
-Clay,1906 Vermillion Central Ward 1,State House,17,DEM,Mark Winegar,240
-Clay,1906 Vermillion Central Ward 1,State House,17,DEM,Ray Ring,251
-Clay,1906 Vermillion Central Ward 1,States Attorney,,REP,Alexis A. Tracy,133
-Clay,1906 Vermillion Central Ward 1,States Attorney,,DEM,Teddi J Gertsma,216
+Clark,1,President,,Donald J. Trump,REP,107
+Clark,2,President,,Donald J. Trump,REP,95
+Clark,3,President,,Donald J. Trump,REP,76
+Clark,4,President,,Donald J. Trump,REP,81
+Clark,5,President,,Donald J. Trump,REP,82
+Clark,6,President,,Donald J. Trump,REP,42
+Clark,7,President,,Donald J. Trump,REP,85
+Clark,8,President,,Donald J. Trump,REP,97
+Clark,9,President,,Donald J. Trump,REP,55
+Clark,10,President,,Donald J. Trump,REP,67
+Clark,11,President,,Donald J. Trump,REP,101
+Clark,12,President,,Donald J. Trump,REP,107
+Clark,13,President,,Donald J. Trump,REP,144
+Clark,1,President,,Gary Johnson,LIB,8
+Clark,2,President,,Gary Johnson,LIB,6
+Clark,3,President,,Gary Johnson,LIB,4
+Clark,4,President,,Gary Johnson,LIB,7
+Clark,5,President,,Gary Johnson,LIB,6
+Clark,6,President,,Gary Johnson,LIB,4
+Clark,7,President,,Gary Johnson,LIB,8
+Clark,8,President,,Gary Johnson,LIB,10
+Clark,9,President,,Gary Johnson,LIB,3
+Clark,10,President,,Gary Johnson,LIB,11
+Clark,11,President,,Gary Johnson,LIB,19
+Clark,12,President,,Gary Johnson,LIB,6
+Clark,13,President,,Gary Johnson,LIB,11
+Clark,1,President,,Hillary Clinton,DEM,42
+Clark,2,President,,Hillary Clinton,DEM,37
+Clark,3,President,,Hillary Clinton,DEM,25
+Clark,4,President,,Hillary Clinton,DEM,26
+Clark,5,President,,Hillary Clinton,DEM,18
+Clark,6,President,,Hillary Clinton,DEM,16
+Clark,7,President,,Hillary Clinton,DEM,24
+Clark,8,President,,Hillary Clinton,DEM,29
+Clark,9,President,,Hillary Clinton,DEM,6
+Clark,10,President,,Hillary Clinton,DEM,26
+Clark,11,President,,Hillary Clinton,DEM,39
+Clark,12,President,,Hillary Clinton,DEM,46
+Clark,13,President,,Hillary Clinton,DEM,64
+Clark,1,President,,Darrell L. Castle,CON,1
+Clark,2,President,,Darrell L. Castle,CON,0
+Clark,3,President,,Darrell L. Castle,CON,1
+Clark,4,President,,Darrell L. Castle,CON,0
+Clark,5,President,,Darrell L. Castle,CON,0
+Clark,6,President,,Darrell L. Castle,CON,1
+Clark,7,President,,Darrell L. Castle,CON,1
+Clark,8,President,,Darrell L. Castle,CON,2
+Clark,9,President,,Darrell L. Castle,CON,1
+Clark,10,President,,Darrell L. Castle,CON,0
+Clark,11,President,,Darrell L. Castle,CON,2
+Clark,12,President,,Darrell L. Castle,CON,2
+Clark,13,President,,Darrell L. Castle,CON,6
+Clark,1,U.S. Senate,,John R. Thune,REP,111
+Clark,2,U.S. Senate,,John R. Thune,REP,106
+Clark,3,U.S. Senate,,John R. Thune,REP,88
+Clark,4,U.S. Senate,,John R. Thune,REP,83
+Clark,5,U.S. Senate,,John R. Thune,REP,84
+Clark,6,U.S. Senate,,John R. Thune,REP,50
+Clark,7,U.S. Senate,,John R. Thune,REP,95
+Clark,8,U.S. Senate,,John R. Thune,REP,111
+Clark,9,U.S. Senate,,John R. Thune,REP,63
+Clark,10,U.S. Senate,,John R. Thune,REP,72
+Clark,11,U.S. Senate,,John R. Thune,REP,108
+Clark,12,U.S. Senate,,John R. Thune,REP,122
+Clark,13,U.S. Senate,,John R. Thune,REP,176
+Clark,1,U.S. Senate,,Jay Williams,DEM,48
+Clark,2,U.S. Senate,,Jay Williams,DEM,31
+Clark,3,U.S. Senate,,Jay Williams,DEM,19
+Clark,4,U.S. Senate,,Jay Williams,DEM,32
+Clark,5,U.S. Senate,,Jay Williams,DEM,24
+Clark,6,U.S. Senate,,Jay Williams,DEM,16
+Clark,7,U.S. Senate,,Jay Williams,DEM,23
+Clark,8,U.S. Senate,,Jay Williams,DEM,28
+Clark,9,U.S. Senate,,Jay Williams,DEM,5
+Clark,10,U.S. Senate,,Jay Williams,DEM,33
+Clark,11,U.S. Senate,,Jay Williams,DEM,55
+Clark,12,U.S. Senate,,Jay Williams,DEM,38
+Clark,13,U.S. Senate,,Jay Williams,DEM,56
+Clark,1,U.S. House,1,Kristi Noem,REP,106
+Clark,2,U.S. House,1,Kristi Noem,REP,92
+Clark,3,U.S. House,1,Kristi Noem,REP,76
+Clark,4,U.S. House,1,Kristi Noem,REP,76
+Clark,5,U.S. House,1,Kristi Noem,REP,79
+Clark,6,U.S. House,1,Kristi Noem,REP,34
+Clark,7,U.S. House,1,Kristi Noem,REP,83
+Clark,8,U.S. House,1,Kristi Noem,REP,90
+Clark,9,U.S. House,1,Kristi Noem,REP,63
+Clark,10,U.S. House,1,Kristi Noem,REP,58
+Clark,11,U.S. House,1,Kristi Noem,REP,95
+Clark,12,U.S. House,1,Kristi Noem,REP,102
+Clark,13,U.S. House,1,Kristi Noem,REP,145
+Clark,1,U.S. House,1,Paula Hawks,DEM,56
+Clark,2,U.S. House,1,Paula Hawks,DEM,47
+Clark,3,U.S. House,1,Paula Hawks,DEM,32
+Clark,4,U.S. House,1,Paula Hawks,DEM,39
+Clark,5,U.S. House,1,Paula Hawks,DEM,30
+Clark,6,U.S. House,1,Paula Hawks,DEM,32
+Clark,7,U.S. House,1,Paula Hawks,DEM,36
+Clark,8,U.S. House,1,Paula Hawks,DEM,45
+Clark,9,U.S. House,1,Paula Hawks,DEM,5
+Clark,10,U.S. House,1,Paula Hawks,DEM,47
+Clark,11,U.S. House,1,Paula Hawks,DEM,71
+Clark,12,U.S. House,1,Paula Hawks,DEM,57
+Clark,13,U.S. House,1,Paula Hawks,DEM,87
+Clark,1,Public Utilities Commissioner,,Chris Nelson,REP,124
+Clark,2,Public Utilities Commissioner,,Chris Nelson,REP,116
+Clark,3,Public Utilities Commissioner,,Chris Nelson,REP,83
+Clark,4,Public Utilities Commissioner,,Chris Nelson,REP,93
+Clark,5,Public Utilities Commissioner,,Chris Nelson,REP,92
+Clark,6,Public Utilities Commissioner,,Chris Nelson,REP,54
+Clark,7,Public Utilities Commissioner,,Chris Nelson,REP,100
+Clark,8,Public Utilities Commissioner,,Chris Nelson,REP,114
+Clark,9,Public Utilities Commissioner,,Chris Nelson,REP,61
+Clark,10,Public Utilities Commissioner,,Chris Nelson,REP,91
+Clark,11,Public Utilities Commissioner,,Chris Nelson,REP,121
+Clark,12,Public Utilities Commissioner,,Chris Nelson,REP,131
+Clark,13,Public Utilities Commissioner,,Chris Nelson,REP,189
+Clark,1,Public Utilities Commissioner,,Henry Red Cloud,DEM,29
+Clark,2,Public Utilities Commissioner,,Henry Red Cloud,DEM,15
+Clark,3,Public Utilities Commissioner,,Henry Red Cloud,DEM,19
+Clark,4,Public Utilities Commissioner,,Henry Red Cloud,DEM,16
+Clark,5,Public Utilities Commissioner,,Henry Red Cloud,DEM,13
+Clark,6,Public Utilities Commissioner,,Henry Red Cloud,DEM,10
+Clark,7,Public Utilities Commissioner,,Henry Red Cloud,DEM,17
+Clark,8,Public Utilities Commissioner,,Henry Red Cloud,DEM,19
+Clark,9,Public Utilities Commissioner,,Henry Red Cloud,DEM,6
+Clark,10,Public Utilities Commissioner,,Henry Red Cloud,DEM,11
+Clark,11,Public Utilities Commissioner,,Henry Red Cloud,DEM,37
+Clark,12,Public Utilities Commissioner,,Henry Red Cloud,DEM,24
+Clark,13,Public Utilities Commissioner,,Henry Red Cloud,DEM,29
+Clark,1,State Senate,2,Brock L. Greenfield,REP,118
+Clark,2,State Senate,2,Brock L. Greenfield,REP,104
+Clark,3,State Senate,2,Brock L. Greenfield,REP,86
+Clark,4,State Senate,2,Brock L. Greenfield,REP,85
+Clark,5,State Senate,2,Brock L. Greenfield,REP,75
+Clark,6,State Senate,2,Brock L. Greenfield,REP,47
+Clark,7,State Senate,2,Brock L. Greenfield,REP,89
+Clark,8,State Senate,2,Brock L. Greenfield,REP,110
+Clark,9,State Senate,2,Brock L. Greenfield,REP,56
+Clark,10,State Senate,2,Brock L. Greenfield,REP,76
+Clark,11,State Senate,2,Brock L. Greenfield,REP,112
+Clark,12,State Senate,2,Brock L. Greenfield,REP,121
+Clark,13,State Senate,2,Brock L. Greenfield,REP,160
+Clark,1,State House,2,Burt Tulson,REP,87
+Clark,2,State House,2,Burt Tulson,REP,82
+Clark,3,State House,2,Burt Tulson,REP,62
+Clark,4,State House,2,Burt Tulson,REP,65
+Clark,5,State House,2,Burt Tulson,REP,63
+Clark,6,State House,2,Burt Tulson,REP,41
+Clark,7,State House,2,Burt Tulson,REP,83
+Clark,8,State House,2,Burt Tulson,REP,82
+Clark,9,State House,2,Burt Tulson,REP,55
+Clark,10,State House,2,Burt Tulson,REP,63
+Clark,11,State House,2,Burt Tulson,REP,88
+Clark,12,State House,2,Burt Tulson,REP,109
+Clark,13,State House,2,Burt Tulson,REP,135
+Clark,1,State House,2,Lana Greenfield,REP,98
+Clark,2,State House,2,Lana Greenfield,REP,90
+Clark,3,State House,2,Lana Greenfield,REP,73
+Clark,4,State House,2,Lana Greenfield,REP,72
+Clark,5,State House,2,Lana Greenfield,REP,60
+Clark,6,State House,2,Lana Greenfield,REP,43
+Clark,7,State House,2,Lana Greenfield,REP,75
+Clark,8,State House,2,Lana Greenfield,REP,81
+Clark,9,State House,2,Lana Greenfield,REP,40
+Clark,10,State House,2,Lana Greenfield,REP,66
+Clark,11,State House,2,Lana Greenfield,REP,91
+Clark,12,State House,2,Lana Greenfield,REP,84
+Clark,13,State House,2,Lana Greenfield,REP,134
+Clark,1,State House,2,John Graham,DEM,58
+Clark,2,State House,2,John Graham,DEM,36
+Clark,3,State House,2,John Graham,DEM,29
+Clark,4,State House,2,John Graham,DEM,39
+Clark,5,State House,2,John Graham,DEM,33
+Clark,6,State House,2,John Graham,DEM,20
+Clark,7,State House,2,John Graham,DEM,36
+Clark,8,State House,2,John Graham,DEM,42
+Clark,9,State House,2,John Graham,DEM,6
+Clark,10,State House,2,John Graham,DEM,37
+Clark,11,State House,2,John Graham,DEM,62
+Clark,12,State House,2,John Graham,DEM,49
+Clark,13,State House,2,John Graham,DEM,82
+Clark,1,County Commissioner,2,Chris Sass,IND,78
+Clark,2,County Commissioner,2,Chris Sass,IND,65
+Clark,4,County Commissioner,2,Chris Sass,IND,46
+Clark,1,County Commissioner,2,Eric J Caulfield,IND,80
+Clark,2,County Commissioner,2,Eric J Caulfield,IND,48
+Clark,4,County Commissioner,2,Eric J Caulfield,IND,46
+Clay,1913 Vermillion SE Ward 2,President,,Trump & Pence,REP,189
+Clay,1913 Vermillion SE Ward 2,President,,Johnson & Weld,LIB,31
+Clay,1913 Vermillion SE Ward 2,President,,Clinton & Kaine,DEM,345
+Clay,1913 Vermillion SE Ward 2,President,,Castle & Bradley,CON,8
+Clay,1913 Vermillion SE Ward 2,U.S. Senate,,John R. Thune,REP,320
+Clay,1913 Vermillion SE Ward 2,U.S. Senate,,Jay Williams,DEM,258
+Clay,1913 Vermillion SE Ward 2,U.S. House,1,Kristi Noem,REP,252
+Clay,1913 Vermillion SE Ward 2,U.S. House,1,Paula Hawks,DEM,320
+Clay,1913 Vermillion SE Ward 2,Public Utilities Commissioner,,Chris Nelson,REP,303
+Clay,1913 Vermillion SE Ward 2,Public Utilities Commissioner,,Henry Red Cloud,DEM,248
+Clay,1913 Vermillion SE Ward 2,State Senate,17,Arthur Rusch,REP,345
+Clay,1913 Vermillion SE Ward 2,State Senate,17,Shane Merrill,DEM,212
+Clay,1913 Vermillion SE Ward 2,State House,17,Debbie Pease,REP,154
+Clay,1913 Vermillion SE Ward 2,State House,17,Nancy Rasmussen,REP,200
+Clay,1913 Vermillion SE Ward 2,State House,17,Mark Winegar,DEM,312
+Clay,1913 Vermillion SE Ward 2,State House,17,Ray Ring,DEM,358
+Clay,1913 Vermillion SE Ward 2,States Attorney,,Alexis A. Tracy,REP,273
+Clay,1913 Vermillion SE Ward 2,States Attorney,,Teddi J Gertsma,DEM,277
+Clay,1912 Vermillion SE Ward 1,President,,Trump & Pence,REP,265
+Clay,1912 Vermillion SE Ward 1,President,,Johnson & Weld,LIB,43
+Clay,1912 Vermillion SE Ward 1,President,,Clinton & Kaine,DEM,412
+Clay,1912 Vermillion SE Ward 1,President,,Castle & Bradley,CON,9
+Clay,1912 Vermillion SE Ward 1,U.S. Senate,,John R. Thune,REP,416
+Clay,1912 Vermillion SE Ward 1,U.S. Senate,,Jay Williams,DEM,327
+Clay,1912 Vermillion SE Ward 1,U.S. House,1,Kristi Noem,REP,340
+Clay,1912 Vermillion SE Ward 1,U.S. House,1,Paula Hawks,DEM,399
+Clay,1912 Vermillion SE Ward 1,Public Utilities Commissioner,,Chris Nelson,REP,416
+Clay,1912 Vermillion SE Ward 1,Public Utilities Commissioner,,Henry Red Cloud,DEM,292
+Clay,1912 Vermillion SE Ward 1,State Senate,17,Arthur Rusch,REP,481
+Clay,1912 Vermillion SE Ward 1,State Senate,17,Shane Merrill,DEM,255
+Clay,1912 Vermillion SE Ward 1,State House,17,Debbie Pease,REP,195
+Clay,1912 Vermillion SE Ward 1,State House,17,Nancy Rasmussen,REP,245
+Clay,1912 Vermillion SE Ward 1,State House,17,Mark Winegar,DEM,377
+Clay,1912 Vermillion SE Ward 1,State House,17,Ray Ring,DEM,512
+Clay,1912 Vermillion SE Ward 1,States Attorney,,Alexis A. Tracy,REP,359
+Clay,1912 Vermillion SE Ward 1,States Attorney,,Teddi J Gertsma,DEM,359
+Clay,1911 Vermillion NW Ward 2,President,,Trump & Pence,REP,156
+Clay,1911 Vermillion NW Ward 2,President,,Johnson & Weld,LIB,17
+Clay,1911 Vermillion NW Ward 2,President,,Clinton & Kaine,DEM,187
+Clay,1911 Vermillion NW Ward 2,President,,Castle & Bradley,CON,3
+Clay,1911 Vermillion NW Ward 2,U.S. Senate,,John R. Thune,REP,209
+Clay,1911 Vermillion NW Ward 2,U.S. Senate,,Jay Williams,DEM,156
+Clay,1911 Vermillion NW Ward 2,U.S. House,1,Kristi Noem,REP,181
+Clay,1911 Vermillion NW Ward 2,U.S. House,1,Paula Hawks,DEM,182
+Clay,1911 Vermillion NW Ward 2,Public Utilities Commissioner,,Chris Nelson,REP,212
+Clay,1911 Vermillion NW Ward 2,Public Utilities Commissioner,,Henry Red Cloud,DEM,144
+Clay,1911 Vermillion NW Ward 2,State Senate,17,Arthur Rusch,REP,214
+Clay,1911 Vermillion NW Ward 2,State Senate,17,Shane Merrill,DEM,147
+Clay,1911 Vermillion NW Ward 2,State House,17,Debbie Pease,REP,107
+Clay,1911 Vermillion NW Ward 2,State House,17,Nancy Rasmussen,REP,146
+Clay,1911 Vermillion NW Ward 2,State House,17,Mark Winegar,DEM,170
+Clay,1911 Vermillion NW Ward 2,State House,17,Ray Ring,DEM,211
+Clay,1911 Vermillion NW Ward 2,States Attorney,,Alexis A. Tracy,REP,197
+Clay,1911 Vermillion NW Ward 2,States Attorney,,Teddi J Gertsma,DEM,161
+Clay,1909 Vermillion NE Ward 2,President,,Trump & Pence,REP,46
+Clay,1909 Vermillion NE Ward 2,President,,Johnson & Weld,LIB,16
+Clay,1909 Vermillion NE Ward 2,President,,Clinton & Kaine,DEM,99
+Clay,1909 Vermillion NE Ward 2,President,,Castle & Bradley,CON,0
+Clay,1909 Vermillion NE Ward 2,U.S. Senate,,John R. Thune,REP,74
+Clay,1909 Vermillion NE Ward 2,U.S. Senate,,Jay Williams,DEM,86
+Clay,1909 Vermillion NE Ward 2,U.S. House,1,Kristi Noem,REP,61
+Clay,1909 Vermillion NE Ward 2,U.S. House,1,Paula Hawks,DEM,99
+Clay,1909 Vermillion NE Ward 2,Public Utilities Commissioner,,Chris Nelson,REP,57
+Clay,1909 Vermillion NE Ward 2,Public Utilities Commissioner,,Henry Red Cloud,DEM,88
+Clay,1909 Vermillion NE Ward 2,State Senate,17,Arthur Rusch,REP,63
+Clay,1909 Vermillion NE Ward 2,State Senate,17,Shane Merrill,DEM,84
+Clay,1909 Vermillion NE Ward 2,State House,17,Debbie Pease,REP,36
+Clay,1909 Vermillion NE Ward 2,State House,17,Nancy Rasmussen,REP,60
+Clay,1909 Vermillion NE Ward 2,State House,17,Mark Winegar,DEM,89
+Clay,1909 Vermillion NE Ward 2,State House,17,Ray Ring,DEM,74
+Clay,1909 Vermillion NE Ward 2,States Attorney,,Alexis A. Tracy,REP,58
+Clay,1909 Vermillion NE Ward 2,States Attorney,,Teddi J Gertsma,DEM,87
+Clay,1908 Vermillion NE Ward 1,President,,Trump & Pence,REP,135
+Clay,1908 Vermillion NE Ward 1,President,,Johnson & Weld,LIB,28
+Clay,1908 Vermillion NE Ward 1,President,,Clinton & Kaine,DEM,150
+Clay,1908 Vermillion NE Ward 1,President,,Castle & Bradley,CON,5
+Clay,1908 Vermillion NE Ward 1,U.S. Senate,,John R. Thune,REP,192
+Clay,1908 Vermillion NE Ward 1,U.S. Senate,,Jay Williams,DEM,125
+Clay,1908 Vermillion NE Ward 1,U.S. House,1,Kristi Noem,REP,161
+Clay,1908 Vermillion NE Ward 1,U.S. House,1,Paula Hawks,DEM,153
+Clay,1908 Vermillion NE Ward 1,Public Utilities Commissioner,,Chris Nelson,REP,160
+Clay,1908 Vermillion NE Ward 1,Public Utilities Commissioner,,Henry Red Cloud,DEM,132
+Clay,1908 Vermillion NE Ward 1,State Senate,17,Arthur Rusch,REP,179
+Clay,1908 Vermillion NE Ward 1,State Senate,17,Shane Merrill,DEM,119
+Clay,1908 Vermillion NE Ward 1,State House,17,Debbie Pease,REP,107
+Clay,1908 Vermillion NE Ward 1,State House,17,Nancy Rasmussen,REP,129
+Clay,1908 Vermillion NE Ward 1,State House,17,Mark Winegar,DEM,143
+Clay,1908 Vermillion NE Ward 1,State House,17,Ray Ring,DEM,141
+Clay,1908 Vermillion NE Ward 1,States Attorney,,Alexis A. Tracy,REP,162
+Clay,1908 Vermillion NE Ward 1,States Attorney,,Teddi J Gertsma,DEM,133
+Clay,1902 Rural Ward 2,President,,Trump & Pence,REP,204
+Clay,1902 Rural Ward 2,President,,Johnson & Weld,LIB,22
+Clay,1902 Rural Ward 2,President,,Clinton & Kaine,DEM,143
+Clay,1902 Rural Ward 2,President,,Castle & Bradley,CON,6
+Clay,1902 Rural Ward 2,U.S. Senate,,John R. Thune,REP,262
+Clay,1902 Rural Ward 2,U.S. Senate,,Jay Williams,DEM,111
+Clay,1902 Rural Ward 2,U.S. House,1,Kristi Noem,REP,221
+Clay,1902 Rural Ward 2,U.S. House,1,Paula Hawks,DEM,157
+Clay,1902 Rural Ward 2,Public Utilities Commissioner,,Chris Nelson,REP,269
+Clay,1902 Rural Ward 2,Public Utilities Commissioner,,Henry Red Cloud,DEM,90
+Clay,1902 Rural Ward 2,State Senate,17,Arthur Rusch,REP,211
+Clay,1902 Rural Ward 2,State Senate,17,Shane Merrill,DEM,154
+Clay,1902 Rural Ward 2,State House,17,Debbie Pease,REP,158
+Clay,1902 Rural Ward 2,State House,17,Nancy Rasmussen,REP,198
+Clay,1902 Rural Ward 2,State House,17,Mark Winegar,DEM,116
+Clay,1902 Rural Ward 2,State House,17,Ray Ring,DEM,159
+Clay,1902 Rural Ward 2,States Attorney,,Alexis A. Tracy,REP,223
+Clay,1902 Rural Ward 2,States Attorney,,Teddi J Gertsma,DEM,120
+Clay,1903 Rural Ward 3,President,,Trump & Pence,REP,472
+Clay,1903 Rural Ward 3,President,,Johnson & Weld,LIB,53
+Clay,1903 Rural Ward 3,President,,Clinton & Kaine,DEM,412
+Clay,1903 Rural Ward 3,President,,Castle & Bradley,CON,6
+Clay,1903 Rural Ward 3,U.S. Senate,,John R. Thune,REP,603
+Clay,1903 Rural Ward 3,U.S. Senate,,Jay Williams,DEM,350
+Clay,1903 Rural Ward 3,U.S. House,1,Kristi Noem,REP,496
+Clay,1903 Rural Ward 3,U.S. House,1,Paula Hawks,DEM,453
+Clay,1903 Rural Ward 3,Public Utilities Commissioner,,Chris Nelson,REP,615
+Clay,1903 Rural Ward 3,Public Utilities Commissioner,,Henry Red Cloud,DEM,299
+Clay,1903 Rural Ward 3,State Senate,17,Arthur Rusch,REP,626
+Clay,1903 Rural Ward 3,State Senate,17,Shane Merrill,DEM,308
+Clay,1903 Rural Ward 3,State House,17,Debbie Pease,REP,324
+Clay,1903 Rural Ward 3,State House,17,Nancy Rasmussen,REP,399
+Clay,1903 Rural Ward 3,State House,17,Mark Winegar,DEM,399
+Clay,1903 Rural Ward 3,State House,17,Ray Ring,DEM,525
+Clay,1903 Rural Ward 3,States Attorney,,Alexis A. Tracy,REP,564
+Clay,1903 Rural Ward 3,States Attorney,,Teddi J Gertsma,DEM,358
+Clay,1901 Rural Ward 1,President,,Trump & Pence,REP,271
+Clay,1901 Rural Ward 1,President,,Johnson & Weld,LIB,12
+Clay,1901 Rural Ward 1,President,,Clinton & Kaine,DEM,121
+Clay,1901 Rural Ward 1,President,,Castle & Bradley,CON,6
+Clay,1901 Rural Ward 1,U.S. Senate,,John R. Thune,REP,309
+Clay,1901 Rural Ward 1,U.S. Senate,,Jay Williams,DEM,102
+Clay,1901 Rural Ward 1,U.S. House,1,Kristi Noem,REP,278
+Clay,1901 Rural Ward 1,U.S. House,1,Paula Hawks,DEM,138
+Clay,1901 Rural Ward 1,Public Utilities Commissioner,,Chris Nelson,REP,320
+Clay,1901 Rural Ward 1,Public Utilities Commissioner,,Henry Red Cloud,DEM,82
+Clay,1901 Rural Ward 1,State Senate,17,Arthur Rusch,REP,268
+Clay,1901 Rural Ward 1,State Senate,17,Shane Merrill,DEM,130
+Clay,1901 Rural Ward 1,State House,17,Debbie Pease,REP,213
+Clay,1901 Rural Ward 1,State House,17,Nancy Rasmussen,REP,245
+Clay,1901 Rural Ward 1,State House,17,Mark Winegar,DEM,108
+Clay,1901 Rural Ward 1,State House,17,Ray Ring,DEM,147
+Clay,1901 Rural Ward 1,States Attorney,,Alexis A. Tracy,REP,267
+Clay,1901 Rural Ward 1,States Attorney,,Teddi J Gertsma,DEM,118
+Clay,1907 Vermillion Central Ward 2,President,,Trump & Pence,REP,74
+Clay,1907 Vermillion Central Ward 2,President,,Johnson & Weld,LIB,13
+Clay,1907 Vermillion Central Ward 2,President,,Clinton & Kaine,DEM,165
+Clay,1907 Vermillion Central Ward 2,President,,Castle & Bradley,CON,4
+Clay,1907 Vermillion Central Ward 2,U.S. Senate,,John R. Thune,REP,103
+Clay,1907 Vermillion Central Ward 2,U.S. Senate,,Jay Williams,DEM,155
+Clay,1907 Vermillion Central Ward 2,U.S. House,1,Kristi Noem,REP,98
+Clay,1907 Vermillion Central Ward 2,U.S. House,1,Paula Hawks,DEM,159
+Clay,1907 Vermillion Central Ward 2,Public Utilities Commissioner,,Chris Nelson,REP,89
+Clay,1907 Vermillion Central Ward 2,Public Utilities Commissioner,,Henry Red Cloud,DEM,150
+Clay,1907 Vermillion Central Ward 2,State Senate,17,Arthur Rusch,REP,96
+Clay,1907 Vermillion Central Ward 2,State Senate,17,Shane Merrill,DEM,143
+Clay,1907 Vermillion Central Ward 2,State House,17,Debbie Pease,REP,64
+Clay,1907 Vermillion Central Ward 2,State House,17,Nancy Rasmussen,REP,82
+Clay,1907 Vermillion Central Ward 2,State House,17,Mark Winegar,DEM,154
+Clay,1907 Vermillion Central Ward 2,State House,17,Ray Ring,DEM,138
+Clay,1907 Vermillion Central Ward 2,States Attorney,,Alexis A. Tracy,REP,104
+Clay,1907 Vermillion Central Ward 2,States Attorney,,Teddi J Gertsma,DEM,135
+Clay,1906 Vermillion Central Ward 1,President,,Trump & Pence,REP,78
+Clay,1906 Vermillion Central Ward 1,President,,Johnson & Weld,LIB,23
+Clay,1906 Vermillion Central Ward 1,President,,Clinton & Kaine,DEM,259
+Clay,1906 Vermillion Central Ward 1,President,,Castle & Bradley,CON,3
+Clay,1906 Vermillion Central Ward 1,U.S. Senate,,John R. Thune,REP,138
+Clay,1906 Vermillion Central Ward 1,U.S. Senate,,Jay Williams,DEM,222
+Clay,1906 Vermillion Central Ward 1,U.S. House,1,Kristi Noem,REP,95
+Clay,1906 Vermillion Central Ward 1,U.S. House,1,Paula Hawks,DEM,261
+Clay,1906 Vermillion Central Ward 1,Public Utilities Commissioner,,Chris Nelson,REP,136
+Clay,1906 Vermillion Central Ward 1,Public Utilities Commissioner,,Henry Red Cloud,DEM,208
+Clay,1906 Vermillion Central Ward 1,State Senate,17,Arthur Rusch,REP,164
+Clay,1906 Vermillion Central Ward 1,State Senate,17,Shane Merrill,DEM,188
+Clay,1906 Vermillion Central Ward 1,State House,17,Debbie Pease,REP,62
+Clay,1906 Vermillion Central Ward 1,State House,17,Nancy Rasmussen,REP,83
+Clay,1906 Vermillion Central Ward 1,State House,17,Mark Winegar,DEM,240
+Clay,1906 Vermillion Central Ward 1,State House,17,Ray Ring,DEM,251
+Clay,1906 Vermillion Central Ward 1,States Attorney,,Alexis A. Tracy,REP,133
+Clay,1906 Vermillion Central Ward 1,States Attorney,,Teddi J Gertsma,DEM,216
 Codington,DEXTER,President,,Donald J. Trump,REP,70
 Codington,"EDEN, PHIPPS, WALLACE",President,,Donald J. Trump,REP,77
 Codington,ELMIRA,President,,Donald J. Trump,REP,150
@@ -2347,182 +2347,182 @@ Corson,Stone Church,State Representative,28A,Oren Lesmeister,DEM,45
 Corson,Wakpala,State Representative,28A,Oren Lesmeister,DEM,75
 Corson,West Rural McLaughlin,State Representative,28A,Oren Lesmeister,DEM,41
 Corson,Total,State Representative,28A,Oren Lesmeister,DEM,706
-Custer,1,President,,REP,Donald J. Trump,706
-Custer,2,President,,REP,Donald J. Trump,114
-Custer,3,President,,REP,Donald J. Trump,132
-Custer,4,President,,REP,Donald J. Trump,240
-Custer,5,President,,REP,Donald J. Trump,491
-Custer,6,President,,REP,Donald J. Trump,250
-Custer,7,President,,REP,Donald J. Trump,134
-Custer,8,President,,REP,Donald J. Trump,256
-Custer,9,President,,REP,Donald J. Trump,845
-Custer,10,President,,REP,Donald J. Trump,125
-Custer,Total,President,,REP,Donald J. Trump,3293
-Custer,1,President,,LIB,Gary Johnson,44
-Custer,2,President,,LIB,Gary Johnson,6
-Custer,3,President,,LIB,Gary Johnson,5
-Custer,4,President,,LIB,Gary Johnson,12
-Custer,5,President,,LIB,Gary Johnson,32
-Custer,6,President,,LIB,Gary Johnson,25
-Custer,7,President,,LIB,Gary Johnson,21
-Custer,8,President,,LIB,Gary Johnson,41
-Custer,9,President,,LIB,Gary Johnson,64
-Custer,10,President,,LIB,Gary Johnson,6
-Custer,Total,President,,LIB,Gary Johnson,256
-Custer,1,President,,DEM,Hillary Clinton,163
-Custer,2,President,,DEM,Hillary Clinton,20
-Custer,3,President,,DEM,Hillary Clinton,54
-Custer,4,President,,DEM,Hillary Clinton,96
-Custer,5,President,,DEM,Hillary Clinton,154
-Custer,6,President,,DEM,Hillary Clinton,115
-Custer,7,President,,DEM,Hillary Clinton,51
-Custer,8,President,,DEM,Hillary Clinton,136
-Custer,9,President,,DEM,Hillary Clinton,305
-Custer,10,President,,DEM,Hillary Clinton,27
-Custer,Total,President,,DEM,Hillary Clinton,1121
-Custer,1,President,,CON,Darrell L. Castle,6
-Custer,2,President,,CON,Darrell L. Castle,0
-Custer,3,President,,CON,Darrell L. Castle,3
-Custer,4,President,,CON,Darrell L. Castle,6
-Custer,5,President,,CON,Darrell L. Castle,1
-Custer,6,President,,CON,Darrell L. Castle,6
-Custer,7,President,,CON,Darrell L. Castle,2
-Custer,8,President,,CON,Darrell L. Castle,6
-Custer,9,President,,CON,Darrell L. Castle,20
-Custer,10,President,,CON,Darrell L. Castle,1
-Custer,Total,President,,CON,Darrell L. Castle,51
-Custer,1,U.S. Senate,,REP,John R. Thune,722
-Custer,2,U.S. Senate,,REP,John R. Thune,113
-Custer,3,U.S. Senate,,REP,John R. Thune,137
-Custer,4,U.S. Senate,,REP,John R. Thune,246
-Custer,5,U.S. Senate,,REP,John R. Thune,520
-Custer,6,U.S. Senate,,REP,John R. Thune,285
-Custer,7,U.S. Senate,,REP,John R. Thune,164
-Custer,8,U.S. Senate,,REP,John R. Thune,305
-Custer,9,U.S. Senate,,REP,John R. Thune,918
-Custer,10,U.S. Senate,,REP,John R. Thune,120
-Custer,Total,U.S. Senate,,REP,John R. Thune,3530
-Custer,1,U.S. Senate,,DEM,Jay Williams,185
-Custer,2,U.S. Senate,,DEM,Jay Williams,27
-Custer,3,U.S. Senate,,DEM,Jay Williams,54
-Custer,4,U.S. Senate,,DEM,Jay Williams,109
-Custer,5,U.S. Senate,,DEM,Jay Williams,154
-Custer,6,U.S. Senate,,DEM,Jay Williams,111
-Custer,7,U.S. Senate,,DEM,Jay Williams,55
-Custer,8,U.S. Senate,,DEM,Jay Williams,126
-Custer,9,U.S. Senate,,DEM,Jay Williams,322
-Custer,10,U.S. Senate,,DEM,Jay Williams,34
-Custer,Total,U.S. Senate,,DEM,Jay Williams,1177
-Custer,1,U.S. House,1,REP,Kristi Noem,705
-Custer,2,U.S. House,1,REP,Kristi Noem,116
-Custer,3,U.S. House,1,REP,Kristi Noem,134
-Custer,4,U.S. House,1,REP,Kristi Noem,240
-Custer,5,U.S. House,1,REP,Kristi Noem,509
-Custer,6,U.S. House,1,REP,Kristi Noem,270
-Custer,7,U.S. House,1,REP,Kristi Noem,157
-Custer,8,U.S. House,1,REP,Kristi Noem,293
-Custer,9,U.S. House,1,REP,Kristi Noem,899
-Custer,10,U.S. House,1,REP,Kristi Noem,122
-Custer,Total,U.S. House,1,REP,Kristi Noem,3445
-Custer,1,U.S. House,1,DEM,Paula Hawks,212
-Custer,2,U.S. House,1,DEM,Paula Hawks,26
-Custer,3,U.S. House,1,DEM,Paula Hawks,58
-Custer,4,U.S. House,1,DEM,Paula Hawks,118
-Custer,5,U.S. House,1,DEM,Paula Hawks,169
-Custer,6,U.S. House,1,DEM,Paula Hawks,125
-Custer,7,U.S. House,1,DEM,Paula Hawks,61
-Custer,8,U.S. House,1,DEM,Paula Hawks,139
-Custer,9,U.S. House,1,DEM,Paula Hawks,347
-Custer,10,U.S. House,1,DEM,Paula Hawks,33
-Custer,Total,U.S. House,1,DEM,Paula Hawks,1288
-Custer,1,Public Utilities Commissioner,,REP,Chris Nelson,735
-Custer,2,Public Utilities Commissioner,,REP,Chris Nelson,115
-Custer,3,Public Utilities Commissioner,,REP,Chris Nelson,128
-Custer,4,Public Utilities Commissioner,,REP,Chris Nelson,240
-Custer,5,Public Utilities Commissioner,,REP,Chris Nelson,506
-Custer,6,Public Utilities Commissioner,,REP,Chris Nelson,283
-Custer,7,Public Utilities Commissioner,,REP,Chris Nelson,153
-Custer,8,Public Utilities Commissioner,,REP,Chris Nelson,314
-Custer,9,Public Utilities Commissioner,,REP,Chris Nelson,915
-Custer,10,Public Utilities Commissioner,,REP,Chris Nelson,118
-Custer,Total,Public Utilities Commissioner,,REP,Chris Nelson,3507
-Custer,1,Public Utilities Commissioner,,DEM,Henry Red Cloud,155
-Custer,2,Public Utilities Commissioner,,DEM,Henry Red Cloud,24
-Custer,3,Public Utilities Commissioner,,DEM,Henry Red Cloud,59
-Custer,4,Public Utilities Commissioner,,DEM,Henry Red Cloud,108
-Custer,5,Public Utilities Commissioner,,DEM,Henry Red Cloud,152
-Custer,6,Public Utilities Commissioner,,DEM,Henry Red Cloud,106
-Custer,7,Public Utilities Commissioner,,DEM,Henry Red Cloud,55
-Custer,8,Public Utilities Commissioner,,DEM,Henry Red Cloud,104
-Custer,9,Public Utilities Commissioner,,DEM,Henry Red Cloud,292
-Custer,10,Public Utilities Commissioner,,DEM,Henry Red Cloud,31
-Custer,Total,Public Utilities Commissioner,,DEM,Henry Red Cloud,1086
-Custer,1,State Senate,30,REP,Lance Russell,673
-Custer,2,State Senate,30,REP,Lance Russell,110
-Custer,3,State Senate,30,REP,Lance Russell,119
-Custer,4,State Senate,30,REP,Lance Russell,226
-Custer,5,State Senate,30,REP,Lance Russell,460
-Custer,6,State Senate,30,REP,Lance Russell,250
-Custer,7,State Senate,30,REP,Lance Russell,153
-Custer,8,State Senate,30,REP,Lance Russell,272
-Custer,9,State Senate,30,REP,Lance Russell,867
-Custer,10,State Senate,30,REP,Lance Russell,119
-Custer,Total,State Senate,30,REP,Lance Russell,3249
-Custer,1,State Senate,30,DEM,Karla R. LaRive,209
-Custer,2,State Senate,30,DEM,Karla R. LaRive,30
-Custer,3,State Senate,30,DEM,Karla R. LaRive,69
-Custer,4,State Senate,30,DEM,Karla R. LaRive,128
-Custer,5,State Senate,30,DEM,Karla R. LaRive,178
-Custer,6,State Senate,30,DEM,Karla R. LaRive,134
-Custer,7,State Senate,30,DEM,Karla R. LaRive,59
-Custer,8,State Senate,30,DEM,Karla R. LaRive,142
-Custer,9,State Senate,30,DEM,Karla R. LaRive,345
-Custer,10,State Senate,30,DEM,Karla R. LaRive,34
-Custer,Total,State Senate,30,DEM,Karla R. LaRive,1328
-Custer,1,State House,30,REP,Julie Frye-Mueller,628
-Custer,2,State House,30,REP,Julie Frye-Mueller,88
-Custer,3,State House,30,REP,Julie Frye-Mueller,109
-Custer,4,State House,30,REP,Julie Frye-Mueller,200
-Custer,5,State House,30,REP,Julie Frye-Mueller,375
-Custer,6,State House,30,REP,Julie Frye-Mueller,200
-Custer,7,State House,30,REP,Julie Frye-Mueller,108
-Custer,8,State House,30,REP,Julie Frye-Mueller,205
-Custer,9,State House,30,REP,Julie Frye-Mueller,742
-Custer,10,State House,30,REP,Julie Frye-Mueller,104
-Custer,Total,State House,30,REP,Julie Frye-Mueller,2759
-Custer,1,State House,30,REP,Tim R. Goodwin,604
-Custer,2,State House,30,REP,Tim R. Goodwin,101
-Custer,3,State House,30,REP,Tim R. Goodwin,102
-Custer,4,State House,30,REP,Tim R. Goodwin,207
-Custer,5,State House,30,REP,Tim R. Goodwin,416
-Custer,6,State House,30,REP,Tim R. Goodwin,220
-Custer,7,State House,30,REP,Tim R. Goodwin,133
-Custer,8,State House,30,REP,Tim R. Goodwin,247
-Custer,9,State House,30,REP,Tim R. Goodwin,779
-Custer,10,State House,30,REP,Tim R. Goodwin,113
-Custer,Total,State House,30,REP,Tim R. Goodwin,2922
-Custer,1,State House,30,DEM,Kristina Ina Winter,167
-Custer,2,State House,30,DEM,Kristina Ina Winter,17
-Custer,3,State House,30,DEM,Kristina Ina Winter,59
-Custer,4,State House,30,DEM,Kristina Ina Winter,96
-Custer,5,State House,30,DEM,Kristina Ina Winter,144
-Custer,6,State House,30,DEM,Kristina Ina Winter,98
-Custer,7,State House,30,DEM,Kristina Ina Winter,44
-Custer,8,State House,30,DEM,Kristina Ina Winter,110
-Custer,9,State House,30,DEM,Kristina Ina Winter,277
-Custer,10,State House,30,DEM,Kristina Ina Winter,30
-Custer,Total,State House,30,DEM,Kristina Ina Winter,1042
-Custer,1,State House,30,DEM,Sandy Arseneault,178
-Custer,2,State House,30,DEM,Sandy Arseneault,29
-Custer,3,State House,30,DEM,Sandy Arseneault,59
-Custer,4,State House,30,DEM,Sandy Arseneault,121
-Custer,5,State House,30,DEM,Sandy Arseneault,228
-Custer,6,State House,30,DEM,Sandy Arseneault,159
-Custer,7,State House,30,DEM,Sandy Arseneault,87
-Custer,8,State House,30,DEM,Sandy Arseneault,173
-Custer,9,State House,30,DEM,Sandy Arseneault,402
-Custer,10,State House,30,DEM,Sandy Arseneault,30
-Custer,Total,State House,30,DEM,Sandy Arseneault,1466
+Custer,1,President,,Donald J. Trump,REP,706
+Custer,2,President,,Donald J. Trump,REP,114
+Custer,3,President,,Donald J. Trump,REP,132
+Custer,4,President,,Donald J. Trump,REP,240
+Custer,5,President,,Donald J. Trump,REP,491
+Custer,6,President,,Donald J. Trump,REP,250
+Custer,7,President,,Donald J. Trump,REP,134
+Custer,8,President,,Donald J. Trump,REP,256
+Custer,9,President,,Donald J. Trump,REP,845
+Custer,10,President,,Donald J. Trump,REP,125
+Custer,Total,President,,Donald J. Trump,REP,3293
+Custer,1,President,,Gary Johnson,LIB,44
+Custer,2,President,,Gary Johnson,LIB,6
+Custer,3,President,,Gary Johnson,LIB,5
+Custer,4,President,,Gary Johnson,LIB,12
+Custer,5,President,,Gary Johnson,LIB,32
+Custer,6,President,,Gary Johnson,LIB,25
+Custer,7,President,,Gary Johnson,LIB,21
+Custer,8,President,,Gary Johnson,LIB,41
+Custer,9,President,,Gary Johnson,LIB,64
+Custer,10,President,,Gary Johnson,LIB,6
+Custer,Total,President,,Gary Johnson,LIB,256
+Custer,1,President,,Hillary Clinton,DEM,163
+Custer,2,President,,Hillary Clinton,DEM,20
+Custer,3,President,,Hillary Clinton,DEM,54
+Custer,4,President,,Hillary Clinton,DEM,96
+Custer,5,President,,Hillary Clinton,DEM,154
+Custer,6,President,,Hillary Clinton,DEM,115
+Custer,7,President,,Hillary Clinton,DEM,51
+Custer,8,President,,Hillary Clinton,DEM,136
+Custer,9,President,,Hillary Clinton,DEM,305
+Custer,10,President,,Hillary Clinton,DEM,27
+Custer,Total,President,,Hillary Clinton,DEM,1121
+Custer,1,President,,Darrell L. Castle,CON,6
+Custer,2,President,,Darrell L. Castle,CON,0
+Custer,3,President,,Darrell L. Castle,CON,3
+Custer,4,President,,Darrell L. Castle,CON,6
+Custer,5,President,,Darrell L. Castle,CON,1
+Custer,6,President,,Darrell L. Castle,CON,6
+Custer,7,President,,Darrell L. Castle,CON,2
+Custer,8,President,,Darrell L. Castle,CON,6
+Custer,9,President,,Darrell L. Castle,CON,20
+Custer,10,President,,Darrell L. Castle,CON,1
+Custer,Total,President,,Darrell L. Castle,CON,51
+Custer,1,U.S. Senate,,John R. Thune,REP,722
+Custer,2,U.S. Senate,,John R. Thune,REP,113
+Custer,3,U.S. Senate,,John R. Thune,REP,137
+Custer,4,U.S. Senate,,John R. Thune,REP,246
+Custer,5,U.S. Senate,,John R. Thune,REP,520
+Custer,6,U.S. Senate,,John R. Thune,REP,285
+Custer,7,U.S. Senate,,John R. Thune,REP,164
+Custer,8,U.S. Senate,,John R. Thune,REP,305
+Custer,9,U.S. Senate,,John R. Thune,REP,918
+Custer,10,U.S. Senate,,John R. Thune,REP,120
+Custer,Total,U.S. Senate,,John R. Thune,REP,3530
+Custer,1,U.S. Senate,,Jay Williams,DEM,185
+Custer,2,U.S. Senate,,Jay Williams,DEM,27
+Custer,3,U.S. Senate,,Jay Williams,DEM,54
+Custer,4,U.S. Senate,,Jay Williams,DEM,109
+Custer,5,U.S. Senate,,Jay Williams,DEM,154
+Custer,6,U.S. Senate,,Jay Williams,DEM,111
+Custer,7,U.S. Senate,,Jay Williams,DEM,55
+Custer,8,U.S. Senate,,Jay Williams,DEM,126
+Custer,9,U.S. Senate,,Jay Williams,DEM,322
+Custer,10,U.S. Senate,,Jay Williams,DEM,34
+Custer,Total,U.S. Senate,,Jay Williams,DEM,1177
+Custer,1,U.S. House,1,Kristi Noem,REP,705
+Custer,2,U.S. House,1,Kristi Noem,REP,116
+Custer,3,U.S. House,1,Kristi Noem,REP,134
+Custer,4,U.S. House,1,Kristi Noem,REP,240
+Custer,5,U.S. House,1,Kristi Noem,REP,509
+Custer,6,U.S. House,1,Kristi Noem,REP,270
+Custer,7,U.S. House,1,Kristi Noem,REP,157
+Custer,8,U.S. House,1,Kristi Noem,REP,293
+Custer,9,U.S. House,1,Kristi Noem,REP,899
+Custer,10,U.S. House,1,Kristi Noem,REP,122
+Custer,Total,U.S. House,1,Kristi Noem,REP,3445
+Custer,1,U.S. House,1,Paula Hawks,DEM,212
+Custer,2,U.S. House,1,Paula Hawks,DEM,26
+Custer,3,U.S. House,1,Paula Hawks,DEM,58
+Custer,4,U.S. House,1,Paula Hawks,DEM,118
+Custer,5,U.S. House,1,Paula Hawks,DEM,169
+Custer,6,U.S. House,1,Paula Hawks,DEM,125
+Custer,7,U.S. House,1,Paula Hawks,DEM,61
+Custer,8,U.S. House,1,Paula Hawks,DEM,139
+Custer,9,U.S. House,1,Paula Hawks,DEM,347
+Custer,10,U.S. House,1,Paula Hawks,DEM,33
+Custer,Total,U.S. House,1,Paula Hawks,DEM,1288
+Custer,1,Public Utilities Commissioner,,Chris Nelson,REP,735
+Custer,2,Public Utilities Commissioner,,Chris Nelson,REP,115
+Custer,3,Public Utilities Commissioner,,Chris Nelson,REP,128
+Custer,4,Public Utilities Commissioner,,Chris Nelson,REP,240
+Custer,5,Public Utilities Commissioner,,Chris Nelson,REP,506
+Custer,6,Public Utilities Commissioner,,Chris Nelson,REP,283
+Custer,7,Public Utilities Commissioner,,Chris Nelson,REP,153
+Custer,8,Public Utilities Commissioner,,Chris Nelson,REP,314
+Custer,9,Public Utilities Commissioner,,Chris Nelson,REP,915
+Custer,10,Public Utilities Commissioner,,Chris Nelson,REP,118
+Custer,Total,Public Utilities Commissioner,,Chris Nelson,REP,3507
+Custer,1,Public Utilities Commissioner,,Henry Red Cloud,DEM,155
+Custer,2,Public Utilities Commissioner,,Henry Red Cloud,DEM,24
+Custer,3,Public Utilities Commissioner,,Henry Red Cloud,DEM,59
+Custer,4,Public Utilities Commissioner,,Henry Red Cloud,DEM,108
+Custer,5,Public Utilities Commissioner,,Henry Red Cloud,DEM,152
+Custer,6,Public Utilities Commissioner,,Henry Red Cloud,DEM,106
+Custer,7,Public Utilities Commissioner,,Henry Red Cloud,DEM,55
+Custer,8,Public Utilities Commissioner,,Henry Red Cloud,DEM,104
+Custer,9,Public Utilities Commissioner,,Henry Red Cloud,DEM,292
+Custer,10,Public Utilities Commissioner,,Henry Red Cloud,DEM,31
+Custer,Total,Public Utilities Commissioner,,Henry Red Cloud,DEM,1086
+Custer,1,State Senate,30,Lance Russell,REP,673
+Custer,2,State Senate,30,Lance Russell,REP,110
+Custer,3,State Senate,30,Lance Russell,REP,119
+Custer,4,State Senate,30,Lance Russell,REP,226
+Custer,5,State Senate,30,Lance Russell,REP,460
+Custer,6,State Senate,30,Lance Russell,REP,250
+Custer,7,State Senate,30,Lance Russell,REP,153
+Custer,8,State Senate,30,Lance Russell,REP,272
+Custer,9,State Senate,30,Lance Russell,REP,867
+Custer,10,State Senate,30,Lance Russell,REP,119
+Custer,Total,State Senate,30,Lance Russell,REP,3249
+Custer,1,State Senate,30,Karla R. LaRive,DEM,209
+Custer,2,State Senate,30,Karla R. LaRive,DEM,30
+Custer,3,State Senate,30,Karla R. LaRive,DEM,69
+Custer,4,State Senate,30,Karla R. LaRive,DEM,128
+Custer,5,State Senate,30,Karla R. LaRive,DEM,178
+Custer,6,State Senate,30,Karla R. LaRive,DEM,134
+Custer,7,State Senate,30,Karla R. LaRive,DEM,59
+Custer,8,State Senate,30,Karla R. LaRive,DEM,142
+Custer,9,State Senate,30,Karla R. LaRive,DEM,345
+Custer,10,State Senate,30,Karla R. LaRive,DEM,34
+Custer,Total,State Senate,30,Karla R. LaRive,DEM,1328
+Custer,1,State House,30,Julie Frye-Mueller,REP,628
+Custer,2,State House,30,Julie Frye-Mueller,REP,88
+Custer,3,State House,30,Julie Frye-Mueller,REP,109
+Custer,4,State House,30,Julie Frye-Mueller,REP,200
+Custer,5,State House,30,Julie Frye-Mueller,REP,375
+Custer,6,State House,30,Julie Frye-Mueller,REP,200
+Custer,7,State House,30,Julie Frye-Mueller,REP,108
+Custer,8,State House,30,Julie Frye-Mueller,REP,205
+Custer,9,State House,30,Julie Frye-Mueller,REP,742
+Custer,10,State House,30,Julie Frye-Mueller,REP,104
+Custer,Total,State House,30,Julie Frye-Mueller,REP,2759
+Custer,1,State House,30,Tim R. Goodwin,REP,604
+Custer,2,State House,30,Tim R. Goodwin,REP,101
+Custer,3,State House,30,Tim R. Goodwin,REP,102
+Custer,4,State House,30,Tim R. Goodwin,REP,207
+Custer,5,State House,30,Tim R. Goodwin,REP,416
+Custer,6,State House,30,Tim R. Goodwin,REP,220
+Custer,7,State House,30,Tim R. Goodwin,REP,133
+Custer,8,State House,30,Tim R. Goodwin,REP,247
+Custer,9,State House,30,Tim R. Goodwin,REP,779
+Custer,10,State House,30,Tim R. Goodwin,REP,113
+Custer,Total,State House,30,Tim R. Goodwin,REP,2922
+Custer,1,State House,30,Kristina Ina Winter,DEM,167
+Custer,2,State House,30,Kristina Ina Winter,DEM,17
+Custer,3,State House,30,Kristina Ina Winter,DEM,59
+Custer,4,State House,30,Kristina Ina Winter,DEM,96
+Custer,5,State House,30,Kristina Ina Winter,DEM,144
+Custer,6,State House,30,Kristina Ina Winter,DEM,98
+Custer,7,State House,30,Kristina Ina Winter,DEM,44
+Custer,8,State House,30,Kristina Ina Winter,DEM,110
+Custer,9,State House,30,Kristina Ina Winter,DEM,277
+Custer,10,State House,30,Kristina Ina Winter,DEM,30
+Custer,Total,State House,30,Kristina Ina Winter,DEM,1042
+Custer,1,State House,30,Sandy Arseneault,DEM,178
+Custer,2,State House,30,Sandy Arseneault,DEM,29
+Custer,3,State House,30,Sandy Arseneault,DEM,59
+Custer,4,State House,30,Sandy Arseneault,DEM,121
+Custer,5,State House,30,Sandy Arseneault,DEM,228
+Custer,6,State House,30,Sandy Arseneault,DEM,159
+Custer,7,State House,30,Sandy Arseneault,DEM,87
+Custer,8,State House,30,Sandy Arseneault,DEM,173
+Custer,9,State House,30,Sandy Arseneault,DEM,402
+Custer,10,State House,30,Sandy Arseneault,DEM,30
+Custer,Total,State House,30,Sandy Arseneault,DEM,1466
 Davison,1,President,,Donald J. Trump,REP,219
 Davison,2,President,,Donald J. Trump,REP,311
 Davison,3,President,,Donald J. Trump,REP,472
@@ -2956,160 +2956,160 @@ Day,12,State Representative,1,Susan Wismer,DEM,110
 Day,13,State Representative,1,Susan Wismer,DEM,105
 Day,14,State Representative,1,Susan Wismer,DEM,140
 Day,TOTAL,State Representative,1,Susan Wismer,DEM,1466
-Deuel,1,U.S. Senate,,REP,John R. Thune,110
-Deuel,3,U.S. Senate,,REP,John R. Thune,223
-Deuel,4,U.S. Senate,,REP,John R. Thune,138
-Deuel,5,U.S. Senate,,REP,John R. Thune,118
-Deuel,6,U.S. Senate,,REP,John R. Thune,147
-Deuel,7,U.S. Senate,,REP,John R. Thune,142
-Deuel,8,U.S. Senate,,REP,John R. Thune,184
-Deuel,9,U.S. Senate,,REP,John R. Thune,218
-Deuel,10,U.S. Senate,,REP,John R. Thune,136
-Deuel,11,U.S. Senate,,REP,John R. Thune,147
-Deuel,Total,U.S. Senate,,REP,John R. Thune,1563
-Deuel,1,U.S. Senate,,DEM,Jay Williams,39
-Deuel,3,U.S. Senate,,DEM,Jay Williams,73
-Deuel,4,U.S. Senate,,DEM,Jay Williams,48
-Deuel,5,U.S. Senate,,DEM,Jay Williams,59
-Deuel,6,U.S. Senate,,DEM,Jay Williams,49
-Deuel,7,U.S. Senate,,DEM,Jay Williams,45
-Deuel,8,U.S. Senate,,DEM,Jay Williams,69
-Deuel,9,U.S. Senate,,DEM,Jay Williams,62
-Deuel,10,U.S. Senate,,DEM,Jay Williams,35
-Deuel,11,U.S. Senate,,DEM,Jay Williams,55
-Deuel,Total,U.S. Senate,,DEM,Jay Williams,534
-Deuel,1,President,,REP,Donald J. Trump,90
-Deuel,3,President,,REP,Donald J. Trump,202
-Deuel,4,President,,REP,Donald J. Trump,105
-Deuel,5,President,,REP,Donald J. Trump,99
-Deuel,6,President,,REP,Donald J. Trump,112
-Deuel,7,President,,REP,Donald J. Trump,140
-Deuel,8,President,,REP,Donald J. Trump,168
-Deuel,9,President,,REP,Donald J. Trump,207
-Deuel,10,President,,REP,Donald J. Trump,111
-Deuel,11,President,,REP,Donald J. Trump,132
-Deuel,Total,President,,REP,Donald J. Trump,1366
-Deuel,1,President,,LIB,Gary Johnson,13
-Deuel,3,President,,LIB,Gary Johnson,15
-Deuel,4,President,,LIB,Gary Johnson,13
-Deuel,5,President,,LIB,Gary Johnson,16
-Deuel,6,President,,LIB,Gary Johnson,13
-Deuel,7,President,,LIB,Gary Johnson,6
-Deuel,8,President,,LIB,Gary Johnson,9
-Deuel,9,President,,LIB,Gary Johnson,13
-Deuel,10,President,,LIB,Gary Johnson,7
-Deuel,11,President,,LIB,Gary Johnson,12
-Deuel,Total,President,,LIB,Gary Johnson,117
-Deuel,1,President,,DEM,Hillary Clinton,43
-Deuel,3,President,,DEM,Hillary Clinton,76
-Deuel,4,President,,DEM,Hillary Clinton,65
-Deuel,5,President,,DEM,Hillary Clinton,58
-Deuel,6,President,,DEM,Hillary Clinton,61
-Deuel,7,President,,DEM,Hillary Clinton,37
-Deuel,8,President,,DEM,Hillary Clinton,71
-Deuel,9,President,,DEM,Hillary Clinton,53
-Deuel,10,President,,DEM,Hillary Clinton,50
-Deuel,11,President,,DEM,Hillary Clinton,56
-Deuel,Total,President,,DEM,Hillary Clinton,570
-Deuel,1,President,,CON,Darrell L. Castle,1
-Deuel,3,President,,CON,Darrell L. Castle,2
-Deuel,4,President,,CON,Darrell L. Castle,2
-Deuel,5,President,,CON,Darrell L. Castle,3
-Deuel,6,President,,CON,Darrell L. Castle,4
-Deuel,7,President,,CON,Darrell L. Castle,3
-Deuel,8,President,,CON,Darrell L. Castle,6
-Deuel,9,President,,CON,Darrell L. Castle,3
-Deuel,10,President,,CON,Darrell L. Castle,1
-Deuel,11,President,,CON,Darrell L. Castle,2
-Deuel,Total,President,,CON,Darrell L. Castle,27
-Deuel,1,Public Utilities commissioner,,REP,Chris Nelson,112
-Deuel,3,Public Utilities commissioner,,REP,Chris Nelson,231
-Deuel,4,Public Utilities commissioner,,REP,Chris Nelson,146
-Deuel,5,Public Utilities commissioner,,REP,Chris Nelson,139
-Deuel,6,Public Utilities commissioner,,REP,Chris Nelson,153
-Deuel,7,Public Utilities commissioner,,REP,Chris Nelson,157
-Deuel,8,Public Utilities commissioner,,REP,Chris Nelson,193
-Deuel,9,Public Utilities commissioner,,REP,Chris Nelson,225
-Deuel,10,Public Utilities commissioner,,REP,Chris Nelson,143
-Deuel,11,Public Utilities commissioner,,REP,Chris Nelson,151
-Deuel,Total,Public Utilities commissioner,,REP,Chris Nelson,1650
-Deuel,1,Public Utilities commissioner,,DEM,Henry Red Cloud,25
-Deuel,3,Public Utilities commissioner,,DEM,Henry Red Cloud,59
-Deuel,4,Public Utilities commissioner,,DEM,Henry Red Cloud,30
-Deuel,5,Public Utilities commissioner,,DEM,Henry Red Cloud,36
-Deuel,6,Public Utilities commissioner,,DEM,Henry Red Cloud,37
-Deuel,7,Public Utilities commissioner,,DEM,Henry Red Cloud,26
-Deuel,8,Public Utilities commissioner,,DEM,Henry Red Cloud,58
-Deuel,9,Public Utilities commissioner,,DEM,Henry Red Cloud,48
-Deuel,10,Public Utilities commissioner,,DEM,Henry Red Cloud,25
-Deuel,11,Public Utilities commissioner,,DEM,Henry Red Cloud,47
-Deuel,Total,Public Utilities commissioner,,DEM,Henry Red Cloud,391
-Deuel,1,U.S. House,1,REP,Kristi Noem,97
-Deuel,3,U.S. House,1,REP,Kristi Noem,202
-Deuel,4,U.S. House,1,REP,Kristi Noem,125
-Deuel,5,U.S. House,1,REP,Kristi Noem,104
-Deuel,6,U.S. House,1,REP,Kristi Noem,130
-Deuel,7,U.S. House,1,REP,Kristi Noem,133
-Deuel,8,U.S. House,1,REP,Kristi Noem,163
-Deuel,9,U.S. House,1,REP,Kristi Noem,196
-Deuel,10,U.S. House,1,REP,Kristi Noem,123
-Deuel,11,U.S. House,1,REP,Kristi Noem,128
-Deuel,Total,U.S. House,1,REP,Kristi Noem,1401
-Deuel,1,U.S. House,1,DEM,Paula Hawks,52
-Deuel,3,U.S. House,1,DEM,Paula Hawks,90
-Deuel,4,U.S. House,1,DEM,Paula Hawks,62
-Deuel,5,U.S. House,1,DEM,Paula Hawks,74
-Deuel,6,U.S. House,1,DEM,Paula Hawks,66
-Deuel,7,U.S. House,1,DEM,Paula Hawks,55
-Deuel,8,U.S. House,1,DEM,Paula Hawks,90
-Deuel,9,U.S. House,1,DEM,Paula Hawks,86
-Deuel,10,U.S. House,1,DEM,Paula Hawks,52
-Deuel,11,U.S. House,1,DEM,Paula Hawks,72
-Deuel,Total,U.S. House,1,DEM,Paula Hawks,699
-Deuel,1,State House,4,REP,John Mills,57
-Deuel,3,State House,4,REP,John Mills,173
-Deuel,4,State House,4,REP,John Mills,91
-Deuel,5,State House,4,REP,John Mills,83
-Deuel,6,State House,4,REP,John Mills,87
-Deuel,7,State House,4,REP,John Mills,110
-Deuel,8,State House,4,REP,John Mills,138
-Deuel,9,State House,4,REP,John Mills,169
-Deuel,10,State House,4,REP,John Mills,108
-Deuel,11,State House,4,REP,John Mills,108
-Deuel,Total,State House,4,REP,John Mills,1124
-Deuel,1,State House,4,REP,Jason W. Kettwig,61
-Deuel,3,State House,4,REP,Jason W. Kettwig,150
-Deuel,4,State House,4,REP,Jason W. Kettwig,87
-Deuel,5,State House,4,REP,Jason W. Kettwig,77
-Deuel,6,State House,4,REP,Jason W. Kettwig,92
-Deuel,7,State House,4,REP,Jason W. Kettwig,104
-Deuel,8,State House,4,REP,Jason W. Kettwig,111
-Deuel,9,State House,4,REP,Jason W. Kettwig,149
-Deuel,10,State House,4,REP,Jason W. Kettwig,101
-Deuel,11,State House,4,REP,Jason W. Kettwig,85
-Deuel,Total,State House,4,REP,Jason W. Kettwig,1017
-Deuel,1,State House,4,DEM,Matt Rosdahl,53
-Deuel,3,State House,4,DEM,Matt Rosdahl,79
-Deuel,4,State House,4,DEM,Matt Rosdahl,79
-Deuel,5,State House,4,DEM,Matt Rosdahl,84
-Deuel,6,State House,4,DEM,Matt Rosdahl,72
-Deuel,7,State House,4,DEM,Matt Rosdahl,41
-Deuel,8,State House,4,DEM,Matt Rosdahl,74
-Deuel,9,State House,4,DEM,Matt Rosdahl,76
-Deuel,10,State House,4,DEM,Matt Rosdahl,41
-Deuel,11,State House,4,DEM,Matt Rosdahl,73
-Deuel,Total,State House,4,DEM,Matt Rosdahl,672
-Deuel,1,State House,4,DEM,Peggy Schuelke,75
-Deuel,3,State House,4,DEM,Peggy Schuelke,106
-Deuel,4,State House,4,DEM,Peggy Schuelke,69
-Deuel,5,State House,4,DEM,Peggy Schuelke,72
-Deuel,6,State House,4,DEM,Peggy Schuelke,80
-Deuel,7,State House,4,DEM,Peggy Schuelke,71
-Deuel,8,State House,4,DEM,Peggy Schuelke,109
-Deuel,9,State House,4,DEM,Peggy Schuelke,86
-Deuel,10,State House,4,DEM,Peggy Schuelke,43
-Deuel,11,State House,4,DEM,Peggy Schuelke,85
-Deuel,Total,State House,4,DEM,Peggy Schuelke,796
+Deuel,1,U.S. Senate,,John R. Thune,REP,110
+Deuel,3,U.S. Senate,,John R. Thune,REP,223
+Deuel,4,U.S. Senate,,John R. Thune,REP,138
+Deuel,5,U.S. Senate,,John R. Thune,REP,118
+Deuel,6,U.S. Senate,,John R. Thune,REP,147
+Deuel,7,U.S. Senate,,John R. Thune,REP,142
+Deuel,8,U.S. Senate,,John R. Thune,REP,184
+Deuel,9,U.S. Senate,,John R. Thune,REP,218
+Deuel,10,U.S. Senate,,John R. Thune,REP,136
+Deuel,11,U.S. Senate,,John R. Thune,REP,147
+Deuel,Total,U.S. Senate,,John R. Thune,REP,1563
+Deuel,1,U.S. Senate,,Jay Williams,DEM,39
+Deuel,3,U.S. Senate,,Jay Williams,DEM,73
+Deuel,4,U.S. Senate,,Jay Williams,DEM,48
+Deuel,5,U.S. Senate,,Jay Williams,DEM,59
+Deuel,6,U.S. Senate,,Jay Williams,DEM,49
+Deuel,7,U.S. Senate,,Jay Williams,DEM,45
+Deuel,8,U.S. Senate,,Jay Williams,DEM,69
+Deuel,9,U.S. Senate,,Jay Williams,DEM,62
+Deuel,10,U.S. Senate,,Jay Williams,DEM,35
+Deuel,11,U.S. Senate,,Jay Williams,DEM,55
+Deuel,Total,U.S. Senate,,Jay Williams,DEM,534
+Deuel,1,President,,Donald J. Trump,REP,90
+Deuel,3,President,,Donald J. Trump,REP,202
+Deuel,4,President,,Donald J. Trump,REP,105
+Deuel,5,President,,Donald J. Trump,REP,99
+Deuel,6,President,,Donald J. Trump,REP,112
+Deuel,7,President,,Donald J. Trump,REP,140
+Deuel,8,President,,Donald J. Trump,REP,168
+Deuel,9,President,,Donald J. Trump,REP,207
+Deuel,10,President,,Donald J. Trump,REP,111
+Deuel,11,President,,Donald J. Trump,REP,132
+Deuel,Total,President,,Donald J. Trump,REP,1366
+Deuel,1,President,,Gary Johnson,LIB,13
+Deuel,3,President,,Gary Johnson,LIB,15
+Deuel,4,President,,Gary Johnson,LIB,13
+Deuel,5,President,,Gary Johnson,LIB,16
+Deuel,6,President,,Gary Johnson,LIB,13
+Deuel,7,President,,Gary Johnson,LIB,6
+Deuel,8,President,,Gary Johnson,LIB,9
+Deuel,9,President,,Gary Johnson,LIB,13
+Deuel,10,President,,Gary Johnson,LIB,7
+Deuel,11,President,,Gary Johnson,LIB,12
+Deuel,Total,President,,Gary Johnson,LIB,117
+Deuel,1,President,,Hillary Clinton,DEM,43
+Deuel,3,President,,Hillary Clinton,DEM,76
+Deuel,4,President,,Hillary Clinton,DEM,65
+Deuel,5,President,,Hillary Clinton,DEM,58
+Deuel,6,President,,Hillary Clinton,DEM,61
+Deuel,7,President,,Hillary Clinton,DEM,37
+Deuel,8,President,,Hillary Clinton,DEM,71
+Deuel,9,President,,Hillary Clinton,DEM,53
+Deuel,10,President,,Hillary Clinton,DEM,50
+Deuel,11,President,,Hillary Clinton,DEM,56
+Deuel,Total,President,,Hillary Clinton,DEM,570
+Deuel,1,President,,Darrell L. Castle,CON,1
+Deuel,3,President,,Darrell L. Castle,CON,2
+Deuel,4,President,,Darrell L. Castle,CON,2
+Deuel,5,President,,Darrell L. Castle,CON,3
+Deuel,6,President,,Darrell L. Castle,CON,4
+Deuel,7,President,,Darrell L. Castle,CON,3
+Deuel,8,President,,Darrell L. Castle,CON,6
+Deuel,9,President,,Darrell L. Castle,CON,3
+Deuel,10,President,,Darrell L. Castle,CON,1
+Deuel,11,President,,Darrell L. Castle,CON,2
+Deuel,Total,President,,Darrell L. Castle,CON,27
+Deuel,1,Public Utilities commissioner,,Chris Nelson,REP,112
+Deuel,3,Public Utilities commissioner,,Chris Nelson,REP,231
+Deuel,4,Public Utilities commissioner,,Chris Nelson,REP,146
+Deuel,5,Public Utilities commissioner,,Chris Nelson,REP,139
+Deuel,6,Public Utilities commissioner,,Chris Nelson,REP,153
+Deuel,7,Public Utilities commissioner,,Chris Nelson,REP,157
+Deuel,8,Public Utilities commissioner,,Chris Nelson,REP,193
+Deuel,9,Public Utilities commissioner,,Chris Nelson,REP,225
+Deuel,10,Public Utilities commissioner,,Chris Nelson,REP,143
+Deuel,11,Public Utilities commissioner,,Chris Nelson,REP,151
+Deuel,Total,Public Utilities commissioner,,Chris Nelson,REP,1650
+Deuel,1,Public Utilities commissioner,,Henry Red Cloud,DEM,25
+Deuel,3,Public Utilities commissioner,,Henry Red Cloud,DEM,59
+Deuel,4,Public Utilities commissioner,,Henry Red Cloud,DEM,30
+Deuel,5,Public Utilities commissioner,,Henry Red Cloud,DEM,36
+Deuel,6,Public Utilities commissioner,,Henry Red Cloud,DEM,37
+Deuel,7,Public Utilities commissioner,,Henry Red Cloud,DEM,26
+Deuel,8,Public Utilities commissioner,,Henry Red Cloud,DEM,58
+Deuel,9,Public Utilities commissioner,,Henry Red Cloud,DEM,48
+Deuel,10,Public Utilities commissioner,,Henry Red Cloud,DEM,25
+Deuel,11,Public Utilities commissioner,,Henry Red Cloud,DEM,47
+Deuel,Total,Public Utilities commissioner,,Henry Red Cloud,DEM,391
+Deuel,1,U.S. House,1,Kristi Noem,REP,97
+Deuel,3,U.S. House,1,Kristi Noem,REP,202
+Deuel,4,U.S. House,1,Kristi Noem,REP,125
+Deuel,5,U.S. House,1,Kristi Noem,REP,104
+Deuel,6,U.S. House,1,Kristi Noem,REP,130
+Deuel,7,U.S. House,1,Kristi Noem,REP,133
+Deuel,8,U.S. House,1,Kristi Noem,REP,163
+Deuel,9,U.S. House,1,Kristi Noem,REP,196
+Deuel,10,U.S. House,1,Kristi Noem,REP,123
+Deuel,11,U.S. House,1,Kristi Noem,REP,128
+Deuel,Total,U.S. House,1,Kristi Noem,REP,1401
+Deuel,1,U.S. House,1,Paula Hawks,DEM,52
+Deuel,3,U.S. House,1,Paula Hawks,DEM,90
+Deuel,4,U.S. House,1,Paula Hawks,DEM,62
+Deuel,5,U.S. House,1,Paula Hawks,DEM,74
+Deuel,6,U.S. House,1,Paula Hawks,DEM,66
+Deuel,7,U.S. House,1,Paula Hawks,DEM,55
+Deuel,8,U.S. House,1,Paula Hawks,DEM,90
+Deuel,9,U.S. House,1,Paula Hawks,DEM,86
+Deuel,10,U.S. House,1,Paula Hawks,DEM,52
+Deuel,11,U.S. House,1,Paula Hawks,DEM,72
+Deuel,Total,U.S. House,1,Paula Hawks,DEM,699
+Deuel,1,State House,4,John Mills,REP,57
+Deuel,3,State House,4,John Mills,REP,173
+Deuel,4,State House,4,John Mills,REP,91
+Deuel,5,State House,4,John Mills,REP,83
+Deuel,6,State House,4,John Mills,REP,87
+Deuel,7,State House,4,John Mills,REP,110
+Deuel,8,State House,4,John Mills,REP,138
+Deuel,9,State House,4,John Mills,REP,169
+Deuel,10,State House,4,John Mills,REP,108
+Deuel,11,State House,4,John Mills,REP,108
+Deuel,Total,State House,4,John Mills,REP,1124
+Deuel,1,State House,4,Jason W. Kettwig,REP,61
+Deuel,3,State House,4,Jason W. Kettwig,REP,150
+Deuel,4,State House,4,Jason W. Kettwig,REP,87
+Deuel,5,State House,4,Jason W. Kettwig,REP,77
+Deuel,6,State House,4,Jason W. Kettwig,REP,92
+Deuel,7,State House,4,Jason W. Kettwig,REP,104
+Deuel,8,State House,4,Jason W. Kettwig,REP,111
+Deuel,9,State House,4,Jason W. Kettwig,REP,149
+Deuel,10,State House,4,Jason W. Kettwig,REP,101
+Deuel,11,State House,4,Jason W. Kettwig,REP,85
+Deuel,Total,State House,4,Jason W. Kettwig,REP,1017
+Deuel,1,State House,4,Matt Rosdahl,DEM,53
+Deuel,3,State House,4,Matt Rosdahl,DEM,79
+Deuel,4,State House,4,Matt Rosdahl,DEM,79
+Deuel,5,State House,4,Matt Rosdahl,DEM,84
+Deuel,6,State House,4,Matt Rosdahl,DEM,72
+Deuel,7,State House,4,Matt Rosdahl,DEM,41
+Deuel,8,State House,4,Matt Rosdahl,DEM,74
+Deuel,9,State House,4,Matt Rosdahl,DEM,76
+Deuel,10,State House,4,Matt Rosdahl,DEM,41
+Deuel,11,State House,4,Matt Rosdahl,DEM,73
+Deuel,Total,State House,4,Matt Rosdahl,DEM,672
+Deuel,1,State House,4,Peggy Schuelke,DEM,75
+Deuel,3,State House,4,Peggy Schuelke,DEM,106
+Deuel,4,State House,4,Peggy Schuelke,DEM,69
+Deuel,5,State House,4,Peggy Schuelke,DEM,72
+Deuel,6,State House,4,Peggy Schuelke,DEM,80
+Deuel,7,State House,4,Peggy Schuelke,DEM,71
+Deuel,8,State House,4,Peggy Schuelke,DEM,109
+Deuel,9,State House,4,Peggy Schuelke,DEM,86
+Deuel,10,State House,4,Peggy Schuelke,DEM,43
+Deuel,11,State House,4,Peggy Schuelke,DEM,85
+Deuel,Total,State House,4,Peggy Schuelke,DEM,796
 Dewey,Precinct 02 Trail City,President,,Donald J. Trump,REP,37
 Dewey,Precinct-04 Timber Lake,President,,Donald J. Trump,REP,238
 Dewey,Precinct-05 Firesteel,President,,Donald J. Trump,REP,39
@@ -3435,166 +3435,166 @@ Edmunds,Roscoe Area,State Representative,23,John A Lake,REP,128
 Edmunds,Bowdle Area,State Representative,23,John A Lake,REP,204
 Edmunds,Hosmer Area,State Representative,23,John A Lake,REP,67
 Edmunds,TOTAL,State Representative,23,John A Lake,REP,947
-Fall River,Beaver,President,,REP,Donald J. Trump,122
-Fall River,Cascade,President,,REP,Donald J. Trump,123
-Fall River,Edgemont Area,President,,REP,Donald J. Trump,413
-Fall River,Hot Springs 1,President,,REP,Donald J. Trump,270
-Fall River,Hot Springs 2,President,,REP,Donald J. Trump,294
-Fall River,Hot Springs 3,President,,REP,Donald J. Trump,253
-Fall River,Hot Springs 4,President,,REP,Donald J. Trump,201
-Fall River,Jackson,President,,REP,Donald J. Trump,658
-Fall River,Oelrichs Area,President,,REP,Donald J. Trump,177
-Fall River,Total,President,,REP,Donald J. Trump,"2,511"
-Fall River,Beaver,President,,LIB,Gary Johnson,7
-Fall River,Cascade,President,,LIB,Gary Johnson,3
-Fall River,Edgemont Area,President,,LIB,Gary Johnson,29
-Fall River,Hot Springs 1,President,,LIB,Gary Johnson,25
-Fall River,Hot Springs 2,President,,LIB,Gary Johnson,17
-Fall River,Hot Springs 3,President,,LIB,Gary Johnson,29
-Fall River,Hot Springs 4,President,,LIB,Gary Johnson,21
-Fall River,Jackson,President,,LIB,Gary Johnson,32
-Fall River,Oelrichs Area,President,,LIB,Gary Johnson,3
-Fall River,Total,President,,LIB,Gary Johnson,166
-Fall River,Beaver,President,,DEM,Hillary Clinton,9
-Fall River,Cascade,President,,DEM,Hillary Clinton,33
-Fall River,Edgemont Area,President,,DEM,Hillary Clinton,82
-Fall River,Hot Springs 1,President,,DEM,Hillary Clinton,121
-Fall River,Hot Springs 2,President,,DEM,Hillary Clinton,135
-Fall River,Hot Springs 3,President,,DEM,Hillary Clinton,142
-Fall River,Hot Springs 4,President,,DEM,Hillary Clinton,97
-Fall River,Jackson,President,,DEM,Hillary Clinton,189
-Fall River,Oelrichs Area,President,,DEM,Hillary Clinton,13
-Fall River,Total,President,,DEM,Hillary Clinton,821
-Fall River,Beaver,President,,CON,Darrell L. Castle,0
-Fall River,Cascade,President,,CON,Darrell L. Castle,5
-Fall River,Edgemont Area,President,,CON,Darrell L. Castle,7
-Fall River,Hot Springs 1,President,,CON,Darrell L. Castle,12
-Fall River,Hot Springs 2,President,,CON,Darrell L. Castle,7
-Fall River,Hot Springs 3,President,,CON,Darrell L. Castle,4
-Fall River,Hot Springs 4,President,,CON,Darrell L. Castle,8
-Fall River,Jackson,President,,CON,Darrell L. Castle,18
-Fall River,Oelrichs Area,President,,CON,Darrell L. Castle,4
-Fall River,Total,President,,CON,Darrell L. Castle,65
-Fall River,Beaver,U.S. Senate,,REP,John R. Thune,113
-Fall River,Cascade,U.S. Senate,,REP,John R. Thune,123
-Fall River,Edgemont Area,U.S. Senate,,REP,John R. Thune,433
-Fall River,Hot Springs 1,U.S. Senate,,REP,John R. Thune,284
-Fall River,Hot Springs 2,U.S. Senate,,REP,John R. Thune,321
-Fall River,Hot Springs 3,U.S. Senate,,REP,John R. Thune,303
-Fall River,Hot Springs 4,U.S. Senate,,REP,John R. Thune,228
-Fall River,Jackson,U.S. Senate,,REP,John R. Thune,684
-Fall River,Oelrichs Area,U.S. Senate,,REP,John R. Thune,182
-Fall River,Total,U.S. Senate,,REP,John R. Thune,"2,671"
-Fall River,Beaver,U.S. Senate,,DEM,Jay Williams,20
-Fall River,Cascade,U.S. Senate,,DEM,Jay Williams,36
-Fall River,Edgemont Area,U.S. Senate,,DEM,Jay Williams,95
-Fall River,Hot Springs 1,U.S. Senate,,DEM,Jay Williams,137
-Fall River,Hot Springs 2,U.S. Senate,,DEM,Jay Williams,129
-Fall River,Hot Springs 3,U.S. Senate,,DEM,Jay Williams,129
-Fall River,Hot Springs 4,U.S. Senate,,DEM,Jay Williams,104
-Fall River,Jackson,U.S. Senate,,DEM,Jay Williams,204
-Fall River,Oelrichs Area,U.S. Senate,,DEM,Jay Williams,14
-Fall River,Total,U.S. Senate,,DEM,Jay Williams,868
-Fall River,Beaver,U.S. House,1,REP,Kristi Noem,118
-Fall River,Cascade,U.S. House,1,REP,Kristi Noem,126
-Fall River,Edgemont Area,U.S. House,1,REP,Kristi Noem,417
-Fall River,Hot Springs 1,U.S. House,1,REP,Kristi Noem,276
-Fall River,Hot Springs 2,U.S. House,1,REP,Kristi Noem,310
-Fall River,Hot Springs 3,U.S. House,1,REP,Kristi Noem,286
-Fall River,Hot Springs 4,U.S. House,1,REP,Kristi Noem,220
-Fall River,Jackson,U.S. House,1,REP,Kristi Noem,665
-Fall River,Oelrichs Area,U.S. House,1,REP,Kristi Noem,177
-Fall River,Total,U.S. House,1,REP,Kristi Noem,"2,595"
-Fall River,Beaver,U.S. House,1,DEM,Paula Hawks,18
-Fall River,Cascade,U.S. House,1,DEM,Paula Hawks,33
-Fall River,Edgemont Area,U.S. House,1,DEM,Paula Hawks,115
-Fall River,Hot Springs 1,U.S. House,1,DEM,Paula Hawks,144
-Fall River,Hot Springs 2,U.S. House,1,DEM,Paula Hawks,133
-Fall River,Hot Springs 3,U.S. House,1,DEM,Paula Hawks,135
-Fall River,Hot Springs 4,U.S. House,1,DEM,Paula Hawks,111
-Fall River,Jackson,U.S. House,1,DEM,Paula Hawks,225
-Fall River,Oelrichs Area,U.S. House,1,DEM,Paula Hawks,21
-Fall River,Total,U.S. House,1,DEM,Paula Hawks,935
-Fall River,Beaver,Public Utilities Commissioner,,REP,Chris Nelson,114
-Fall River,Cascade,Public Utilities Commissioner,,REP,Chris Nelson,124
-Fall River,Edgemont Area,Public Utilities Commissioner,,REP,Chris Nelson,402
-Fall River,Hot Springs 1,Public Utilities Commissioner,,REP,Chris Nelson,262
-Fall River,Hot Springs 2,Public Utilities Commissioner,,REP,Chris Nelson,313
-Fall River,Hot Springs 3,Public Utilities Commissioner,,REP,Chris Nelson,288
-Fall River,Hot Springs 4,Public Utilities Commissioner,,REP,Chris Nelson,204
-Fall River,Jackson,Public Utilities Commissioner,,REP,Chris Nelson,660
-Fall River,Oelrichs Area,Public Utilities Commissioner,,REP,Chris Nelson,174
-Fall River,Total,Public Utilities Commissioner,,REP,Chris Nelson,"2,541"
-Fall River,Beaver,Public Utilities Commissioner,,DEM,Henry Red Cloud,15
-Fall River,Cascade,Public Utilities Commissioner,,DEM,Henry Red Cloud,34
-Fall River,Edgemont Area,Public Utilities Commissioner,,DEM,Henry Red Cloud,108
-Fall River,Hot Springs 1,Public Utilities Commissioner,,DEM,Henry Red Cloud,146
-Fall River,Hot Springs 2,Public Utilities Commissioner,,DEM,Henry Red Cloud,125
-Fall River,Hot Springs 3,Public Utilities Commissioner,,DEM,Henry Red Cloud,121
-Fall River,Hot Springs 4,Public Utilities Commissioner,,DEM,Henry Red Cloud,112
-Fall River,Jackson,Public Utilities Commissioner,,DEM,Henry Red Cloud,209
-Fall River,Oelrichs Area,Public Utilities Commissioner,,DEM,Henry Red Cloud,18
-Fall River,Total,Public Utilities Commissioner,,DEM,Henry Red Cloud,888
-Fall River,Beaver,State Senate,30,REP,Lance Russell,96
-Fall River,Cascade,State Senate,30,REP,Lance Russell,112
-Fall River,Edgemont Area,State Senate,30,REP,Lance Russell,364
-Fall River,Hot Springs 1,State Senate,30,REP,Lance Russell,251
-Fall River,Hot Springs 2,State Senate,30,REP,Lance Russell,281
-Fall River,Hot Springs 3,State Senate,30,REP,Lance Russell,259
-Fall River,Hot Springs 4,State Senate,30,REP,Lance Russell,196
-Fall River,Jackson,State Senate,30,REP,Lance Russell,552
-Fall River,Oelrichs Area,State Senate,30,REP,Lance Russell,160
-Fall River,Total,State Senate,30,REP,Lance Russell,"2,271"
-Fall River,Beaver,State Senate,30,DEM,Karla R. LaRive,32
-Fall River,Cascade,State Senate,30,DEM,Karla R. LaRive,49
-Fall River,Edgemont Area,State Senate,30,DEM,Karla R. LaRive,144
-Fall River,Hot Springs 1,State Senate,30,DEM,Karla R. LaRive,164
-Fall River,Hot Springs 2,State Senate,30,DEM,Karla R. LaRive,166
-Fall River,Hot Springs 3,State Senate,30,DEM,Karla R. LaRive,165
-Fall River,Hot Springs 4,State Senate,30,DEM,Karla R. LaRive,124
-Fall River,Jackson,State Senate,30,DEM,Karla R. LaRive,312
-Fall River,Oelrichs Area,State Senate,30,DEM,Karla R. LaRive,37
-Fall River,Total,State Senate,30,DEM,Karla R. LaRive,"1,193"
-Fall River,Beaver,State House,30,REP,Julie Frye-Mueller,102
-Fall River,Cascade,State House,30,REP,Julie Frye-Mueller,99
-Fall River,Edgemont Area,State House,30,REP,Julie Frye-Mueller,329
-Fall River,Hot Springs 1,State House,30,REP,Julie Frye-Mueller,214
-Fall River,Hot Springs 2,State House,30,REP,Julie Frye-Mueller,246
-Fall River,Hot Springs 3,State House,30,REP,Julie Frye-Mueller,234
-Fall River,Hot Springs 4,State House,30,REP,Julie Frye-Mueller,169
-Fall River,Jackson,State House,30,REP,Julie Frye-Mueller,539
-Fall River,Oelrichs Area,State House,30,REP,Julie Frye-Mueller,151
-Fall River,Total,State House,30,REP,Julie Frye-Mueller,"2,083"
-Fall River,Beaver,State House,30,REP,Tim R. Goodwin,106
-Fall River,Cascade,State House,30,REP,Tim R. Goodwin,108
-Fall River,Edgemont Area,State House,30,REP,Tim R. Goodwin,328
-Fall River,Hot Springs 1,State House,30,REP,Tim R. Goodwin,210
-Fall River,Hot Springs 2,State House,30,REP,Tim R. Goodwin,258
-Fall River,Hot Springs 3,State House,30,REP,Tim R. Goodwin,208
-Fall River,Hot Springs 4,State House,30,REP,Tim R. Goodwin,166
-Fall River,Jackson,State House,30,REP,Tim R. Goodwin,545
-Fall River,Oelrichs Area,State House,30,REP,Tim R. Goodwin,144
-Fall River,Total,State House,30,REP,Tim R. Goodwin,"2,073"
-Fall River,Beaver,State House,30,DEM,Kristine Ina Winter,15
-Fall River,Cascade,State House,30,DEM,Kristine Ina Winter,36
-Fall River,Edgemont Area,State House,30,DEM,Kristine Ina Winter,106
-Fall River,Hot Springs 1,State House,30,DEM,Kristine Ina Winter,149
-Fall River,Hot Springs 2,State House,30,DEM,Kristine Ina Winter,119
-Fall River,Hot Springs 3,State House,30,DEM,Kristine Ina Winter,136
-Fall River,Hot Springs 4,State House,30,DEM,Kristine Ina Winter,115
-Fall River,Jackson,State House,30,DEM,Kristine Ina Winter,230
-Fall River,Oelrichs Area,State House,30,DEM,Kristine Ina Winter,18
-Fall River,Total,State House,30,DEM,Kristine Ina Winter,924
-Fall River,Beaver,State House,30,DEM,Sandy Arseneault,17
-Fall River,Cascade,State House,30,DEM,Sandy Arseneault,34
-Fall River,Edgemont Area,State House,30,DEM,Sandy Arseneault,121
-Fall River,Hot Springs 1,State House,30,DEM,Sandy Arseneault,148
-Fall River,Hot Springs 2,State House,30,DEM,Sandy Arseneault,146
-Fall River,Hot Springs 3,State House,30,DEM,Sandy Arseneault,135
-Fall River,Hot Springs 4,State House,30,DEM,Sandy Arseneault,104
-Fall River,Jackson,State House,30,DEM,Sandy Arseneault,224
-Fall River,Oelrichs Area,State House,30,DEM,Sandy Arseneault,21
-Fall River,Total,State House,30,DEM,Sandy Arseneault,950
+Fall River,Beaver,President,,Donald J. Trump,REP,122
+Fall River,Cascade,President,,Donald J. Trump,REP,123
+Fall River,Edgemont Area,President,,Donald J. Trump,REP,413
+Fall River,Hot Springs 1,President,,Donald J. Trump,REP,270
+Fall River,Hot Springs 2,President,,Donald J. Trump,REP,294
+Fall River,Hot Springs 3,President,,Donald J. Trump,REP,253
+Fall River,Hot Springs 4,President,,Donald J. Trump,REP,201
+Fall River,Jackson,President,,Donald J. Trump,REP,658
+Fall River,Oelrichs Area,President,,Donald J. Trump,REP,177
+Fall River,Total,President,,Donald J. Trump,"2,REP,511"
+Fall River,Beaver,President,,Gary Johnson,LIB,7
+Fall River,Cascade,President,,Gary Johnson,LIB,3
+Fall River,Edgemont Area,President,,Gary Johnson,LIB,29
+Fall River,Hot Springs 1,President,,Gary Johnson,LIB,25
+Fall River,Hot Springs 2,President,,Gary Johnson,LIB,17
+Fall River,Hot Springs 3,President,,Gary Johnson,LIB,29
+Fall River,Hot Springs 4,President,,Gary Johnson,LIB,21
+Fall River,Jackson,President,,Gary Johnson,LIB,32
+Fall River,Oelrichs Area,President,,Gary Johnson,LIB,3
+Fall River,Total,President,,Gary Johnson,LIB,166
+Fall River,Beaver,President,,Hillary Clinton,DEM,9
+Fall River,Cascade,President,,Hillary Clinton,DEM,33
+Fall River,Edgemont Area,President,,Hillary Clinton,DEM,82
+Fall River,Hot Springs 1,President,,Hillary Clinton,DEM,121
+Fall River,Hot Springs 2,President,,Hillary Clinton,DEM,135
+Fall River,Hot Springs 3,President,,Hillary Clinton,DEM,142
+Fall River,Hot Springs 4,President,,Hillary Clinton,DEM,97
+Fall River,Jackson,President,,Hillary Clinton,DEM,189
+Fall River,Oelrichs Area,President,,Hillary Clinton,DEM,13
+Fall River,Total,President,,Hillary Clinton,DEM,821
+Fall River,Beaver,President,,Darrell L. Castle,CON,0
+Fall River,Cascade,President,,Darrell L. Castle,CON,5
+Fall River,Edgemont Area,President,,Darrell L. Castle,CON,7
+Fall River,Hot Springs 1,President,,Darrell L. Castle,CON,12
+Fall River,Hot Springs 2,President,,Darrell L. Castle,CON,7
+Fall River,Hot Springs 3,President,,Darrell L. Castle,CON,4
+Fall River,Hot Springs 4,President,,Darrell L. Castle,CON,8
+Fall River,Jackson,President,,Darrell L. Castle,CON,18
+Fall River,Oelrichs Area,President,,Darrell L. Castle,CON,4
+Fall River,Total,President,,Darrell L. Castle,CON,65
+Fall River,Beaver,U.S. Senate,,John R. Thune,REP,113
+Fall River,Cascade,U.S. Senate,,John R. Thune,REP,123
+Fall River,Edgemont Area,U.S. Senate,,John R. Thune,REP,433
+Fall River,Hot Springs 1,U.S. Senate,,John R. Thune,REP,284
+Fall River,Hot Springs 2,U.S. Senate,,John R. Thune,REP,321
+Fall River,Hot Springs 3,U.S. Senate,,John R. Thune,REP,303
+Fall River,Hot Springs 4,U.S. Senate,,John R. Thune,REP,228
+Fall River,Jackson,U.S. Senate,,John R. Thune,REP,684
+Fall River,Oelrichs Area,U.S. Senate,,John R. Thune,REP,182
+Fall River,Total,U.S. Senate,,John R. Thune,"2,REP,671"
+Fall River,Beaver,U.S. Senate,,Jay Williams,DEM,20
+Fall River,Cascade,U.S. Senate,,Jay Williams,DEM,36
+Fall River,Edgemont Area,U.S. Senate,,Jay Williams,DEM,95
+Fall River,Hot Springs 1,U.S. Senate,,Jay Williams,DEM,137
+Fall River,Hot Springs 2,U.S. Senate,,Jay Williams,DEM,129
+Fall River,Hot Springs 3,U.S. Senate,,Jay Williams,DEM,129
+Fall River,Hot Springs 4,U.S. Senate,,Jay Williams,DEM,104
+Fall River,Jackson,U.S. Senate,,Jay Williams,DEM,204
+Fall River,Oelrichs Area,U.S. Senate,,Jay Williams,DEM,14
+Fall River,Total,U.S. Senate,,Jay Williams,DEM,868
+Fall River,Beaver,U.S. House,1,Kristi Noem,REP,118
+Fall River,Cascade,U.S. House,1,Kristi Noem,REP,126
+Fall River,Edgemont Area,U.S. House,1,Kristi Noem,REP,417
+Fall River,Hot Springs 1,U.S. House,1,Kristi Noem,REP,276
+Fall River,Hot Springs 2,U.S. House,1,Kristi Noem,REP,310
+Fall River,Hot Springs 3,U.S. House,1,Kristi Noem,REP,286
+Fall River,Hot Springs 4,U.S. House,1,Kristi Noem,REP,220
+Fall River,Jackson,U.S. House,1,Kristi Noem,REP,665
+Fall River,Oelrichs Area,U.S. House,1,Kristi Noem,REP,177
+Fall River,Total,U.S. House,1,Kristi Noem,"2,REP,595"
+Fall River,Beaver,U.S. House,1,Paula Hawks,DEM,18
+Fall River,Cascade,U.S. House,1,Paula Hawks,DEM,33
+Fall River,Edgemont Area,U.S. House,1,Paula Hawks,DEM,115
+Fall River,Hot Springs 1,U.S. House,1,Paula Hawks,DEM,144
+Fall River,Hot Springs 2,U.S. House,1,Paula Hawks,DEM,133
+Fall River,Hot Springs 3,U.S. House,1,Paula Hawks,DEM,135
+Fall River,Hot Springs 4,U.S. House,1,Paula Hawks,DEM,111
+Fall River,Jackson,U.S. House,1,Paula Hawks,DEM,225
+Fall River,Oelrichs Area,U.S. House,1,Paula Hawks,DEM,21
+Fall River,Total,U.S. House,1,Paula Hawks,DEM,935
+Fall River,Beaver,Public Utilities Commissioner,,Chris Nelson,REP,114
+Fall River,Cascade,Public Utilities Commissioner,,Chris Nelson,REP,124
+Fall River,Edgemont Area,Public Utilities Commissioner,,Chris Nelson,REP,402
+Fall River,Hot Springs 1,Public Utilities Commissioner,,Chris Nelson,REP,262
+Fall River,Hot Springs 2,Public Utilities Commissioner,,Chris Nelson,REP,313
+Fall River,Hot Springs 3,Public Utilities Commissioner,,Chris Nelson,REP,288
+Fall River,Hot Springs 4,Public Utilities Commissioner,,Chris Nelson,REP,204
+Fall River,Jackson,Public Utilities Commissioner,,Chris Nelson,REP,660
+Fall River,Oelrichs Area,Public Utilities Commissioner,,Chris Nelson,REP,174
+Fall River,Total,Public Utilities Commissioner,,Chris Nelson,"2,REP,541"
+Fall River,Beaver,Public Utilities Commissioner,,Henry Red Cloud,DEM,15
+Fall River,Cascade,Public Utilities Commissioner,,Henry Red Cloud,DEM,34
+Fall River,Edgemont Area,Public Utilities Commissioner,,Henry Red Cloud,DEM,108
+Fall River,Hot Springs 1,Public Utilities Commissioner,,Henry Red Cloud,DEM,146
+Fall River,Hot Springs 2,Public Utilities Commissioner,,Henry Red Cloud,DEM,125
+Fall River,Hot Springs 3,Public Utilities Commissioner,,Henry Red Cloud,DEM,121
+Fall River,Hot Springs 4,Public Utilities Commissioner,,Henry Red Cloud,DEM,112
+Fall River,Jackson,Public Utilities Commissioner,,Henry Red Cloud,DEM,209
+Fall River,Oelrichs Area,Public Utilities Commissioner,,Henry Red Cloud,DEM,18
+Fall River,Total,Public Utilities Commissioner,,Henry Red Cloud,DEM,888
+Fall River,Beaver,State Senate,30,Lance Russell,REP,96
+Fall River,Cascade,State Senate,30,Lance Russell,REP,112
+Fall River,Edgemont Area,State Senate,30,Lance Russell,REP,364
+Fall River,Hot Springs 1,State Senate,30,Lance Russell,REP,251
+Fall River,Hot Springs 2,State Senate,30,Lance Russell,REP,281
+Fall River,Hot Springs 3,State Senate,30,Lance Russell,REP,259
+Fall River,Hot Springs 4,State Senate,30,Lance Russell,REP,196
+Fall River,Jackson,State Senate,30,Lance Russell,REP,552
+Fall River,Oelrichs Area,State Senate,30,Lance Russell,REP,160
+Fall River,Total,State Senate,30,Lance Russell,REP,"2,271"
+Fall River,Beaver,State Senate,30,Karla R. LaRive,DEM,32
+Fall River,Cascade,State Senate,30,Karla R. LaRive,DEM,49
+Fall River,Edgemont Area,State Senate,30,Karla R. LaRive,DEM,144
+Fall River,Hot Springs 1,State Senate,30,Karla R. LaRive,DEM,164
+Fall River,Hot Springs 2,State Senate,30,Karla R. LaRive,DEM,166
+Fall River,Hot Springs 3,State Senate,30,Karla R. LaRive,DEM,165
+Fall River,Hot Springs 4,State Senate,30,Karla R. LaRive,DEM,124
+Fall River,Jackson,State Senate,30,Karla R. LaRive,DEM,312
+Fall River,Oelrichs Area,State Senate,30,Karla R. LaRive,DEM,37
+Fall River,Total,State Senate,30,Karla R. LaRive,DEM,"1,193"
+Fall River,Beaver,State House,30,Julie Frye-Mueller,REP,102
+Fall River,Cascade,State House,30,Julie Frye-Mueller,REP,99
+Fall River,Edgemont Area,State House,30,Julie Frye-Mueller,REP,329
+Fall River,Hot Springs 1,State House,30,Julie Frye-Mueller,REP,214
+Fall River,Hot Springs 2,State House,30,Julie Frye-Mueller,REP,246
+Fall River,Hot Springs 3,State House,30,Julie Frye-Mueller,REP,234
+Fall River,Hot Springs 4,State House,30,Julie Frye-Mueller,REP,169
+Fall River,Jackson,State House,30,Julie Frye-Mueller,REP,539
+Fall River,Oelrichs Area,State House,30,Julie Frye-Mueller,REP,151
+Fall River,Total,State House,30,Julie Frye-Mueller,REP,"2,083"
+Fall River,Beaver,State House,30,Tim R. Goodwin,REP,106
+Fall River,Cascade,State House,30,Tim R. Goodwin,REP,108
+Fall River,Edgemont Area,State House,30,Tim R. Goodwin,REP,328
+Fall River,Hot Springs 1,State House,30,Tim R. Goodwin,REP,210
+Fall River,Hot Springs 2,State House,30,Tim R. Goodwin,REP,258
+Fall River,Hot Springs 3,State House,30,Tim R. Goodwin,REP,208
+Fall River,Hot Springs 4,State House,30,Tim R. Goodwin,REP,166
+Fall River,Jackson,State House,30,Tim R. Goodwin,REP,545
+Fall River,Oelrichs Area,State House,30,Tim R. Goodwin,REP,144
+Fall River,Total,State House,30,Tim R. Goodwin,REP,"2,073"
+Fall River,Beaver,State House,30,Kristine Ina Winter,DEM,15
+Fall River,Cascade,State House,30,Kristine Ina Winter,DEM,36
+Fall River,Edgemont Area,State House,30,Kristine Ina Winter,DEM,106
+Fall River,Hot Springs 1,State House,30,Kristine Ina Winter,DEM,149
+Fall River,Hot Springs 2,State House,30,Kristine Ina Winter,DEM,119
+Fall River,Hot Springs 3,State House,30,Kristine Ina Winter,DEM,136
+Fall River,Hot Springs 4,State House,30,Kristine Ina Winter,DEM,115
+Fall River,Jackson,State House,30,Kristine Ina Winter,DEM,230
+Fall River,Oelrichs Area,State House,30,Kristine Ina Winter,DEM,18
+Fall River,Total,State House,30,Kristine Ina Winter,DEM,924
+Fall River,Beaver,State House,30,Sandy Arseneault,DEM,17
+Fall River,Cascade,State House,30,Sandy Arseneault,DEM,34
+Fall River,Edgemont Area,State House,30,Sandy Arseneault,DEM,121
+Fall River,Hot Springs 1,State House,30,Sandy Arseneault,DEM,148
+Fall River,Hot Springs 2,State House,30,Sandy Arseneault,DEM,146
+Fall River,Hot Springs 3,State House,30,Sandy Arseneault,DEM,135
+Fall River,Hot Springs 4,State House,30,Sandy Arseneault,DEM,104
+Fall River,Jackson,State House,30,Sandy Arseneault,DEM,224
+Fall River,Oelrichs Area,State House,30,Sandy Arseneault,DEM,21
+Fall River,Total,State House,30,Sandy Arseneault,DEM,950
 Faulk,1,President,,Donald J. Trump,REP,139
 Faulk,2,President,,Donald J. Trump,REP,81
 Faulk,3,President,,Donald J. Trump,REP,109
@@ -4003,62 +4003,62 @@ Grant,52,State Representative,4,Peggy Schuelke,DEM,34
 Grant,53,State Representative,4,Peggy Schuelke,DEM,31
 Grant,54,State Representative,4,Peggy Schuelke,DEM,97
 Grant,Total,State Representative,4,Peggy Schuelke,DEM,1694
-Gregory,1,President,,REP,Donald J. Trump,758
-Gregory,2,President,,REP,Donald J. Trump,569
-Gregory,3,President,,REP,Donald J. Trump,273
-Gregory,Total,President,,REP,Donald J. Trump,1600
-Gregory,1,President,,LIB,Gary Johnson,37
-Gregory,2,President,,LIB,Gary Johnson,23
-Gregory,3,President,,LIB,Gary Johnson,18
-Gregory,Total,President,,LIB,Gary Johnson,78
-Gregory,1,President,,DEM,Hillary Clinton,174
-Gregory,2,President,,DEM,Hillary Clinton,160
-Gregory,3,President,,DEM,Hillary Clinton,57
-Gregory,Total,President,,DEM,Hillary Clinton,391
-Gregory,1,President,,CON,Darrell L. Castle,8
-Gregory,2,President,,CON,Darrell L. Castle,10
-Gregory,3,President,,CON,Darrell L. Castle,4
-Gregory,Total,President,,CON,Darrell L. Castle,22
-Gregory,1,U.S. Senate,,REP,John R. Thune,773
-Gregory,2,U.S. Senate,,REP,John R. Thune,605
-Gregory,3,U.S. Senate,,REP,John R. Thune,293
-Gregory,Total,U.S. Senate,,REP,John R. Thune,1671
-Gregory,1,U.S. Senate,,DEM,Jay Williams,208
-Gregory,2,U.S. Senate,,DEM,Jay Williams,161
-Gregory,3,U.S. Senate,,DEM,Jay Williams,57
-Gregory,Total,U.S. Senate,,DEM,Jay Williams,426
-Gregory,1,U.S. House,1,REP,Kristi Noem,710
-Gregory,2,U.S. House,1,REP,Kristi Noem,540
-Gregory,3,U.S. House,1,REP,Kristi Noem,269
-Gregory,Total,U.S. House,1,REP,Kristi Noem,1519
-Gregory,1,U.S. House,1,DEM,Paula Hawks,274
-Gregory,2,U.S. House,1,DEM,Paula Hawks,217
-Gregory,3,U.S. House,1,DEM,Paula Hawks,81
-Gregory,Total,U.S. House,1,DEM,Paula Hawks,572
-Gregory,1,Public Utilities Commissioner,,REP,Chris Nelson,761
-Gregory,2,Public Utilities Commissioner,,REP,Chris Nelson,611
-Gregory,3,Public Utilities Commissioner,,REP,Chris Nelson,282
-Gregory,Total,Public Utilities Commissioner,,REP,Chris Nelson,1654
-Gregory,1,Public Utilities Commissioner,,DEM,Henry Red Cloud,182
-Gregory,2,Public Utilities Commissioner,,DEM,Henry Red Cloud,128
-Gregory,3,Public Utilities Commissioner,,DEM,Henry Red Cloud,45
-Gregory,Total,Public Utilities Commissioner,,DEM,Henry Red Cloud,355
-Gregory,1,State Senate,21,DEM,Billie H. Sutton,742
-Gregory,2,State Senate,21,DEM,Billie H. Sutton,553
-Gregory,3,State Senate,21,DEM,Billie H. Sutton,221
-Gregory,Total,State Senate,21,DEM,Billie H. Sutton,1516
-Gregory,1,State House,21,REP,Lee Qualm,464
-Gregory,2,State House,21,REP,Lee Qualm,400
-Gregory,3,State House,21,REP,Lee Qualm,222
-Gregory,Total,State House,21,REP,Lee Qualm,1086
-Gregory,1,State House,21,DEM,Gary Burrus,424
-Gregory,2,State House,21,DEM,Gary Burrus,347
-Gregory,3,State House,21,DEM,Gary Burrus,103
-Gregory,Total,State House,21,DEM,Gary Burrus,874
-Gregory,1,State House,21,DEM,Julie Bartling,644
-Gregory,2,State House,21,DEM,Julie Bartling,515
-Gregory,3,State House,21,DEM,Julie Bartling,190
-Gregory,Total,State House,21,DEM,Julie Bartling,1349
+Gregory,1,President,,Donald J. Trump,REP,758
+Gregory,2,President,,Donald J. Trump,REP,569
+Gregory,3,President,,Donald J. Trump,REP,273
+Gregory,Total,President,,Donald J. Trump,REP,1600
+Gregory,1,President,,Gary Johnson,LIB,37
+Gregory,2,President,,Gary Johnson,LIB,23
+Gregory,3,President,,Gary Johnson,LIB,18
+Gregory,Total,President,,Gary Johnson,LIB,78
+Gregory,1,President,,Hillary Clinton,DEM,174
+Gregory,2,President,,Hillary Clinton,DEM,160
+Gregory,3,President,,Hillary Clinton,DEM,57
+Gregory,Total,President,,Hillary Clinton,DEM,391
+Gregory,1,President,,Darrell L. Castle,CON,8
+Gregory,2,President,,Darrell L. Castle,CON,10
+Gregory,3,President,,Darrell L. Castle,CON,4
+Gregory,Total,President,,Darrell L. Castle,CON,22
+Gregory,1,U.S. Senate,,John R. Thune,REP,773
+Gregory,2,U.S. Senate,,John R. Thune,REP,605
+Gregory,3,U.S. Senate,,John R. Thune,REP,293
+Gregory,Total,U.S. Senate,,John R. Thune,REP,1671
+Gregory,1,U.S. Senate,,Jay Williams,DEM,208
+Gregory,2,U.S. Senate,,Jay Williams,DEM,161
+Gregory,3,U.S. Senate,,Jay Williams,DEM,57
+Gregory,Total,U.S. Senate,,Jay Williams,DEM,426
+Gregory,1,U.S. House,1,Kristi Noem,REP,710
+Gregory,2,U.S. House,1,Kristi Noem,REP,540
+Gregory,3,U.S. House,1,Kristi Noem,REP,269
+Gregory,Total,U.S. House,1,Kristi Noem,REP,1519
+Gregory,1,U.S. House,1,Paula Hawks,DEM,274
+Gregory,2,U.S. House,1,Paula Hawks,DEM,217
+Gregory,3,U.S. House,1,Paula Hawks,DEM,81
+Gregory,Total,U.S. House,1,Paula Hawks,DEM,572
+Gregory,1,Public Utilities Commissioner,,Chris Nelson,REP,761
+Gregory,2,Public Utilities Commissioner,,Chris Nelson,REP,611
+Gregory,3,Public Utilities Commissioner,,Chris Nelson,REP,282
+Gregory,Total,Public Utilities Commissioner,,Chris Nelson,REP,1654
+Gregory,1,Public Utilities Commissioner,,Henry Red Cloud,DEM,182
+Gregory,2,Public Utilities Commissioner,,Henry Red Cloud,DEM,128
+Gregory,3,Public Utilities Commissioner,,Henry Red Cloud,DEM,45
+Gregory,Total,Public Utilities Commissioner,,Henry Red Cloud,DEM,355
+Gregory,1,State Senate,21,Billie H. Sutton,DEM,742
+Gregory,2,State Senate,21,Billie H. Sutton,DEM,553
+Gregory,3,State Senate,21,Billie H. Sutton,DEM,221
+Gregory,Total,State Senate,21,Billie H. Sutton,DEM,1516
+Gregory,1,State House,21,Lee Qualm,REP,464
+Gregory,2,State House,21,Lee Qualm,REP,400
+Gregory,3,State House,21,Lee Qualm,REP,222
+Gregory,Total,State House,21,Lee Qualm,REP,1086
+Gregory,1,State House,21,Gary Burrus,DEM,424
+Gregory,2,State House,21,Gary Burrus,DEM,347
+Gregory,3,State House,21,Gary Burrus,DEM,103
+Gregory,Total,State House,21,Gary Burrus,DEM,874
+Gregory,1,State House,21,Julie Bartling,DEM,644
+Gregory,2,State House,21,Julie Bartling,DEM,515
+Gregory,3,State House,21,Julie Bartling,DEM,190
+Gregory,Total,State House,21,Julie Bartling,DEM,1349
 Haakon,1,President,,Donald J. Trump,REP,96
 Haakon,4,President,,Donald J. Trump,REP,129
 Haakon,16,President,,Donald J. Trump,REP,188
@@ -4413,204 +4413,204 @@ Hand,9(10),State Representative,23,John A. Lake,REP,95
 Hand,11,State Representative,23,John A. Lake,REP,190
 Hand,12,State Representative,23,John A. Lake,REP,239
 Hand,TOTAL,State Representative,23,John A. Lake,REP,954
-Hanson,1,President,,REP,Donald J. Trump,689
-Hanson,2,President,,REP,Donald J. Trump,244
-Hanson,3,President,,REP,Donald J. Trump,236
-Hanson,4,President,,REP,Donald J. Trump,230
-Hanson,5,President,,REP,Donald J. Trump,98
-Hanson,Total,President,,REP,Donald J. Trump,1497
-Hanson,1,President,,LIB,Gary Johnson,28
-Hanson,2,President,,LIB,Gary Johnson,18
-Hanson,3,President,,LIB,Gary Johnson,3
-Hanson,4,President,,LIB,Gary Johnson,9
-Hanson,5,President,,LIB,Gary Johnson,1
-Hanson,Total,President,,LIB,Gary Johnson,59
-Hanson,1,President,,DEM,Hillary Clinton,233
-Hanson,2,President,,DEM,Hillary Clinton,87
-Hanson,3,President,,DEM,Hillary Clinton,50
-Hanson,4,President,,DEM,Hillary Clinton,38
-Hanson,5,President,,DEM,Hillary Clinton,16
-Hanson,Total,President,,DEM,Hillary Clinton,424
-Hanson,1,President,,CON,Darrell L. Castle,13
-Hanson,2,President,,CON,Darrell L. Castle,2
-Hanson,3,President,,CON,Darrell L. Castle,7
-Hanson,4,President,,CON,Darrell L. Castle,4
-Hanson,5,President,,CON,Darrell L. Castle,0
-Hanson,Total,President,,CON,Darrell L. Castle,26
-Hanson,1,U.S. Senate,,REP,John R. Thune,694
-Hanson,2,U.S. Senate,,REP,John R. Thune,265
-Hanson,3,U.S. Senate,,REP,John R. Thune,232
-Hanson,4,U.S. Senate,,REP,John R. Thune,226
-Hanson,5,U.S. Senate,,REP,John R. Thune,95
-Hanson,Total,U.S. Senate,,REP,John R. Thune,1512
-Hanson,1,U.S. Senate,,DEM,Jay Williams,223
-Hanson,2,U.S. Senate,,DEM,Jay Williams,91
-Hanson,3,U.S. Senate,,DEM,Jay Williams,66
-Hanson,4,U.S. Senate,,DEM,Jay Williams,50
-Hanson,5,U.S. Senate,,DEM,Jay Williams,21
-Hanson,Total,U.S. Senate,,DEM,Jay Williams,451
-Hanson,1,U.S. House,1,REP,Kristi Noem,657
-Hanson,2,U.S. House,1,REP,Kristi Noem,246
-Hanson,3,U.S. House,1,REP,Kristi Noem,230
-Hanson,4,U.S. House,1,REP,Kristi Noem,222
-Hanson,5,U.S. House,1,REP,Kristi Noem,89
-Hanson,Total,U.S. House,1,REP,Kristi Noem,1444
-Hanson,1,U.S. House,1,DEM,Paula Hawks,258
-Hanson,2,U.S. House,1,DEM,Paula Hawks,111
-Hanson,3,U.S. House,1,DEM,Paula Hawks,69
-Hanson,4,U.S. House,1,DEM,Paula Hawks,58
-Hanson,5,U.S. House,1,DEM,Paula Hawks,29
-Hanson,Total,U.S. House,1,DEM,Paula Hawks,525
-Hanson,1,Public Utilities Commissioner,,REP,Chris Nelson,652
-Hanson,2,Public Utilities Commissioner,,REP,Chris Nelson,290
-Hanson,3,Public Utilities Commissioner,,REP,Chris Nelson,253
-Hanson,4,Public Utilities Commissioner,,REP,Chris Nelson,238
-Hanson,5,Public Utilities Commissioner,,REP,Chris Nelson,96
-Hanson,Total,Public Utilities Commissioner,,REP,Chris Nelson,1529
-Hanson,1,Public Utilities Commissioner,,DEM,Henry Red Cloud,205
-Hanson,2,Public Utilities Commissioner,,DEM,Henry Red Cloud,60
-Hanson,3,Public Utilities Commissioner,,DEM,Henry Red Cloud,38
-Hanson,4,Public Utilities Commissioner,,DEM,Henry Red Cloud,38
-Hanson,5,Public Utilities Commissioner,,DEM,Henry Red Cloud,14
-Hanson,Total,Public Utilities Commissioner,,DEM,Henry Red Cloud,355
-Hanson,1,State Senate,19,REP,Stace Nelson,672
-Hanson,2,State Senate,19,REP,Stace Nelson,282
-Hanson,3,State Senate,19,REP,Stace Nelson,265
-Hanson,4,State Senate,19,REP,Stace Nelson,241
-Hanson,5,State Senate,19,REP,Stace Nelson,105
-Hanson,Total,State Senate,19,REP,Stace Nelson,1565
-Hanson,1,State Senate,19,DEM,Russell Graeff,197
-Hanson,2,State Senate,19,DEM,Russell Graeff,74
-Hanson,3,State Senate,19,DEM,Russell Graeff,37
-Hanson,4,State Senate,19,DEM,Russell Graeff,36
-Hanson,5,State Senate,19,DEM,Russell Graeff,13
-Hanson,Total,State Senate,19,DEM,Russell Graeff,357
-Hanson,1,State House,19,REP,Kent S. Peterson,569
-Hanson,2,State House,19,REP,Kent S. Peterson,186
-Hanson,3,State House,19,REP,Kent S. Peterson,170
-Hanson,4,State House,19,REP,Kent S. Peterson,177
-Hanson,5,State House,19,REP,Kent S. Peterson,60
-Hanson,Total,State House,19,REP,Kent S. Peterson,1162
-Hanson,1,State House,19,REP,Kyle Schoenfish,521
-Hanson,2,State House,19,REP,Kyle Schoenfish,207
-Hanson,3,State House,19,REP,Kyle Schoenfish,150
-Hanson,4,State House,19,REP,Kyle Schoenfish,177
-Hanson,5,State House,19,REP,Kyle Schoenfish,60
-Hanson,Total,State House,19,REP,Kyle Schoenfish,1115
-Hanson,1,State House,19,DEM,Melissa R. Mentele,238
-Hanson,2,State House,19,DEM,Melissa R. Mentele,110
-Hanson,3,State House,19,DEM,Melissa R. Mentele,90
-Hanson,4,State House,19,DEM,Melissa R. Mentele,76
-Hanson,5,State House,19,DEM,Melissa R. Mentele,29
-Hanson,Total,State House,19,DEM,Melissa R. Mentele,543
-Harding,1,President,,REP,Donald J. Trump,140
-Harding,2,President,,REP,Donald J. Trump,110
-Harding,3,President,,REP,Donald J. Trump,48
-Harding,4,President,,REP,Donald J. Trump,101
-Harding,5,President,,REP,Donald J. Trump,42
-Harding,6,President,,REP,Donald J. Trump,81
-Harding,7,President,,REP,Donald J. Trump,55
-Harding,8,President,,REP,Donald J. Trump,118
-Harding,Total,President,,REP,Donald J. Trump,695
-Harding,1,President,,LIB,Gary Johnson,10
-Harding,2,President,,LIB,Gary Johnson,7
-Harding,3,President,,LIB,Gary Johnson,3
-Harding,4,President,,LIB,Gary Johnson,4
-Harding,5,President,,LIB,Gary Johnson,0
-Harding,6,President,,LIB,Gary Johnson,3
-Harding,7,President,,LIB,Gary Johnson,1
-Harding,8,President,,LIB,Gary Johnson,3
-Harding,Total,President,,LIB,Gary Johnson,31
-Harding,1,President,,DEM,Hillary Clinton,11
-Harding,2,President,,DEM,Hillary Clinton,4
-Harding,3,President,,DEM,Hillary Clinton,5
-Harding,4,President,,DEM,Hillary Clinton,7
-Harding,5,President,,DEM,Hillary Clinton,0
-Harding,6,President,,DEM,Hillary Clinton,5
-Harding,7,President,,DEM,Hillary Clinton,3
-Harding,8,President,,DEM,Hillary Clinton,3
-Harding,Total,President,,DEM,Hillary Clinton,38
-Harding,1,President,,CON,Darrell L. Castle,2
-Harding,2,President,,CON,Darrell L. Castle,1
-Harding,3,President,,CON,Darrell L. Castle,1
-Harding,4,President,,CON,Darrell L. Castle,0
-Harding,5,President,,CON,Darrell L. Castle,0
-Harding,6,President,,CON,Darrell L. Castle,2
-Harding,7,President,,CON,Darrell L. Castle,0
-Harding,8,President,,CON,Darrell L. Castle,0
-Harding,Total,President,,CON,Darrell L. Castle,6
-Harding,1,U.S. Senate,,REP,John R. Thune,141
-Harding,2,U.S. Senate,,REP,John R. Thune,96
-Harding,3,U.S. Senate,,REP,John R. Thune,53
-Harding,4,U.S. Senate,,REP,John R. Thune,101
-Harding,5,U.S. Senate,,REP,John R. Thune,41
-Harding,6,U.S. Senate,,REP,John R. Thune,79
-Harding,7,U.S. Senate,,REP,John R. Thune,53
-Harding,8,U.S. Senate,,REP,John R. Thune,120
-Harding,Total,U.S. Senate,,REP,John R. Thune,684
-Harding,1,U.S. Senate,,DEM,Jay Williams,18
-Harding,2,U.S. Senate,,DEM,Jay Williams,21
-Harding,3,U.S. Senate,,DEM,Jay Williams,4
-Harding,4,U.S. Senate,,DEM,Jay Williams,13
-Harding,5,U.S. Senate,,DEM,Jay Williams,0
-Harding,6,U.S. Senate,,DEM,Jay Williams,9
-Harding,7,U.S. Senate,,DEM,Jay Williams,5
-Harding,8,U.S. Senate,,DEM,Jay Williams,4
-Harding,Total,U.S. Senate,,DEM,Jay Williams,74
-Harding,1,U.S. House,1,REP,Kristi Noem,140
-Harding,2,U.S. House,1,REP,Kristi Noem,99
-Harding,3,U.S. House,1,REP,Kristi Noem,50
-Harding,4,U.S. House,1,REP,Kristi Noem,98
-Harding,5,U.S. House,1,REP,Kristi Noem,41
-Harding,6,U.S. House,1,REP,Kristi Noem,78
-Harding,7,U.S. House,1,REP,Kristi Noem,55
-Harding,8,U.S. House,1,REP,Kristi Noem,118
-Harding,Total,U.S. House,1,REP,Kristi Noem,679
-Harding,1,U.S. House,1,DEM,Paula Hawks,18
-Harding,2,U.S. House,1,DEM,Paula Hawks,21
-Harding,3,U.S. House,1,DEM,Paula Hawks,5
-Harding,4,U.S. House,1,DEM,Paula Hawks,16
-Harding,5,U.S. House,1,DEM,Paula Hawks,0
-Harding,6,U.S. House,1,DEM,Paula Hawks,11
-Harding,7,U.S. House,1,DEM,Paula Hawks,3
-Harding,8,U.S. House,1,DEM,Paula Hawks,3
-Harding,Total,U.S. House,1,DEM,Paula Hawks,77
-Harding,1,Public Utilities Commissioner,,REP,Chris Nelson,141
-Harding,2,Public Utilities Commissioner,,REP,Chris Nelson,102
-Harding,3,Public Utilities Commissioner,,REP,Chris Nelson,51
-Harding,4,Public Utilities Commissioner,,REP,Chris Nelson,106
-Harding,5,Public Utilities Commissioner,,REP,Chris Nelson,42
-Harding,6,Public Utilities Commissioner,,REP,Chris Nelson,84
-Harding,7,Public Utilities Commissioner,,REP,Chris Nelson,55
-Harding,8,Public Utilities Commissioner,,REP,Chris Nelson,118
-Harding,Total,Public Utilities Commissioner,,REP,Chris Nelson,699
-Harding,1,Public Utilities Commissioner,,DEM,Henry Red Cloud,14
-Harding,2,Public Utilities Commissioner,,DEM,Henry Red Cloud,15
-Harding,3,Public Utilities Commissioner,,DEM,Henry Red Cloud,4
-Harding,4,Public Utilities Commissioner,,DEM,Henry Red Cloud,8
-Harding,5,Public Utilities Commissioner,,DEM,Henry Red Cloud,0
-Harding,6,Public Utilities Commissioner,,DEM,Henry Red Cloud,4
-Harding,7,Public Utilities Commissioner,,DEM,Henry Red Cloud,4
-Harding,8,Public Utilities Commissioner,,DEM,Henry Red Cloud,5
-Harding,Total,Public Utilities Commissioner,,DEM,Henry Red Cloud,54
-Harding,1,State Senate,28,REP,Ryan M. Maher,143
-Harding,2,State Senate,28,REP,Ryan M. Maher,108
-Harding,3,State Senate,28,REP,Ryan M. Maher,49
-Harding,4,State Senate,28,REP,Ryan M. Maher,100
-Harding,5,State Senate,28,REP,Ryan M. Maher,40
-Harding,6,State Senate,28,REP,Ryan M. Maher,85
-Harding,7,State Senate,28,REP,Ryan M. Maher,57
-Harding,8,State Senate,28,REP,Ryan M. Maher,117
-Harding,Total,State Senate,28,REP,Ryan M. Maher,699
-Harding,1,State Representative,28B,REP,Sam Marty,141
-Harding,2,State Representative,28B,REP,Sam Marty,105
-Harding,3,State Representative,28B,REP,Sam Marty,50
-Harding,4,State Representative,28B,REP,Sam Marty,98
-Harding,5,State Representative,28B,REP,Sam Marty,42
-Harding,6,State Representative,28B,REP,Sam Marty,83
-Harding,7,State Representative,28B,REP,Sam Marty,54
-Harding,8,State Representative,28B,REP,Sam Marty,116
-Harding,Total,State Representative,28B,REP,Sam Marty,689
+Hanson,1,President,,Donald J. Trump,REP,689
+Hanson,2,President,,Donald J. Trump,REP,244
+Hanson,3,President,,Donald J. Trump,REP,236
+Hanson,4,President,,Donald J. Trump,REP,230
+Hanson,5,President,,Donald J. Trump,REP,98
+Hanson,Total,President,,Donald J. Trump,REP,1497
+Hanson,1,President,,Gary Johnson,LIB,28
+Hanson,2,President,,Gary Johnson,LIB,18
+Hanson,3,President,,Gary Johnson,LIB,3
+Hanson,4,President,,Gary Johnson,LIB,9
+Hanson,5,President,,Gary Johnson,LIB,1
+Hanson,Total,President,,Gary Johnson,LIB,59
+Hanson,1,President,,Hillary Clinton,DEM,233
+Hanson,2,President,,Hillary Clinton,DEM,87
+Hanson,3,President,,Hillary Clinton,DEM,50
+Hanson,4,President,,Hillary Clinton,DEM,38
+Hanson,5,President,,Hillary Clinton,DEM,16
+Hanson,Total,President,,Hillary Clinton,DEM,424
+Hanson,1,President,,Darrell L. Castle,CON,13
+Hanson,2,President,,Darrell L. Castle,CON,2
+Hanson,3,President,,Darrell L. Castle,CON,7
+Hanson,4,President,,Darrell L. Castle,CON,4
+Hanson,5,President,,Darrell L. Castle,CON,0
+Hanson,Total,President,,Darrell L. Castle,CON,26
+Hanson,1,U.S. Senate,,John R. Thune,REP,694
+Hanson,2,U.S. Senate,,John R. Thune,REP,265
+Hanson,3,U.S. Senate,,John R. Thune,REP,232
+Hanson,4,U.S. Senate,,John R. Thune,REP,226
+Hanson,5,U.S. Senate,,John R. Thune,REP,95
+Hanson,Total,U.S. Senate,,John R. Thune,REP,1512
+Hanson,1,U.S. Senate,,Jay Williams,DEM,223
+Hanson,2,U.S. Senate,,Jay Williams,DEM,91
+Hanson,3,U.S. Senate,,Jay Williams,DEM,66
+Hanson,4,U.S. Senate,,Jay Williams,DEM,50
+Hanson,5,U.S. Senate,,Jay Williams,DEM,21
+Hanson,Total,U.S. Senate,,Jay Williams,DEM,451
+Hanson,1,U.S. House,1,Kristi Noem,REP,657
+Hanson,2,U.S. House,1,Kristi Noem,REP,246
+Hanson,3,U.S. House,1,Kristi Noem,REP,230
+Hanson,4,U.S. House,1,Kristi Noem,REP,222
+Hanson,5,U.S. House,1,Kristi Noem,REP,89
+Hanson,Total,U.S. House,1,Kristi Noem,REP,1444
+Hanson,1,U.S. House,1,Paula Hawks,DEM,258
+Hanson,2,U.S. House,1,Paula Hawks,DEM,111
+Hanson,3,U.S. House,1,Paula Hawks,DEM,69
+Hanson,4,U.S. House,1,Paula Hawks,DEM,58
+Hanson,5,U.S. House,1,Paula Hawks,DEM,29
+Hanson,Total,U.S. House,1,Paula Hawks,DEM,525
+Hanson,1,Public Utilities Commissioner,,Chris Nelson,REP,652
+Hanson,2,Public Utilities Commissioner,,Chris Nelson,REP,290
+Hanson,3,Public Utilities Commissioner,,Chris Nelson,REP,253
+Hanson,4,Public Utilities Commissioner,,Chris Nelson,REP,238
+Hanson,5,Public Utilities Commissioner,,Chris Nelson,REP,96
+Hanson,Total,Public Utilities Commissioner,,Chris Nelson,REP,1529
+Hanson,1,Public Utilities Commissioner,,Henry Red Cloud,DEM,205
+Hanson,2,Public Utilities Commissioner,,Henry Red Cloud,DEM,60
+Hanson,3,Public Utilities Commissioner,,Henry Red Cloud,DEM,38
+Hanson,4,Public Utilities Commissioner,,Henry Red Cloud,DEM,38
+Hanson,5,Public Utilities Commissioner,,Henry Red Cloud,DEM,14
+Hanson,Total,Public Utilities Commissioner,,Henry Red Cloud,DEM,355
+Hanson,1,State Senate,19,Stace Nelson,REP,672
+Hanson,2,State Senate,19,Stace Nelson,REP,282
+Hanson,3,State Senate,19,Stace Nelson,REP,265
+Hanson,4,State Senate,19,Stace Nelson,REP,241
+Hanson,5,State Senate,19,Stace Nelson,REP,105
+Hanson,Total,State Senate,19,Stace Nelson,REP,1565
+Hanson,1,State Senate,19,Russell Graeff,DEM,197
+Hanson,2,State Senate,19,Russell Graeff,DEM,74
+Hanson,3,State Senate,19,Russell Graeff,DEM,37
+Hanson,4,State Senate,19,Russell Graeff,DEM,36
+Hanson,5,State Senate,19,Russell Graeff,DEM,13
+Hanson,Total,State Senate,19,Russell Graeff,DEM,357
+Hanson,1,State House,19,Kent S. Peterson,REP,569
+Hanson,2,State House,19,Kent S. Peterson,REP,186
+Hanson,3,State House,19,Kent S. Peterson,REP,170
+Hanson,4,State House,19,Kent S. Peterson,REP,177
+Hanson,5,State House,19,Kent S. Peterson,REP,60
+Hanson,Total,State House,19,Kent S. Peterson,REP,1162
+Hanson,1,State House,19,Kyle Schoenfish,REP,521
+Hanson,2,State House,19,Kyle Schoenfish,REP,207
+Hanson,3,State House,19,Kyle Schoenfish,REP,150
+Hanson,4,State House,19,Kyle Schoenfish,REP,177
+Hanson,5,State House,19,Kyle Schoenfish,REP,60
+Hanson,Total,State House,19,Kyle Schoenfish,REP,1115
+Hanson,1,State House,19,Melissa R. Mentele,DEM,238
+Hanson,2,State House,19,Melissa R. Mentele,DEM,110
+Hanson,3,State House,19,Melissa R. Mentele,DEM,90
+Hanson,4,State House,19,Melissa R. Mentele,DEM,76
+Hanson,5,State House,19,Melissa R. Mentele,DEM,29
+Hanson,Total,State House,19,Melissa R. Mentele,DEM,543
+Harding,1,President,,Donald J. Trump,REP,140
+Harding,2,President,,Donald J. Trump,REP,110
+Harding,3,President,,Donald J. Trump,REP,48
+Harding,4,President,,Donald J. Trump,REP,101
+Harding,5,President,,Donald J. Trump,REP,42
+Harding,6,President,,Donald J. Trump,REP,81
+Harding,7,President,,Donald J. Trump,REP,55
+Harding,8,President,,Donald J. Trump,REP,118
+Harding,Total,President,,Donald J. Trump,REP,695
+Harding,1,President,,Gary Johnson,LIB,10
+Harding,2,President,,Gary Johnson,LIB,7
+Harding,3,President,,Gary Johnson,LIB,3
+Harding,4,President,,Gary Johnson,LIB,4
+Harding,5,President,,Gary Johnson,LIB,0
+Harding,6,President,,Gary Johnson,LIB,3
+Harding,7,President,,Gary Johnson,LIB,1
+Harding,8,President,,Gary Johnson,LIB,3
+Harding,Total,President,,Gary Johnson,LIB,31
+Harding,1,President,,Hillary Clinton,DEM,11
+Harding,2,President,,Hillary Clinton,DEM,4
+Harding,3,President,,Hillary Clinton,DEM,5
+Harding,4,President,,Hillary Clinton,DEM,7
+Harding,5,President,,Hillary Clinton,DEM,0
+Harding,6,President,,Hillary Clinton,DEM,5
+Harding,7,President,,Hillary Clinton,DEM,3
+Harding,8,President,,Hillary Clinton,DEM,3
+Harding,Total,President,,Hillary Clinton,DEM,38
+Harding,1,President,,Darrell L. Castle,CON,2
+Harding,2,President,,Darrell L. Castle,CON,1
+Harding,3,President,,Darrell L. Castle,CON,1
+Harding,4,President,,Darrell L. Castle,CON,0
+Harding,5,President,,Darrell L. Castle,CON,0
+Harding,6,President,,Darrell L. Castle,CON,2
+Harding,7,President,,Darrell L. Castle,CON,0
+Harding,8,President,,Darrell L. Castle,CON,0
+Harding,Total,President,,Darrell L. Castle,CON,6
+Harding,1,U.S. Senate,,John R. Thune,REP,141
+Harding,2,U.S. Senate,,John R. Thune,REP,96
+Harding,3,U.S. Senate,,John R. Thune,REP,53
+Harding,4,U.S. Senate,,John R. Thune,REP,101
+Harding,5,U.S. Senate,,John R. Thune,REP,41
+Harding,6,U.S. Senate,,John R. Thune,REP,79
+Harding,7,U.S. Senate,,John R. Thune,REP,53
+Harding,8,U.S. Senate,,John R. Thune,REP,120
+Harding,Total,U.S. Senate,,John R. Thune,REP,684
+Harding,1,U.S. Senate,,Jay Williams,DEM,18
+Harding,2,U.S. Senate,,Jay Williams,DEM,21
+Harding,3,U.S. Senate,,Jay Williams,DEM,4
+Harding,4,U.S. Senate,,Jay Williams,DEM,13
+Harding,5,U.S. Senate,,Jay Williams,DEM,0
+Harding,6,U.S. Senate,,Jay Williams,DEM,9
+Harding,7,U.S. Senate,,Jay Williams,DEM,5
+Harding,8,U.S. Senate,,Jay Williams,DEM,4
+Harding,Total,U.S. Senate,,Jay Williams,DEM,74
+Harding,1,U.S. House,1,Kristi Noem,REP,140
+Harding,2,U.S. House,1,Kristi Noem,REP,99
+Harding,3,U.S. House,1,Kristi Noem,REP,50
+Harding,4,U.S. House,1,Kristi Noem,REP,98
+Harding,5,U.S. House,1,Kristi Noem,REP,41
+Harding,6,U.S. House,1,Kristi Noem,REP,78
+Harding,7,U.S. House,1,Kristi Noem,REP,55
+Harding,8,U.S. House,1,Kristi Noem,REP,118
+Harding,Total,U.S. House,1,Kristi Noem,REP,679
+Harding,1,U.S. House,1,Paula Hawks,DEM,18
+Harding,2,U.S. House,1,Paula Hawks,DEM,21
+Harding,3,U.S. House,1,Paula Hawks,DEM,5
+Harding,4,U.S. House,1,Paula Hawks,DEM,16
+Harding,5,U.S. House,1,Paula Hawks,DEM,0
+Harding,6,U.S. House,1,Paula Hawks,DEM,11
+Harding,7,U.S. House,1,Paula Hawks,DEM,3
+Harding,8,U.S. House,1,Paula Hawks,DEM,3
+Harding,Total,U.S. House,1,Paula Hawks,DEM,77
+Harding,1,Public Utilities Commissioner,,Chris Nelson,REP,141
+Harding,2,Public Utilities Commissioner,,Chris Nelson,REP,102
+Harding,3,Public Utilities Commissioner,,Chris Nelson,REP,51
+Harding,4,Public Utilities Commissioner,,Chris Nelson,REP,106
+Harding,5,Public Utilities Commissioner,,Chris Nelson,REP,42
+Harding,6,Public Utilities Commissioner,,Chris Nelson,REP,84
+Harding,7,Public Utilities Commissioner,,Chris Nelson,REP,55
+Harding,8,Public Utilities Commissioner,,Chris Nelson,REP,118
+Harding,Total,Public Utilities Commissioner,,Chris Nelson,REP,699
+Harding,1,Public Utilities Commissioner,,Henry Red Cloud,DEM,14
+Harding,2,Public Utilities Commissioner,,Henry Red Cloud,DEM,15
+Harding,3,Public Utilities Commissioner,,Henry Red Cloud,DEM,4
+Harding,4,Public Utilities Commissioner,,Henry Red Cloud,DEM,8
+Harding,5,Public Utilities Commissioner,,Henry Red Cloud,DEM,0
+Harding,6,Public Utilities Commissioner,,Henry Red Cloud,DEM,4
+Harding,7,Public Utilities Commissioner,,Henry Red Cloud,DEM,4
+Harding,8,Public Utilities Commissioner,,Henry Red Cloud,DEM,5
+Harding,Total,Public Utilities Commissioner,,Henry Red Cloud,DEM,54
+Harding,1,State Senate,28,Ryan M. Maher,REP,143
+Harding,2,State Senate,28,Ryan M. Maher,REP,108
+Harding,3,State Senate,28,Ryan M. Maher,REP,49
+Harding,4,State Senate,28,Ryan M. Maher,REP,100
+Harding,5,State Senate,28,Ryan M. Maher,REP,40
+Harding,6,State Senate,28,Ryan M. Maher,REP,85
+Harding,7,State Senate,28,Ryan M. Maher,REP,57
+Harding,8,State Senate,28,Ryan M. Maher,REP,117
+Harding,Total,State Senate,28,Ryan M. Maher,REP,699
+Harding,1,State Representative,28B,Sam Marty,REP,141
+Harding,2,State Representative,28B,Sam Marty,REP,105
+Harding,3,State Representative,28B,Sam Marty,REP,50
+Harding,4,State Representative,28B,Sam Marty,REP,98
+Harding,5,State Representative,28B,Sam Marty,REP,42
+Harding,6,State Representative,28B,Sam Marty,REP,83
+Harding,7,State Representative,28B,Sam Marty,REP,54
+Harding,8,State Representative,28B,Sam Marty,REP,116
+Harding,Total,State Representative,28B,Sam Marty,REP,689
 Hughes,Absentee,President,,Donald J. Trump,REP,1140
 Hughes,Blunt City Hall,President,,Donald J. Trump,REP,151
 Hughes,Faith Lutheran Church,President,,Donald J. Trump,REP,1164
@@ -5423,175 +5423,175 @@ Lake,8,State Representative,8,Kory Rawstern,DEM,716
 Lake,9,State Representative,8,Kory Rawstern,DEM,150
 Lake,10,State Representative,8,Kory Rawstern,DEM,148
 Lake,TOTAL,State Representative,8,Kory Rawstern,DEM,1578
-Lawrence,Spearfish 1,President,,REP,Donald J. Trump,468
-Lawrence,Spearfish 2,President,,REP,Donald J. Trump,611
-Lawrence,Spearfish 3,President,,REP,Donald J. Trump,698
-Lawrence,Lead,President,,REP,Donald J. Trump,455
-Lawrence,Deadwood,President,,REP,Donald J. Trump,166
-Lawrence,Boxelder,President,,REP,Donald J. Trump,134
-Lawrence,Rural #1,President,,REP,Donald J. Trump,312
-Lawrence,St.Onge,President,,REP,Donald J. Trump,116
-Lawrence,Whitewood,President,,REP,Donald J. Trump,467
-Lawrence,Rural #2,President,,REP,Donald J. Trump,1015
-Lawrence,Absentee,President,,REP,Donald J. Trump,2969
-Lawrence,Provisional,President,,REP,Donald J. Trump,
-Lawrence,TOTALS,President,,REP,Donald J. Trump,7411
-Lawrence,Spearfish 1,President,,LIB,Gary Johnson,107
-Lawrence,Spearfish 2,President,,LIB,Gary Johnson,109
-Lawrence,Spearfish 3,President,,LIB,Gary Johnson,103
-Lawrence,Lead,President,,LIB,Gary Johnson,87
-Lawrence,Deadwood,President,,LIB,Gary Johnson,28
-Lawrence,Boxelder,President,,LIB,Gary Johnson,14
-Lawrence,Rural #1,President,,LIB,Gary Johnson,45
-Lawrence,St.Onge,President,,LIB,Gary Johnson,11
-Lawrence,Whitewood,President,,LIB,Gary Johnson,53
-Lawrence,Rural #2,President,,LIB,Gary Johnson,96
-Lawrence,Absentee,President,,LIB,Gary Johnson,281
-Lawrence,Provisional,President,,LIB,Gary Johnson,
-Lawrence,TOTALS,President,,LIB,Gary Johnson,934
-Lawrence,Spearfish 1,President,,DEM,Hillary Clinton,264
-Lawrence,Spearfish 2,President,,DEM,Hillary Clinton,259
-Lawrence,Spearfish 3,President,,DEM,Hillary Clinton,327
-Lawrence,Lead,President,,DEM,Hillary Clinton,237
-Lawrence,Deadwood,President,,DEM,Hillary Clinton,122
-Lawrence,Boxelder,President,,DEM,Hillary Clinton,52
-Lawrence,Rural #1,President,,DEM,Hillary Clinton,116
-Lawrence,St.Onge,President,,DEM,Hillary Clinton,26
-Lawrence,Whitewood,President,,DEM,Hillary Clinton,100
-Lawrence,Rural #2,President,,DEM,Hillary Clinton,268
-Lawrence,Absentee,President,,DEM,Hillary Clinton,1585
-Lawrence,Provisional,President,,DEM,Hillary Clinton,
-Lawrence,TOTALS,President,,DEM,Hillary Clinton,3356
-Lawrence,Spearfish 1,President,,CON,Darrell L. Castle,18
-Lawrence,Spearfish 2,President,,CON,Darrell L. Castle,20
-Lawrence,Spearfish 3,President,,CON,Darrell L. Castle,13
-Lawrence,Lead,President,,CON,Darrell L. Castle,10
-Lawrence,Deadwood,President,,CON,Darrell L. Castle,1
-Lawrence,Boxelder,President,,CON,Darrell L. Castle,3
-Lawrence,Rural #1,President,,CON,Darrell L. Castle,4
-Lawrence,St.Onge,President,,CON,Darrell L. Castle,3
-Lawrence,Whitewood,President,,CON,Darrell L. Castle,6
-Lawrence,Rural #2,President,,CON,Darrell L. Castle,22
-Lawrence,Absentee,President,,CON,Darrell L. Castle,41
-Lawrence,Provisional,President,,CON,Darrell L. Castle,
-Lawrence,TOTALS,President,,CON,Darrell L. Castle,141
-Lawrence,Spearfish 1,U.S. Senate,,REP,John R. Thune,610
-Lawrence,Spearfish 2,U.S. Senate,,REP,John R. Thune,731
-Lawrence,Spearfish 3,U.S. Senate,,REP,John R. Thune,858
-Lawrence,Lead,U.S. Senate,,REP,John R. Thune,554
-Lawrence,Deadwood,U.S. Senate,,REP,John R. Thune,201
-Lawrence,Boxelder,U.S. Senate,,REP,John R. Thune,149
-Lawrence,Rural #1,U.S. Senate,,REP,John R. Thune,378
-Lawrence,St.Onge,U.S. Senate,,REP,John R. Thune,123
-Lawrence,Whitewood,U.S. Senate,,REP,John R. Thune,497
-Lawrence,Rural #2,U.S. Senate,,REP,John R. Thune,1135
-Lawrence,Absentee,U.S. Senate,,REP,John R. Thune,3330
-Lawrence,Provisional,U.S. Senate,,REP,John R. Thune,
-Lawrence,TOTALS,U.S. Senate,,REP,John R. Thune,8566
-Lawrence,Spearfish 1,U.S. Senate,,DEM,Jay Williams,247
-Lawrence,Spearfish 2,U.S. Senate,,DEM,Jay Williams,269
-Lawrence,Spearfish 3,U.S. Senate,,DEM,Jay Williams,284
-Lawrence,Lead,U.S. Senate,,DEM,Jay Williams,239
-Lawrence,Deadwood,U.S. Senate,,DEM,Jay Williams,113
-Lawrence,Boxelder,U.S. Senate,,DEM,Jay Williams,56
-Lawrence,Rural #1,U.S. Senate,,DEM,Jay Williams,103
-Lawrence,St.Onge,U.S. Senate,,DEM,Jay Williams,30
-Lawrence,Whitewood,U.S. Senate,,DEM,Jay Williams,131
-Lawrence,Rural #2,U.S. Senate,,DEM,Jay Williams,264
-Lawrence,Absentee,U.S. Senate,,DEM,Jay Williams,1531
-Lawrence,Provisional,U.S. Senate,,DEM,Jay Williams,
-Lawrence,TOTALS,U.S. Senate,,DEM,Jay Williams,3267
-Lawrence,Spearfish 1,U.S. House,1,REP,Kristi Noem,570
-Lawrence,Spearfish 2,U.S. House,1,REP,Kristi Noem,696
-Lawrence,Spearfish 3,U.S. House,1,REP,Kristi Noem,817
-Lawrence,Lead,U.S. House,1,REP,Kristi Noem,502
-Lawrence,Deadwood,U.S. House,1,REP,Kristi Noem,180
-Lawrence,Boxelder,U.S. House,1,REP,Kristi Noem,144
-Lawrence,Rural #1,U.S. House,1,REP,Kristi Noem,352
-Lawrence,St.Onge,U.S. House,1,REP,Kristi Noem,120
-Lawrence,Whitewood,U.S. House,1,REP,Kristi Noem,469
-Lawrence,Rural #2,U.S. House,1,REP,Kristi Noem,1071
-Lawrence,Absentee,U.S. House,1,REP,Kristi Noem,3120
-Lawrence,Provisional,U.S. House,1,REP,Kristi Noem,
-Lawrence,TOTALS,U.S. House,1,REP,Kristi Noem,8041
-Lawrence,Spearfish 1,U.S. House,1,DEM,Paula Hawks,281
-Lawrence,Spearfish 2,U.S. House,1,DEM,Paula Hawks,300
-Lawrence,Spearfish 3,U.S. House,1,DEM,Paula Hawks,325
-Lawrence,Lead,U.S. House,1,DEM,Paula Hawks,288
-Lawrence,Deadwood,U.S. House,1,DEM,Paula Hawks,134
-Lawrence,Boxelder,U.S. House,1,DEM,Paula Hawks,60
-Lawrence,Rural #1,U.S. House,1,DEM,Paula Hawks,130
-Lawrence,St.Onge,U.S. House,1,DEM,Paula Hawks,32
-Lawrence,Whitewood,U.S. House,1,DEM,Paula Hawks,160
-Lawrence,Rural #2,U.S. House,1,DEM,Paula Hawks,317
-Lawrence,Absentee,U.S. House,1,DEM,Paula Hawks,1747
-Lawrence,Provisional,U.S. House,1,DEM,Paula Hawks,
-Lawrence,TOTALS,U.S. House,1,DEM,Paula Hawks,3774
-Lawrence,Spearfish 1,Public Utilities Commissioner,,REP,Chris Nelson,588
-Lawrence,Spearfish 2,Public Utilities Commissioner,,REP,Chris Nelson,704
-Lawrence,Spearfish 3,Public Utilities Commissioner,,REP,Chris Nelson,851
-Lawrence,Lead,Public Utilities Commissioner,,REP,Chris Nelson,543
-Lawrence,Deadwood,Public Utilities Commissioner,,REP,Chris Nelson,196
-Lawrence,Boxelder,Public Utilities Commissioner,,REP,Chris Nelson,134
-Lawrence,Rural #1,Public Utilities Commissioner,,REP,Chris Nelson,370
-Lawrence,St.Onge,Public Utilities Commissioner,,REP,Chris Nelson,126
-Lawrence,Whitewood,Public Utilities Commissioner,,REP,Chris Nelson,482
-Lawrence,Rural #2,Public Utilities Commissioner,,REP,Chris Nelson,1115
-Lawrence,Absentee,Public Utilities Commissioner,,REP,Chris Nelson,3402
-Lawrence,Provisional,Public Utilities Commissioner,,REP,Chris Nelson,
-Lawrence,TOTALS,Public Utilities Commissioner,,REP,Chris Nelson,8511
-Lawrence,Spearfish 1,Public Utilities Commissioner,,DEM,Henry Red Cloud,239
-Lawrence,Spearfish 2,Public Utilities Commissioner,,DEM,Henry Red Cloud,255
-Lawrence,Spearfish 3,Public Utilities Commissioner,,DEM,Henry Red Cloud,258
-Lawrence,Lead,Public Utilities Commissioner,,DEM,Henry Red Cloud,218
-Lawrence,Deadwood,Public Utilities Commissioner,,DEM,Henry Red Cloud,117
-Lawrence,Boxelder,Public Utilities Commissioner,,DEM,Henry Red Cloud,66
-Lawrence,Rural #1,Public Utilities Commissioner,,DEM,Henry Red Cloud,100
-Lawrence,St.Onge,Public Utilities Commissioner,,DEM,Henry Red Cloud,30
-Lawrence,Whitewood,Public Utilities Commissioner,,DEM,Henry Red Cloud,130
-Lawrence,Rural #2,Public Utilities Commissioner,,DEM,Henry Red Cloud,260
-Lawrence,Absentee,Public Utilities Commissioner,,DEM,Henry Red Cloud,1316
-Lawrence,Provisional,Public Utilities Commissioner,,DEM,Henry Red Cloud,
-Lawrence,TOTALS,Public Utilities Commissioner,,DEM,Henry Red Cloud,2989
-Lawrence,Spearfish 1,State Senate,31,REP,Bob Ewing,636
-Lawrence,Spearfish 2,State Senate,31,REP,Bob Ewing,744
-Lawrence,Spearfish 3,State Senate,31,REP,Bob Ewing,886
-Lawrence,Lead,State Senate,31,REP,Bob Ewing,550
-Lawrence,Deadwood,State Senate,31,REP,Bob Ewing,217
-Lawrence,Boxelder,State Senate,31,REP,Bob Ewing,146
-Lawrence,Rural #1,State Senate,31,REP,Bob Ewing,352
-Lawrence,St.Onge,State Senate,31,REP,Bob Ewing,130
-Lawrence,Whitewood,State Senate,31,REP,Bob Ewing,478
-Lawrence,Rural #2,State Senate,31,REP,Bob Ewing,1158
-Lawrence,Absentee,State Senate,31,REP,Bob Ewing,3384
-Lawrence,Provisional,State Senate,31,REP,Bob Ewing,
-Lawrence,TOTALS,State Senate,31,REP,Bob Ewing,8681
-Lawrence,Spearfish 1,State House,31,REP,Timothy R. Johns,460
-Lawrence,Spearfish 2,State House,31,REP,Timothy R. Johns,607
-Lawrence,Spearfish 3,State House,31,REP,Timothy R. Johns,690
-Lawrence,Lead,State House,31,REP,Timothy R. Johns,529
-Lawrence,Deadwood,State House,31,REP,Timothy R. Johns,198
-Lawrence,Boxelder,State House,31,REP,Timothy R. Johns,123
-Lawrence,Rural #1,State House,31,REP,Timothy R. Johns,306
-Lawrence,St.Onge,State House,31,REP,Timothy R. Johns,96
-Lawrence,Whitewood,State House,31,REP,Timothy R. Johns,373
-Lawrence,Rural #2,State House,31,REP,Timothy R. Johns,915
-Lawrence,Absentee,State House,31,REP,Timothy R. Johns,3062
-Lawrence,Provisional,State House,31,REP,Timothy R. Johns,
-Lawrence,TOTALS,State House,31,REP,Timothy R. Johns,7359
-Lawrence,Spearfish 1,State House,31,REP,Charles M. Turbiville,452
-Lawrence,Spearfish 2,State House,31,REP,Charles M. Turbiville,519
-Lawrence,Spearfish 3,State House,31,REP,Charles M. Turbiville,640
-Lawrence,Lead,State House,31,REP,Charles M. Turbiville,393
-Lawrence,Deadwood,State House,31,REP,Charles M. Turbiville,161
-Lawrence,Boxelder,State House,31,REP,Charles M. Turbiville,91
-Lawrence,Rural #1,State House,31,REP,Charles M. Turbiville,247
-Lawrence,St.Onge,State House,31,REP,Charles M. Turbiville,88
-Lawrence,Whitewood,State House,31,REP,Charles M. Turbiville,342
-Lawrence,Rural #2,State House,31,REP,Charles M. Turbiville,811
-Lawrence,Absentee,State House,31,REP,Charles M. Turbiville,2392
-Lawrence,Provisional,State House,31,REP,Charles M. Turbiville,
-Lawrence,TOTALS,State House,31,REP,Charles M. Turbiville,6136
+Lawrence,Spearfish 1,President,,Donald J. Trump,REP,468
+Lawrence,Spearfish 2,President,,Donald J. Trump,REP,611
+Lawrence,Spearfish 3,President,,Donald J. Trump,REP,698
+Lawrence,Lead,President,,Donald J. Trump,REP,455
+Lawrence,Deadwood,President,,Donald J. Trump,REP,166
+Lawrence,Boxelder,President,,Donald J. Trump,REP,134
+Lawrence,Rural #1,President,,Donald J. Trump,REP,312
+Lawrence,St.Onge,President,,Donald J. Trump,REP,116
+Lawrence,Whitewood,President,,Donald J. Trump,REP,467
+Lawrence,Rural #2,President,,Donald J. Trump,REP,1015
+Lawrence,Absentee,President,,Donald J. Trump,REP,2969
+Lawrence,Provisional,President,,Donald J. Trump,REP,
+Lawrence,TOTALS,President,,Donald J. Trump,REP,7411
+Lawrence,Spearfish 1,President,,Gary Johnson,LIB,107
+Lawrence,Spearfish 2,President,,Gary Johnson,LIB,109
+Lawrence,Spearfish 3,President,,Gary Johnson,LIB,103
+Lawrence,Lead,President,,Gary Johnson,LIB,87
+Lawrence,Deadwood,President,,Gary Johnson,LIB,28
+Lawrence,Boxelder,President,,Gary Johnson,LIB,14
+Lawrence,Rural #1,President,,Gary Johnson,LIB,45
+Lawrence,St.Onge,President,,Gary Johnson,LIB,11
+Lawrence,Whitewood,President,,Gary Johnson,LIB,53
+Lawrence,Rural #2,President,,Gary Johnson,LIB,96
+Lawrence,Absentee,President,,Gary Johnson,LIB,281
+Lawrence,Provisional,President,,Gary Johnson,LIB,
+Lawrence,TOTALS,President,,Gary Johnson,LIB,934
+Lawrence,Spearfish 1,President,,Hillary Clinton,DEM,264
+Lawrence,Spearfish 2,President,,Hillary Clinton,DEM,259
+Lawrence,Spearfish 3,President,,Hillary Clinton,DEM,327
+Lawrence,Lead,President,,Hillary Clinton,DEM,237
+Lawrence,Deadwood,President,,Hillary Clinton,DEM,122
+Lawrence,Boxelder,President,,Hillary Clinton,DEM,52
+Lawrence,Rural #1,President,,Hillary Clinton,DEM,116
+Lawrence,St.Onge,President,,Hillary Clinton,DEM,26
+Lawrence,Whitewood,President,,Hillary Clinton,DEM,100
+Lawrence,Rural #2,President,,Hillary Clinton,DEM,268
+Lawrence,Absentee,President,,Hillary Clinton,DEM,1585
+Lawrence,Provisional,President,,Hillary Clinton,DEM,
+Lawrence,TOTALS,President,,Hillary Clinton,DEM,3356
+Lawrence,Spearfish 1,President,,Darrell L. Castle,CON,18
+Lawrence,Spearfish 2,President,,Darrell L. Castle,CON,20
+Lawrence,Spearfish 3,President,,Darrell L. Castle,CON,13
+Lawrence,Lead,President,,Darrell L. Castle,CON,10
+Lawrence,Deadwood,President,,Darrell L. Castle,CON,1
+Lawrence,Boxelder,President,,Darrell L. Castle,CON,3
+Lawrence,Rural #1,President,,Darrell L. Castle,CON,4
+Lawrence,St.Onge,President,,Darrell L. Castle,CON,3
+Lawrence,Whitewood,President,,Darrell L. Castle,CON,6
+Lawrence,Rural #2,President,,Darrell L. Castle,CON,22
+Lawrence,Absentee,President,,Darrell L. Castle,CON,41
+Lawrence,Provisional,President,,Darrell L. Castle,CON,
+Lawrence,TOTALS,President,,Darrell L. Castle,CON,141
+Lawrence,Spearfish 1,U.S. Senate,,John R. Thune,REP,610
+Lawrence,Spearfish 2,U.S. Senate,,John R. Thune,REP,731
+Lawrence,Spearfish 3,U.S. Senate,,John R. Thune,REP,858
+Lawrence,Lead,U.S. Senate,,John R. Thune,REP,554
+Lawrence,Deadwood,U.S. Senate,,John R. Thune,REP,201
+Lawrence,Boxelder,U.S. Senate,,John R. Thune,REP,149
+Lawrence,Rural #1,U.S. Senate,,John R. Thune,REP,378
+Lawrence,St.Onge,U.S. Senate,,John R. Thune,REP,123
+Lawrence,Whitewood,U.S. Senate,,John R. Thune,REP,497
+Lawrence,Rural #2,U.S. Senate,,John R. Thune,REP,1135
+Lawrence,Absentee,U.S. Senate,,John R. Thune,REP,3330
+Lawrence,Provisional,U.S. Senate,,John R. Thune,REP,
+Lawrence,TOTALS,U.S. Senate,,John R. Thune,REP,8566
+Lawrence,Spearfish 1,U.S. Senate,,Jay Williams,DEM,247
+Lawrence,Spearfish 2,U.S. Senate,,Jay Williams,DEM,269
+Lawrence,Spearfish 3,U.S. Senate,,Jay Williams,DEM,284
+Lawrence,Lead,U.S. Senate,,Jay Williams,DEM,239
+Lawrence,Deadwood,U.S. Senate,,Jay Williams,DEM,113
+Lawrence,Boxelder,U.S. Senate,,Jay Williams,DEM,56
+Lawrence,Rural #1,U.S. Senate,,Jay Williams,DEM,103
+Lawrence,St.Onge,U.S. Senate,,Jay Williams,DEM,30
+Lawrence,Whitewood,U.S. Senate,,Jay Williams,DEM,131
+Lawrence,Rural #2,U.S. Senate,,Jay Williams,DEM,264
+Lawrence,Absentee,U.S. Senate,,Jay Williams,DEM,1531
+Lawrence,Provisional,U.S. Senate,,Jay Williams,DEM,
+Lawrence,TOTALS,U.S. Senate,,Jay Williams,DEM,3267
+Lawrence,Spearfish 1,U.S. House,1,Kristi Noem,REP,570
+Lawrence,Spearfish 2,U.S. House,1,Kristi Noem,REP,696
+Lawrence,Spearfish 3,U.S. House,1,Kristi Noem,REP,817
+Lawrence,Lead,U.S. House,1,Kristi Noem,REP,502
+Lawrence,Deadwood,U.S. House,1,Kristi Noem,REP,180
+Lawrence,Boxelder,U.S. House,1,Kristi Noem,REP,144
+Lawrence,Rural #1,U.S. House,1,Kristi Noem,REP,352
+Lawrence,St.Onge,U.S. House,1,Kristi Noem,REP,120
+Lawrence,Whitewood,U.S. House,1,Kristi Noem,REP,469
+Lawrence,Rural #2,U.S. House,1,Kristi Noem,REP,1071
+Lawrence,Absentee,U.S. House,1,Kristi Noem,REP,3120
+Lawrence,Provisional,U.S. House,1,Kristi Noem,REP,
+Lawrence,TOTALS,U.S. House,1,Kristi Noem,REP,8041
+Lawrence,Spearfish 1,U.S. House,1,Paula Hawks,DEM,281
+Lawrence,Spearfish 2,U.S. House,1,Paula Hawks,DEM,300
+Lawrence,Spearfish 3,U.S. House,1,Paula Hawks,DEM,325
+Lawrence,Lead,U.S. House,1,Paula Hawks,DEM,288
+Lawrence,Deadwood,U.S. House,1,Paula Hawks,DEM,134
+Lawrence,Boxelder,U.S. House,1,Paula Hawks,DEM,60
+Lawrence,Rural #1,U.S. House,1,Paula Hawks,DEM,130
+Lawrence,St.Onge,U.S. House,1,Paula Hawks,DEM,32
+Lawrence,Whitewood,U.S. House,1,Paula Hawks,DEM,160
+Lawrence,Rural #2,U.S. House,1,Paula Hawks,DEM,317
+Lawrence,Absentee,U.S. House,1,Paula Hawks,DEM,1747
+Lawrence,Provisional,U.S. House,1,Paula Hawks,DEM,
+Lawrence,TOTALS,U.S. House,1,Paula Hawks,DEM,3774
+Lawrence,Spearfish 1,Public Utilities Commissioner,,Chris Nelson,REP,588
+Lawrence,Spearfish 2,Public Utilities Commissioner,,Chris Nelson,REP,704
+Lawrence,Spearfish 3,Public Utilities Commissioner,,Chris Nelson,REP,851
+Lawrence,Lead,Public Utilities Commissioner,,Chris Nelson,REP,543
+Lawrence,Deadwood,Public Utilities Commissioner,,Chris Nelson,REP,196
+Lawrence,Boxelder,Public Utilities Commissioner,,Chris Nelson,REP,134
+Lawrence,Rural #1,Public Utilities Commissioner,,Chris Nelson,REP,370
+Lawrence,St.Onge,Public Utilities Commissioner,,Chris Nelson,REP,126
+Lawrence,Whitewood,Public Utilities Commissioner,,Chris Nelson,REP,482
+Lawrence,Rural #2,Public Utilities Commissioner,,Chris Nelson,REP,1115
+Lawrence,Absentee,Public Utilities Commissioner,,Chris Nelson,REP,3402
+Lawrence,Provisional,Public Utilities Commissioner,,Chris Nelson,REP,
+Lawrence,TOTALS,Public Utilities Commissioner,,Chris Nelson,REP,8511
+Lawrence,Spearfish 1,Public Utilities Commissioner,,Henry Red Cloud,DEM,239
+Lawrence,Spearfish 2,Public Utilities Commissioner,,Henry Red Cloud,DEM,255
+Lawrence,Spearfish 3,Public Utilities Commissioner,,Henry Red Cloud,DEM,258
+Lawrence,Lead,Public Utilities Commissioner,,Henry Red Cloud,DEM,218
+Lawrence,Deadwood,Public Utilities Commissioner,,Henry Red Cloud,DEM,117
+Lawrence,Boxelder,Public Utilities Commissioner,,Henry Red Cloud,DEM,66
+Lawrence,Rural #1,Public Utilities Commissioner,,Henry Red Cloud,DEM,100
+Lawrence,St.Onge,Public Utilities Commissioner,,Henry Red Cloud,DEM,30
+Lawrence,Whitewood,Public Utilities Commissioner,,Henry Red Cloud,DEM,130
+Lawrence,Rural #2,Public Utilities Commissioner,,Henry Red Cloud,DEM,260
+Lawrence,Absentee,Public Utilities Commissioner,,Henry Red Cloud,DEM,1316
+Lawrence,Provisional,Public Utilities Commissioner,,Henry Red Cloud,DEM,
+Lawrence,TOTALS,Public Utilities Commissioner,,Henry Red Cloud,DEM,2989
+Lawrence,Spearfish 1,State Senate,31,Bob Ewing,REP,636
+Lawrence,Spearfish 2,State Senate,31,Bob Ewing,REP,744
+Lawrence,Spearfish 3,State Senate,31,Bob Ewing,REP,886
+Lawrence,Lead,State Senate,31,Bob Ewing,REP,550
+Lawrence,Deadwood,State Senate,31,Bob Ewing,REP,217
+Lawrence,Boxelder,State Senate,31,Bob Ewing,REP,146
+Lawrence,Rural #1,State Senate,31,Bob Ewing,REP,352
+Lawrence,St.Onge,State Senate,31,Bob Ewing,REP,130
+Lawrence,Whitewood,State Senate,31,Bob Ewing,REP,478
+Lawrence,Rural #2,State Senate,31,Bob Ewing,REP,1158
+Lawrence,Absentee,State Senate,31,Bob Ewing,REP,3384
+Lawrence,Provisional,State Senate,31,Bob Ewing,REP,
+Lawrence,TOTALS,State Senate,31,Bob Ewing,REP,8681
+Lawrence,Spearfish 1,State House,31,Timothy R. Johns,REP,460
+Lawrence,Spearfish 2,State House,31,Timothy R. Johns,REP,607
+Lawrence,Spearfish 3,State House,31,Timothy R. Johns,REP,690
+Lawrence,Lead,State House,31,Timothy R. Johns,REP,529
+Lawrence,Deadwood,State House,31,Timothy R. Johns,REP,198
+Lawrence,Boxelder,State House,31,Timothy R. Johns,REP,123
+Lawrence,Rural #1,State House,31,Timothy R. Johns,REP,306
+Lawrence,St.Onge,State House,31,Timothy R. Johns,REP,96
+Lawrence,Whitewood,State House,31,Timothy R. Johns,REP,373
+Lawrence,Rural #2,State House,31,Timothy R. Johns,REP,915
+Lawrence,Absentee,State House,31,Timothy R. Johns,REP,3062
+Lawrence,Provisional,State House,31,Timothy R. Johns,REP,
+Lawrence,TOTALS,State House,31,Timothy R. Johns,REP,7359
+Lawrence,Spearfish 1,State House,31,Charles M. Turbiville,REP,452
+Lawrence,Spearfish 2,State House,31,Charles M. Turbiville,REP,519
+Lawrence,Spearfish 3,State House,31,Charles M. Turbiville,REP,640
+Lawrence,Lead,State House,31,Charles M. Turbiville,REP,393
+Lawrence,Deadwood,State House,31,Charles M. Turbiville,REP,161
+Lawrence,Boxelder,State House,31,Charles M. Turbiville,REP,91
+Lawrence,Rural #1,State House,31,Charles M. Turbiville,REP,247
+Lawrence,St.Onge,State House,31,Charles M. Turbiville,REP,88
+Lawrence,Whitewood,State House,31,Charles M. Turbiville,REP,342
+Lawrence,Rural #2,State House,31,Charles M. Turbiville,REP,811
+Lawrence,Absentee,State House,31,Charles M. Turbiville,REP,2392
+Lawrence,Provisional,State House,31,Charles M. Turbiville,REP,
+Lawrence,TOTALS,State House,31,Charles M. Turbiville,REP,6136
 Lincoln,02-Norway & Fairview,President,,Donald J. Trump,REP,187
 Lincoln,06-Highland & Canton,President,,Donald J. Trump,REP,315
 Lincoln,08-Lincoln & Delaware,President,,Donald J. Trump,REP,145
@@ -6130,102 +6130,102 @@ Lincoln,26-Brooklyn & Pleasant,State Representative,16,Ann Tornberg,DEM,198
 Lincoln,29-Harrisburg 2,State Representative,16,Ann Tornberg,DEM,0
 Lincoln,30-Canton 4 & 5,State Representative,16,Ann Tornberg,DEM,203
 Lincoln,TOTAL,State Representative,16,Ann Tornberg,DEM,1556
-Lyman,Total,President,,REP,Donald J. Trump,977
-Lyman,Iona,President,,REP,Donald J. Trump,58
-Lyman,Oacoma,President,,REP,Donald J. Trump,216
-Lyman,Reliance,President,,REP,Donald J. Trump,100
-Lyman,Lower Brule,President,,REP,Donald J. Trump,15
-Lyman,Kennebec,President,,REP,Donald J. Trump,213
-Lyman,Presho,President,,REP,Donald J. Trump,293
-Lyman,Vivian,President,,REP,Donald J. Trump,82
-Lyman,Total,President,,LIB,Gary Johnson,56
-Lyman,Iona,President,,LIB,Gary Johnson,3
-Lyman,Oacoma,President,,LIB,Gary Johnson,10
-Lyman,Reliance,President,,LIB,Gary Johnson,2
-Lyman,Lower Brule,President,,LIB,Gary Johnson,7
-Lyman,Kennebec,President,,LIB,Gary Johnson,14
-Lyman,Presho,President,,LIB,Gary Johnson,17
-Lyman,Vivian,President,,LIB,Gary Johnson,3
-Lyman,Total,President,,DEM,Hillary Clinton,369
-Lyman,Iona,President,,DEM,Hillary Clinton,6
-Lyman,Oacoma,President,,DEM,Hillary Clinton,92
-Lyman,Reliance,President,,DEM,Hillary Clinton,33
-Lyman,Lower Brule,President,,DEM,Hillary Clinton,143
-Lyman,Kennebec,President,,DEM,Hillary Clinton,22
-Lyman,Presho,President,,DEM,Hillary Clinton,60
-Lyman,Vivian,President,,DEM,Hillary Clinton,13
-Lyman,Total,President,,CON,Darrell L. Castle,19
-Lyman,Iona,President,,CON,Darrell L. Castle,1
-Lyman,Oacoma,President,,CON,Darrell L. Castle,3
-Lyman,Reliance,President,,CON,Darrell L. Castle,3
-Lyman,Lower Brule,President,,CON,Darrell L. Castle,6
-Lyman,Kennebec,President,,CON,Darrell L. Castle,2
-Lyman,Presho,President,,CON,Darrell L. Castle,3
-Lyman,Vivian,President,,CON,Darrell L. Castle,1
-Lyman,Total,U.S. Senate,,REP,John R. Thune,1051
-Lyman,Iona,U.S. Senate,,REP,John R. Thune,48
-Lyman,Oacoma,U.S. Senate,,REP,John R. Thune,232
-Lyman,Reliance,U.S. Senate,,REP,John R. Thune,109
-Lyman,Lower Brule,U.S. Senate,,REP,John R. Thune,48
-Lyman,Kennebec,U.S. Senate,,REP,John R. Thune,217
-Lyman,Presho,U.S. Senate,,REP,John R. Thune,311
-Lyman,Vivian,U.S. Senate,,REP,John R. Thune,86
-Lyman,Total,U.S. Senate,,DEM,Jay Williams,378
-Lyman,Iona,U.S. Senate,,DEM,Jay Williams,20
-Lyman,Oacoma,U.S. Senate,,DEM,Jay Williams,86
-Lyman,Reliance,U.S. Senate,,DEM,Jay Williams,31
-Lyman,Lower Brule,U.S. Senate,,DEM,Jay Williams,125
-Lyman,Kennebec,U.S. Senate,,DEM,Jay Williams,30
-Lyman,Presho,U.S. Senate,,DEM,Jay Williams,70
-Lyman,Vivian,U.S. Senate,,DEM,Jay Williams,16
-Lyman,Total,U.S. House,1,REP,Kristi Noem,948
-Lyman,Iona,U.S. House,1,REP,Kristi Noem,45
-Lyman,Oacoma,U.S. House,1,REP,Kristi Noem,209
-Lyman,Reliance,U.S. House,1,REP,Kristi Noem,99
-Lyman,Lower Brule,U.S. House,1,REP,Kristi Noem,31
-Lyman,Kennebec,U.S. House,1,REP,Kristi Noem,207
-Lyman,Presho,U.S. House,1,REP,Kristi Noem,280
-Lyman,Vivian,U.S. House,1,REP,Kristi Noem,77
-Lyman,Total,U.S. House,1,DEM,Paula Hawks,487
-Lyman,Iona,U.S. House,1,DEM,Paula Hawks,22
-Lyman,Oacoma,U.S. House,1,DEM,Paula Hawks,114
-Lyman,Reliance,U.S. House,1,DEM,Paula Hawks,41
-Lyman,Lower Brule,U.S. House,1,DEM,Paula Hawks,143
-Lyman,Kennebec,U.S. House,1,DEM,Paula Hawks,44
-Lyman,Presho,U.S. House,1,DEM,Paula Hawks,100
-Lyman,Vivian,U.S. House,1,DEM,Paula Hawks,23
-Lyman,Total,Public Utilities Commissioner,,REP,Chris Nelson,1049
-Lyman,Iona,Public Utilities Commissioner,,REP,Chris Nelson,48
-Lyman,Oacoma,Public Utilities Commissioner,,REP,Chris Nelson,252
-Lyman,Reliance,Public Utilities Commissioner,,REP,Chris Nelson,111
-Lyman,Lower Brule,Public Utilities Commissioner,,REP,Chris Nelson,12
-Lyman,Kennebec,Public Utilities Commissioner,,REP,Chris Nelson,225
-Lyman,Presho,Public Utilities Commissioner,,REP,Chris Nelson,318
-Lyman,Vivian,Public Utilities Commissioner,,REP,Chris Nelson,83
-Lyman,Total,Public Utilities Commissioner,,DEM,Henry Red Cloud,338
-Lyman,Iona,Public Utilities Commissioner,,DEM,Henry Red Cloud,15
-Lyman,Oacoma,Public Utilities Commissioner,,DEM,Henry Red Cloud,63
-Lyman,Reliance,Public Utilities Commissioner,,DEM,Henry Red Cloud,25
-Lyman,Lower Brule,Public Utilities Commissioner,,DEM,Henry Red Cloud,157
-Lyman,Kennebec,Public Utilities Commissioner,,DEM,Henry Red Cloud,20
-Lyman,Presho,Public Utilities Commissioner,,DEM,Henry Red Cloud,48
-Lyman,Vivian,Public Utilities Commissioner,,DEM,Henry Red Cloud,10
-Lyman,Total,State Senate,26,REP,Troy Heinert,748
-Lyman,Iona,State Senate,26,REP,Troy Heinert,33
-Lyman,Oacoma,State Senate,26,REP,Troy Heinert,164
-Lyman,Reliance,State Senate,26,REP,Troy Heinert,77
-Lyman,Lower Brule,State Senate,26,REP,Troy Heinert,138
-Lyman,Kennebec,State Senate,26,REP,Troy Heinert,106
-Lyman,Presho,State Senate,26,REP,Troy Heinert,189
-Lyman,Vivian,State Senate,26,REP,Troy Heinert,41
-Lyman,Total,State Representative,26B,REP,James Schaefer,1093
-Lyman,Iona,State Representative,26B,REP,James Schaefer,47
-Lyman,Oacoma,State Representative,26B,REP,James Schaefer,248
-Lyman,Reliance,State Representative,26B,REP,James Schaefer,116
-Lyman,Lower Brule,State Representative,26B,REP,James Schaefer,63
-Lyman,Kennebec,State Representative,26B,REP,James Schaefer,214
-Lyman,Presho,State Representative,26B,REP,James Schaefer,319
-Lyman,Vivian,State Representative,26B,REP,James Schaefer,86
+Lyman,Total,President,,Donald J. Trump,REP,977
+Lyman,Iona,President,,Donald J. Trump,REP,58
+Lyman,Oacoma,President,,Donald J. Trump,REP,216
+Lyman,Reliance,President,,Donald J. Trump,REP,100
+Lyman,Lower Brule,President,,Donald J. Trump,REP,15
+Lyman,Kennebec,President,,Donald J. Trump,REP,213
+Lyman,Presho,President,,Donald J. Trump,REP,293
+Lyman,Vivian,President,,Donald J. Trump,REP,82
+Lyman,Total,President,,Gary Johnson,LIB,56
+Lyman,Iona,President,,Gary Johnson,LIB,3
+Lyman,Oacoma,President,,Gary Johnson,LIB,10
+Lyman,Reliance,President,,Gary Johnson,LIB,2
+Lyman,Lower Brule,President,,Gary Johnson,LIB,7
+Lyman,Kennebec,President,,Gary Johnson,LIB,14
+Lyman,Presho,President,,Gary Johnson,LIB,17
+Lyman,Vivian,President,,Gary Johnson,LIB,3
+Lyman,Total,President,,Hillary Clinton,DEM,369
+Lyman,Iona,President,,Hillary Clinton,DEM,6
+Lyman,Oacoma,President,,Hillary Clinton,DEM,92
+Lyman,Reliance,President,,Hillary Clinton,DEM,33
+Lyman,Lower Brule,President,,Hillary Clinton,DEM,143
+Lyman,Kennebec,President,,Hillary Clinton,DEM,22
+Lyman,Presho,President,,Hillary Clinton,DEM,60
+Lyman,Vivian,President,,Hillary Clinton,DEM,13
+Lyman,Total,President,,Darrell L. Castle,CON,19
+Lyman,Iona,President,,Darrell L. Castle,CON,1
+Lyman,Oacoma,President,,Darrell L. Castle,CON,3
+Lyman,Reliance,President,,Darrell L. Castle,CON,3
+Lyman,Lower Brule,President,,Darrell L. Castle,CON,6
+Lyman,Kennebec,President,,Darrell L. Castle,CON,2
+Lyman,Presho,President,,Darrell L. Castle,CON,3
+Lyman,Vivian,President,,Darrell L. Castle,CON,1
+Lyman,Total,U.S. Senate,,John R. Thune,REP,1051
+Lyman,Iona,U.S. Senate,,John R. Thune,REP,48
+Lyman,Oacoma,U.S. Senate,,John R. Thune,REP,232
+Lyman,Reliance,U.S. Senate,,John R. Thune,REP,109
+Lyman,Lower Brule,U.S. Senate,,John R. Thune,REP,48
+Lyman,Kennebec,U.S. Senate,,John R. Thune,REP,217
+Lyman,Presho,U.S. Senate,,John R. Thune,REP,311
+Lyman,Vivian,U.S. Senate,,John R. Thune,REP,86
+Lyman,Total,U.S. Senate,,Jay Williams,DEM,378
+Lyman,Iona,U.S. Senate,,Jay Williams,DEM,20
+Lyman,Oacoma,U.S. Senate,,Jay Williams,DEM,86
+Lyman,Reliance,U.S. Senate,,Jay Williams,DEM,31
+Lyman,Lower Brule,U.S. Senate,,Jay Williams,DEM,125
+Lyman,Kennebec,U.S. Senate,,Jay Williams,DEM,30
+Lyman,Presho,U.S. Senate,,Jay Williams,DEM,70
+Lyman,Vivian,U.S. Senate,,Jay Williams,DEM,16
+Lyman,Total,U.S. House,1,Kristi Noem,REP,948
+Lyman,Iona,U.S. House,1,Kristi Noem,REP,45
+Lyman,Oacoma,U.S. House,1,Kristi Noem,REP,209
+Lyman,Reliance,U.S. House,1,Kristi Noem,REP,99
+Lyman,Lower Brule,U.S. House,1,Kristi Noem,REP,31
+Lyman,Kennebec,U.S. House,1,Kristi Noem,REP,207
+Lyman,Presho,U.S. House,1,Kristi Noem,REP,280
+Lyman,Vivian,U.S. House,1,Kristi Noem,REP,77
+Lyman,Total,U.S. House,1,Paula Hawks,DEM,487
+Lyman,Iona,U.S. House,1,Paula Hawks,DEM,22
+Lyman,Oacoma,U.S. House,1,Paula Hawks,DEM,114
+Lyman,Reliance,U.S. House,1,Paula Hawks,DEM,41
+Lyman,Lower Brule,U.S. House,1,Paula Hawks,DEM,143
+Lyman,Kennebec,U.S. House,1,Paula Hawks,DEM,44
+Lyman,Presho,U.S. House,1,Paula Hawks,DEM,100
+Lyman,Vivian,U.S. House,1,Paula Hawks,DEM,23
+Lyman,Total,Public Utilities Commissioner,,Chris Nelson,REP,1049
+Lyman,Iona,Public Utilities Commissioner,,Chris Nelson,REP,48
+Lyman,Oacoma,Public Utilities Commissioner,,Chris Nelson,REP,252
+Lyman,Reliance,Public Utilities Commissioner,,Chris Nelson,REP,111
+Lyman,Lower Brule,Public Utilities Commissioner,,Chris Nelson,REP,12
+Lyman,Kennebec,Public Utilities Commissioner,,Chris Nelson,REP,225
+Lyman,Presho,Public Utilities Commissioner,,Chris Nelson,REP,318
+Lyman,Vivian,Public Utilities Commissioner,,Chris Nelson,REP,83
+Lyman,Total,Public Utilities Commissioner,,Henry Red Cloud,DEM,338
+Lyman,Iona,Public Utilities Commissioner,,Henry Red Cloud,DEM,15
+Lyman,Oacoma,Public Utilities Commissioner,,Henry Red Cloud,DEM,63
+Lyman,Reliance,Public Utilities Commissioner,,Henry Red Cloud,DEM,25
+Lyman,Lower Brule,Public Utilities Commissioner,,Henry Red Cloud,DEM,157
+Lyman,Kennebec,Public Utilities Commissioner,,Henry Red Cloud,DEM,20
+Lyman,Presho,Public Utilities Commissioner,,Henry Red Cloud,DEM,48
+Lyman,Vivian,Public Utilities Commissioner,,Henry Red Cloud,DEM,10
+Lyman,Total,State Senate,26,Troy Heinert,REP,748
+Lyman,Iona,State Senate,26,Troy Heinert,REP,33
+Lyman,Oacoma,State Senate,26,Troy Heinert,REP,164
+Lyman,Reliance,State Senate,26,Troy Heinert,REP,77
+Lyman,Lower Brule,State Senate,26,Troy Heinert,REP,138
+Lyman,Kennebec,State Senate,26,Troy Heinert,REP,106
+Lyman,Presho,State Senate,26,Troy Heinert,REP,189
+Lyman,Vivian,State Senate,26,Troy Heinert,REP,41
+Lyman,Total,State Representative,26B,James Schaefer,REP,1093
+Lyman,Iona,State Representative,26B,James Schaefer,REP,47
+Lyman,Oacoma,State Representative,26B,James Schaefer,REP,248
+Lyman,Reliance,State Representative,26B,James Schaefer,REP,116
+Lyman,Lower Brule,State Representative,26B,James Schaefer,REP,63
+Lyman,Kennebec,State Representative,26B,James Schaefer,REP,214
+Lyman,Presho,State Representative,26B,James Schaefer,REP,319
+Lyman,Vivian,State Representative,26B,James Schaefer,REP,86
 Marshall,A1,President,,Donald J. Trump,REP,122
 Marshall,A2,President,,Donald J. Trump,REP,78
 Marshall,A3,President,,Donald J. Trump,REP,156
@@ -6356,202 +6356,202 @@ Marshall,A7,State Representative,1,Susan Wismer,DEM,97
 Marshall,A8,State Representative,1,Susan Wismer,DEM,153
 Marshall,A9,State Representative,1,Susan Wismer,DEM,121
 Marshall,TOTAL,State Representative,1,Susan Wismer,DEM,1301
-McCook,1,President,,REP,Donald J. Trump,322
-McCook,2,President,,REP,Donald J. Trump,102
-McCook,3,President,,REP,Donald J. Trump,383
-McCook,4,President,,REP,Donald J. Trump,379
-McCook,5,President,,REP,Donald J. Trump,377
-McCook,6,President,,REP,Donald J. Trump,231
-McCook,Total,President,,REP,Donald J. Trump,1794
-McCook,1,President,,LIB,Gary Johnson,30
-McCook,2,President,,LIB,Gary Johnson,2
-McCook,3,President,,LIB,Gary Johnson,23
-McCook,4,President,,LIB,Gary Johnson,16
-McCook,5,President,,LIB,Gary Johnson,34
-McCook,6,President,,LIB,Gary Johnson,25
-McCook,Total,President,,LIB,Gary Johnson,130
-McCook,1,President,,DEM,Hillary Clinton,150
-McCook,2,President,,DEM,Hillary Clinton,42
-McCook,3,President,,DEM,Hillary Clinton,126
-McCook,4,President,,DEM,Hillary Clinton,67
-McCook,5,President,,DEM,Hillary Clinton,180
-McCook,6,President,,DEM,Hillary Clinton,58
-McCook,Total,President,,DEM,Hillary Clinton,623
-McCook,1,President,,CON,Darrell L. Castle,6
-McCook,2,President,,CON,Darrell L. Castle,1
-McCook,3,President,,CON,Darrell L. Castle,13
-McCook,4,President,,CON,Darrell L. Castle,3
-McCook,5,President,,CON,Darrell L. Castle,8
-McCook,6,President,,CON,Darrell L. Castle,9
-McCook,Total,President,,CON,Darrell L. Castle,40
-McCook,1,U.S. Senate,,REP,John R. Thune,368
-McCook,2,U.S. Senate,,REP,John R. Thune,100
-McCook,3,U.S. Senate,,REP,John R. Thune,434
-McCook,4,U.S. Senate,,REP,John R. Thune,412
-McCook,5,U.S. Senate,,REP,John R. Thune,444
-McCook,6,U.S. Senate,,REP,John R. Thune,263
-McCook,Total,U.S. Senate,,REP,John R. Thune,2021
-McCook,1,U.S. Senate,,DEM,Jay Williams,147
-McCook,2,U.S. Senate,,DEM,Jay Williams,51
-McCook,3,U.S. Senate,,DEM,Jay Williams,113
-McCook,4,U.S. Senate,,DEM,Jay Williams,62
-McCook,5,U.S. Senate,,DEM,Jay Williams,163
-McCook,6,U.S. Senate,,DEM,Jay Williams,63
-McCook,Total,U.S. Senate,,DEM,Jay Williams,599
-McCook,1,U.S. House,1,REP,Kristi Noem,303
-McCook,2,U.S. House,1,REP,Kristi Noem,88
-McCook,3,U.S. House,1,REP,Kristi Noem,391
-McCook,4,U.S. House,1,REP,Kristi Noem,382
-McCook,5,U.S. House,1,REP,Kristi Noem,389
-McCook,6,U.S. House,1,REP,Kristi Noem,233
-McCook,Total,U.S. House,1,REP,Kristi Noem,1786
-McCook,1,U.S. House,1,DEM,Paula Hawks,214
-McCook,2,U.S. House,1,DEM,Paula Hawks,61
-McCook,3,U.S. House,1,DEM,Paula Hawks,160
-McCook,4,U.S. House,1,DEM,Paula Hawks,92
-McCook,5,U.S. House,1,DEM,Paula Hawks,223
-McCook,6,U.S. House,1,DEM,Paula Hawks,94
-McCook,Total,U.S. House,1,DEM,Paula Hawks,844
-McCook,1,Public Utilities Commissioner,,REP,Chris Nelson,385
-McCook,2,Public Utilities Commissioner,,REP,Chris Nelson,122
-McCook,3,Public Utilities Commissioner,,REP,Chris Nelson,445
-McCook,4,Public Utilities Commissioner,,REP,Chris Nelson,421
-McCook,5,Public Utilities Commissioner,,REP,Chris Nelson,490
-McCook,6,Public Utilities Commissioner,,REP,Chris Nelson,287
-McCook,Total,Public Utilities Commissioner,,REP,Chris Nelson,2150
-McCook,1,Public Utilities Commissioner,,DEM,Henry Red Cloud,104
-McCook,2,Public Utilities Commissioner,,DEM,Henry Red Cloud,25
-McCook,3,Public Utilities Commissioner,,DEM,Henry Red Cloud,92
-McCook,4,Public Utilities Commissioner,,DEM,Henry Red Cloud,35
-McCook,5,Public Utilities Commissioner,,DEM,Henry Red Cloud,105
-McCook,6,Public Utilities Commissioner,,DEM,Henry Red Cloud,32
-McCook,Total,Public Utilities Commissioner,,DEM,Henry Red Cloud,393
-McCook,1,State Senate,19,REP,Stace Nelson,350
-McCook,2,State Senate,19,REP,Stace Nelson,112
-McCook,3,State Senate,19,REP,Stace Nelson,401
-McCook,4,State Senate,19,REP,Stace Nelson,420
-McCook,5,State Senate,19,REP,Stace Nelson,423
-McCook,6,State Senate,19,REP,Stace Nelson,234
-McCook,Total,State Senate,19,REP,Stace Nelson,1940
-McCook,1,State Senate,19,DEM,Russell Graeff,139
-McCook,2,State Senate,19,DEM,Russell Graeff,35
-McCook,3,State Senate,19,DEM,Russell Graeff,125
-McCook,4,State Senate,19,DEM,Russell Graeff,39
-McCook,5,State Senate,19,DEM,Russell Graeff,176
-McCook,6,State Senate,19,DEM,Russell Graeff,81
-McCook,Total,State Senate,19,DEM,Russell Graeff,595
-McCook,1,State House,19,REP,Kent Peterson,314
-McCook,2,State House,19,REP,Kent Peterson,103
-McCook,3,State House,19,REP,Kent Peterson,360
-McCook,4,State House,19,REP,Kent Peterson,349
-McCook,5,State House,19,REP,Kent Peterson,478
-McCook,6,State House,19,REP,Kent Peterson,276
-McCook,Total,State House,19,REP,Kent Peterson,1880
-McCook,1,State House,19,REP,Kyle Schoenfish,221
-McCook,2,State House,19,REP,Kyle Schoenfish,60
-McCook,3,State House,19,REP,Kyle Schoenfish,336
-McCook,4,State House,19,REP,Kyle Schoenfish,299
-McCook,5,State House,19,REP,Kyle Schoenfish,247
-McCook,6,State House,19,REP,Kyle Schoenfish,141
-McCook,Total,State House,19,REP,Kyle Schoenfish,1304
-McCook,1,State House,19,DEM,Melissa Mentele,182
-McCook,2,State House,19,DEM,Melissa Mentele,56
-McCook,3,State House,19,DEM,Melissa Mentele,137
-McCook,4,State House,19,DEM,Melissa Mentele,82
-McCook,5,State House,19,DEM,Melissa Mentele,191
-McCook,6,State House,19,DEM,Melissa Mentele,81
-McCook,Total,State House,19,DEM,Melissa Mentele,729
-McPherson,1,President,,REP,Donald J. Trump,149
-McPherson,2,President,,REP,Donald J. Trump,135
-McPherson,3,President,,REP,Donald J. Trump,56
-McPherson,4,President,,REP,Donald J. Trump,187
-McPherson,5,President,,REP,Donald J. Trump,198
-McPherson,6,President,,REP,Donald J. Trump,167
-McPherson,Total,President,,REP,Donald J. Trump,892
-McPherson,1,President,,LIB,Gary Johnson,9
-McPherson,2,President,,LIB,Gary Johnson,10
-McPherson,3,President,,LIB,Gary Johnson,0
-McPherson,4,President,,LIB,Gary Johnson,9
-McPherson,5,President,,LIB,Gary Johnson,5
-McPherson,6,President,,LIB,Gary Johnson,10
-McPherson,Total,President,,LIB,Gary Johnson,43
-McPherson,1,President,,DEM,Hillary Clinton,33
-McPherson,2,President,,DEM,Hillary Clinton,40
-McPherson,3,President,,DEM,Hillary Clinton,5
-McPherson,4,President,,DEM,Hillary Clinton,32
-McPherson,5,President,,DEM,Hillary Clinton,34
-McPherson,6,President,,DEM,Hillary Clinton,48
-McPherson,Total,President,,DEM,Hillary Clinton,192
-McPherson,1,President,,CON,Darrell L. Castle,0
-McPherson,2,President,,CON,Darrell L. Castle,4
-McPherson,3,President,,CON,Darrell L. Castle,2
-McPherson,4,President,,CON,Darrell L. Castle,3
-McPherson,5,President,,CON,Darrell L. Castle,0
-McPherson,6,President,,CON,Darrell L. Castle,1
-McPherson,Total,President,,CON,Darrell L. Castle,10
-McPherson,1,U.S. Senate,,REP,John R. Thune,204
-McPherson,2,U.S. Senate,,REP,John R. Thune,154
-McPherson,3,U.S. Senate,,REP,John R. Thune,49
-McPherson,4,U.S. Senate,,REP,John R. Thune,195
-McPherson,5,U.S. Senate,,REP,John R. Thune,216
-McPherson,6,U.S. Senate,,REP,John R. Thune,191
-McPherson,Total,U.S. Senate,,REP,John R. Thune,1009
-McPherson,1,U.S. Senate,,DEM,Jay Williams,38
-McPherson,2,U.S. Senate,,DEM,Jay Williams,33
-McPherson,3,U.S. Senate,,DEM,Jay Williams,10
-McPherson,4,U.S. Senate,,DEM,Jay Williams,33
-McPherson,5,U.S. Senate,,DEM,Jay Williams,17
-McPherson,6,U.S. Senate,,DEM,Jay Williams,34
-McPherson,Total,U.S. Senate,,DEM,Jay Williams,165
-McPherson,1,U.S. House,1,REP,Kristi Noem,200
-McPherson,2,U.S. House,1,REP,Kristi Noem,129
-McPherson,3,U.S. House,1,REP,Kristi Noem,46
-McPherson,4,U.S. House,1,REP,Kristi Noem,189
-McPherson,5,U.S. House,1,REP,Kristi Noem,199
-McPherson,6,U.S. House,1,REP,Kristi Noem,177
-McPherson,Total,U.S. House,1,REP,Kristi Noem,940
-McPherson,1,U.S. House,1,DEM,Paula Hawks,45
-McPherson,2,U.S. House,1,DEM,Paula Hawks,58
-McPherson,3,U.S. House,1,DEM,Paula Hawks,14
-McPherson,4,U.S. House,1,DEM,Paula Hawks,43
-McPherson,5,U.S. House,1,DEM,Paula Hawks,32
-McPherson,6,U.S. House,1,DEM,Paula Hawks,49
-McPherson,Total,U.S. House,1,DEM,Paula Hawks,241
-McPherson,1,Public Utilities Commissioner,,REP,Chris Nelson,214
-McPherson,2,Public Utilities Commissioner,,REP,Chris Nelson,161
-McPherson,3,Public Utilities Commissioner,,REP,Chris Nelson,52
-McPherson,4,Public Utilities Commissioner,,REP,Chris Nelson,203
-McPherson,5,Public Utilities Commissioner,,REP,Chris Nelson,201
-McPherson,6,Public Utilities Commissioner,,REP,Chris Nelson,190
-McPherson,Total,Public Utilities Commissioner,,REP,Chris Nelson,1021
-McPherson,1,Public Utilities Commissioner,,DEM,Henry Red Cloud,23
-McPherson,2,Public Utilities Commissioner,,DEM,Henry Red Cloud,23
-McPherson,3,Public Utilities Commissioner,,DEM,Henry Red Cloud,3
-McPherson,4,Public Utilities Commissioner,,DEM,Henry Red Cloud,27
-McPherson,5,Public Utilities Commissioner,,DEM,Henry Red Cloud,16
-McPherson,6,Public Utilities Commissioner,,DEM,Henry Red Cloud,24
-McPherson,Total,Public Utilities Commissioner,,DEM,Henry Red Cloud,116
-McPherson,1,State Senate,23,REP,Justin R. Cronin,135
-McPherson,2,State Senate,23,REP,Justin R. Cronin,145
-McPherson,3,State Senate,23,REP,Justin R. Cronin,46
-McPherson,4,State Senate,23,REP,Justin R. Cronin,173
-McPherson,5,State Senate,23,REP,Justin R. Cronin,184
-McPherson,6,State Senate,23,REP,Justin R. Cronin,163
-McPherson,Total,State Senate,23,REP,Justin R. Cronin,846
-McPherson,1,State Representative,23,REP,Spencer Gosch,123
-McPherson,2,State Representative,23,REP,Spencer Gosch,127
-McPherson,3,State Representative,23,REP,Spencer Gosch,37
-McPherson,4,State Representative,23,REP,Spencer Gosch,158
-McPherson,5,State Representative,23,REP,Spencer Gosch,177
-McPherson,6,State Representative,23,REP,Spencer Gosch,152
-McPherson,Total,State Representative,23,REP,Spencer Gosch,774
-McPherson,1,State Representative,23,REP,John A. Lake,98
-McPherson,2,State Representative,23,REP,John A. Lake,96
-McPherson,3,State Representative,23,REP,John A. Lake,27
-McPherson,4,State Representative,23,REP,John A. Lake,119
-McPherson,5,State Representative,23,REP,John A. Lake,120
-McPherson,6,State Representative,23,REP,John A. Lake,97
-McPherson,Total,State Representative,23,REP,John A. Lake,557
+McCook,1,President,,Donald J. Trump,REP,322
+McCook,2,President,,Donald J. Trump,REP,102
+McCook,3,President,,Donald J. Trump,REP,383
+McCook,4,President,,Donald J. Trump,REP,379
+McCook,5,President,,Donald J. Trump,REP,377
+McCook,6,President,,Donald J. Trump,REP,231
+McCook,Total,President,,Donald J. Trump,REP,1794
+McCook,1,President,,Gary Johnson,LIB,30
+McCook,2,President,,Gary Johnson,LIB,2
+McCook,3,President,,Gary Johnson,LIB,23
+McCook,4,President,,Gary Johnson,LIB,16
+McCook,5,President,,Gary Johnson,LIB,34
+McCook,6,President,,Gary Johnson,LIB,25
+McCook,Total,President,,Gary Johnson,LIB,130
+McCook,1,President,,Hillary Clinton,DEM,150
+McCook,2,President,,Hillary Clinton,DEM,42
+McCook,3,President,,Hillary Clinton,DEM,126
+McCook,4,President,,Hillary Clinton,DEM,67
+McCook,5,President,,Hillary Clinton,DEM,180
+McCook,6,President,,Hillary Clinton,DEM,58
+McCook,Total,President,,Hillary Clinton,DEM,623
+McCook,1,President,,Darrell L. Castle,CON,6
+McCook,2,President,,Darrell L. Castle,CON,1
+McCook,3,President,,Darrell L. Castle,CON,13
+McCook,4,President,,Darrell L. Castle,CON,3
+McCook,5,President,,Darrell L. Castle,CON,8
+McCook,6,President,,Darrell L. Castle,CON,9
+McCook,Total,President,,Darrell L. Castle,CON,40
+McCook,1,U.S. Senate,,John R. Thune,REP,368
+McCook,2,U.S. Senate,,John R. Thune,REP,100
+McCook,3,U.S. Senate,,John R. Thune,REP,434
+McCook,4,U.S. Senate,,John R. Thune,REP,412
+McCook,5,U.S. Senate,,John R. Thune,REP,444
+McCook,6,U.S. Senate,,John R. Thune,REP,263
+McCook,Total,U.S. Senate,,John R. Thune,REP,2021
+McCook,1,U.S. Senate,,Jay Williams,DEM,147
+McCook,2,U.S. Senate,,Jay Williams,DEM,51
+McCook,3,U.S. Senate,,Jay Williams,DEM,113
+McCook,4,U.S. Senate,,Jay Williams,DEM,62
+McCook,5,U.S. Senate,,Jay Williams,DEM,163
+McCook,6,U.S. Senate,,Jay Williams,DEM,63
+McCook,Total,U.S. Senate,,Jay Williams,DEM,599
+McCook,1,U.S. House,1,Kristi Noem,REP,303
+McCook,2,U.S. House,1,Kristi Noem,REP,88
+McCook,3,U.S. House,1,Kristi Noem,REP,391
+McCook,4,U.S. House,1,Kristi Noem,REP,382
+McCook,5,U.S. House,1,Kristi Noem,REP,389
+McCook,6,U.S. House,1,Kristi Noem,REP,233
+McCook,Total,U.S. House,1,Kristi Noem,REP,1786
+McCook,1,U.S. House,1,Paula Hawks,DEM,214
+McCook,2,U.S. House,1,Paula Hawks,DEM,61
+McCook,3,U.S. House,1,Paula Hawks,DEM,160
+McCook,4,U.S. House,1,Paula Hawks,DEM,92
+McCook,5,U.S. House,1,Paula Hawks,DEM,223
+McCook,6,U.S. House,1,Paula Hawks,DEM,94
+McCook,Total,U.S. House,1,Paula Hawks,DEM,844
+McCook,1,Public Utilities Commissioner,,Chris Nelson,REP,385
+McCook,2,Public Utilities Commissioner,,Chris Nelson,REP,122
+McCook,3,Public Utilities Commissioner,,Chris Nelson,REP,445
+McCook,4,Public Utilities Commissioner,,Chris Nelson,REP,421
+McCook,5,Public Utilities Commissioner,,Chris Nelson,REP,490
+McCook,6,Public Utilities Commissioner,,Chris Nelson,REP,287
+McCook,Total,Public Utilities Commissioner,,Chris Nelson,REP,2150
+McCook,1,Public Utilities Commissioner,,Henry Red Cloud,DEM,104
+McCook,2,Public Utilities Commissioner,,Henry Red Cloud,DEM,25
+McCook,3,Public Utilities Commissioner,,Henry Red Cloud,DEM,92
+McCook,4,Public Utilities Commissioner,,Henry Red Cloud,DEM,35
+McCook,5,Public Utilities Commissioner,,Henry Red Cloud,DEM,105
+McCook,6,Public Utilities Commissioner,,Henry Red Cloud,DEM,32
+McCook,Total,Public Utilities Commissioner,,Henry Red Cloud,DEM,393
+McCook,1,State Senate,19,Stace Nelson,REP,350
+McCook,2,State Senate,19,Stace Nelson,REP,112
+McCook,3,State Senate,19,Stace Nelson,REP,401
+McCook,4,State Senate,19,Stace Nelson,REP,420
+McCook,5,State Senate,19,Stace Nelson,REP,423
+McCook,6,State Senate,19,Stace Nelson,REP,234
+McCook,Total,State Senate,19,Stace Nelson,REP,1940
+McCook,1,State Senate,19,Russell Graeff,DEM,139
+McCook,2,State Senate,19,Russell Graeff,DEM,35
+McCook,3,State Senate,19,Russell Graeff,DEM,125
+McCook,4,State Senate,19,Russell Graeff,DEM,39
+McCook,5,State Senate,19,Russell Graeff,DEM,176
+McCook,6,State Senate,19,Russell Graeff,DEM,81
+McCook,Total,State Senate,19,Russell Graeff,DEM,595
+McCook,1,State House,19,Kent Peterson,REP,314
+McCook,2,State House,19,Kent Peterson,REP,103
+McCook,3,State House,19,Kent Peterson,REP,360
+McCook,4,State House,19,Kent Peterson,REP,349
+McCook,5,State House,19,Kent Peterson,REP,478
+McCook,6,State House,19,Kent Peterson,REP,276
+McCook,Total,State House,19,Kent Peterson,REP,1880
+McCook,1,State House,19,Kyle Schoenfish,REP,221
+McCook,2,State House,19,Kyle Schoenfish,REP,60
+McCook,3,State House,19,Kyle Schoenfish,REP,336
+McCook,4,State House,19,Kyle Schoenfish,REP,299
+McCook,5,State House,19,Kyle Schoenfish,REP,247
+McCook,6,State House,19,Kyle Schoenfish,REP,141
+McCook,Total,State House,19,Kyle Schoenfish,REP,1304
+McCook,1,State House,19,Melissa Mentele,DEM,182
+McCook,2,State House,19,Melissa Mentele,DEM,56
+McCook,3,State House,19,Melissa Mentele,DEM,137
+McCook,4,State House,19,Melissa Mentele,DEM,82
+McCook,5,State House,19,Melissa Mentele,DEM,191
+McCook,6,State House,19,Melissa Mentele,DEM,81
+McCook,Total,State House,19,Melissa Mentele,DEM,729
+McPherson,1,President,,Donald J. Trump,REP,149
+McPherson,2,President,,Donald J. Trump,REP,135
+McPherson,3,President,,Donald J. Trump,REP,56
+McPherson,4,President,,Donald J. Trump,REP,187
+McPherson,5,President,,Donald J. Trump,REP,198
+McPherson,6,President,,Donald J. Trump,REP,167
+McPherson,Total,President,,Donald J. Trump,REP,892
+McPherson,1,President,,Gary Johnson,LIB,9
+McPherson,2,President,,Gary Johnson,LIB,10
+McPherson,3,President,,Gary Johnson,LIB,0
+McPherson,4,President,,Gary Johnson,LIB,9
+McPherson,5,President,,Gary Johnson,LIB,5
+McPherson,6,President,,Gary Johnson,LIB,10
+McPherson,Total,President,,Gary Johnson,LIB,43
+McPherson,1,President,,Hillary Clinton,DEM,33
+McPherson,2,President,,Hillary Clinton,DEM,40
+McPherson,3,President,,Hillary Clinton,DEM,5
+McPherson,4,President,,Hillary Clinton,DEM,32
+McPherson,5,President,,Hillary Clinton,DEM,34
+McPherson,6,President,,Hillary Clinton,DEM,48
+McPherson,Total,President,,Hillary Clinton,DEM,192
+McPherson,1,President,,Darrell L. Castle,CON,0
+McPherson,2,President,,Darrell L. Castle,CON,4
+McPherson,3,President,,Darrell L. Castle,CON,2
+McPherson,4,President,,Darrell L. Castle,CON,3
+McPherson,5,President,,Darrell L. Castle,CON,0
+McPherson,6,President,,Darrell L. Castle,CON,1
+McPherson,Total,President,,Darrell L. Castle,CON,10
+McPherson,1,U.S. Senate,,John R. Thune,REP,204
+McPherson,2,U.S. Senate,,John R. Thune,REP,154
+McPherson,3,U.S. Senate,,John R. Thune,REP,49
+McPherson,4,U.S. Senate,,John R. Thune,REP,195
+McPherson,5,U.S. Senate,,John R. Thune,REP,216
+McPherson,6,U.S. Senate,,John R. Thune,REP,191
+McPherson,Total,U.S. Senate,,John R. Thune,REP,1009
+McPherson,1,U.S. Senate,,Jay Williams,DEM,38
+McPherson,2,U.S. Senate,,Jay Williams,DEM,33
+McPherson,3,U.S. Senate,,Jay Williams,DEM,10
+McPherson,4,U.S. Senate,,Jay Williams,DEM,33
+McPherson,5,U.S. Senate,,Jay Williams,DEM,17
+McPherson,6,U.S. Senate,,Jay Williams,DEM,34
+McPherson,Total,U.S. Senate,,Jay Williams,DEM,165
+McPherson,1,U.S. House,1,Kristi Noem,REP,200
+McPherson,2,U.S. House,1,Kristi Noem,REP,129
+McPherson,3,U.S. House,1,Kristi Noem,REP,46
+McPherson,4,U.S. House,1,Kristi Noem,REP,189
+McPherson,5,U.S. House,1,Kristi Noem,REP,199
+McPherson,6,U.S. House,1,Kristi Noem,REP,177
+McPherson,Total,U.S. House,1,Kristi Noem,REP,940
+McPherson,1,U.S. House,1,Paula Hawks,DEM,45
+McPherson,2,U.S. House,1,Paula Hawks,DEM,58
+McPherson,3,U.S. House,1,Paula Hawks,DEM,14
+McPherson,4,U.S. House,1,Paula Hawks,DEM,43
+McPherson,5,U.S. House,1,Paula Hawks,DEM,32
+McPherson,6,U.S. House,1,Paula Hawks,DEM,49
+McPherson,Total,U.S. House,1,Paula Hawks,DEM,241
+McPherson,1,Public Utilities Commissioner,,Chris Nelson,REP,214
+McPherson,2,Public Utilities Commissioner,,Chris Nelson,REP,161
+McPherson,3,Public Utilities Commissioner,,Chris Nelson,REP,52
+McPherson,4,Public Utilities Commissioner,,Chris Nelson,REP,203
+McPherson,5,Public Utilities Commissioner,,Chris Nelson,REP,201
+McPherson,6,Public Utilities Commissioner,,Chris Nelson,REP,190
+McPherson,Total,Public Utilities Commissioner,,Chris Nelson,REP,1021
+McPherson,1,Public Utilities Commissioner,,Henry Red Cloud,DEM,23
+McPherson,2,Public Utilities Commissioner,,Henry Red Cloud,DEM,23
+McPherson,3,Public Utilities Commissioner,,Henry Red Cloud,DEM,3
+McPherson,4,Public Utilities Commissioner,,Henry Red Cloud,DEM,27
+McPherson,5,Public Utilities Commissioner,,Henry Red Cloud,DEM,16
+McPherson,6,Public Utilities Commissioner,,Henry Red Cloud,DEM,24
+McPherson,Total,Public Utilities Commissioner,,Henry Red Cloud,DEM,116
+McPherson,1,State Senate,23,Justin R. Cronin,REP,135
+McPherson,2,State Senate,23,Justin R. Cronin,REP,145
+McPherson,3,State Senate,23,Justin R. Cronin,REP,46
+McPherson,4,State Senate,23,Justin R. Cronin,REP,173
+McPherson,5,State Senate,23,Justin R. Cronin,REP,184
+McPherson,6,State Senate,23,Justin R. Cronin,REP,163
+McPherson,Total,State Senate,23,Justin R. Cronin,REP,846
+McPherson,1,State Representative,23,Spencer Gosch,REP,123
+McPherson,2,State Representative,23,Spencer Gosch,REP,127
+McPherson,3,State Representative,23,Spencer Gosch,REP,37
+McPherson,4,State Representative,23,Spencer Gosch,REP,158
+McPherson,5,State Representative,23,Spencer Gosch,REP,177
+McPherson,6,State Representative,23,Spencer Gosch,REP,152
+McPherson,Total,State Representative,23,Spencer Gosch,REP,774
+McPherson,1,State Representative,23,John A. Lake,REP,98
+McPherson,2,State Representative,23,John A. Lake,REP,96
+McPherson,3,State Representative,23,John A. Lake,REP,27
+McPherson,4,State Representative,23,John A. Lake,REP,119
+McPherson,5,State Representative,23,John A. Lake,REP,120
+McPherson,6,State Representative,23,John A. Lake,REP,97
+McPherson,Total,State Representative,23,John A. Lake,REP,557
 Meade,ALKALI #6A,President,,Donald J. Trump,REP,104
 Meade,BASE #23,President,,Donald J. Trump,REP,274
 Meade,BEAR BUTTE #9,President,,Donald J. Trump,REP,121
@@ -7099,219 +7099,219 @@ Meade,SUMMERSET #10,State Representative,33,Jimm Hadd,DEM,178
 Meade,WEST BLACK HAWK #16,State Representative,33,Jimm Hadd,DEM,100
 Meade,TOTAL,State Representative,33,Jimm Hadd,DEM,475
 Mellette,Central 2,Registered Voters,,,,366
-Mellette,Central 2,President,,REP,Donald J. Trump,104
-Mellette,Central 2,President,,LIB,Gary Johnson,15
-Mellette,Central 2,President,,DEM,Hillary Clinton,65
-Mellette,Central 2,President,,CON,Darrell L. Castle,1
+Mellette,Central 2,President,,Donald J. Trump,REP,104
+Mellette,Central 2,President,,Gary Johnson,LIB,15
+Mellette,Central 2,President,,Hillary Clinton,DEM,65
+Mellette,Central 2,President,,Darrell L. Castle,CON,1
 Mellette,Central 2,President,,,Total,185
-Mellette,Central 2,U.S. Senate,,REP,John R. Thune,123
-Mellette,Central 2,U.S. Senate,,DEM,Jay Williams,65
-Mellette,Central 2,U.S. House,1,REP,Kristi Noem,109
-Mellette,Central 2,U.S. House,1,DEM,Paula Hawks,79
-Mellette,Central 2,Public Utilities Commissioner,,REP,Chris Nelson,112
-Mellette,Central 2,Public Utilities Commissioner,,DEM,Henry Red Cloud,74
-Mellette,Central 2,State Senate,26,REP,Troy Heinert,120
-Mellette,Central 2,State House,26A,REP,Shawn Bourdeaux,116
+Mellette,Central 2,U.S. Senate,,John R. Thune,REP,123
+Mellette,Central 2,U.S. Senate,,Jay Williams,DEM,65
+Mellette,Central 2,U.S. House,1,Kristi Noem,REP,109
+Mellette,Central 2,U.S. House,1,Paula Hawks,DEM,79
+Mellette,Central 2,Public Utilities Commissioner,,Chris Nelson,REP,112
+Mellette,Central 2,Public Utilities Commissioner,,Henry Red Cloud,DEM,74
+Mellette,Central 2,State Senate,26,Troy Heinert,REP,120
+Mellette,Central 2,State House,26A,Shawn Bourdeaux,REP,116
 Mellette,WR 5,Registered Voters,,,,343
-Mellette,WR 5,President,,REP,Donald J. Trump,96
-Mellette,WR 5,President,,LIB,Gary Johnson,6
-Mellette,WR 5,President,,DEM,Hillary Clinton,85
-Mellette,WR 5,President,,CON,Darrell L. Castle,4
+Mellette,WR 5,President,,Donald J. Trump,REP,96
+Mellette,WR 5,President,,Gary Johnson,LIB,6
+Mellette,WR 5,President,,Hillary Clinton,DEM,85
+Mellette,WR 5,President,,Darrell L. Castle,CON,4
 Mellette,WR 5,President,,,Total,199
-Mellette,WR 5,U.S. Senate,,REP,John R. Thune,115
-Mellette,WR 5,U.S. Senate,,DEM,Jay Williams,79
-Mellette,WR 5,U.S. House,1,REP,Kristi Noem,99
-Mellette,WR 5,U.S. House,1,DEM,Paula Hawks,98
-Mellette,WR 5,Public Utilities Commissioner,,REP,Chris Nelson,111
-Mellette,WR 5,Public Utilities Commissioner,,DEM,Henry Red Cloud,78
-Mellette,WR 5,State Senate,26,REP,Troy Heinert,143
-Mellette,WR 5,State House,26A,REP,Shawn Bourdeaux,123
+Mellette,WR 5,U.S. Senate,,John R. Thune,REP,115
+Mellette,WR 5,U.S. Senate,,Jay Williams,DEM,79
+Mellette,WR 5,U.S. House,1,Kristi Noem,REP,99
+Mellette,WR 5,U.S. House,1,Paula Hawks,DEM,98
+Mellette,WR 5,Public Utilities Commissioner,,Chris Nelson,REP,111
+Mellette,WR 5,Public Utilities Commissioner,,Henry Red Cloud,DEM,78
+Mellette,WR 5,State Senate,26,Troy Heinert,REP,143
+Mellette,WR 5,State House,26A,Shawn Bourdeaux,REP,123
 Mellette,East 3,Registered Voters,,,,189
-Mellette,East 3,President,,REP,Donald J. Trump,109
-Mellette,East 3,President,,LIB,Gary Johnson,5
-Mellette,East 3,President,,DEM,Hillary Clinton,26
-Mellette,East 3,President,,CON,Darrell L. Castle,4
+Mellette,East 3,President,,Donald J. Trump,REP,109
+Mellette,East 3,President,,Gary Johnson,LIB,5
+Mellette,East 3,President,,Hillary Clinton,DEM,26
+Mellette,East 3,President,,Darrell L. Castle,CON,4
 Mellette,East 3,President,,,Total,144
-Mellette,East 3,U.S. Senate,,REP,John R. Thune,112
-Mellette,East 3,U.S. Senate,,DEM,Jay Williams,27
-Mellette,East 3,U.S. House,1,REP,Kristi Noem,111
-Mellette,East 3,U.S. House,1,DEM,Paula Hawks,32
-Mellette,East 3,Public Utilities Commissioner,,REP,Chris Nelson,124
-Mellette,East 3,Public Utilities Commissioner,,DEM,Henry Red Cloud,20
-Mellette,East 3,State Senate,26,REP,Troy Heinert,69
-Mellette,East 3,State House,26A,REP,Shawn Bourdeaux,46
+Mellette,East 3,U.S. Senate,,John R. Thune,REP,112
+Mellette,East 3,U.S. Senate,,Jay Williams,DEM,27
+Mellette,East 3,U.S. House,1,Kristi Noem,REP,111
+Mellette,East 3,U.S. House,1,Paula Hawks,DEM,32
+Mellette,East 3,Public Utilities Commissioner,,Chris Nelson,REP,124
+Mellette,East 3,Public Utilities Commissioner,,Henry Red Cloud,DEM,20
+Mellette,East 3,State Senate,26,Troy Heinert,REP,69
+Mellette,East 3,State House,26A,Shawn Bourdeaux,REP,46
 Mellette,West 6,Registered Voters,,,,274
-Mellette,West 6,President,,REP,Donald J. Trump,93
-Mellette,West 6,President,,LIB,Gary Johnson,6
-Mellette,West 6,President,,DEM,Hillary Clinton,62
-Mellette,West 6,President,,CON,Darrell L. Castle,2
+Mellette,West 6,President,,Donald J. Trump,REP,93
+Mellette,West 6,President,,Gary Johnson,LIB,6
+Mellette,West 6,President,,Hillary Clinton,DEM,62
+Mellette,West 6,President,,Darrell L. Castle,CON,2
 Mellette,West 6,President,,,Total,163
-Mellette,West 6,U.S. Senate,,REP,John R. Thune,114
-Mellette,West 6,U.S. Senate,,DEM,Jay Williams,53
-Mellette,West 6,U.S. House,1,REP,Kristi Noem,100
-Mellette,West 6,U.S. House,1,DEM,Paula Hawks,65
-Mellette,West 6,Public Utilities Commissioner,,REP,Chris Nelson,102
-Mellette,West 6,Public Utilities Commissioner,,DEM,Henry Red Cloud,60
-Mellette,West 6,State Senate,26,REP,Troy Heinert,101
-Mellette,West 6,State House,26A,REP,Shawn Bourdeaux,86
+Mellette,West 6,U.S. Senate,,John R. Thune,REP,114
+Mellette,West 6,U.S. Senate,,Jay Williams,DEM,53
+Mellette,West 6,U.S. House,1,Kristi Noem,REP,100
+Mellette,West 6,U.S. House,1,Paula Hawks,DEM,65
+Mellette,West 6,Public Utilities Commissioner,,Chris Nelson,REP,102
+Mellette,West 6,Public Utilities Commissioner,,Henry Red Cloud,DEM,60
+Mellette,West 6,State Senate,26,Troy Heinert,REP,101
+Mellette,West 6,State House,26A,Shawn Bourdeaux,REP,86
 Mellette,,Registered Voters,,,,1172
-Mellette,,President,,REP,Donald J. Trump,402
-Mellette,,President,,LIB,Gary Johnson,32
-Mellette,,President,,DEM,Hillary Clinton,238
-Mellette,,President,,CON,Darrell L. Castle,11
+Mellette,,President,,Donald J. Trump,REP,402
+Mellette,,President,,Gary Johnson,LIB,32
+Mellette,,President,,Hillary Clinton,DEM,238
+Mellette,,President,,Darrell L. Castle,CON,11
 Mellette,,President,,,Total,691
-Mellette,,U.S. Senate,,REP,John R. Thune,464
-Mellette,,U.S. Senate,,DEM,Jay Williams,224
-Mellette,,U.S. House,1,REP,Kristi Noem,419
-Mellette,,U.S. House,1,DEM,Paula Hawks,274
-Mellette,,Public Utilities Commissioner,,REP,Chris Nelson,449
-Mellette,,Public Utilities Commissioner,,DEM,Henry Red Cloud,232
-Mellette,,State Senate,26,REP,Troy Heinert,433
-Mellette,,State House,26A,REP,Shawn Bourdeaux,371
-Miner,HOWARD WARD 1,President,,REP,Trump & Pence,76
-Miner,HOWARD WARD 2,President,,REP,Trump & Pence,75
-Miner,HOWARD WARD 3,President,,REP,Trump & Pence,62
-Miner,VERMILLION-CANOVA-ROCK CREEK,President,,REP,Trump & Pence,81
-Miner,BEAVER-CLINTON-MINER,President,,REP,Trump & Pence,63
-Miner,CLEARWATER-HOWARD-ROSWELL,President,,REP,Trump & Pence,132
-Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,President,,REP,Trump & Pence,125
-Miner,GREEN VALLEY-CARTHAGE-REDSTONE,President,,REP,Trump & Pence,92
-Miner,TOTAL,President,,REP,Trump & Pence,706
-Miner,HOWARD WARD 1,President,,LIB,Johnson & Weld,8
-Miner,HOWARD WARD 2,President,,LIB,Johnson & Weld,7
-Miner,HOWARD WARD 3,President,,LIB,Johnson & Weld,13
-Miner,VERMILLION-CANOVA-ROCK CREEK,President,,LIB,Johnson & Weld,11
-Miner,BEAVER-CLINTON-MINER,President,,LIB,Johnson & Weld,2
-Miner,CLEARWATER-HOWARD-ROSWELL,President,,LIB,Johnson & Weld,10
-Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,President,,LIB,Johnson & Weld,6
-Miner,GREEN VALLEY-CARTHAGE-REDSTONE,President,,LIB,Johnson & Weld,10
-Miner,TOTAL,President,,LIB,Johnson & Weld,67
-Miner,HOWARD WARD 1,President,,DEM,Clinton & Kaine,51
-Miner,HOWARD WARD 2,President,,DEM,Clinton & Kaine,38
-Miner,HOWARD WARD 3,President,,DEM,Clinton & Kaine,26
-Miner,VERMILLION-CANOVA-ROCK CREEK,President,,DEM,Clinton & Kaine,44
-Miner,BEAVER-CLINTON-MINER,President,,DEM,Clinton & Kaine,18
-Miner,CLEARWATER-HOWARD-ROSWELL,President,,DEM,Clinton & Kaine,41
-Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,President,,DEM,Clinton & Kaine,40
-Miner,GREEN VALLEY-CARTHAGE-REDSTONE,President,,DEM,Clinton & Kaine,23
-Miner,TOTAL,President,,DEM,Clinton & Kaine,281
-Miner,HOWARD WARD 1,President,,CON,Castle & Bradley,2
-Miner,HOWARD WARD 2,President,,CON,Castle & Bradley,2
-Miner,HOWARD WARD 3,President,,CON,Castle & Bradley,1
-Miner,VERMILLION-CANOVA-ROCK CREEK,President,,CON,Castle & Bradley,1
-Miner,BEAVER-CLINTON-MINER,President,,CON,Castle & Bradley,0
-Miner,CLEARWATER-HOWARD-ROSWELL,President,,CON,Castle & Bradley,0
-Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,President,,CON,Castle & Bradley,3
-Miner,GREEN VALLEY-CARTHAGE-REDSTONE,President,,CON,Castle & Bradley,1
-Miner,TOTAL,President,,CON,Castle & Bradley,10
-Miner,HOWARD WARD 1,U.S. Senate,,REP,John R. Thune,92
-Miner,HOWARD WARD 2,U.S. Senate,,REP,John R. Thune,89
-Miner,HOWARD WARD 3,U.S. Senate,,REP,John R. Thune,78
-Miner,VERMILLION-CANOVA-ROCK CREEK,U.S. Senate,,REP,John R. Thune,106
-Miner,BEAVER-CLINTON-MINER,U.S. Senate,,REP,John R. Thune,67
-Miner,CLEARWATER-HOWARD-ROSWELL,U.S. Senate,,REP,John R. Thune,142
-Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,U.S. Senate,,REP,John R. Thune,128
-Miner,GREEN VALLEY-CARTHAGE-REDSTONE,U.S. Senate,,REP,John R. Thune,105
-Miner,TOTAL,U.S. Senate,,REP,John R. Thune,807
-Miner,HOWARD WARD 1,U.S. Senate,,DEM,Jay Williams,45
-Miner,HOWARD WARD 2,U.S. Senate,,DEM,Jay Williams,36
-Miner,HOWARD WARD 3,U.S. Senate,,DEM,Jay Williams,27
-Miner,VERMILLION-CANOVA-ROCK CREEK,U.S. Senate,,DEM,Jay Williams,34
-Miner,BEAVER-CLINTON-MINER,U.S. Senate,,DEM,Jay Williams,16
-Miner,CLEARWATER-HOWARD-ROSWELL,U.S. Senate,,DEM,Jay Williams,47
-Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,U.S. Senate,,DEM,Jay Williams,55
-Miner,GREEN VALLEY-CARTHAGE-REDSTONE,U.S. Senate,,DEM,Jay Williams,24
-Miner,TOTAL,U.S. Senate,,DEM,Jay Williams,284
-Miner,HOWARD WARD 1,U.S. House,1,REP,Kristi Noem,78
-Miner,HOWARD WARD 2,U.S. House,1,REP,Kristi Noem,77
-Miner,HOWARD WARD 3,U.S. House,1,REP,Kristi Noem,68
-Miner,VERMILLION-CANOVA-ROCK CREEK,U.S. House,1,REP,Kristi Noem,84
-Miner,BEAVER-CLINTON-MINER,U.S. House,1,REP,Kristi Noem,54
-Miner,CLEARWATER-HOWARD-ROSWELL,U.S. House,1,REP,Kristi Noem,124
-Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,U.S. House,1,REP,Kristi Noem,108
-Miner,GREEN VALLEY-CARTHAGE-REDSTONE,U.S. House,1,REP,Kristi Noem,101
-Miner,TOTAL,U.S. House,1,REP,Kristi Noem,694
-Miner,HOWARD WARD 1,U.S. House,1,DEM,Paula Hawks,59
-Miner,HOWARD WARD 2,U.S. House,1,DEM,Paula Hawks,48
-Miner,HOWARD WARD 3,U.S. House,1,DEM,Paula Hawks,37
-Miner,VERMILLION-CANOVA-ROCK CREEK,U.S. House,1,DEM,Paula Hawks,55
-Miner,BEAVER-CLINTON-MINER,U.S. House,1,DEM,Paula Hawks,30
-Miner,CLEARWATER-HOWARD-ROSWELL,U.S. House,1,DEM,Paula Hawks,65
-Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,U.S. House,1,DEM,Paula Hawks,74
-Miner,GREEN VALLEY-CARTHAGE-REDSTONE,U.S. House,1,DEM,Paula Hawks,30
-Miner,TOTAL,U.S. House,1,DEM,Paula Hawks,398
-Miner,HOWARD WARD 1,Public Utilities Commissioner,,REP,Chris Nelson,96
-Miner,HOWARD WARD 2,Public Utilities Commissioner,,REP,Chris Nelson,101
-Miner,HOWARD WARD 3,Public Utilities Commissioner,,REP,Chris Nelson,86
-Miner,VERMILLION-CANOVA-ROCK CREEK,Public Utilities Commissioner,,REP,Chris Nelson,118
-Miner,BEAVER-CLINTON-MINER,Public Utilities Commissioner,,REP,Chris Nelson,66
-Miner,CLEARWATER-HOWARD-ROSWELL,Public Utilities Commissioner,,REP,Chris Nelson,168
-Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,Public Utilities Commissioner,,REP,Chris Nelson,141
-Miner,GREEN VALLEY-CARTHAGE-REDSTONE,Public Utilities Commissioner,,REP,Chris Nelson,109
-Miner,TOTAL,Public Utilities Commissioner,,REP,Chris Nelson,885
-Miner,HOWARD WARD 1,Public Utilities Commissioner,,DEM,Henry Red Cloud,29
-Miner,HOWARD WARD 2,Public Utilities Commissioner,,DEM,Henry Red Cloud,20
-Miner,HOWARD WARD 3,Public Utilities Commissioner,,DEM,Henry Red Cloud,18
-Miner,VERMILLION-CANOVA-ROCK CREEK,Public Utilities Commissioner,,DEM,Henry Red Cloud,22
-Miner,BEAVER-CLINTON-MINER,Public Utilities Commissioner,,DEM,Henry Red Cloud,16
-Miner,CLEARWATER-HOWARD-ROSWELL,Public Utilities Commissioner,,DEM,Henry Red Cloud,19
-Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,Public Utilities Commissioner,,DEM,Henry Red Cloud,33
-Miner,GREEN VALLEY-CARTHAGE-REDSTONE,Public Utilities Commissioner,,DEM,Henry Red Cloud,19
-Miner,TOTAL,Public Utilities Commissioner,,DEM,Henry Red Cloud,176
-Miner,HOWARD WARD 1,State Senate,8,REP,Jordan Youngberg,47
-Miner,HOWARD WARD 2,State Senate,8,REP,Jordan Youngberg,49
-Miner,HOWARD WARD 3,State Senate,8,REP,Jordan Youngberg,36
-Miner,VERMILLION-CANOVA-ROCK CREEK,State Senate,8,REP,Jordan Youngberg,54
-Miner,BEAVER-CLINTON-MINER,State Senate,8,REP,Jordan Youngberg,50
-Miner,CLEARWATER-HOWARD-ROSWELL,State Senate,8,REP,Jordan Youngberg,107
-Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,State Senate,8,REP,Jordan Youngberg,78
-Miner,GREEN VALLEY-CARTHAGE-REDSTONE,State Senate,8,REP,Jordan Youngberg,82
-Miner,TOTAL,State Senate,8,REP,Jordan Youngberg,503
-Miner,HOWARD WARD 1,State Senate,8,DEM,Scott Parsley,88
-Miner,HOWARD WARD 2,State Senate,8,DEM,Scott Parsley,75
-Miner,HOWARD WARD 3,State Senate,8,DEM,Scott Parsley,67
-Miner,VERMILLION-CANOVA-ROCK CREEK,State Senate,8,DEM,Scott Parsley,87
-Miner,BEAVER-CLINTON-MINER,State Senate,8,DEM,Scott Parsley,31
-Miner,CLEARWATER-HOWARD-ROSWELL,State Senate,8,DEM,Scott Parsley,82
-Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,State Senate,8,DEM,Scott Parsley,91
-Miner,GREEN VALLEY-CARTHAGE-REDSTONE,State Senate,8,DEM,Scott Parsley,45
-Miner,TOTAL,State Senate,8,DEM,Scott Parsley,566
-Miner,HOWARD WARD 1,State House,8,REP,Mathew Wollmann,58
-Miner,HOWARD WARD 2,State House,8,REP,Mathew Wollmann,67
-Miner,HOWARD WARD 3,State House,8,REP,Mathew Wollmann,62
-Miner,VERMILLION-CANOVA-ROCK CREEK,State House,8,REP,Mathew Wollmann,77
-Miner,BEAVER-CLINTON-MINER,State House,8,REP,Mathew Wollmann,46
-Miner,CLEARWATER-HOWARD-ROSWELL,State House,8,REP,Mathew Wollmann,137
-Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,State House,8,REP,Mathew Wollmann,94
-Miner,GREEN VALLEY-CARTHAGE-REDSTONE,State House,8,REP,Mathew Wollmann,83
-Miner,TOTAL,State House,8,REP,Mathew Wollmann,624
-Miner,HOWARD WARD 1,State House,8,REP,Leslie Heinemann,59
-Miner,HOWARD WARD 2,State House,8,REP,Leslie Heinemann,57
-Miner,HOWARD WARD 3,State House,8,REP,Leslie Heinemann,52
-Miner,VERMILLION-CANOVA-ROCK CREEK,State House,8,REP,Leslie Heinemann,76
-Miner,BEAVER-CLINTON-MINER,State House,8,REP,Leslie Heinemann,46
-Miner,CLEARWATER-HOWARD-ROSWELL,State House,8,REP,Leslie Heinemann,105
-Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,State House,8,REP,Leslie Heinemann,71
-Miner,GREEN VALLEY-CARTHAGE-REDSTONE,State House,8,REP,Leslie Heinemann,68
-Miner,TOTAL,State House,8,REP,Leslie Heinemann,534
-Miner,HOWARD WARD 1,State House,8,DEM,Jason Unger,70
-Miner,HOWARD WARD 2,State House,8,DEM,Jason Unger,57
-Miner,HOWARD WARD 3,State House,8,DEM,Jason Unger,42
-Miner,VERMILLION-CANOVA-ROCK CREEK,State House,8,DEM,Jason Unger,57
-Miner,BEAVER-CLINTON-MINER,State House,8,DEM,Jason Unger,29
-Miner,CLEARWATER-HOWARD-ROSWELL,State House,8,DEM,Jason Unger,67
-Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,State House,8,DEM,Jason Unger,76
-Miner,GREEN VALLEY-CARTHAGE-REDSTONE,State House,8,DEM,Jason Unger,44
-Miner,TOTAL,State House,8,DEM,Jason Unger,442
-Miner,HOWARD WARD 1,State House,8,DEM,Kory Rawstern,41
-Miner,HOWARD WARD 2,State House,8,DEM,Kory Rawstern,32
-Miner,HOWARD WARD 3,State House,8,DEM,Kory Rawstern,24
-Miner,VERMILLION-CANOVA-ROCK CREEK,State House,8,DEM,Kory Rawstern,39
-Miner,BEAVER-CLINTON-MINER,State House,8,DEM,Kory Rawstern,17
-Miner,CLEARWATER-HOWARD-ROSWELL,State House,8,DEM,Kory Rawstern,28
-Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,State House,8,DEM,Kory Rawstern,43
-Miner,GREEN VALLEY-CARTHAGE-REDSTONE,State House,8,DEM,Kory Rawstern,23
-Miner,TOTAL,State House,8,DEM,Kory Rawstern,247
+Mellette,,U.S. Senate,,John R. Thune,REP,464
+Mellette,,U.S. Senate,,Jay Williams,DEM,224
+Mellette,,U.S. House,1,Kristi Noem,REP,419
+Mellette,,U.S. House,1,Paula Hawks,DEM,274
+Mellette,,Public Utilities Commissioner,,Chris Nelson,REP,449
+Mellette,,Public Utilities Commissioner,,Henry Red Cloud,DEM,232
+Mellette,,State Senate,26,Troy Heinert,REP,433
+Mellette,,State House,26A,Shawn Bourdeaux,REP,371
+Miner,HOWARD WARD 1,President,,Trump & Pence,REP,76
+Miner,HOWARD WARD 2,President,,Trump & Pence,REP,75
+Miner,HOWARD WARD 3,President,,Trump & Pence,REP,62
+Miner,VERMILLION-CANOVA-ROCK CREEK,President,,Trump & Pence,REP,81
+Miner,BEAVER-CLINTON-MINER,President,,Trump & Pence,REP,63
+Miner,CLEARWATER-HOWARD-ROSWELL,President,,Trump & Pence,REP,132
+Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,President,,Trump & Pence,REP,125
+Miner,GREEN VALLEY-CARTHAGE-REDSTONE,President,,Trump & Pence,REP,92
+Miner,TOTAL,President,,Trump & Pence,REP,706
+Miner,HOWARD WARD 1,President,,Johnson & Weld,LIB,8
+Miner,HOWARD WARD 2,President,,Johnson & Weld,LIB,7
+Miner,HOWARD WARD 3,President,,Johnson & Weld,LIB,13
+Miner,VERMILLION-CANOVA-ROCK CREEK,President,,Johnson & Weld,LIB,11
+Miner,BEAVER-CLINTON-MINER,President,,Johnson & Weld,LIB,2
+Miner,CLEARWATER-HOWARD-ROSWELL,President,,Johnson & Weld,LIB,10
+Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,President,,Johnson & Weld,LIB,6
+Miner,GREEN VALLEY-CARTHAGE-REDSTONE,President,,Johnson & Weld,LIB,10
+Miner,TOTAL,President,,Johnson & Weld,LIB,67
+Miner,HOWARD WARD 1,President,,Clinton & Kaine,DEM,51
+Miner,HOWARD WARD 2,President,,Clinton & Kaine,DEM,38
+Miner,HOWARD WARD 3,President,,Clinton & Kaine,DEM,26
+Miner,VERMILLION-CANOVA-ROCK CREEK,President,,Clinton & Kaine,DEM,44
+Miner,BEAVER-CLINTON-MINER,President,,Clinton & Kaine,DEM,18
+Miner,CLEARWATER-HOWARD-ROSWELL,President,,Clinton & Kaine,DEM,41
+Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,President,,Clinton & Kaine,DEM,40
+Miner,GREEN VALLEY-CARTHAGE-REDSTONE,President,,Clinton & Kaine,DEM,23
+Miner,TOTAL,President,,Clinton & Kaine,DEM,281
+Miner,HOWARD WARD 1,President,,Castle & Bradley,CON,2
+Miner,HOWARD WARD 2,President,,Castle & Bradley,CON,2
+Miner,HOWARD WARD 3,President,,Castle & Bradley,CON,1
+Miner,VERMILLION-CANOVA-ROCK CREEK,President,,Castle & Bradley,CON,1
+Miner,BEAVER-CLINTON-MINER,President,,Castle & Bradley,CON,0
+Miner,CLEARWATER-HOWARD-ROSWELL,President,,Castle & Bradley,CON,0
+Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,President,,Castle & Bradley,CON,3
+Miner,GREEN VALLEY-CARTHAGE-REDSTONE,President,,Castle & Bradley,CON,1
+Miner,TOTAL,President,,Castle & Bradley,CON,10
+Miner,HOWARD WARD 1,U.S. Senate,,John R. Thune,REP,92
+Miner,HOWARD WARD 2,U.S. Senate,,John R. Thune,REP,89
+Miner,HOWARD WARD 3,U.S. Senate,,John R. Thune,REP,78
+Miner,VERMILLION-CANOVA-ROCK CREEK,U.S. Senate,,John R. Thune,REP,106
+Miner,BEAVER-CLINTON-MINER,U.S. Senate,,John R. Thune,REP,67
+Miner,CLEARWATER-HOWARD-ROSWELL,U.S. Senate,,John R. Thune,REP,142
+Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,U.S. Senate,,John R. Thune,REP,128
+Miner,GREEN VALLEY-CARTHAGE-REDSTONE,U.S. Senate,,John R. Thune,REP,105
+Miner,TOTAL,U.S. Senate,,John R. Thune,REP,807
+Miner,HOWARD WARD 1,U.S. Senate,,Jay Williams,DEM,45
+Miner,HOWARD WARD 2,U.S. Senate,,Jay Williams,DEM,36
+Miner,HOWARD WARD 3,U.S. Senate,,Jay Williams,DEM,27
+Miner,VERMILLION-CANOVA-ROCK CREEK,U.S. Senate,,Jay Williams,DEM,34
+Miner,BEAVER-CLINTON-MINER,U.S. Senate,,Jay Williams,DEM,16
+Miner,CLEARWATER-HOWARD-ROSWELL,U.S. Senate,,Jay Williams,DEM,47
+Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,U.S. Senate,,Jay Williams,DEM,55
+Miner,GREEN VALLEY-CARTHAGE-REDSTONE,U.S. Senate,,Jay Williams,DEM,24
+Miner,TOTAL,U.S. Senate,,Jay Williams,DEM,284
+Miner,HOWARD WARD 1,U.S. House,1,Kristi Noem,REP,78
+Miner,HOWARD WARD 2,U.S. House,1,Kristi Noem,REP,77
+Miner,HOWARD WARD 3,U.S. House,1,Kristi Noem,REP,68
+Miner,VERMILLION-CANOVA-ROCK CREEK,U.S. House,1,Kristi Noem,REP,84
+Miner,BEAVER-CLINTON-MINER,U.S. House,1,Kristi Noem,REP,54
+Miner,CLEARWATER-HOWARD-ROSWELL,U.S. House,1,Kristi Noem,REP,124
+Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,U.S. House,1,Kristi Noem,REP,108
+Miner,GREEN VALLEY-CARTHAGE-REDSTONE,U.S. House,1,Kristi Noem,REP,101
+Miner,TOTAL,U.S. House,1,Kristi Noem,REP,694
+Miner,HOWARD WARD 1,U.S. House,1,Paula Hawks,DEM,59
+Miner,HOWARD WARD 2,U.S. House,1,Paula Hawks,DEM,48
+Miner,HOWARD WARD 3,U.S. House,1,Paula Hawks,DEM,37
+Miner,VERMILLION-CANOVA-ROCK CREEK,U.S. House,1,Paula Hawks,DEM,55
+Miner,BEAVER-CLINTON-MINER,U.S. House,1,Paula Hawks,DEM,30
+Miner,CLEARWATER-HOWARD-ROSWELL,U.S. House,1,Paula Hawks,DEM,65
+Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,U.S. House,1,Paula Hawks,DEM,74
+Miner,GREEN VALLEY-CARTHAGE-REDSTONE,U.S. House,1,Paula Hawks,DEM,30
+Miner,TOTAL,U.S. House,1,Paula Hawks,DEM,398
+Miner,HOWARD WARD 1,Public Utilities Commissioner,,Chris Nelson,REP,96
+Miner,HOWARD WARD 2,Public Utilities Commissioner,,Chris Nelson,REP,101
+Miner,HOWARD WARD 3,Public Utilities Commissioner,,Chris Nelson,REP,86
+Miner,VERMILLION-CANOVA-ROCK CREEK,Public Utilities Commissioner,,Chris Nelson,REP,118
+Miner,BEAVER-CLINTON-MINER,Public Utilities Commissioner,,Chris Nelson,REP,66
+Miner,CLEARWATER-HOWARD-ROSWELL,Public Utilities Commissioner,,Chris Nelson,REP,168
+Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,Public Utilities Commissioner,,Chris Nelson,REP,141
+Miner,GREEN VALLEY-CARTHAGE-REDSTONE,Public Utilities Commissioner,,Chris Nelson,REP,109
+Miner,TOTAL,Public Utilities Commissioner,,Chris Nelson,REP,885
+Miner,HOWARD WARD 1,Public Utilities Commissioner,,Henry Red Cloud,DEM,29
+Miner,HOWARD WARD 2,Public Utilities Commissioner,,Henry Red Cloud,DEM,20
+Miner,HOWARD WARD 3,Public Utilities Commissioner,,Henry Red Cloud,DEM,18
+Miner,VERMILLION-CANOVA-ROCK CREEK,Public Utilities Commissioner,,Henry Red Cloud,DEM,22
+Miner,BEAVER-CLINTON-MINER,Public Utilities Commissioner,,Henry Red Cloud,DEM,16
+Miner,CLEARWATER-HOWARD-ROSWELL,Public Utilities Commissioner,,Henry Red Cloud,DEM,19
+Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,Public Utilities Commissioner,,Henry Red Cloud,DEM,33
+Miner,GREEN VALLEY-CARTHAGE-REDSTONE,Public Utilities Commissioner,,Henry Red Cloud,DEM,19
+Miner,TOTAL,Public Utilities Commissioner,,Henry Red Cloud,DEM,176
+Miner,HOWARD WARD 1,State Senate,8,Jordan Youngberg,REP,47
+Miner,HOWARD WARD 2,State Senate,8,Jordan Youngberg,REP,49
+Miner,HOWARD WARD 3,State Senate,8,Jordan Youngberg,REP,36
+Miner,VERMILLION-CANOVA-ROCK CREEK,State Senate,8,Jordan Youngberg,REP,54
+Miner,BEAVER-CLINTON-MINER,State Senate,8,Jordan Youngberg,REP,50
+Miner,CLEARWATER-HOWARD-ROSWELL,State Senate,8,Jordan Youngberg,REP,107
+Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,State Senate,8,Jordan Youngberg,REP,78
+Miner,GREEN VALLEY-CARTHAGE-REDSTONE,State Senate,8,Jordan Youngberg,REP,82
+Miner,TOTAL,State Senate,8,Jordan Youngberg,REP,503
+Miner,HOWARD WARD 1,State Senate,8,Scott Parsley,DEM,88
+Miner,HOWARD WARD 2,State Senate,8,Scott Parsley,DEM,75
+Miner,HOWARD WARD 3,State Senate,8,Scott Parsley,DEM,67
+Miner,VERMILLION-CANOVA-ROCK CREEK,State Senate,8,Scott Parsley,DEM,87
+Miner,BEAVER-CLINTON-MINER,State Senate,8,Scott Parsley,DEM,31
+Miner,CLEARWATER-HOWARD-ROSWELL,State Senate,8,Scott Parsley,DEM,82
+Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,State Senate,8,Scott Parsley,DEM,91
+Miner,GREEN VALLEY-CARTHAGE-REDSTONE,State Senate,8,Scott Parsley,DEM,45
+Miner,TOTAL,State Senate,8,Scott Parsley,DEM,566
+Miner,HOWARD WARD 1,State House,8,Mathew Wollmann,REP,58
+Miner,HOWARD WARD 2,State House,8,Mathew Wollmann,REP,67
+Miner,HOWARD WARD 3,State House,8,Mathew Wollmann,REP,62
+Miner,VERMILLION-CANOVA-ROCK CREEK,State House,8,Mathew Wollmann,REP,77
+Miner,BEAVER-CLINTON-MINER,State House,8,Mathew Wollmann,REP,46
+Miner,CLEARWATER-HOWARD-ROSWELL,State House,8,Mathew Wollmann,REP,137
+Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,State House,8,Mathew Wollmann,REP,94
+Miner,GREEN VALLEY-CARTHAGE-REDSTONE,State House,8,Mathew Wollmann,REP,83
+Miner,TOTAL,State House,8,Mathew Wollmann,REP,624
+Miner,HOWARD WARD 1,State House,8,Leslie Heinemann,REP,59
+Miner,HOWARD WARD 2,State House,8,Leslie Heinemann,REP,57
+Miner,HOWARD WARD 3,State House,8,Leslie Heinemann,REP,52
+Miner,VERMILLION-CANOVA-ROCK CREEK,State House,8,Leslie Heinemann,REP,76
+Miner,BEAVER-CLINTON-MINER,State House,8,Leslie Heinemann,REP,46
+Miner,CLEARWATER-HOWARD-ROSWELL,State House,8,Leslie Heinemann,REP,105
+Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,State House,8,Leslie Heinemann,REP,71
+Miner,GREEN VALLEY-CARTHAGE-REDSTONE,State House,8,Leslie Heinemann,REP,68
+Miner,TOTAL,State House,8,Leslie Heinemann,REP,534
+Miner,HOWARD WARD 1,State House,8,Jason Unger,DEM,70
+Miner,HOWARD WARD 2,State House,8,Jason Unger,DEM,57
+Miner,HOWARD WARD 3,State House,8,Jason Unger,DEM,42
+Miner,VERMILLION-CANOVA-ROCK CREEK,State House,8,Jason Unger,DEM,57
+Miner,BEAVER-CLINTON-MINER,State House,8,Jason Unger,DEM,29
+Miner,CLEARWATER-HOWARD-ROSWELL,State House,8,Jason Unger,DEM,67
+Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,State House,8,Jason Unger,DEM,76
+Miner,GREEN VALLEY-CARTHAGE-REDSTONE,State House,8,Jason Unger,DEM,44
+Miner,TOTAL,State House,8,Jason Unger,DEM,442
+Miner,HOWARD WARD 1,State House,8,Kory Rawstern,DEM,41
+Miner,HOWARD WARD 2,State House,8,Kory Rawstern,DEM,32
+Miner,HOWARD WARD 3,State House,8,Kory Rawstern,DEM,24
+Miner,VERMILLION-CANOVA-ROCK CREEK,State House,8,Kory Rawstern,DEM,39
+Miner,BEAVER-CLINTON-MINER,State House,8,Kory Rawstern,DEM,17
+Miner,CLEARWATER-HOWARD-ROSWELL,State House,8,Kory Rawstern,DEM,28
+Miner,HENDEN-ADAMS-BELLEVIEW-GRAFTON,State House,8,Kory Rawstern,DEM,43
+Miner,GREEN VALLEY-CARTHAGE-REDSTONE,State House,8,Kory Rawstern,DEM,23
+Miner,TOTAL,State House,8,Kory Rawstern,DEM,247
 Minnehaha,Precinct-VP01,President,,Donald Trump,REP,528
 Minnehaha,Precinct-VP02,President,,Donald Trump,REP,1274
 Minnehaha,Precinct-VP03,President,,Donald Trump,REP,1500
@@ -8777,721 +8777,721 @@ Oglala Lakota,Pine Ridge 3,State Representative,27,Everette L McKinley,IND,29
 Oglala Lakota,Porcupine,State Representative,27,Everette L McKinley,IND,22
 Oglala Lakota,Rockyford,State Representative,27,Everette L McKinley,IND,7
 Oglala Lakota,TOTAL,State Representative,27,Everette L McKinley,IND,167
-Pennington,1-Jan,President,,REP,Donald J. Trump,900
-Pennington,2-Jan,President,,REP,Donald J. Trump,1146
-Pennington,3-Jan,President,,REP,Donald J. Trump,1619
-Pennington,4-Jan,President,,REP,Donald J. Trump,603
-Pennington,1-Feb,President,,REP,Donald J. Trump,61
-Pennington,2-Feb,President,,REP,Donald J. Trump,49
-Pennington,3-Feb,President,,REP,Donald J. Trump,819
-Pennington,4-Feb,President,,REP,Donald J. Trump,1189
-Pennington,5-Feb,President,,REP,Donald J. Trump,91
-Pennington,1-Mar,President,,REP,Donald J. Trump,377
-Pennington,2-Mar,President,,REP,Donald J. Trump,2028
-Pennington,3-Mar,President,,REP,Donald J. Trump,547
-Pennington,4-Mar,President,,REP,Donald J. Trump,1634
-Pennington,5-Mar,President,,REP,Donald J. Trump,221
-Pennington,1-Apr,President,,REP,Donald J. Trump,228
-Pennington,2-Apr,President,,REP,Donald J. Trump,696
-Pennington,3-Apr,President,,REP,Donald J. Trump,547
-Pennington,4-Apr,President,,REP,Donald J. Trump,464
-Pennington,5-Apr,President,,REP,Donald J. Trump,506
-Pennington,1-May,President,,REP,Donald J. Trump,263
-Pennington,2-May,President,,REP,Donald J. Trump,950
-Pennington,3-May,President,,REP,Donald J. Trump,1249
-Pennington,4-May,President,,REP,Donald J. Trump,672
-Pennington,5-May,President,,REP,Donald J. Trump,215
-Pennington,AW,President,,REP,Donald J. Trump,1830
-Pennington,BE,President,,REP,Donald J. Trump,957
-Pennington,CA,President,,REP,Donald J. Trump,490
-Pennington,CL,President,,REP,Donald J. Trump,272
-Pennington,CR,President,,REP,Donald J. Trump,54
-Pennington,DI,President,,REP,Donald J. Trump,708
-Pennington,EL,President,,REP,Donald J. Trump,305
-Pennington,HC,President,,REP,Donald J. Trump,800
-Pennington,HP,President,,REP,Donald J. Trump,1338
-Pennington,JS,President,,REP,Donald J. Trump,865
-Pennington,KY,President,,REP,Donald J. Trump,387
-Pennington,NH,President,,REP,Donald J. Trump,192
-Pennington,NU,President,,REP,Donald J. Trump,432
-Pennington,QU,President,,REP,Donald J. Trump,180
-Pennington,RH,President,,REP,Donald J. Trump,38
-Pennington,RV,President,,REP,Donald J. Trump,807
-Pennington,VF,President,,REP,Donald J. Trump,1111
-Pennington,VV,President,,REP,Donald J. Trump,722
-Pennington,WL,President,,REP,Donald J. Trump,314
-Pennington,WP,President,,REP,Donald J. Trump,852
-Pennington,WS,President,,REP,Donald J. Trump,76
-Pennington,1-Jan,President,,LIB,Gary Johnson,123
-Pennington,2-Jan,President,,LIB,Gary Johnson,146
-Pennington,3-Jan,President,,LIB,Gary Johnson,135
-Pennington,4-Jan,President,,LIB,Gary Johnson,52
-Pennington,1-Feb,President,,LIB,Gary Johnson,7
-Pennington,2-Feb,President,,LIB,Gary Johnson,9
-Pennington,3-Feb,President,,LIB,Gary Johnson,119
-Pennington,4-Feb,President,,LIB,Gary Johnson,233
-Pennington,5-Feb,President,,LIB,Gary Johnson,21
-Pennington,1-Mar,President,,LIB,Gary Johnson,59
-Pennington,2-Mar,President,,LIB,Gary Johnson,182
-Pennington,3-Mar,President,,LIB,Gary Johnson,39
-Pennington,4-Mar,President,,LIB,Gary Johnson,218
-Pennington,5-Mar,President,,LIB,Gary Johnson,20
-Pennington,1-Apr,President,,LIB,Gary Johnson,37
-Pennington,2-Apr,President,,LIB,Gary Johnson,111
-Pennington,3-Apr,President,,LIB,Gary Johnson,44
-Pennington,4-Apr,President,,LIB,Gary Johnson,108
-Pennington,5-Apr,President,,LIB,Gary Johnson,66
-Pennington,1-May,President,,LIB,Gary Johnson,42
-Pennington,2-May,President,,LIB,Gary Johnson,172
-Pennington,3-May,President,,LIB,Gary Johnson,155
-Pennington,4-May,President,,LIB,Gary Johnson,141
-Pennington,5-May,President,,LIB,Gary Johnson,14
-Pennington,AW,President,,LIB,Gary Johnson,83
-Pennington,BE,President,,LIB,Gary Johnson,124
-Pennington,CA,President,,LIB,Gary Johnson,31
-Pennington,CL,President,,LIB,Gary Johnson,45
-Pennington,CR,President,,LIB,Gary Johnson,5
-Pennington,DI,President,,LIB,Gary Johnson,66
-Pennington,EL,President,,LIB,Gary Johnson,39
-Pennington,HC,President,,LIB,Gary Johnson,68
-Pennington,HP,President,,LIB,Gary Johnson,79
-Pennington,JS,President,,LIB,Gary Johnson,60
-Pennington,KY,President,,LIB,Gary Johnson,26
-Pennington,NH,President,,LIB,Gary Johnson,23
-Pennington,NU,President,,LIB,Gary Johnson,19
-Pennington,QU,President,,LIB,Gary Johnson,10
-Pennington,RH,President,,LIB,Gary Johnson,5
-Pennington,RV,President,,LIB,Gary Johnson,107
-Pennington,VF,President,,LIB,Gary Johnson,123
-Pennington,VV,President,,LIB,Gary Johnson,82
-Pennington,WL,President,,LIB,Gary Johnson,15
-Pennington,WP,President,,LIB,Gary Johnson,73
-Pennington,WS,President,,LIB,Gary Johnson,3
-Pennington,1-Jan,President,,DEM,Hillary Clinton,393
-Pennington,2-Jan,President,,DEM,Hillary Clinton,590
-Pennington,3-Jan,President,,DEM,Hillary Clinton,734
-Pennington,4-Jan,President,,DEM,Hillary Clinton,270
-Pennington,1-Feb,President,,DEM,Hillary Clinton,51
-Pennington,2-Feb,President,,DEM,Hillary Clinton,20
-Pennington,3-Feb,President,,DEM,Hillary Clinton,410
-Pennington,4-Feb,President,,DEM,Hillary Clinton,794
-Pennington,5-Feb,President,,DEM,Hillary Clinton,88
-Pennington,1-Mar,President,,DEM,Hillary Clinton,236
-Pennington,2-Mar,President,,DEM,Hillary Clinton,792
-Pennington,3-Mar,President,,DEM,Hillary Clinton,275
-Pennington,4-Mar,President,,DEM,Hillary Clinton,981
-Pennington,5-Mar,President,,DEM,Hillary Clinton,102
-Pennington,1-Apr,President,,DEM,Hillary Clinton,149
-Pennington,2-Apr,President,,DEM,Hillary Clinton,439
-Pennington,3-Apr,President,,DEM,Hillary Clinton,303
-Pennington,4-Apr,President,,DEM,Hillary Clinton,402
-Pennington,5-Apr,President,,DEM,Hillary Clinton,242
-Pennington,1-May,President,,DEM,Hillary Clinton,198
-Pennington,2-May,President,,DEM,Hillary Clinton,644
-Pennington,3-May,President,,DEM,Hillary Clinton,716
-Pennington,4-May,President,,DEM,Hillary Clinton,744
-Pennington,5-May,President,,DEM,Hillary Clinton,115
-Pennington,AW,President,,DEM,Hillary Clinton,898
-Pennington,BE,President,,DEM,Hillary Clinton,293
-Pennington,CA,President,,DEM,Hillary Clinton,68
-Pennington,CL,President,,DEM,Hillary Clinton,137
-Pennington,CR,President,,DEM,Hillary Clinton,4
-Pennington,DI,President,,DEM,Hillary Clinton,215
-Pennington,EL,President,,DEM,Hillary Clinton,105
-Pennington,HC,President,,DEM,Hillary Clinton,272
-Pennington,HP,President,,DEM,Hillary Clinton,384
-Pennington,JS,President,,DEM,Hillary Clinton,348
-Pennington,KY,President,,DEM,Hillary Clinton,125
-Pennington,NH,President,,DEM,Hillary Clinton,65
-Pennington,NU,President,,DEM,Hillary Clinton,100
-Pennington,QU,President,,DEM,Hillary Clinton,20
-Pennington,RH,President,,DEM,Hillary Clinton,25
-Pennington,RV,President,,DEM,Hillary Clinton,317
-Pennington,VF,President,,DEM,Hillary Clinton,335
-Pennington,VV,President,,DEM,Hillary Clinton,273
-Pennington,WL,President,,DEM,Hillary Clinton,58
-Pennington,WP,President,,DEM,Hillary Clinton,340
-Pennington,WS,President,,DEM,Hillary Clinton,4
-Pennington,1-Jan,President,,CON,Darrell L. Castle,22
-Pennington,2-Jan,President,,CON,Darrell L. Castle,24
-Pennington,3-Jan,President,,CON,Darrell L. Castle,29
-Pennington,4-Jan,President,,CON,Darrell L. Castle,10
-Pennington,1-Feb,President,,CON,Darrell L. Castle,2
-Pennington,2-Feb,President,,CON,Darrell L. Castle,1
-Pennington,3-Feb,President,,CON,Darrell L. Castle,18
-Pennington,4-Feb,President,,CON,Darrell L. Castle,27
-Pennington,5-Feb,President,,CON,Darrell L. Castle,3
-Pennington,1-Mar,President,,CON,Darrell L. Castle,10
-Pennington,2-Mar,President,,CON,Darrell L. Castle,18
-Pennington,3-Mar,President,,CON,Darrell L. Castle,7
-Pennington,4-Mar,President,,CON,Darrell L. Castle,23
-Pennington,5-Mar,President,,CON,Darrell L. Castle,1
-Pennington,1-Apr,President,,CON,Darrell L. Castle,8
-Pennington,2-Apr,President,,CON,Darrell L. Castle,13
-Pennington,3-Apr,President,,CON,Darrell L. Castle,12
-Pennington,4-Apr,President,,CON,Darrell L. Castle,23
-Pennington,5-Apr,President,,CON,Darrell L. Castle,15
-Pennington,1-May,President,,CON,Darrell L. Castle,8
-Pennington,2-May,President,,CON,Darrell L. Castle,16
-Pennington,3-May,President,,CON,Darrell L. Castle,27
-Pennington,4-May,President,,CON,Darrell L. Castle,16
-Pennington,5-May,President,,CON,Darrell L. Castle,8
-Pennington,AW,President,,CON,Darrell L. Castle,26
-Pennington,BE,President,,CON,Darrell L. Castle,9
-Pennington,CA,President,,CON,Darrell L. Castle,8
-Pennington,CL,President,,CON,Darrell L. Castle,1
-Pennington,CR,President,,CON,Darrell L. Castle,0
-Pennington,DI,President,,CON,Darrell L. Castle,8
-Pennington,EL,President,,CON,Darrell L. Castle,2
-Pennington,HC,President,,CON,Darrell L. Castle,10
-Pennington,HP,President,,CON,Darrell L. Castle,15
-Pennington,JS,President,,CON,Darrell L. Castle,15
-Pennington,KY,President,,CON,Darrell L. Castle,4
-Pennington,NH,President,,CON,Darrell L. Castle,7
-Pennington,NU,President,,CON,Darrell L. Castle,5
-Pennington,QU,President,,CON,Darrell L. Castle,1
-Pennington,RH,President,,CON,Darrell L. Castle,1
-Pennington,RV,President,,CON,Darrell L. Castle,19
-Pennington,VF,President,,CON,Darrell L. Castle,18
-Pennington,VV,President,,CON,Darrell L. Castle,17
-Pennington,WL,President,,CON,Darrell L. Castle,5
-Pennington,WP,President,,CON,Darrell L. Castle,13
-Pennington,WS,President,,CON,Darrell L. Castle,1
-Pennington,1-Jan,U.S. Senate,,REP,John R. Thune,1070
-Pennington,2-Jan,U.S. Senate,,REP,John R. Thune,1350
-Pennington,3-Jan,U.S. Senate,,REP,John R. Thune,1886
-Pennington,4-Jan,U.S. Senate,,REP,John R. Thune,684
-Pennington,1-Feb,U.S. Senate,,REP,John R. Thune,71
-Pennington,2-Feb,U.S. Senate,,REP,John R. Thune,57
-Pennington,3-Feb,U.S. Senate,,REP,John R. Thune,943
-Pennington,4-Feb,U.S. Senate,,REP,John R. Thune,1413
-Pennington,5-Feb,U.S. Senate,,REP,John R. Thune,104
-Pennington,1-Mar,U.S. Senate,,REP,John R. Thune,472
-Pennington,2-Mar,U.S. Senate,,REP,John R. Thune,2382
-Pennington,3-Mar,U.S. Senate,,REP,John R. Thune,644
-Pennington,4-Mar,U.S. Senate,,REP,John R. Thune,1958
-Pennington,5-Mar,U.S. Senate,,REP,John R. Thune,262
-Pennington,1-Apr,U.S. Senate,,REP,John R. Thune,265
-Pennington,2-Apr,U.S. Senate,,REP,John R. Thune,789
-Pennington,3-Apr,U.S. Senate,,REP,John R. Thune,614
-Pennington,4-Apr,U.S. Senate,,REP,John R. Thune,555
-Pennington,5-Apr,U.S. Senate,,REP,John R. Thune,583
-Pennington,1-May,U.S. Senate,,REP,John R. Thune,322
-Pennington,2-May,U.S. Senate,,REP,John R. Thune,1146
-Pennington,3-May,U.S. Senate,,REP,John R. Thune,1473
-Pennington,4-May,U.S. Senate,,REP,John R. Thune,896
-Pennington,5-May,U.S. Senate,,REP,John R. Thune,246
-Pennington,AW,U.S. Senate,,REP,John R. Thune,1809
-Pennington,BE,U.S. Senate,,REP,John R. Thune,1068
-Pennington,CA,U.S. Senate,,REP,John R. Thune,496
-Pennington,CL,U.S. Senate,,REP,John R. Thune,332
-Pennington,CR,U.S. Senate,,REP,John R. Thune,57
-Pennington,DI,U.S. Senate,,REP,John R. Thune,793
-Pennington,EL,U.S. Senate,,REP,John R. Thune,342
-Pennington,HC,U.S. Senate,,REP,John R. Thune,878
-Pennington,HP,U.S. Senate,,REP,John R. Thune,1450
-Pennington,JS,U.S. Senate,,REP,John R. Thune,966
-Pennington,KY,U.S. Senate,,REP,John R. Thune,408
-Pennington,NH,U.S. Senate,,REP,John R. Thune,204
-Pennington,NU,U.S. Senate,,REP,John R. Thune,436
-Pennington,QU,U.S. Senate,,REP,John R. Thune,185
-Pennington,RH,U.S. Senate,,REP,John R. Thune,39
-Pennington,RV,U.S. Senate,,REP,John R. Thune,910
-Pennington,VF,U.S. Senate,,REP,John R. Thune,1199
-Pennington,VV,U.S. Senate,,REP,John R. Thune,810
-Pennington,WL,U.S. Senate,,REP,John R. Thune,334
-Pennington,WP,U.S. Senate,,REP,John R. Thune,990
-Pennington,WS,U.S. Senate,,REP,John R. Thune,76
-Pennington,1-Jan,U.S. Senate,,DEM,Jay Williams,359
-Pennington,2-Jan,U.S. Senate,,DEM,Jay Williams,551
-Pennington,3-Jan,U.S. Senate,,DEM,Jay Williams,626
-Pennington,4-Jan,U.S. Senate,,DEM,Jay Williams,255
-Pennington,1-Feb,U.S. Senate,,DEM,Jay Williams,48
-Pennington,2-Feb,U.S. Senate,,DEM,Jay Williams,21
-Pennington,3-Feb,U.S. Senate,,DEM,Jay Williams,401
-Pennington,4-Feb,U.S. Senate,,DEM,Jay Williams,819
-Pennington,5-Feb,U.S. Senate,,DEM,Jay Williams,92
-Pennington,1-Mar,U.S. Senate,,DEM,Jay Williams,209
-Pennington,2-Mar,U.S. Senate,,DEM,Jay Williams,663
-Pennington,3-Mar,U.S. Senate,,DEM,Jay Williams,213
-Pennington,4-Mar,U.S. Senate,,DEM,Jay Williams,888
-Pennington,5-Mar,U.S. Senate,,DEM,Jay Williams,86
-Pennington,1-Apr,U.S. Senate,,DEM,Jay Williams,151
-Pennington,2-Apr,U.S. Senate,,DEM,Jay Williams,457
-Pennington,3-Apr,U.S. Senate,,DEM,Jay Williams,288
-Pennington,4-Apr,U.S. Senate,,DEM,Jay Williams,435
-Pennington,5-Apr,U.S. Senate,,DEM,Jay Williams,242
-Pennington,1-May,U.S. Senate,,DEM,Jay Williams,183
-Pennington,2-May,U.S. Senate,,DEM,Jay Williams,620
-Pennington,3-May,U.S. Senate,,DEM,Jay Williams,668
-Pennington,4-May,U.S. Senate,,DEM,Jay Williams,661
-Pennington,5-May,U.S. Senate,,DEM,Jay Williams,109
-Pennington,AW,U.S. Senate,,DEM,Jay Williams,792
-Pennington,BE,U.S. Senate,,DEM,Jay Williams,289
-Pennington,CA,U.S. Senate,,DEM,Jay Williams,96
-Pennington,CL,U.S. Senate,,DEM,Jay Williams,125
-Pennington,CR,U.S. Senate,,DEM,Jay Williams,6
-Pennington,DI,U.S. Senate,,DEM,Jay Williams,201
-Pennington,EL,U.S. Senate,,DEM,Jay Williams,95
-Pennington,HC,U.S. Senate,,DEM,Jay Williams,264
-Pennington,HP,U.S. Senate,,DEM,Jay Williams,330
-Pennington,JS,U.S. Senate,,DEM,Jay Williams,323
-Pennington,KY,U.S. Senate,,DEM,Jay Williams,127
-Pennington,NH,U.S. Senate,,DEM,Jay Williams,78
-Pennington,NU,U.S. Senate,,DEM,Jay Williams,118
-Pennington,QU,U.S. Senate,,DEM,Jay Williams,20
-Pennington,RH,U.S. Senate,,DEM,Jay Williams,30
-Pennington,RV,U.S. Senate,,DEM,Jay Williams,322
-Pennington,VF,U.S. Senate,,DEM,Jay Williams,346
-Pennington,VV,U.S. Senate,,DEM,Jay Williams,270
-Pennington,WL,U.S. Senate,,DEM,Jay Williams,48
-Pennington,WP,U.S. Senate,,DEM,Jay Williams,278
-Pennington,WS,U.S. Senate,,DEM,Jay Williams,4
-Pennington,1-Jan,U.S. House,1,REP,Kristi Noem,989
-Pennington,2-Jan,U.S. House,1,REP,Kristi Noem,1234
-Pennington,3-Jan,U.S. House,1,REP,Kristi Noem,1719
-Pennington,4-Jan,U.S. House,1,REP,Kristi Noem,638
-Pennington,1-Feb,U.S. House,1,REP,Kristi Noem,64
-Pennington,2-Feb,U.S. House,1,REP,Kristi Noem,53
-Pennington,3-Feb,U.S. House,1,REP,Kristi Noem,878
-Pennington,4-Feb,U.S. House,1,REP,Kristi Noem,1290
-Pennington,5-Feb,U.S. House,1,REP,Kristi Noem,94
-Pennington,1-Mar,U.S. House,1,REP,Kristi Noem,425
-Pennington,2-Mar,U.S. House,1,REP,Kristi Noem,2218
-Pennington,3-Mar,U.S. House,1,REP,Kristi Noem,604
-Pennington,4-Mar,U.S. House,1,REP,Kristi Noem,1796
-Pennington,5-Mar,U.S. House,1,REP,Kristi Noem,245
-Pennington,1-Apr,U.S. House,1,REP,Kristi Noem,246
-Pennington,2-Apr,U.S. House,1,REP,Kristi Noem,729
-Pennington,3-Apr,U.S. House,1,REP,Kristi Noem,570
-Pennington,4-Apr,U.S. House,1,REP,Kristi Noem,494
-Pennington,5-Apr,U.S. House,1,REP,Kristi Noem,551
-Pennington,1-May,U.S. House,1,REP,Kristi Noem,295
-Pennington,2-May,U.S. House,1,REP,Kristi Noem,1048
-Pennington,3-May,U.S. House,1,REP,Kristi Noem,1366
-Pennington,4-May,U.S. House,1,REP,Kristi Noem,774
-Pennington,5-May,U.S. House,1,REP,Kristi Noem,230
-Pennington,AW,U.S. House,1,REP,Kristi Noem,1785
-Pennington,BE,U.S. House,1,REP,Kristi Noem,1010
-Pennington,CA,U.S. House,1,REP,Kristi Noem,496
-Pennington,CL,U.S. House,1,REP,Kristi Noem,301
-Pennington,CR,U.S. House,1,REP,Kristi Noem,54
-Pennington,DI,U.S. House,1,REP,Kristi Noem,752
-Pennington,EL,U.S. House,1,REP,Kristi Noem,332
-Pennington,HC,U.S. House,1,REP,Kristi Noem,847
-Pennington,HP,U.S. House,1,REP,Kristi Noem,1385
-Pennington,JS,U.S. House,1,REP,Kristi Noem,916
-Pennington,KY,U.S. House,1,REP,Kristi Noem,394
-Pennington,NH,U.S. House,1,REP,Kristi Noem,188
-Pennington,NU,U.S. House,1,REP,Kristi Noem,422
-Pennington,QU,U.S. House,1,REP,Kristi Noem,176
-Pennington,RH,U.S. House,1,REP,Kristi Noem,38
-Pennington,RV,U.S. House,1,REP,Kristi Noem,865
-Pennington,VF,U.S. House,1,REP,Kristi Noem,1138
-Pennington,VV,U.S. House,1,REP,Kristi Noem,767
-Pennington,WL,U.S. House,1,REP,Kristi Noem,316
-Pennington,WP,U.S. House,1,REP,Kristi Noem,937
-Pennington,WS,U.S. House,1,REP,Kristi Noem,77
-Pennington,1-Jan,U.S. House,1,DEM,Paula Hawks,435
-Pennington,2-Jan,U.S. House,1,DEM,Paula Hawks,658
-Pennington,3-Jan,U.S. House,1,DEM,Paula Hawks,775
-Pennington,4-Jan,U.S. House,1,DEM,Paula Hawks,301
-Pennington,1-Feb,U.S. House,1,DEM,Paula Hawks,54
-Pennington,2-Feb,U.S. House,1,DEM,Paula Hawks,25
-Pennington,3-Feb,U.S. House,1,DEM,Paula Hawks,466
-Pennington,4-Feb,U.S. House,1,DEM,Paula Hawks,941
-Pennington,5-Feb,U.S. House,1,DEM,Paula Hawks,101
-Pennington,1-Mar,U.S. House,1,DEM,Paula Hawks,253
-Pennington,2-Mar,U.S. House,1,DEM,Paula Hawks,842
-Pennington,3-Mar,U.S. House,1,DEM,Paula Hawks,256
-Pennington,4-Mar,U.S. House,1,DEM,Paula Hawks,1064
-Pennington,5-Mar,U.S. House,1,DEM,Paula Hawks,108
-Pennington,1-Apr,U.S. House,1,DEM,Paula Hawks,173
-Pennington,2-Apr,U.S. House,1,DEM,Paula Hawks,517
-Pennington,3-Apr,U.S. House,1,DEM,Paula Hawks,332
-Pennington,4-Apr,U.S. House,1,DEM,Paula Hawks,492
-Pennington,5-Apr,U.S. House,1,DEM,Paula Hawks,276
-Pennington,1-May,U.S. House,1,DEM,Paula Hawks,214
-Pennington,2-May,U.S. House,1,DEM,Paula Hawks,718
-Pennington,3-May,U.S. House,1,DEM,Paula Hawks,782
-Pennington,4-May,U.S. House,1,DEM,Paula Hawks,792
-Pennington,5-May,U.S. House,1,DEM,Paula Hawks,121
-Pennington,AW,U.S. House,1,DEM,Paula Hawks,810
-Pennington,BE,U.S. House,1,DEM,Paula Hawks,345
-Pennington,CA,U.S. House,1,DEM,Paula Hawks,103
-Pennington,CL,U.S. House,1,DEM,Paula Hawks,152
-Pennington,CR,U.S. House,1,DEM,Paula Hawks,8
-Pennington,DI,U.S. House,1,DEM,Paula Hawks,250
-Pennington,EL,U.S. House,1,DEM,Paula Hawks,105
-Pennington,HC,U.S. House,1,DEM,Paula Hawks,294
-Pennington,HP,U.S. House,1,DEM,Paula Hawks,406
-Pennington,JS,U.S. House,1,DEM,Paula Hawks,377
-Pennington,KY,U.S. House,1,DEM,Paula Hawks,141
-Pennington,NH,U.S. House,1,DEM,Paula Hawks,96
-Pennington,NU,U.S. House,1,DEM,Paula Hawks,129
-Pennington,QU,U.S. House,1,DEM,Paula Hawks,29
-Pennington,RH,U.S. House,1,DEM,Paula Hawks,30
-Pennington,RV,U.S. House,1,DEM,Paula Hawks,374
-Pennington,VF,U.S. House,1,DEM,Paula Hawks,425
-Pennington,VV,U.S. House,1,DEM,Paula Hawks,312
-Pennington,WL,U.S. House,1,DEM,Paula Hawks,72
-Pennington,WP,U.S. House,1,DEM,Paula Hawks,342
-Pennington,WS,U.S. House,1,DEM,Paula Hawks,6
-Pennington,1-Jan,Public Utilities Commissioner,,REP,Chris Nelson,1018
-Pennington,2-Jan,Public Utilities Commissioner,,REP,Chris Nelson,1331
-Pennington,3-Jan,Public Utilities Commissioner,,REP,Chris Nelson,1828
-Pennington,4-Jan,Public Utilities Commissioner,,REP,Chris Nelson,688
-Pennington,1-Feb,Public Utilities Commissioner,,REP,Chris Nelson,63
-Pennington,2-Feb,Public Utilities Commissioner,,REP,Chris Nelson,54
-Pennington,3-Feb,Public Utilities Commissioner,,REP,Chris Nelson,871
-Pennington,4-Feb,Public Utilities Commissioner,,REP,Chris Nelson,1310
-Pennington,5-Feb,Public Utilities Commissioner,,REP,Chris Nelson,91
-Pennington,1-Mar,Public Utilities Commissioner,,REP,Chris Nelson,463
-Pennington,2-Mar,Public Utilities Commissioner,,REP,Chris Nelson,2348
-Pennington,3-Mar,Public Utilities Commissioner,,REP,Chris Nelson,633
-Pennington,4-Mar,Public Utilities Commissioner,,REP,Chris Nelson,1987
-Pennington,5-Mar,Public Utilities Commissioner,,REP,Chris Nelson,262
-Pennington,1-Apr,Public Utilities Commissioner,,REP,Chris Nelson,243
-Pennington,2-Apr,Public Utilities Commissioner,,REP,Chris Nelson,744
-Pennington,3-Apr,Public Utilities Commissioner,,REP,Chris Nelson,586
-Pennington,4-Apr,Public Utilities Commissioner,,REP,Chris Nelson,502
-Pennington,5-Apr,Public Utilities Commissioner,,REP,Chris Nelson,572
-Pennington,1-May,Public Utilities Commissioner,,REP,Chris Nelson,318
-Pennington,2-May,Public Utilities Commissioner,,REP,Chris Nelson,1121
-Pennington,3-May,Public Utilities Commissioner,,REP,Chris Nelson,1494
-Pennington,4-May,Public Utilities Commissioner,,REP,Chris Nelson,866
-Pennington,5-May,Public Utilities Commissioner,,REP,Chris Nelson,260
-Pennington,AW,Public Utilities Commissioner,,REP,Chris Nelson,1622
-Pennington,BE,Public Utilities Commissioner,,REP,Chris Nelson,981
-Pennington,CA,Public Utilities Commissioner,,REP,Chris Nelson,490
-Pennington,CL,Public Utilities Commissioner,,REP,Chris Nelson,318
-Pennington,CR,Public Utilities Commissioner,,REP,Chris Nelson,50
-Pennington,DI,Public Utilities Commissioner,,REP,Chris Nelson,779
-Pennington,EL,Public Utilities Commissioner,,REP,Chris Nelson,306
-Pennington,HC,Public Utilities Commissioner,,REP,Chris Nelson,824
-Pennington,HP,Public Utilities Commissioner,,REP,Chris Nelson,1430
-Pennington,JS,Public Utilities Commissioner,,REP,Chris Nelson,981
-Pennington,KY,Public Utilities Commissioner,,REP,Chris Nelson,393
-Pennington,NH,Public Utilities Commissioner,,REP,Chris Nelson,198
-Pennington,NU,Public Utilities Commissioner,,REP,Chris Nelson,435
-Pennington,QU,Public Utilities Commissioner,,REP,Chris Nelson,178
-Pennington,RH,Public Utilities Commissioner,,REP,Chris Nelson,39
-Pennington,RV,Public Utilities Commissioner,,REP,Chris Nelson,913
-Pennington,VF,Public Utilities Commissioner,,REP,Chris Nelson,1155
-Pennington,VV,Public Utilities Commissioner,,REP,Chris Nelson,757
-Pennington,WL,Public Utilities Commissioner,,REP,Chris Nelson,322
-Pennington,WP,Public Utilities Commissioner,,REP,Chris Nelson,993
-Pennington,WS,Public Utilities Commissioner,,REP,Chris Nelson,75
-Pennington,1-Jan,Public Utilities Commissioner,,DEM,Henry Red Cloud,353
-Pennington,2-Jan,Public Utilities Commissioner,,DEM,Henry Red Cloud,514
-Pennington,3-Jan,Public Utilities Commissioner,,DEM,Henry Red Cloud,565
-Pennington,4-Jan,Public Utilities Commissioner,,DEM,Henry Red Cloud,210
-Pennington,1-Feb,Public Utilities Commissioner,,DEM,Henry Red Cloud,51
-Pennington,2-Feb,Public Utilities Commissioner,,DEM,Henry Red Cloud,25
-Pennington,3-Feb,Public Utilities Commissioner,,DEM,Henry Red Cloud,410
-Pennington,4-Feb,Public Utilities Commissioner,,DEM,Henry Red Cloud,836
-Pennington,5-Feb,Public Utilities Commissioner,,DEM,Henry Red Cloud,96
-Pennington,1-Mar,Public Utilities Commissioner,,DEM,Henry Red Cloud,193
-Pennington,2-Mar,Public Utilities Commissioner,,DEM,Henry Red Cloud,589
-Pennington,3-Mar,Public Utilities Commissioner,,DEM,Henry Red Cloud,202
-Pennington,4-Mar,Public Utilities Commissioner,,DEM,Henry Red Cloud,781
-Pennington,5-Mar,Public Utilities Commissioner,,DEM,Henry Red Cloud,80
-Pennington,1-Apr,Public Utilities Commissioner,,DEM,Henry Red Cloud,167
-Pennington,2-Apr,Public Utilities Commissioner,,DEM,Henry Red Cloud,467
-Pennington,3-Apr,Public Utilities Commissioner,,DEM,Henry Red Cloud,283
-Pennington,4-Apr,Public Utilities Commissioner,,DEM,Henry Red Cloud,459
-Pennington,5-Apr,Public Utilities Commissioner,,DEM,Henry Red Cloud,215
-Pennington,1-May,Public Utilities Commissioner,,DEM,Henry Red Cloud,175
-Pennington,2-May,Public Utilities Commissioner,,DEM,Henry Red Cloud,580
-Pennington,3-May,Public Utilities Commissioner,,DEM,Henry Red Cloud,566
-Pennington,4-May,Public Utilities Commissioner,,DEM,Henry Red Cloud,640
-Pennington,5-May,Public Utilities Commissioner,,DEM,Henry Red Cloud,85
-Pennington,AW,Public Utilities Commissioner,,DEM,Henry Red Cloud,767
-Pennington,BE,Public Utilities Commissioner,,DEM,Henry Red Cloud,306
-Pennington,CA,Public Utilities Commissioner,,DEM,Henry Red Cloud,81
-Pennington,CL,Public Utilities Commissioner,,DEM,Henry Red Cloud,123
-Pennington,CR,Public Utilities Commissioner,,DEM,Henry Red Cloud,8
-Pennington,DI,Public Utilities Commissioner,,DEM,Henry Red Cloud,199
-Pennington,EL,Public Utilities Commissioner,,DEM,Henry Red Cloud,99
-Pennington,HC,Public Utilities Commissioner,,DEM,Henry Red Cloud,280
-Pennington,HP,Public Utilities Commissioner,,DEM,Henry Red Cloud,298
-Pennington,JS,Public Utilities Commissioner,,DEM,Henry Red Cloud,284
-Pennington,KY,Public Utilities Commissioner,,DEM,Henry Red Cloud,122
-Pennington,NH,Public Utilities Commissioner,,DEM,Henry Red Cloud,72
-Pennington,NU,Public Utilities Commissioner,,DEM,Henry Red Cloud,97
-Pennington,QU,Public Utilities Commissioner,,DEM,Henry Red Cloud,18
-Pennington,RH,Public Utilities Commissioner,,DEM,Henry Red Cloud,27
-Pennington,RV,Public Utilities Commissioner,,DEM,Henry Red Cloud,268
-Pennington,VF,Public Utilities Commissioner,,DEM,Henry Red Cloud,324
-Pennington,VV,Public Utilities Commissioner,,DEM,Henry Red Cloud,269
-Pennington,WL,Public Utilities Commissioner,,DEM,Henry Red Cloud,49
-Pennington,WP,Public Utilities Commissioner,,DEM,Henry Red Cloud,251
-Pennington,WS,Public Utilities Commissioner,,DEM,Henry Red Cloud,6
-Pennington,CA,State Senate,27,DEM,Kevin Killer,15
-Pennington,CR,State Senate,27,DEM,Kevin Killer,8
-Pennington,QU,State Senate,27,DEM,Kevin Killer,50
-Pennington,EL,State Senate,29,REP,Gary L. Cammack,267
-Pennington,EL,State Senate,29,IND,LeRoy Kindler,110
-Pennington,CA,State Senate,30,REP,Lance Russell,405
-Pennington,HC,State Senate,30,REP,Lance Russell,788
-Pennington,HR,State Senate,30,REP,Lance Russell,1280
-Pennington,KY,State Senate,30,REP,Lance Russell,378
-Pennington,NU,State Senate,30,REP,Lance Russell,401
-Pennington,RH,State Senate,30,REP,Lance Russell,39
-Pennington,WL,State Senate,30,REP,Lance Russell,290
-Pennington,WS,State Senate,30,REP,Lance Russell,75
-Pennington,CA,State Senate,30,DEM,Karla R. LaRive,87
-Pennington,HC,State Senate,30,DEM,Karla R. LaRive,305
-Pennington,HR,State Senate,30,DEM,Karla R. LaRive,379
-Pennington,KY,State Senate,30,DEM,Karla R. LaRive,135
-Pennington,NU,State Senate,30,DEM,Karla R. LaRive,126
-Pennington,RH,State Senate,30,DEM,Karla R. LaRive,22
-Pennington,WL,State Senate,30,DEM,Karla R. LaRive,72
-Pennington,WS,State Senate,30,DEM,Karla R. LaRive,6
-Pennington,1-Jan,State Senate,32,REP,Alan D. Solano,1013
-Pennington,2-Jan,State Senate,32,REP,Alan D. Solano,1301
-Pennington,3-Jan,State Senate,32,REP,Alan D. Solano,1774
-Pennington,4-Feb,State Senate,32,REP,Alan D. Solano,1301
-Pennington,5-Feb,State Senate,32,REP,Alan D. Solano,95
-Pennington,1-Mar,State Senate,32,REP,Alan D. Solano,409
-Pennington,4-May,State Senate,32,REP,Alan D. Solano,827
-Pennington,HR,State Senate,32,REP,Alan D. Solano,44
-Pennington,1-Jan,State Senate,32,DEM,David A. Hubbard,357
-Pennington,2-Jan,State Senate,32,DEM,David A. Hubbard,542
-Pennington,3-Jan,State Senate,32,DEM,David A. Hubbard,622
-Pennington,4-Feb,State Senate,32,DEM,David A. Hubbard,813
-Pennington,5-Feb,State Senate,32,DEM,David A. Hubbard,93
-Pennington,1-Mar,State Senate,32,DEM,David A. Hubbard,241
-Pennington,4-May,State Senate,32,DEM,David A. Hubbard,678
-Pennington,HR,State Senate,32,DEM,David A. Hubbard,13
-Pennington,2-Feb,State Senate,33,REP,Phil Jensen,49
-Pennington,5-Mar,State Senate,33,REP,Phil Jensen,185
-Pennington,3-Apr,State Senate,33,REP,Phil Jensen,475
-Pennington,4-Apr,State Senate,33,REP,Phil Jensen,423
-Pennington,5-Apr,State Senate,33,REP,Phil Jensen,461
-Pennington,5-May,State Senate,33,REP,Phil Jensen,192
-Pennington,AW,State Senate,33,REP,Phil Jensen,1722
-Pennington,CL,State Senate,33,REP,Phil Jensen,240
-Pennington,DT,State Senate,33,REP,Phil Jensen,627
-Pennington,JS,State Senate,33,REP,Phil Jensen,759
-Pennington,NH,State Senate,33,REP,Phil Jensen,176
-Pennington,WP,State Senate,33,REP,Phil Jensen,756
-Pennington,2-Feb,State Senate,33,DEM,Haven Stuck,27
-Pennington,5-Mar,State Senate,33,DEM,Haven Stuck,154
-Pennington,3-Apr,State Senate,33,DEM,Haven Stuck,392
-Pennington,4-Apr,State Senate,33,DEM,Haven Stuck,531
-Pennington,5-Apr,State Senate,33,DEM,Haven Stuck,332
-Pennington,5-May,State Senate,33,DEM,Haven Stuck,148
-Pennington,AW,State Senate,33,DEM,Haven Stuck,752
-Pennington,CL,State Senate,33,DEM,Haven Stuck,203
-Pennington,DT,State Senate,33,DEM,Haven Stuck,355
-Pennington,JS,State Senate,33,DEM,Haven Stuck,503
-Pennington,NH,State Senate,33,DEM,Haven Stuck,92
-Pennington,WP,State Senate,33,DEM,Haven Stuck,496
-Pennington,1-Feb,State Senate,34,REP,Jeffrey D. Partridge,58
-Pennington,2-Mar,State Senate,34,REP,Jeffrey D. Partridge,2104
-Pennington,3-Mar,State Senate,34,REP,Jeffrey D. Partridge,568
-Pennington,4-Mar,State Senate,34,REP,Jeffrey D. Partridge,1745
-Pennington,1-Apr,State Senate,34,REP,Jeffrey D. Partridge,232
-Pennington,1-May,State Senate,34,REP,Jeffrey D. Partridge,273
-Pennington,2-May,State Senate,34,REP,Jeffrey D. Partridge,994
-Pennington,3-May,State Senate,34,REP,Jeffrey D. Partridge,1318
-Pennington,1-Feb,State Senate,34,DEM,Jay C. Shultz,55
-Pennington,2-Mar,State Senate,34,DEM,Jay C. Shultz,811
-Pennington,3-Mar,State Senate,34,DEM,Jay C. Shultz,253
-Pennington,4-Mar,State Senate,34,DEM,Jay C. Shultz,1010
-Pennington,1-Apr,State Senate,34,DEM,Jay C. Shultz,164
-Pennington,1-May,State Senate,34,DEM,Jay C. Shultz,201
-Pennington,2-May,State Senate,34,DEM,Jay C. Shultz,676
-Pennington,3-May,State Senate,34,DEM,Jay C. Shultz,719
-Pennington,4-Jan,State Senate,35,REP,Terri L. Haverly,663
-Pennington,3-Feb,State Senate,35,REP,Terri L. Haverly,883
-Pennington,2-Apr,State Senate,35,REP,Terri L. Haverly,763
-Pennington,BE,State Senate,35,REP,Terri L. Haverly,997
-Pennington,RV,State Senate,35,REP,Terri L. Haverly,892
-Pennington,VF,State Senate,35,REP,Terri L. Haverly,1148
-Pennington,VV,State Senate,35,REP,Terri L. Haverly,791
-Pennington,CA,State House,27,REP,Elizabeth May,58
-Pennington,CR,State House,27,REP,Elizabeth May,48
-Pennington,QU,State House,27,REP,Elizabeth May,145
-Pennington,CA,State House,27,REP,Steve Livermont,54
-Pennington,CR,State House,27,REP,Steve Livermont,42
-Pennington,QU,State House,27,REP,Steve Livermont,163
-Pennington,CA,State House,27,DEM,Red Dawn Foster,4
-Pennington,CR,State House,27,DEM,Red Dawn Foster,2
-Pennington,QU,State House,27,DEM,Red Dawn Foster,10
-Pennington,CA,State House,27,DEM,Jim Bradford,10
-Pennington,CR,State House,27,DEM,Jim Bradford,4
-Pennington,QU,State House,27,DEM,Jim Bradford,23
-Pennington,CA,State House,27,IND,Everette L.. McKinley,8
-Pennington,CR,State House,27,IND,Everette L.. McKinley,6
-Pennington,QU,State House,27,IND,Everette L.. McKinley,17
-Pennington,EL,State House,29,REP,Larry Rhoden,248
-Pennington,EL,State House,29,REP,Thomas J. Brunner,156
-Pennington,CA,State House,30,REP,Julie Frye-Mueller,352
-Pennington,HO,State House,30,REP,Julie Frye-Mueller,653
-Pennington,HR,State House,30,REP,Julie Frye-Mueller,1155
-Pennington,KY,State House,30,REP,Julie Frye-Mueller,339
-Pennington,NU,State House,30,REP,Julie Frye-Mueller,360
-Pennington,RH,State House,30,REP,Julie Frye-Mueller,38
-Pennington,WL,State House,30,REP,Julie Frye-Mueller,260
-Pennington,WS,State House,30,REP,Julie Frye-Mueller,63
-Pennington,CA,State House,30,REP,Tim R. Goodwin,338
-Pennington,HO,State House,30,REP,Tim R. Goodwin,734
-Pennington,HR,State House,30,REP,Tim R. Goodwin,1145
-Pennington,KY,State House,30,REP,Tim R. Goodwin,332
-Pennington,NU,State House,30,REP,Tim R. Goodwin,363
-Pennington,RH,State House,30,REP,Tim R. Goodwin,32
-Pennington,WL,State House,30,REP,Tim R. Goodwin,238
-Pennington,WS,State House,30,REP,Tim R. Goodwin,57
-Pennington,CA,State House,30,DEM,Kristine Ina Winter,70
-Pennington,HO,State House,30,DEM,Kristine Ina Winter,242
-Pennington,HR,State House,30,DEM,Kristine Ina Winter,337
-Pennington,KY,State House,30,DEM,Kristine Ina Winter,107
-Pennington,NU,State House,30,DEM,Kristine Ina Winter,97
-Pennington,RH,State House,30,DEM,Kristine Ina Winter,24
-Pennington,WL,State House,30,DEM,Kristine Ina Winter,67
-Pennington,WS,State House,30,DEM,Kristine Ina Winter,5
-Pennington,CA,State House,30,DEM,Sandy Arseneault,72
-Pennington,HO,State House,30,DEM,Sandy Arseneault,280
-Pennington,HR,State House,30,DEM,Sandy Arseneault,327
-Pennington,KY,State House,30,DEM,Sandy Arseneault,111
-Pennington,NU,State House,30,DEM,Sandy Arseneault,98
-Pennington,RH,State House,30,DEM,Sandy Arseneault,25
-Pennington,WL,State House,30,DEM,Sandy Arseneault,58
-Pennington,WS,State House,30,DEM,Sandy Arseneault,10
-Pennington,1-Jan,State House,32,REP,Kristin A. Conzet,839
-Pennington,2-Jan,State House,32,REP,Kristin A. Conzet,1022
-Pennington,3-Jan,State House,32,REP,Kristin A. Conzet,1475
-Pennington,4-Feb,State House,32,REP,Kristin A. Conzet,971
-Pennington,5-Feb,State House,32,REP,Kristin A. Conzet,83
-Pennington,1-Mar,State House,32,REP,Kristin A. Conzet,325
-Pennington,4-May,State House,32,REP,Kristin A. Conzet,664
-Pennington,HR,State House,32,REP,Kristin A. Conzet,40
-Pennington,1-Jan,State House,32,REP,Sean McPherson,777
-Pennington,2-Jan,State House,32,REP,Sean McPherson,943
-Pennington,3-Jan,State House,32,REP,Sean McPherson,1332
-Pennington,4-Feb,State House,32,REP,Sean McPherson,977
-Pennington,5-Feb,State House,32,REP,Sean McPherson,73
-Pennington,1-Mar,State House,32,REP,Sean McPherson,330
-Pennington,4-May,State House,32,REP,Sean McPherson,599
-Pennington,HR,State House,32,REP,Sean McPherson,37
-Pennington,1-Jan,State House,32,DEM,Nik Aberle,290
-Pennington,2-Jan,State House,32,DEM,Nik Aberle,378
-Pennington,3-Jan,State House,32,DEM,Nik Aberle,489
-Pennington,4-Feb,State House,32,DEM,Nik Aberle,591
-Pennington,5-Feb,State House,32,DEM,Nik Aberle,65
-Pennington,1-Mar,State House,32,DEM,Nik Aberle,150
-Pennington,4-May,State House,32,DEM,Nik Aberle,495
-Pennington,HR,State House,32,DEM,Nik Aberle,7
-Pennington,1-Jan,State House,32,DEM,Susan Kelts,465
-Pennington,2-Jan,State House,32,DEM,Susan Kelts,737
-Pennington,3-Jan,State House,32,DEM,Susan Kelts,922
-Pennington,4-Feb,State House,32,DEM,Susan Kelts,982
-Pennington,5-Feb,State House,32,DEM,Susan Kelts,91
-Pennington,1-Mar,State House,32,DEM,Susan Kelts,293
-Pennington,4-May,State House,32,DEM,Susan Kelts,837
-Pennington,HR,State House,32,DEM,Susan Kelts,14
-Pennington,2-Feb,State House,33,REP,Taffy Howard,40
-Pennington,5-Mar,State House,33,REP,Taffy Howard,202
-Pennington,3-Apr,State House,33,REP,Taffy Howard,399
-Pennington,4-Apr,State House,33,REP,Taffy Howard,355
-Pennington,5-Apr,State House,33,REP,Taffy Howard,410
-Pennington,5-May,State House,33,REP,Taffy Howard,199
-Pennington,AW,State House,33,REP,Taffy Howard,1553
-Pennington,CL,State House,33,REP,Taffy Howard,252
-Pennington,DT,State House,33,REP,Taffy Howard,606
-Pennington,JS,State House,33,REP,Taffy Howard,732
-Pennington,NH,State House,33,REP,Taffy Howard,148
-Pennington,WP,State House,33,REP,Taffy Howard,781
-Pennington,2-Feb,State House,33,REP,David Johnson,42
-Pennington,5-Mar,State House,33,REP,David Johnson,233
-Pennington,3-Apr,State House,33,REP,David Johnson,543
-Pennington,4-Apr,State House,33,REP,David Johnson,492
-Pennington,5-Apr,State House,33,REP,David Johnson,489
-Pennington,5-May,State House,33,REP,David Johnson,235
-Pennington,AW,State House,33,REP,David Johnson,1556
-Pennington,CL,State House,33,REP,David Johnson,283
-Pennington,DT,State House,33,REP,David Johnson,717
-Pennington,JS,State House,33,REP,David Johnson,877
-Pennington,NH,State House,33,REP,David Johnson,166
-Pennington,WP,State House,33,REP,David Johnson,892
-Pennington,2-Feb,State House,33,DEM,Ethan Marsland,19
-Pennington,5-Mar,State House,33,DEM,Ethan Marsland,76
-Pennington,3-Apr,State House,33,DEM,Ethan Marsland,230
-Pennington,4-Apr,State House,33,DEM,Ethan Marsland,360
-Pennington,5-Apr,State House,33,DEM,Ethan Marsland,180
-Pennington,5-May,State House,33,DEM,Ethan Marsland,75
-Pennington,AW,State House,33,DEM,Ethan Marsland,670
-Pennington,CL,State House,33,DEM,Ethan Marsland,94
-Pennington,DT,State House,33,DEM,Ethan Marsland,139
-Pennington,JS,State House,33,DEM,Ethan Marsland,219
-Pennington,NH,State House,33,DEM,Ethan Marsland,67
-Pennington,WP,State House,33,DEM,Ethan Marsland,244
-Pennington,2-Feb,State House,33,DEM,Jim Hadd,19
-Pennington,5-Mar,State House,33,DEM,Jim Hadd,81
-Pennington,3-Apr,State House,33,DEM,Jim Hadd,249
-Pennington,4-Apr,State House,33,DEM,Jim Hadd,324
-Pennington,5-Apr,State House,33,DEM,Jim Hadd,225
-Pennington,5-May,State House,33,DEM,Jim Hadd,94
-Pennington,AW,State House,33,DEM,Jim Hadd,677
-Pennington,CL,State House,33,DEM,Jim Hadd,121
-Pennington,DT,State House,33,DEM,Jim Hadd,230
-Pennington,JS,State House,33,DEM,Jim Hadd,335
-Pennington,NH,State House,33,DEM,Jim Hadd,65
-Pennington,WP,State House,33,DEM,Jim Hadd,281
-Pennington,1-Feb,State House,34,REP,Craig Tieszen,61
-Pennington,2-Mar,State House,34,REP,Craig Tieszen,2169
-Pennington,3-Mar,State House,34,REP,Craig Tieszen,576
-Pennington,4-Mar,State House,34,REP,Craig Tieszen,1834
-Pennington,1-Apr,State House,34,REP,Craig Tieszen,221
-Pennington,1-May,State House,34,REP,Craig Tieszen,262
-Pennington,2-May,State House,34,REP,Craig Tieszen,1032
-Pennington,3-May,State House,34,REP,Craig Tieszen,1407
-Pennington,1-Feb,State House,34,REP,Dan Dryden,45
-Pennington,2-Mar,State House,34,REP,Dan Dryden,1619
-Pennington,3-Mar,State House,34,REP,Dan Dryden,427
-Pennington,4-Mar,State House,34,REP,Dan Dryden,1325
-Pennington,1-Apr,State House,34,REP,Dan Dryden,165
-Pennington,1-May,State House,34,REP,Dan Dryden,217
-Pennington,2-May,State House,34,REP,Dan Dryden,725
-Pennington,3-May,State House,34,REP,Dan Dryden,967
-Pennington,1-Feb,State House,34,DEM,Steve Stenson,53
-Pennington,2-Mar,State House,34,DEM,Steve Stenson,739
-Pennington,3-Mar,State House,34,DEM,Steve Stenson,242
-Pennington,4-Mar,State House,34,DEM,Steve Stenson,956
-Pennington,1-Apr,State House,34,DEM,Steve Stenson,156
-Pennington,1-May,State House,34,DEM,Steve Stenson,179
-Pennington,2-May,State House,34,DEM,Steve Stenson,645
-Pennington,3-May,State House,34,DEM,Steve Stenson,700
-Pennington,4-Jan,State House,35,REP,Lynne DiSanto,537
-Pennington,3-Feb,State House,35,REP,Lynne DiSanto,727
-Pennington,2-Apr,State House,35,REP,Lynne DiSanto,576
-Pennington,BE,State House,35,REP,Lynne DiSanto,776
-Pennington,RV,State House,35,REP,Lynne DiSanto,737
-Pennington,VF,State House,35,REP,Lynne DiSanto,946
-Pennington,VV,State House,35,REP,Lynne DiSanto,656
-Pennington,4-Jan,State House,35,REP,"Blaine ""Chip"" Campbell",477
-Pennington,3-Feb,State House,35,REP,"Blaine ""Chip"" Campbell",601
-Pennington,2-Apr,State House,35,REP,"Blaine ""Chip"" Campbell",523
-Pennington,BE,State House,35,REP,"Blaine ""Chip"" Campbell",698
-Pennington,RV,State House,35,REP,"Blaine ""Chip"" Campbell",615
-Pennington,VF,State House,35,REP,"Blaine ""Chip"" Campbell",816
-Pennington,VV,State House,35,REP,"Blaine ""Chip"" Campbell",550
-Pennington,4-Jan,State House,35,DEM,Dave Freytag,259
-Pennington,3-Feb,State House,35,DEM,Dave Freytag,434
-Pennington,2-Apr,State House,35,DEM,Dave Freytag,456
-Pennington,BE,State House,35,DEM,Dave Freytag,333
-Pennington,RV,State House,35,DEM,Dave Freytag,363
-Pennington,VF,State House,35,DEM,Dave Freytag,370
-Pennington,VV,State House,35,DEM,Dave Freytag,313
-Pennington,4-Jan,State House,35,DEM,Michael T. Hanson,210
-Pennington,3-Feb,State House,35,DEM,Michael T. Hanson,351
-Pennington,2-Apr,State House,35,DEM,Michael T. Hanson,392
-Pennington,BE,State House,35,DEM,Michael T. Hanson,271
-Pennington,RV,State House,35,DEM,Michael T. Hanson,245
-Pennington,VF,State House,35,DEM,Michael T. Hanson,287
-Pennington,VV,State House,35,DEM,Michael T. Hanson,239
+Pennington,1-Jan,President,,Donald J. Trump,REP,900
+Pennington,2-Jan,President,,Donald J. Trump,REP,1146
+Pennington,3-Jan,President,,Donald J. Trump,REP,1619
+Pennington,4-Jan,President,,Donald J. Trump,REP,603
+Pennington,1-Feb,President,,Donald J. Trump,REP,61
+Pennington,2-Feb,President,,Donald J. Trump,REP,49
+Pennington,3-Feb,President,,Donald J. Trump,REP,819
+Pennington,4-Feb,President,,Donald J. Trump,REP,1189
+Pennington,5-Feb,President,,Donald J. Trump,REP,91
+Pennington,1-Mar,President,,Donald J. Trump,REP,377
+Pennington,2-Mar,President,,Donald J. Trump,REP,2028
+Pennington,3-Mar,President,,Donald J. Trump,REP,547
+Pennington,4-Mar,President,,Donald J. Trump,REP,1634
+Pennington,5-Mar,President,,Donald J. Trump,REP,221
+Pennington,1-Apr,President,,Donald J. Trump,REP,228
+Pennington,2-Apr,President,,Donald J. Trump,REP,696
+Pennington,3-Apr,President,,Donald J. Trump,REP,547
+Pennington,4-Apr,President,,Donald J. Trump,REP,464
+Pennington,5-Apr,President,,Donald J. Trump,REP,506
+Pennington,1-May,President,,Donald J. Trump,REP,263
+Pennington,2-May,President,,Donald J. Trump,REP,950
+Pennington,3-May,President,,Donald J. Trump,REP,1249
+Pennington,4-May,President,,Donald J. Trump,REP,672
+Pennington,5-May,President,,Donald J. Trump,REP,215
+Pennington,AW,President,,Donald J. Trump,REP,1830
+Pennington,BE,President,,Donald J. Trump,REP,957
+Pennington,CA,President,,Donald J. Trump,REP,490
+Pennington,CL,President,,Donald J. Trump,REP,272
+Pennington,CR,President,,Donald J. Trump,REP,54
+Pennington,DI,President,,Donald J. Trump,REP,708
+Pennington,EL,President,,Donald J. Trump,REP,305
+Pennington,HC,President,,Donald J. Trump,REP,800
+Pennington,HP,President,,Donald J. Trump,REP,1338
+Pennington,JS,President,,Donald J. Trump,REP,865
+Pennington,KY,President,,Donald J. Trump,REP,387
+Pennington,NH,President,,Donald J. Trump,REP,192
+Pennington,NU,President,,Donald J. Trump,REP,432
+Pennington,QU,President,,Donald J. Trump,REP,180
+Pennington,RH,President,,Donald J. Trump,REP,38
+Pennington,RV,President,,Donald J. Trump,REP,807
+Pennington,VF,President,,Donald J. Trump,REP,1111
+Pennington,VV,President,,Donald J. Trump,REP,722
+Pennington,WL,President,,Donald J. Trump,REP,314
+Pennington,WP,President,,Donald J. Trump,REP,852
+Pennington,WS,President,,Donald J. Trump,REP,76
+Pennington,1-Jan,President,,Gary Johnson,LIB,123
+Pennington,2-Jan,President,,Gary Johnson,LIB,146
+Pennington,3-Jan,President,,Gary Johnson,LIB,135
+Pennington,4-Jan,President,,Gary Johnson,LIB,52
+Pennington,1-Feb,President,,Gary Johnson,LIB,7
+Pennington,2-Feb,President,,Gary Johnson,LIB,9
+Pennington,3-Feb,President,,Gary Johnson,LIB,119
+Pennington,4-Feb,President,,Gary Johnson,LIB,233
+Pennington,5-Feb,President,,Gary Johnson,LIB,21
+Pennington,1-Mar,President,,Gary Johnson,LIB,59
+Pennington,2-Mar,President,,Gary Johnson,LIB,182
+Pennington,3-Mar,President,,Gary Johnson,LIB,39
+Pennington,4-Mar,President,,Gary Johnson,LIB,218
+Pennington,5-Mar,President,,Gary Johnson,LIB,20
+Pennington,1-Apr,President,,Gary Johnson,LIB,37
+Pennington,2-Apr,President,,Gary Johnson,LIB,111
+Pennington,3-Apr,President,,Gary Johnson,LIB,44
+Pennington,4-Apr,President,,Gary Johnson,LIB,108
+Pennington,5-Apr,President,,Gary Johnson,LIB,66
+Pennington,1-May,President,,Gary Johnson,LIB,42
+Pennington,2-May,President,,Gary Johnson,LIB,172
+Pennington,3-May,President,,Gary Johnson,LIB,155
+Pennington,4-May,President,,Gary Johnson,LIB,141
+Pennington,5-May,President,,Gary Johnson,LIB,14
+Pennington,AW,President,,Gary Johnson,LIB,83
+Pennington,BE,President,,Gary Johnson,LIB,124
+Pennington,CA,President,,Gary Johnson,LIB,31
+Pennington,CL,President,,Gary Johnson,LIB,45
+Pennington,CR,President,,Gary Johnson,LIB,5
+Pennington,DI,President,,Gary Johnson,LIB,66
+Pennington,EL,President,,Gary Johnson,LIB,39
+Pennington,HC,President,,Gary Johnson,LIB,68
+Pennington,HP,President,,Gary Johnson,LIB,79
+Pennington,JS,President,,Gary Johnson,LIB,60
+Pennington,KY,President,,Gary Johnson,LIB,26
+Pennington,NH,President,,Gary Johnson,LIB,23
+Pennington,NU,President,,Gary Johnson,LIB,19
+Pennington,QU,President,,Gary Johnson,LIB,10
+Pennington,RH,President,,Gary Johnson,LIB,5
+Pennington,RV,President,,Gary Johnson,LIB,107
+Pennington,VF,President,,Gary Johnson,LIB,123
+Pennington,VV,President,,Gary Johnson,LIB,82
+Pennington,WL,President,,Gary Johnson,LIB,15
+Pennington,WP,President,,Gary Johnson,LIB,73
+Pennington,WS,President,,Gary Johnson,LIB,3
+Pennington,1-Jan,President,,Hillary Clinton,DEM,393
+Pennington,2-Jan,President,,Hillary Clinton,DEM,590
+Pennington,3-Jan,President,,Hillary Clinton,DEM,734
+Pennington,4-Jan,President,,Hillary Clinton,DEM,270
+Pennington,1-Feb,President,,Hillary Clinton,DEM,51
+Pennington,2-Feb,President,,Hillary Clinton,DEM,20
+Pennington,3-Feb,President,,Hillary Clinton,DEM,410
+Pennington,4-Feb,President,,Hillary Clinton,DEM,794
+Pennington,5-Feb,President,,Hillary Clinton,DEM,88
+Pennington,1-Mar,President,,Hillary Clinton,DEM,236
+Pennington,2-Mar,President,,Hillary Clinton,DEM,792
+Pennington,3-Mar,President,,Hillary Clinton,DEM,275
+Pennington,4-Mar,President,,Hillary Clinton,DEM,981
+Pennington,5-Mar,President,,Hillary Clinton,DEM,102
+Pennington,1-Apr,President,,Hillary Clinton,DEM,149
+Pennington,2-Apr,President,,Hillary Clinton,DEM,439
+Pennington,3-Apr,President,,Hillary Clinton,DEM,303
+Pennington,4-Apr,President,,Hillary Clinton,DEM,402
+Pennington,5-Apr,President,,Hillary Clinton,DEM,242
+Pennington,1-May,President,,Hillary Clinton,DEM,198
+Pennington,2-May,President,,Hillary Clinton,DEM,644
+Pennington,3-May,President,,Hillary Clinton,DEM,716
+Pennington,4-May,President,,Hillary Clinton,DEM,744
+Pennington,5-May,President,,Hillary Clinton,DEM,115
+Pennington,AW,President,,Hillary Clinton,DEM,898
+Pennington,BE,President,,Hillary Clinton,DEM,293
+Pennington,CA,President,,Hillary Clinton,DEM,68
+Pennington,CL,President,,Hillary Clinton,DEM,137
+Pennington,CR,President,,Hillary Clinton,DEM,4
+Pennington,DI,President,,Hillary Clinton,DEM,215
+Pennington,EL,President,,Hillary Clinton,DEM,105
+Pennington,HC,President,,Hillary Clinton,DEM,272
+Pennington,HP,President,,Hillary Clinton,DEM,384
+Pennington,JS,President,,Hillary Clinton,DEM,348
+Pennington,KY,President,,Hillary Clinton,DEM,125
+Pennington,NH,President,,Hillary Clinton,DEM,65
+Pennington,NU,President,,Hillary Clinton,DEM,100
+Pennington,QU,President,,Hillary Clinton,DEM,20
+Pennington,RH,President,,Hillary Clinton,DEM,25
+Pennington,RV,President,,Hillary Clinton,DEM,317
+Pennington,VF,President,,Hillary Clinton,DEM,335
+Pennington,VV,President,,Hillary Clinton,DEM,273
+Pennington,WL,President,,Hillary Clinton,DEM,58
+Pennington,WP,President,,Hillary Clinton,DEM,340
+Pennington,WS,President,,Hillary Clinton,DEM,4
+Pennington,1-Jan,President,,Darrell L. Castle,CON,22
+Pennington,2-Jan,President,,Darrell L. Castle,CON,24
+Pennington,3-Jan,President,,Darrell L. Castle,CON,29
+Pennington,4-Jan,President,,Darrell L. Castle,CON,10
+Pennington,1-Feb,President,,Darrell L. Castle,CON,2
+Pennington,2-Feb,President,,Darrell L. Castle,CON,1
+Pennington,3-Feb,President,,Darrell L. Castle,CON,18
+Pennington,4-Feb,President,,Darrell L. Castle,CON,27
+Pennington,5-Feb,President,,Darrell L. Castle,CON,3
+Pennington,1-Mar,President,,Darrell L. Castle,CON,10
+Pennington,2-Mar,President,,Darrell L. Castle,CON,18
+Pennington,3-Mar,President,,Darrell L. Castle,CON,7
+Pennington,4-Mar,President,,Darrell L. Castle,CON,23
+Pennington,5-Mar,President,,Darrell L. Castle,CON,1
+Pennington,1-Apr,President,,Darrell L. Castle,CON,8
+Pennington,2-Apr,President,,Darrell L. Castle,CON,13
+Pennington,3-Apr,President,,Darrell L. Castle,CON,12
+Pennington,4-Apr,President,,Darrell L. Castle,CON,23
+Pennington,5-Apr,President,,Darrell L. Castle,CON,15
+Pennington,1-May,President,,Darrell L. Castle,CON,8
+Pennington,2-May,President,,Darrell L. Castle,CON,16
+Pennington,3-May,President,,Darrell L. Castle,CON,27
+Pennington,4-May,President,,Darrell L. Castle,CON,16
+Pennington,5-May,President,,Darrell L. Castle,CON,8
+Pennington,AW,President,,Darrell L. Castle,CON,26
+Pennington,BE,President,,Darrell L. Castle,CON,9
+Pennington,CA,President,,Darrell L. Castle,CON,8
+Pennington,CL,President,,Darrell L. Castle,CON,1
+Pennington,CR,President,,Darrell L. Castle,CON,0
+Pennington,DI,President,,Darrell L. Castle,CON,8
+Pennington,EL,President,,Darrell L. Castle,CON,2
+Pennington,HC,President,,Darrell L. Castle,CON,10
+Pennington,HP,President,,Darrell L. Castle,CON,15
+Pennington,JS,President,,Darrell L. Castle,CON,15
+Pennington,KY,President,,Darrell L. Castle,CON,4
+Pennington,NH,President,,Darrell L. Castle,CON,7
+Pennington,NU,President,,Darrell L. Castle,CON,5
+Pennington,QU,President,,Darrell L. Castle,CON,1
+Pennington,RH,President,,Darrell L. Castle,CON,1
+Pennington,RV,President,,Darrell L. Castle,CON,19
+Pennington,VF,President,,Darrell L. Castle,CON,18
+Pennington,VV,President,,Darrell L. Castle,CON,17
+Pennington,WL,President,,Darrell L. Castle,CON,5
+Pennington,WP,President,,Darrell L. Castle,CON,13
+Pennington,WS,President,,Darrell L. Castle,CON,1
+Pennington,1-Jan,U.S. Senate,,John R. Thune,REP,1070
+Pennington,2-Jan,U.S. Senate,,John R. Thune,REP,1350
+Pennington,3-Jan,U.S. Senate,,John R. Thune,REP,1886
+Pennington,4-Jan,U.S. Senate,,John R. Thune,REP,684
+Pennington,1-Feb,U.S. Senate,,John R. Thune,REP,71
+Pennington,2-Feb,U.S. Senate,,John R. Thune,REP,57
+Pennington,3-Feb,U.S. Senate,,John R. Thune,REP,943
+Pennington,4-Feb,U.S. Senate,,John R. Thune,REP,1413
+Pennington,5-Feb,U.S. Senate,,John R. Thune,REP,104
+Pennington,1-Mar,U.S. Senate,,John R. Thune,REP,472
+Pennington,2-Mar,U.S. Senate,,John R. Thune,REP,2382
+Pennington,3-Mar,U.S. Senate,,John R. Thune,REP,644
+Pennington,4-Mar,U.S. Senate,,John R. Thune,REP,1958
+Pennington,5-Mar,U.S. Senate,,John R. Thune,REP,262
+Pennington,1-Apr,U.S. Senate,,John R. Thune,REP,265
+Pennington,2-Apr,U.S. Senate,,John R. Thune,REP,789
+Pennington,3-Apr,U.S. Senate,,John R. Thune,REP,614
+Pennington,4-Apr,U.S. Senate,,John R. Thune,REP,555
+Pennington,5-Apr,U.S. Senate,,John R. Thune,REP,583
+Pennington,1-May,U.S. Senate,,John R. Thune,REP,322
+Pennington,2-May,U.S. Senate,,John R. Thune,REP,1146
+Pennington,3-May,U.S. Senate,,John R. Thune,REP,1473
+Pennington,4-May,U.S. Senate,,John R. Thune,REP,896
+Pennington,5-May,U.S. Senate,,John R. Thune,REP,246
+Pennington,AW,U.S. Senate,,John R. Thune,REP,1809
+Pennington,BE,U.S. Senate,,John R. Thune,REP,1068
+Pennington,CA,U.S. Senate,,John R. Thune,REP,496
+Pennington,CL,U.S. Senate,,John R. Thune,REP,332
+Pennington,CR,U.S. Senate,,John R. Thune,REP,57
+Pennington,DI,U.S. Senate,,John R. Thune,REP,793
+Pennington,EL,U.S. Senate,,John R. Thune,REP,342
+Pennington,HC,U.S. Senate,,John R. Thune,REP,878
+Pennington,HP,U.S. Senate,,John R. Thune,REP,1450
+Pennington,JS,U.S. Senate,,John R. Thune,REP,966
+Pennington,KY,U.S. Senate,,John R. Thune,REP,408
+Pennington,NH,U.S. Senate,,John R. Thune,REP,204
+Pennington,NU,U.S. Senate,,John R. Thune,REP,436
+Pennington,QU,U.S. Senate,,John R. Thune,REP,185
+Pennington,RH,U.S. Senate,,John R. Thune,REP,39
+Pennington,RV,U.S. Senate,,John R. Thune,REP,910
+Pennington,VF,U.S. Senate,,John R. Thune,REP,1199
+Pennington,VV,U.S. Senate,,John R. Thune,REP,810
+Pennington,WL,U.S. Senate,,John R. Thune,REP,334
+Pennington,WP,U.S. Senate,,John R. Thune,REP,990
+Pennington,WS,U.S. Senate,,John R. Thune,REP,76
+Pennington,1-Jan,U.S. Senate,,Jay Williams,DEM,359
+Pennington,2-Jan,U.S. Senate,,Jay Williams,DEM,551
+Pennington,3-Jan,U.S. Senate,,Jay Williams,DEM,626
+Pennington,4-Jan,U.S. Senate,,Jay Williams,DEM,255
+Pennington,1-Feb,U.S. Senate,,Jay Williams,DEM,48
+Pennington,2-Feb,U.S. Senate,,Jay Williams,DEM,21
+Pennington,3-Feb,U.S. Senate,,Jay Williams,DEM,401
+Pennington,4-Feb,U.S. Senate,,Jay Williams,DEM,819
+Pennington,5-Feb,U.S. Senate,,Jay Williams,DEM,92
+Pennington,1-Mar,U.S. Senate,,Jay Williams,DEM,209
+Pennington,2-Mar,U.S. Senate,,Jay Williams,DEM,663
+Pennington,3-Mar,U.S. Senate,,Jay Williams,DEM,213
+Pennington,4-Mar,U.S. Senate,,Jay Williams,DEM,888
+Pennington,5-Mar,U.S. Senate,,Jay Williams,DEM,86
+Pennington,1-Apr,U.S. Senate,,Jay Williams,DEM,151
+Pennington,2-Apr,U.S. Senate,,Jay Williams,DEM,457
+Pennington,3-Apr,U.S. Senate,,Jay Williams,DEM,288
+Pennington,4-Apr,U.S. Senate,,Jay Williams,DEM,435
+Pennington,5-Apr,U.S. Senate,,Jay Williams,DEM,242
+Pennington,1-May,U.S. Senate,,Jay Williams,DEM,183
+Pennington,2-May,U.S. Senate,,Jay Williams,DEM,620
+Pennington,3-May,U.S. Senate,,Jay Williams,DEM,668
+Pennington,4-May,U.S. Senate,,Jay Williams,DEM,661
+Pennington,5-May,U.S. Senate,,Jay Williams,DEM,109
+Pennington,AW,U.S. Senate,,Jay Williams,DEM,792
+Pennington,BE,U.S. Senate,,Jay Williams,DEM,289
+Pennington,CA,U.S. Senate,,Jay Williams,DEM,96
+Pennington,CL,U.S. Senate,,Jay Williams,DEM,125
+Pennington,CR,U.S. Senate,,Jay Williams,DEM,6
+Pennington,DI,U.S. Senate,,Jay Williams,DEM,201
+Pennington,EL,U.S. Senate,,Jay Williams,DEM,95
+Pennington,HC,U.S. Senate,,Jay Williams,DEM,264
+Pennington,HP,U.S. Senate,,Jay Williams,DEM,330
+Pennington,JS,U.S. Senate,,Jay Williams,DEM,323
+Pennington,KY,U.S. Senate,,Jay Williams,DEM,127
+Pennington,NH,U.S. Senate,,Jay Williams,DEM,78
+Pennington,NU,U.S. Senate,,Jay Williams,DEM,118
+Pennington,QU,U.S. Senate,,Jay Williams,DEM,20
+Pennington,RH,U.S. Senate,,Jay Williams,DEM,30
+Pennington,RV,U.S. Senate,,Jay Williams,DEM,322
+Pennington,VF,U.S. Senate,,Jay Williams,DEM,346
+Pennington,VV,U.S. Senate,,Jay Williams,DEM,270
+Pennington,WL,U.S. Senate,,Jay Williams,DEM,48
+Pennington,WP,U.S. Senate,,Jay Williams,DEM,278
+Pennington,WS,U.S. Senate,,Jay Williams,DEM,4
+Pennington,1-Jan,U.S. House,1,Kristi Noem,REP,989
+Pennington,2-Jan,U.S. House,1,Kristi Noem,REP,1234
+Pennington,3-Jan,U.S. House,1,Kristi Noem,REP,1719
+Pennington,4-Jan,U.S. House,1,Kristi Noem,REP,638
+Pennington,1-Feb,U.S. House,1,Kristi Noem,REP,64
+Pennington,2-Feb,U.S. House,1,Kristi Noem,REP,53
+Pennington,3-Feb,U.S. House,1,Kristi Noem,REP,878
+Pennington,4-Feb,U.S. House,1,Kristi Noem,REP,1290
+Pennington,5-Feb,U.S. House,1,Kristi Noem,REP,94
+Pennington,1-Mar,U.S. House,1,Kristi Noem,REP,425
+Pennington,2-Mar,U.S. House,1,Kristi Noem,REP,2218
+Pennington,3-Mar,U.S. House,1,Kristi Noem,REP,604
+Pennington,4-Mar,U.S. House,1,Kristi Noem,REP,1796
+Pennington,5-Mar,U.S. House,1,Kristi Noem,REP,245
+Pennington,1-Apr,U.S. House,1,Kristi Noem,REP,246
+Pennington,2-Apr,U.S. House,1,Kristi Noem,REP,729
+Pennington,3-Apr,U.S. House,1,Kristi Noem,REP,570
+Pennington,4-Apr,U.S. House,1,Kristi Noem,REP,494
+Pennington,5-Apr,U.S. House,1,Kristi Noem,REP,551
+Pennington,1-May,U.S. House,1,Kristi Noem,REP,295
+Pennington,2-May,U.S. House,1,Kristi Noem,REP,1048
+Pennington,3-May,U.S. House,1,Kristi Noem,REP,1366
+Pennington,4-May,U.S. House,1,Kristi Noem,REP,774
+Pennington,5-May,U.S. House,1,Kristi Noem,REP,230
+Pennington,AW,U.S. House,1,Kristi Noem,REP,1785
+Pennington,BE,U.S. House,1,Kristi Noem,REP,1010
+Pennington,CA,U.S. House,1,Kristi Noem,REP,496
+Pennington,CL,U.S. House,1,Kristi Noem,REP,301
+Pennington,CR,U.S. House,1,Kristi Noem,REP,54
+Pennington,DI,U.S. House,1,Kristi Noem,REP,752
+Pennington,EL,U.S. House,1,Kristi Noem,REP,332
+Pennington,HC,U.S. House,1,Kristi Noem,REP,847
+Pennington,HP,U.S. House,1,Kristi Noem,REP,1385
+Pennington,JS,U.S. House,1,Kristi Noem,REP,916
+Pennington,KY,U.S. House,1,Kristi Noem,REP,394
+Pennington,NH,U.S. House,1,Kristi Noem,REP,188
+Pennington,NU,U.S. House,1,Kristi Noem,REP,422
+Pennington,QU,U.S. House,1,Kristi Noem,REP,176
+Pennington,RH,U.S. House,1,Kristi Noem,REP,38
+Pennington,RV,U.S. House,1,Kristi Noem,REP,865
+Pennington,VF,U.S. House,1,Kristi Noem,REP,1138
+Pennington,VV,U.S. House,1,Kristi Noem,REP,767
+Pennington,WL,U.S. House,1,Kristi Noem,REP,316
+Pennington,WP,U.S. House,1,Kristi Noem,REP,937
+Pennington,WS,U.S. House,1,Kristi Noem,REP,77
+Pennington,1-Jan,U.S. House,1,Paula Hawks,DEM,435
+Pennington,2-Jan,U.S. House,1,Paula Hawks,DEM,658
+Pennington,3-Jan,U.S. House,1,Paula Hawks,DEM,775
+Pennington,4-Jan,U.S. House,1,Paula Hawks,DEM,301
+Pennington,1-Feb,U.S. House,1,Paula Hawks,DEM,54
+Pennington,2-Feb,U.S. House,1,Paula Hawks,DEM,25
+Pennington,3-Feb,U.S. House,1,Paula Hawks,DEM,466
+Pennington,4-Feb,U.S. House,1,Paula Hawks,DEM,941
+Pennington,5-Feb,U.S. House,1,Paula Hawks,DEM,101
+Pennington,1-Mar,U.S. House,1,Paula Hawks,DEM,253
+Pennington,2-Mar,U.S. House,1,Paula Hawks,DEM,842
+Pennington,3-Mar,U.S. House,1,Paula Hawks,DEM,256
+Pennington,4-Mar,U.S. House,1,Paula Hawks,DEM,1064
+Pennington,5-Mar,U.S. House,1,Paula Hawks,DEM,108
+Pennington,1-Apr,U.S. House,1,Paula Hawks,DEM,173
+Pennington,2-Apr,U.S. House,1,Paula Hawks,DEM,517
+Pennington,3-Apr,U.S. House,1,Paula Hawks,DEM,332
+Pennington,4-Apr,U.S. House,1,Paula Hawks,DEM,492
+Pennington,5-Apr,U.S. House,1,Paula Hawks,DEM,276
+Pennington,1-May,U.S. House,1,Paula Hawks,DEM,214
+Pennington,2-May,U.S. House,1,Paula Hawks,DEM,718
+Pennington,3-May,U.S. House,1,Paula Hawks,DEM,782
+Pennington,4-May,U.S. House,1,Paula Hawks,DEM,792
+Pennington,5-May,U.S. House,1,Paula Hawks,DEM,121
+Pennington,AW,U.S. House,1,Paula Hawks,DEM,810
+Pennington,BE,U.S. House,1,Paula Hawks,DEM,345
+Pennington,CA,U.S. House,1,Paula Hawks,DEM,103
+Pennington,CL,U.S. House,1,Paula Hawks,DEM,152
+Pennington,CR,U.S. House,1,Paula Hawks,DEM,8
+Pennington,DI,U.S. House,1,Paula Hawks,DEM,250
+Pennington,EL,U.S. House,1,Paula Hawks,DEM,105
+Pennington,HC,U.S. House,1,Paula Hawks,DEM,294
+Pennington,HP,U.S. House,1,Paula Hawks,DEM,406
+Pennington,JS,U.S. House,1,Paula Hawks,DEM,377
+Pennington,KY,U.S. House,1,Paula Hawks,DEM,141
+Pennington,NH,U.S. House,1,Paula Hawks,DEM,96
+Pennington,NU,U.S. House,1,Paula Hawks,DEM,129
+Pennington,QU,U.S. House,1,Paula Hawks,DEM,29
+Pennington,RH,U.S. House,1,Paula Hawks,DEM,30
+Pennington,RV,U.S. House,1,Paula Hawks,DEM,374
+Pennington,VF,U.S. House,1,Paula Hawks,DEM,425
+Pennington,VV,U.S. House,1,Paula Hawks,DEM,312
+Pennington,WL,U.S. House,1,Paula Hawks,DEM,72
+Pennington,WP,U.S. House,1,Paula Hawks,DEM,342
+Pennington,WS,U.S. House,1,Paula Hawks,DEM,6
+Pennington,1-Jan,Public Utilities Commissioner,,Chris Nelson,REP,1018
+Pennington,2-Jan,Public Utilities Commissioner,,Chris Nelson,REP,1331
+Pennington,3-Jan,Public Utilities Commissioner,,Chris Nelson,REP,1828
+Pennington,4-Jan,Public Utilities Commissioner,,Chris Nelson,REP,688
+Pennington,1-Feb,Public Utilities Commissioner,,Chris Nelson,REP,63
+Pennington,2-Feb,Public Utilities Commissioner,,Chris Nelson,REP,54
+Pennington,3-Feb,Public Utilities Commissioner,,Chris Nelson,REP,871
+Pennington,4-Feb,Public Utilities Commissioner,,Chris Nelson,REP,1310
+Pennington,5-Feb,Public Utilities Commissioner,,Chris Nelson,REP,91
+Pennington,1-Mar,Public Utilities Commissioner,,Chris Nelson,REP,463
+Pennington,2-Mar,Public Utilities Commissioner,,Chris Nelson,REP,2348
+Pennington,3-Mar,Public Utilities Commissioner,,Chris Nelson,REP,633
+Pennington,4-Mar,Public Utilities Commissioner,,Chris Nelson,REP,1987
+Pennington,5-Mar,Public Utilities Commissioner,,Chris Nelson,REP,262
+Pennington,1-Apr,Public Utilities Commissioner,,Chris Nelson,REP,243
+Pennington,2-Apr,Public Utilities Commissioner,,Chris Nelson,REP,744
+Pennington,3-Apr,Public Utilities Commissioner,,Chris Nelson,REP,586
+Pennington,4-Apr,Public Utilities Commissioner,,Chris Nelson,REP,502
+Pennington,5-Apr,Public Utilities Commissioner,,Chris Nelson,REP,572
+Pennington,1-May,Public Utilities Commissioner,,Chris Nelson,REP,318
+Pennington,2-May,Public Utilities Commissioner,,Chris Nelson,REP,1121
+Pennington,3-May,Public Utilities Commissioner,,Chris Nelson,REP,1494
+Pennington,4-May,Public Utilities Commissioner,,Chris Nelson,REP,866
+Pennington,5-May,Public Utilities Commissioner,,Chris Nelson,REP,260
+Pennington,AW,Public Utilities Commissioner,,Chris Nelson,REP,1622
+Pennington,BE,Public Utilities Commissioner,,Chris Nelson,REP,981
+Pennington,CA,Public Utilities Commissioner,,Chris Nelson,REP,490
+Pennington,CL,Public Utilities Commissioner,,Chris Nelson,REP,318
+Pennington,CR,Public Utilities Commissioner,,Chris Nelson,REP,50
+Pennington,DI,Public Utilities Commissioner,,Chris Nelson,REP,779
+Pennington,EL,Public Utilities Commissioner,,Chris Nelson,REP,306
+Pennington,HC,Public Utilities Commissioner,,Chris Nelson,REP,824
+Pennington,HP,Public Utilities Commissioner,,Chris Nelson,REP,1430
+Pennington,JS,Public Utilities Commissioner,,Chris Nelson,REP,981
+Pennington,KY,Public Utilities Commissioner,,Chris Nelson,REP,393
+Pennington,NH,Public Utilities Commissioner,,Chris Nelson,REP,198
+Pennington,NU,Public Utilities Commissioner,,Chris Nelson,REP,435
+Pennington,QU,Public Utilities Commissioner,,Chris Nelson,REP,178
+Pennington,RH,Public Utilities Commissioner,,Chris Nelson,REP,39
+Pennington,RV,Public Utilities Commissioner,,Chris Nelson,REP,913
+Pennington,VF,Public Utilities Commissioner,,Chris Nelson,REP,1155
+Pennington,VV,Public Utilities Commissioner,,Chris Nelson,REP,757
+Pennington,WL,Public Utilities Commissioner,,Chris Nelson,REP,322
+Pennington,WP,Public Utilities Commissioner,,Chris Nelson,REP,993
+Pennington,WS,Public Utilities Commissioner,,Chris Nelson,REP,75
+Pennington,1-Jan,Public Utilities Commissioner,,Henry Red Cloud,DEM,353
+Pennington,2-Jan,Public Utilities Commissioner,,Henry Red Cloud,DEM,514
+Pennington,3-Jan,Public Utilities Commissioner,,Henry Red Cloud,DEM,565
+Pennington,4-Jan,Public Utilities Commissioner,,Henry Red Cloud,DEM,210
+Pennington,1-Feb,Public Utilities Commissioner,,Henry Red Cloud,DEM,51
+Pennington,2-Feb,Public Utilities Commissioner,,Henry Red Cloud,DEM,25
+Pennington,3-Feb,Public Utilities Commissioner,,Henry Red Cloud,DEM,410
+Pennington,4-Feb,Public Utilities Commissioner,,Henry Red Cloud,DEM,836
+Pennington,5-Feb,Public Utilities Commissioner,,Henry Red Cloud,DEM,96
+Pennington,1-Mar,Public Utilities Commissioner,,Henry Red Cloud,DEM,193
+Pennington,2-Mar,Public Utilities Commissioner,,Henry Red Cloud,DEM,589
+Pennington,3-Mar,Public Utilities Commissioner,,Henry Red Cloud,DEM,202
+Pennington,4-Mar,Public Utilities Commissioner,,Henry Red Cloud,DEM,781
+Pennington,5-Mar,Public Utilities Commissioner,,Henry Red Cloud,DEM,80
+Pennington,1-Apr,Public Utilities Commissioner,,Henry Red Cloud,DEM,167
+Pennington,2-Apr,Public Utilities Commissioner,,Henry Red Cloud,DEM,467
+Pennington,3-Apr,Public Utilities Commissioner,,Henry Red Cloud,DEM,283
+Pennington,4-Apr,Public Utilities Commissioner,,Henry Red Cloud,DEM,459
+Pennington,5-Apr,Public Utilities Commissioner,,Henry Red Cloud,DEM,215
+Pennington,1-May,Public Utilities Commissioner,,Henry Red Cloud,DEM,175
+Pennington,2-May,Public Utilities Commissioner,,Henry Red Cloud,DEM,580
+Pennington,3-May,Public Utilities Commissioner,,Henry Red Cloud,DEM,566
+Pennington,4-May,Public Utilities Commissioner,,Henry Red Cloud,DEM,640
+Pennington,5-May,Public Utilities Commissioner,,Henry Red Cloud,DEM,85
+Pennington,AW,Public Utilities Commissioner,,Henry Red Cloud,DEM,767
+Pennington,BE,Public Utilities Commissioner,,Henry Red Cloud,DEM,306
+Pennington,CA,Public Utilities Commissioner,,Henry Red Cloud,DEM,81
+Pennington,CL,Public Utilities Commissioner,,Henry Red Cloud,DEM,123
+Pennington,CR,Public Utilities Commissioner,,Henry Red Cloud,DEM,8
+Pennington,DI,Public Utilities Commissioner,,Henry Red Cloud,DEM,199
+Pennington,EL,Public Utilities Commissioner,,Henry Red Cloud,DEM,99
+Pennington,HC,Public Utilities Commissioner,,Henry Red Cloud,DEM,280
+Pennington,HP,Public Utilities Commissioner,,Henry Red Cloud,DEM,298
+Pennington,JS,Public Utilities Commissioner,,Henry Red Cloud,DEM,284
+Pennington,KY,Public Utilities Commissioner,,Henry Red Cloud,DEM,122
+Pennington,NH,Public Utilities Commissioner,,Henry Red Cloud,DEM,72
+Pennington,NU,Public Utilities Commissioner,,Henry Red Cloud,DEM,97
+Pennington,QU,Public Utilities Commissioner,,Henry Red Cloud,DEM,18
+Pennington,RH,Public Utilities Commissioner,,Henry Red Cloud,DEM,27
+Pennington,RV,Public Utilities Commissioner,,Henry Red Cloud,DEM,268
+Pennington,VF,Public Utilities Commissioner,,Henry Red Cloud,DEM,324
+Pennington,VV,Public Utilities Commissioner,,Henry Red Cloud,DEM,269
+Pennington,WL,Public Utilities Commissioner,,Henry Red Cloud,DEM,49
+Pennington,WP,Public Utilities Commissioner,,Henry Red Cloud,DEM,251
+Pennington,WS,Public Utilities Commissioner,,Henry Red Cloud,DEM,6
+Pennington,CA,State Senate,27,Kevin Killer,DEM,15
+Pennington,CR,State Senate,27,Kevin Killer,DEM,8
+Pennington,QU,State Senate,27,Kevin Killer,DEM,50
+Pennington,EL,State Senate,29,Gary L. Cammack,REP,267
+Pennington,EL,State Senate,29,LeRoy Kindler,IND,110
+Pennington,CA,State Senate,30,Lance Russell,REP,405
+Pennington,HC,State Senate,30,Lance Russell,REP,788
+Pennington,HR,State Senate,30,Lance Russell,REP,1280
+Pennington,KY,State Senate,30,Lance Russell,REP,378
+Pennington,NU,State Senate,30,Lance Russell,REP,401
+Pennington,RH,State Senate,30,Lance Russell,REP,39
+Pennington,WL,State Senate,30,Lance Russell,REP,290
+Pennington,WS,State Senate,30,Lance Russell,REP,75
+Pennington,CA,State Senate,30,Karla R. LaRive,DEM,87
+Pennington,HC,State Senate,30,Karla R. LaRive,DEM,305
+Pennington,HR,State Senate,30,Karla R. LaRive,DEM,379
+Pennington,KY,State Senate,30,Karla R. LaRive,DEM,135
+Pennington,NU,State Senate,30,Karla R. LaRive,DEM,126
+Pennington,RH,State Senate,30,Karla R. LaRive,DEM,22
+Pennington,WL,State Senate,30,Karla R. LaRive,DEM,72
+Pennington,WS,State Senate,30,Karla R. LaRive,DEM,6
+Pennington,1-Jan,State Senate,32,Alan D. Solano,REP,1013
+Pennington,2-Jan,State Senate,32,Alan D. Solano,REP,1301
+Pennington,3-Jan,State Senate,32,Alan D. Solano,REP,1774
+Pennington,4-Feb,State Senate,32,Alan D. Solano,REP,1301
+Pennington,5-Feb,State Senate,32,Alan D. Solano,REP,95
+Pennington,1-Mar,State Senate,32,Alan D. Solano,REP,409
+Pennington,4-May,State Senate,32,Alan D. Solano,REP,827
+Pennington,HR,State Senate,32,Alan D. Solano,REP,44
+Pennington,1-Jan,State Senate,32,David A. Hubbard,DEM,357
+Pennington,2-Jan,State Senate,32,David A. Hubbard,DEM,542
+Pennington,3-Jan,State Senate,32,David A. Hubbard,DEM,622
+Pennington,4-Feb,State Senate,32,David A. Hubbard,DEM,813
+Pennington,5-Feb,State Senate,32,David A. Hubbard,DEM,93
+Pennington,1-Mar,State Senate,32,David A. Hubbard,DEM,241
+Pennington,4-May,State Senate,32,David A. Hubbard,DEM,678
+Pennington,HR,State Senate,32,David A. Hubbard,DEM,13
+Pennington,2-Feb,State Senate,33,Phil Jensen,REP,49
+Pennington,5-Mar,State Senate,33,Phil Jensen,REP,185
+Pennington,3-Apr,State Senate,33,Phil Jensen,REP,475
+Pennington,4-Apr,State Senate,33,Phil Jensen,REP,423
+Pennington,5-Apr,State Senate,33,Phil Jensen,REP,461
+Pennington,5-May,State Senate,33,Phil Jensen,REP,192
+Pennington,AW,State Senate,33,Phil Jensen,REP,1722
+Pennington,CL,State Senate,33,Phil Jensen,REP,240
+Pennington,DT,State Senate,33,Phil Jensen,REP,627
+Pennington,JS,State Senate,33,Phil Jensen,REP,759
+Pennington,NH,State Senate,33,Phil Jensen,REP,176
+Pennington,WP,State Senate,33,Phil Jensen,REP,756
+Pennington,2-Feb,State Senate,33,Haven Stuck,DEM,27
+Pennington,5-Mar,State Senate,33,Haven Stuck,DEM,154
+Pennington,3-Apr,State Senate,33,Haven Stuck,DEM,392
+Pennington,4-Apr,State Senate,33,Haven Stuck,DEM,531
+Pennington,5-Apr,State Senate,33,Haven Stuck,DEM,332
+Pennington,5-May,State Senate,33,Haven Stuck,DEM,148
+Pennington,AW,State Senate,33,Haven Stuck,DEM,752
+Pennington,CL,State Senate,33,Haven Stuck,DEM,203
+Pennington,DT,State Senate,33,Haven Stuck,DEM,355
+Pennington,JS,State Senate,33,Haven Stuck,DEM,503
+Pennington,NH,State Senate,33,Haven Stuck,DEM,92
+Pennington,WP,State Senate,33,Haven Stuck,DEM,496
+Pennington,1-Feb,State Senate,34,Jeffrey D. Partridge,REP,58
+Pennington,2-Mar,State Senate,34,Jeffrey D. Partridge,REP,2104
+Pennington,3-Mar,State Senate,34,Jeffrey D. Partridge,REP,568
+Pennington,4-Mar,State Senate,34,Jeffrey D. Partridge,REP,1745
+Pennington,1-Apr,State Senate,34,Jeffrey D. Partridge,REP,232
+Pennington,1-May,State Senate,34,Jeffrey D. Partridge,REP,273
+Pennington,2-May,State Senate,34,Jeffrey D. Partridge,REP,994
+Pennington,3-May,State Senate,34,Jeffrey D. Partridge,REP,1318
+Pennington,1-Feb,State Senate,34,Jay C. Shultz,DEM,55
+Pennington,2-Mar,State Senate,34,Jay C. Shultz,DEM,811
+Pennington,3-Mar,State Senate,34,Jay C. Shultz,DEM,253
+Pennington,4-Mar,State Senate,34,Jay C. Shultz,DEM,1010
+Pennington,1-Apr,State Senate,34,Jay C. Shultz,DEM,164
+Pennington,1-May,State Senate,34,Jay C. Shultz,DEM,201
+Pennington,2-May,State Senate,34,Jay C. Shultz,DEM,676
+Pennington,3-May,State Senate,34,Jay C. Shultz,DEM,719
+Pennington,4-Jan,State Senate,35,Terri L. Haverly,REP,663
+Pennington,3-Feb,State Senate,35,Terri L. Haverly,REP,883
+Pennington,2-Apr,State Senate,35,Terri L. Haverly,REP,763
+Pennington,BE,State Senate,35,Terri L. Haverly,REP,997
+Pennington,RV,State Senate,35,Terri L. Haverly,REP,892
+Pennington,VF,State Senate,35,Terri L. Haverly,REP,1148
+Pennington,VV,State Senate,35,Terri L. Haverly,REP,791
+Pennington,CA,State House,27,Elizabeth May,REP,58
+Pennington,CR,State House,27,Elizabeth May,REP,48
+Pennington,QU,State House,27,Elizabeth May,REP,145
+Pennington,CA,State House,27,Steve Livermont,REP,54
+Pennington,CR,State House,27,Steve Livermont,REP,42
+Pennington,QU,State House,27,Steve Livermont,REP,163
+Pennington,CA,State House,27,Red Dawn Foster,DEM,4
+Pennington,CR,State House,27,Red Dawn Foster,DEM,2
+Pennington,QU,State House,27,Red Dawn Foster,DEM,10
+Pennington,CA,State House,27,Jim Bradford,DEM,10
+Pennington,CR,State House,27,Jim Bradford,DEM,4
+Pennington,QU,State House,27,Jim Bradford,DEM,23
+Pennington,CA,State House,27,Everette L.. McKinley,IND,8
+Pennington,CR,State House,27,Everette L.. McKinley,IND,6
+Pennington,QU,State House,27,Everette L.. McKinley,IND,17
+Pennington,EL,State House,29,Larry Rhoden,REP,248
+Pennington,EL,State House,29,Thomas J. Brunner,REP,156
+Pennington,CA,State House,30,Julie Frye-Mueller,REP,352
+Pennington,HO,State House,30,Julie Frye-Mueller,REP,653
+Pennington,HR,State House,30,Julie Frye-Mueller,REP,1155
+Pennington,KY,State House,30,Julie Frye-Mueller,REP,339
+Pennington,NU,State House,30,Julie Frye-Mueller,REP,360
+Pennington,RH,State House,30,Julie Frye-Mueller,REP,38
+Pennington,WL,State House,30,Julie Frye-Mueller,REP,260
+Pennington,WS,State House,30,Julie Frye-Mueller,REP,63
+Pennington,CA,State House,30,Tim R. Goodwin,REP,338
+Pennington,HO,State House,30,Tim R. Goodwin,REP,734
+Pennington,HR,State House,30,Tim R. Goodwin,REP,1145
+Pennington,KY,State House,30,Tim R. Goodwin,REP,332
+Pennington,NU,State House,30,Tim R. Goodwin,REP,363
+Pennington,RH,State House,30,Tim R. Goodwin,REP,32
+Pennington,WL,State House,30,Tim R. Goodwin,REP,238
+Pennington,WS,State House,30,Tim R. Goodwin,REP,57
+Pennington,CA,State House,30,Kristine Ina Winter,DEM,70
+Pennington,HO,State House,30,Kristine Ina Winter,DEM,242
+Pennington,HR,State House,30,Kristine Ina Winter,DEM,337
+Pennington,KY,State House,30,Kristine Ina Winter,DEM,107
+Pennington,NU,State House,30,Kristine Ina Winter,DEM,97
+Pennington,RH,State House,30,Kristine Ina Winter,DEM,24
+Pennington,WL,State House,30,Kristine Ina Winter,DEM,67
+Pennington,WS,State House,30,Kristine Ina Winter,DEM,5
+Pennington,CA,State House,30,Sandy Arseneault,DEM,72
+Pennington,HO,State House,30,Sandy Arseneault,DEM,280
+Pennington,HR,State House,30,Sandy Arseneault,DEM,327
+Pennington,KY,State House,30,Sandy Arseneault,DEM,111
+Pennington,NU,State House,30,Sandy Arseneault,DEM,98
+Pennington,RH,State House,30,Sandy Arseneault,DEM,25
+Pennington,WL,State House,30,Sandy Arseneault,DEM,58
+Pennington,WS,State House,30,Sandy Arseneault,DEM,10
+Pennington,1-Jan,State House,32,Kristin A. Conzet,REP,839
+Pennington,2-Jan,State House,32,Kristin A. Conzet,REP,1022
+Pennington,3-Jan,State House,32,Kristin A. Conzet,REP,1475
+Pennington,4-Feb,State House,32,Kristin A. Conzet,REP,971
+Pennington,5-Feb,State House,32,Kristin A. Conzet,REP,83
+Pennington,1-Mar,State House,32,Kristin A. Conzet,REP,325
+Pennington,4-May,State House,32,Kristin A. Conzet,REP,664
+Pennington,HR,State House,32,Kristin A. Conzet,REP,40
+Pennington,1-Jan,State House,32,Sean McPherson,REP,777
+Pennington,2-Jan,State House,32,Sean McPherson,REP,943
+Pennington,3-Jan,State House,32,Sean McPherson,REP,1332
+Pennington,4-Feb,State House,32,Sean McPherson,REP,977
+Pennington,5-Feb,State House,32,Sean McPherson,REP,73
+Pennington,1-Mar,State House,32,Sean McPherson,REP,330
+Pennington,4-May,State House,32,Sean McPherson,REP,599
+Pennington,HR,State House,32,Sean McPherson,REP,37
+Pennington,1-Jan,State House,32,Nik Aberle,DEM,290
+Pennington,2-Jan,State House,32,Nik Aberle,DEM,378
+Pennington,3-Jan,State House,32,Nik Aberle,DEM,489
+Pennington,4-Feb,State House,32,Nik Aberle,DEM,591
+Pennington,5-Feb,State House,32,Nik Aberle,DEM,65
+Pennington,1-Mar,State House,32,Nik Aberle,DEM,150
+Pennington,4-May,State House,32,Nik Aberle,DEM,495
+Pennington,HR,State House,32,Nik Aberle,DEM,7
+Pennington,1-Jan,State House,32,Susan Kelts,DEM,465
+Pennington,2-Jan,State House,32,Susan Kelts,DEM,737
+Pennington,3-Jan,State House,32,Susan Kelts,DEM,922
+Pennington,4-Feb,State House,32,Susan Kelts,DEM,982
+Pennington,5-Feb,State House,32,Susan Kelts,DEM,91
+Pennington,1-Mar,State House,32,Susan Kelts,DEM,293
+Pennington,4-May,State House,32,Susan Kelts,DEM,837
+Pennington,HR,State House,32,Susan Kelts,DEM,14
+Pennington,2-Feb,State House,33,Taffy Howard,REP,40
+Pennington,5-Mar,State House,33,Taffy Howard,REP,202
+Pennington,3-Apr,State House,33,Taffy Howard,REP,399
+Pennington,4-Apr,State House,33,Taffy Howard,REP,355
+Pennington,5-Apr,State House,33,Taffy Howard,REP,410
+Pennington,5-May,State House,33,Taffy Howard,REP,199
+Pennington,AW,State House,33,Taffy Howard,REP,1553
+Pennington,CL,State House,33,Taffy Howard,REP,252
+Pennington,DT,State House,33,Taffy Howard,REP,606
+Pennington,JS,State House,33,Taffy Howard,REP,732
+Pennington,NH,State House,33,Taffy Howard,REP,148
+Pennington,WP,State House,33,Taffy Howard,REP,781
+Pennington,2-Feb,State House,33,David Johnson,REP,42
+Pennington,5-Mar,State House,33,David Johnson,REP,233
+Pennington,3-Apr,State House,33,David Johnson,REP,543
+Pennington,4-Apr,State House,33,David Johnson,REP,492
+Pennington,5-Apr,State House,33,David Johnson,REP,489
+Pennington,5-May,State House,33,David Johnson,REP,235
+Pennington,AW,State House,33,David Johnson,REP,1556
+Pennington,CL,State House,33,David Johnson,REP,283
+Pennington,DT,State House,33,David Johnson,REP,717
+Pennington,JS,State House,33,David Johnson,REP,877
+Pennington,NH,State House,33,David Johnson,REP,166
+Pennington,WP,State House,33,David Johnson,REP,892
+Pennington,2-Feb,State House,33,Ethan Marsland,DEM,19
+Pennington,5-Mar,State House,33,Ethan Marsland,DEM,76
+Pennington,3-Apr,State House,33,Ethan Marsland,DEM,230
+Pennington,4-Apr,State House,33,Ethan Marsland,DEM,360
+Pennington,5-Apr,State House,33,Ethan Marsland,DEM,180
+Pennington,5-May,State House,33,Ethan Marsland,DEM,75
+Pennington,AW,State House,33,Ethan Marsland,DEM,670
+Pennington,CL,State House,33,Ethan Marsland,DEM,94
+Pennington,DT,State House,33,Ethan Marsland,DEM,139
+Pennington,JS,State House,33,Ethan Marsland,DEM,219
+Pennington,NH,State House,33,Ethan Marsland,DEM,67
+Pennington,WP,State House,33,Ethan Marsland,DEM,244
+Pennington,2-Feb,State House,33,Jim Hadd,DEM,19
+Pennington,5-Mar,State House,33,Jim Hadd,DEM,81
+Pennington,3-Apr,State House,33,Jim Hadd,DEM,249
+Pennington,4-Apr,State House,33,Jim Hadd,DEM,324
+Pennington,5-Apr,State House,33,Jim Hadd,DEM,225
+Pennington,5-May,State House,33,Jim Hadd,DEM,94
+Pennington,AW,State House,33,Jim Hadd,DEM,677
+Pennington,CL,State House,33,Jim Hadd,DEM,121
+Pennington,DT,State House,33,Jim Hadd,DEM,230
+Pennington,JS,State House,33,Jim Hadd,DEM,335
+Pennington,NH,State House,33,Jim Hadd,DEM,65
+Pennington,WP,State House,33,Jim Hadd,DEM,281
+Pennington,1-Feb,State House,34,Craig Tieszen,REP,61
+Pennington,2-Mar,State House,34,Craig Tieszen,REP,2169
+Pennington,3-Mar,State House,34,Craig Tieszen,REP,576
+Pennington,4-Mar,State House,34,Craig Tieszen,REP,1834
+Pennington,1-Apr,State House,34,Craig Tieszen,REP,221
+Pennington,1-May,State House,34,Craig Tieszen,REP,262
+Pennington,2-May,State House,34,Craig Tieszen,REP,1032
+Pennington,3-May,State House,34,Craig Tieszen,REP,1407
+Pennington,1-Feb,State House,34,Dan Dryden,REP,45
+Pennington,2-Mar,State House,34,Dan Dryden,REP,1619
+Pennington,3-Mar,State House,34,Dan Dryden,REP,427
+Pennington,4-Mar,State House,34,Dan Dryden,REP,1325
+Pennington,1-Apr,State House,34,Dan Dryden,REP,165
+Pennington,1-May,State House,34,Dan Dryden,REP,217
+Pennington,2-May,State House,34,Dan Dryden,REP,725
+Pennington,3-May,State House,34,Dan Dryden,REP,967
+Pennington,1-Feb,State House,34,Steve Stenson,DEM,53
+Pennington,2-Mar,State House,34,Steve Stenson,DEM,739
+Pennington,3-Mar,State House,34,Steve Stenson,DEM,242
+Pennington,4-Mar,State House,34,Steve Stenson,DEM,956
+Pennington,1-Apr,State House,34,Steve Stenson,DEM,156
+Pennington,1-May,State House,34,Steve Stenson,DEM,179
+Pennington,2-May,State House,34,Steve Stenson,DEM,645
+Pennington,3-May,State House,34,Steve Stenson,DEM,700
+Pennington,4-Jan,State House,35,Lynne DiSanto,REP,537
+Pennington,3-Feb,State House,35,Lynne DiSanto,REP,727
+Pennington,2-Apr,State House,35,Lynne DiSanto,REP,576
+Pennington,BE,State House,35,Lynne DiSanto,REP,776
+Pennington,RV,State House,35,Lynne DiSanto,REP,737
+Pennington,VF,State House,35,Lynne DiSanto,REP,946
+Pennington,VV,State House,35,Lynne DiSanto,REP,656
+Pennington,4-Jan,State House,35,"Blaine ""Chip"" Campbell",REP,477
+Pennington,3-Feb,State House,35,"Blaine ""Chip"" Campbell",REP,601
+Pennington,2-Apr,State House,35,"Blaine ""Chip"" Campbell",REP,523
+Pennington,BE,State House,35,"Blaine ""Chip"" Campbell",REP,698
+Pennington,RV,State House,35,"Blaine ""Chip"" Campbell",REP,615
+Pennington,VF,State House,35,"Blaine ""Chip"" Campbell",REP,816
+Pennington,VV,State House,35,"Blaine ""Chip"" Campbell",REP,550
+Pennington,4-Jan,State House,35,Dave Freytag,DEM,259
+Pennington,3-Feb,State House,35,Dave Freytag,DEM,434
+Pennington,2-Apr,State House,35,Dave Freytag,DEM,456
+Pennington,BE,State House,35,Dave Freytag,DEM,333
+Pennington,RV,State House,35,Dave Freytag,DEM,363
+Pennington,VF,State House,35,Dave Freytag,DEM,370
+Pennington,VV,State House,35,Dave Freytag,DEM,313
+Pennington,4-Jan,State House,35,Michael T. Hanson,DEM,210
+Pennington,3-Feb,State House,35,Michael T. Hanson,DEM,351
+Pennington,2-Apr,State House,35,Michael T. Hanson,DEM,392
+Pennington,BE,State House,35,Michael T. Hanson,DEM,271
+Pennington,RV,State House,35,Michael T. Hanson,DEM,245
+Pennington,VF,State House,35,Michael T. Hanson,DEM,287
+Pennington,VV,State House,35,Michael T. Hanson,DEM,239
 Perkins,1,President,,Donald J. Trump,REP,219
 Perkins,2,President,,Donald J. Trump,REP,88
 Perkins,3,President,,Donald J. Trump,REP,230
@@ -9624,58 +9624,58 @@ Perkins,8,State Representative,28B,Sam Marty,REP,56
 Perkins,9,State Representative,28B,Sam Marty,REP,71
 Perkins,12,State Representative,28B,Sam Marty,REP,280
 Perkins,Total,State Representative,28B,Sam Marty,REP,1355
-Potter,Absentee Precinct,President,,REP,Donald J. Trump,201
-Potter,Gettysburg Legion Annex,President,,REP,Donald J. Trump,601
-Potter,Hoven American Legion,President,,REP,Donald J. Trump,269
-Potter,Total,President,,REP,Donald J. Trump,"1,071"
-Potter,Absentee Precinct,President,,LIB,Gary Johnson,13
-Potter,Gettysburg Legion Annex,President,,LIB,Gary Johnson,22
-Potter,Hoven American Legion,President,,LIB,Gary Johnson,5
-Potter,Total,President,,LIB,Gary Johnson,40
-Potter,Absentee Precinct,President,,DEM,Hillary Clinton,61
-Potter,Gettysburg Legion Annex,President,,DEM,Hillary Clinton,117
-Potter,Hoven American Legion,President,,DEM,Hillary Clinton,37
-Potter,Total,President,,DEM,Hillary Clinton,215
-Potter,Absentee Precinct,President,,CON,Darrell L. Castle,4
-Potter,Gettysburg Legion Annex,President,,CON,Darrell L. Castle,3
-Potter,Hoven American Legion,President,,CON,Darrell L. Castle,4
-Potter,Total,President,,CON,Darrell L. Castle,11
-Potter,Absentee Precinct,U.S. Senate,,REP,John R. Thune,211
-Potter,Gettysburg Legion Annex,U.S. Senate,,REP,John R. Thune,597
-Potter,Hoven American Legion,U.S. Senate,,REP,John R. Thune,279
-Potter,Total,U.S. Senate,,REP,John R. Thune,"1,087"
-Potter,Absentee Precinct,U.S. Senate,,DEM,Jay Williams,69
-Potter,Gettysburg Legion Annex,U.S. Senate,,DEM,Jay Williams,142
-Potter,Hoven American Legion,U.S. Senate,,DEM,Jay Williams,42
-Potter,Total,U.S. Senate,,DEM,Jay Williams,253
-Potter,Absentee Precinct,U.S. House,1,REP,Kristi Noem,212
-Potter,Gettysburg Legion Annex,U.S. House,1,REP,Kristi Noem,594
-Potter,Hoven American Legion,U.S. House,1,REP,Kristi Noem,270
-Potter,Total,U.S. House,1,REP,Kristi Noem,"1,076"
-Potter,Absentee Precinct,U.S. House,1,DEM,Paula Hawks,64
-Potter,Gettysburg Legion Annex,U.S. House,1,DEM,Paula Hawks,156
-Potter,Hoven American Legion,U.S. House,1,DEM,Paula Hawks,48
-Potter,Total,U.S. House,1,DEM,Paula Hawks,268
-Potter,Absentee Precinct,Public Utilities Commissioner,,REP,Chris Nelson,219
-Potter,Gettysburg Legion Annex,Public Utilities Commissioner,,REP,Chris Nelson,649
-Potter,Hoven American Legion,Public Utilities Commissioner,,REP,Chris Nelson,298
-Potter,Total,Public Utilities Commissioner,,REP,Chris Nelson,"1,166"
-Potter,Absentee Precinct,Public Utilities Commissioner,,DEM,Henry Red Cloud,45
-Potter,Gettysburg Legion Annex,Public Utilities Commissioner,,DEM,Henry Red Cloud,79
-Potter,Hoven American Legion,Public Utilities Commissioner,,DEM,Henry Red Cloud,15
-Potter,Total,Public Utilities Commissioner,,DEM,Henry Red Cloud,139
-Potter,Absentee Precinct,State Senate,23,REP,Justin R. Cronin,214
-Potter,Gettysburg Legion Annex,State Senate,23,REP,Justin R. Cronin,636
-Potter,Hoven American Legion,State Senate,23,REP,Justin R. Cronin,272
-Potter,Total,State Senate,23,REP,Justin R. Cronin,"1,122"
-Potter,Absentee Precinct,State House,23,REP,Spencer Gosch,106
-Potter,Gettysburg Legion Annex,State House,23,REP,Spencer Gosch,291
-Potter,Hoven American Legion,State House,23,REP,Spencer Gosch,150
-Potter,Total,State House,23,REP,Spencer Gosch,547
-Potter,Absentee Precinct,State House,23,REP,John A. Lake,229
-Potter,Gettysburg Legion Annex,State House,23,REP,John A. Lake,682
-Potter,Hoven American Legion,State House,23,REP,John A. Lake,250
-Potter,Total,State House,23,REP,John A. Lake,"1,161county"
+Potter,Absentee Precinct,President,,Donald J. Trump,REP,201
+Potter,Gettysburg Legion Annex,President,,Donald J. Trump,REP,601
+Potter,Hoven American Legion,President,,Donald J. Trump,REP,269
+Potter,Total,President,,Donald J. Trump,"1,REP,071"
+Potter,Absentee Precinct,President,,Gary Johnson,LIB,13
+Potter,Gettysburg Legion Annex,President,,Gary Johnson,LIB,22
+Potter,Hoven American Legion,President,,Gary Johnson,LIB,5
+Potter,Total,President,,Gary Johnson,LIB,40
+Potter,Absentee Precinct,President,,Hillary Clinton,DEM,61
+Potter,Gettysburg Legion Annex,President,,Hillary Clinton,DEM,117
+Potter,Hoven American Legion,President,,Hillary Clinton,DEM,37
+Potter,Total,President,,Hillary Clinton,DEM,215
+Potter,Absentee Precinct,President,,Darrell L. Castle,CON,4
+Potter,Gettysburg Legion Annex,President,,Darrell L. Castle,CON,3
+Potter,Hoven American Legion,President,,Darrell L. Castle,CON,4
+Potter,Total,President,,Darrell L. Castle,CON,11
+Potter,Absentee Precinct,U.S. Senate,,John R. Thune,REP,211
+Potter,Gettysburg Legion Annex,U.S. Senate,,John R. Thune,REP,597
+Potter,Hoven American Legion,U.S. Senate,,John R. Thune,REP,279
+Potter,Total,U.S. Senate,,John R. Thune,"1,REP,087"
+Potter,Absentee Precinct,U.S. Senate,,Jay Williams,DEM,69
+Potter,Gettysburg Legion Annex,U.S. Senate,,Jay Williams,DEM,142
+Potter,Hoven American Legion,U.S. Senate,,Jay Williams,DEM,42
+Potter,Total,U.S. Senate,,Jay Williams,DEM,253
+Potter,Absentee Precinct,U.S. House,1,Kristi Noem,REP,212
+Potter,Gettysburg Legion Annex,U.S. House,1,Kristi Noem,REP,594
+Potter,Hoven American Legion,U.S. House,1,Kristi Noem,REP,270
+Potter,Total,U.S. House,1,Kristi Noem,"1,REP,076"
+Potter,Absentee Precinct,U.S. House,1,Paula Hawks,DEM,64
+Potter,Gettysburg Legion Annex,U.S. House,1,Paula Hawks,DEM,156
+Potter,Hoven American Legion,U.S. House,1,Paula Hawks,DEM,48
+Potter,Total,U.S. House,1,Paula Hawks,DEM,268
+Potter,Absentee Precinct,Public Utilities Commissioner,,Chris Nelson,REP,219
+Potter,Gettysburg Legion Annex,Public Utilities Commissioner,,Chris Nelson,REP,649
+Potter,Hoven American Legion,Public Utilities Commissioner,,Chris Nelson,REP,298
+Potter,Total,Public Utilities Commissioner,,Chris Nelson,"1,REP,166"
+Potter,Absentee Precinct,Public Utilities Commissioner,,Henry Red Cloud,DEM,45
+Potter,Gettysburg Legion Annex,Public Utilities Commissioner,,Henry Red Cloud,DEM,79
+Potter,Hoven American Legion,Public Utilities Commissioner,,Henry Red Cloud,DEM,15
+Potter,Total,Public Utilities Commissioner,,Henry Red Cloud,DEM,139
+Potter,Absentee Precinct,State Senate,23,Justin R. Cronin,REP,214
+Potter,Gettysburg Legion Annex,State Senate,23,Justin R. Cronin,REP,636
+Potter,Hoven American Legion,State Senate,23,Justin R. Cronin,REP,272
+Potter,Total,State Senate,23,Justin R. Cronin,REP,"1,122"
+Potter,Absentee Precinct,State House,23,Spencer Gosch,REP,106
+Potter,Gettysburg Legion Annex,State House,23,Spencer Gosch,REP,291
+Potter,Hoven American Legion,State House,23,Spencer Gosch,REP,150
+Potter,Total,State House,23,Spencer Gosch,REP,547
+Potter,Absentee Precinct,State House,23,John A. Lake,REP,229
+Potter,Gettysburg Legion Annex,State House,23,John A. Lake,REP,682
+Potter,Hoven American Legion,State House,23,John A. Lake,REP,250
+Potter,Total,State House,23,John A. Lake,REP,"1,161county"
 Roberts,1,President,,Donald J. Trump,REP,113
 Roberts,2,President,,Donald J. Trump,REP,303
 Roberts,3,President,,Donald J. Trump,REP,104
@@ -9845,86 +9845,86 @@ Roberts,11,State Representative,1,Susan Wismer,DEM,387
 Roberts,12 (14),State Representative,1,Susan Wismer,DEM,182
 Roberts,13,State Representative,1,Susan Wismer,DEM,149
 ,TOTAL,State Representative,1,Susan Wismer,DEM,1966
-Sanborn,1,President,,REP,Donald J. Trump,193
-Sanborn,2,President,,REP,Donald J. Trump,239
-Sanborn,4,President,,REP,Donald J. Trump,210
-Sanborn,5,President,,REP,Donald J. Trump,177
-Sanborn,Total,President,,REP,Donald J. Trump,819
-Sanborn,1,President,,LIB,Gary Johnson,16
-Sanborn,2,President,,LIB,Gary Johnson,15
-Sanborn,4,President,,LIB,Gary Johnson,14
-Sanborn,5,President,,LIB,Gary Johnson,6
-Sanborn,Total,President,,LIB,Gary Johnson,51
-Sanborn,1,President,,DEM,Hillary Clinton,59
-Sanborn,2,President,,DEM,Hillary Clinton,54
-Sanborn,4,President,,DEM,Hillary Clinton,63
-Sanborn,5,President,,DEM,Hillary Clinton,65
-Sanborn,Total,President,,DEM,Hillary Clinton,241
-Sanborn,1,President,,CON,Darrell L. Castle,3
-Sanborn,2,President,,CON,Darrell L. Castle,5
-Sanborn,4,President,,CON,Darrell L. Castle,2
-Sanborn,5,President,,CON,Darrell L. Castle,2
-Sanborn,Total,President,,CON,Darrell L. Castle,12
-Sanborn,1,U.S. Senate,,REP,John R. Thune,219
-Sanborn,2,U.S. Senate,,REP,John R. Thune,251
-Sanborn,4,U.S. Senate,,REP,John R. Thune,218
-Sanborn,5,U.S. Senate,,REP,John R. Thune,201
-Sanborn,Total,U.S. Senate,,REP,John R. Thune,889
-Sanborn,1,U.S. Senate,,DEM,Jay Williams,51
-Sanborn,2,U.S. Senate,,DEM,Jay Williams,63
-Sanborn,4,U.S. Senate,,DEM,Jay Williams,77
-Sanborn,5,U.S. Senate,,DEM,Jay Williams,53
-Sanborn,Total,U.S. Senate,,DEM,Jay Williams,244
-Sanborn,1,U.S. House,1,REP,Kristi Noem,189
-Sanborn,2,U.S. House,1,REP,Kristi Noem,225
-Sanborn,4,U.S. House,1,REP,Kristi Noem,206
-Sanborn,5,U.S. House,1,REP,Kristi Noem,184
-Sanborn,Total,U.S. House,1,REP,Kristi Noem,804
-Sanborn,1,U.S. House,1,DEM,Paula Hawks,78
-Sanborn,2,U.S. House,1,DEM,Paula Hawks,90
-Sanborn,4,U.S. House,1,DEM,Paula Hawks,87
-Sanborn,5,U.S. House,1,DEM,Paula Hawks,70
-Sanborn,Total,U.S. House,1,DEM,Paula Hawks,325
-Sanborn,1,Public Utilities Commissioner,,REP,Chris Nelson,226
-Sanborn,2,Public Utilities Commissioner,,REP,Chris Nelson,253
-Sanborn,4,Public Utilities Commissioner,,REP,Chris Nelson,236
-Sanborn,5,Public Utilities Commissioner,,REP,Chris Nelson,209
-Sanborn,Total,Public Utilities Commissioner,,REP,Chris Nelson,924
-Sanborn,1,Public Utilities Commissioner,,DEM,Henry Red Cloud,33
-Sanborn,2,Public Utilities Commissioner,,DEM,Henry Red Cloud,48
-Sanborn,4,Public Utilities Commissioner,,DEM,Henry Red Cloud,49
-Sanborn,5,Public Utilities Commissioner,,DEM,Henry Red Cloud,42
-Sanborn,Total,Public Utilities Commissioner,,DEM,Henry Red Cloud,172
-Sanborn,1,State Senate,8,REP,Jordan Youngberg,164
-Sanborn,2,State Senate,8,REP,Jordan Youngberg,179
-Sanborn,4,State Senate,8,REP,Jordan Youngberg,168
-Sanborn,5,State Senate,8,REP,Jordan Youngberg,159
-Sanborn,Total,State Senate,8,REP,Jordan Youngberg,670
-Sanborn,1,State Senate,8,DEM,Scott Parsley,88
-Sanborn,2,State Senate,8,DEM,Scott Parsley,114
-Sanborn,4,State Senate,8,DEM,Scott Parsley,111
-Sanborn,5,State Senate,8,DEM,Scott Parsley,87
-Sanborn,Total,State Senate,8,DEM,Scott Parsley,400
-Sanborn,1,State Representative,8,REP,Mathew Wollman,152
-Sanborn,2,State Representative,8,REP,Mathew Wollman,193
-Sanborn,4,State Representative,8,REP,Mathew Wollman,144
-Sanborn,5,State Representative,8,REP,Mathew Wollman,158
-Sanborn,Total,State Representative,8,REP,Mathew Wollman,647
-Sanborn,1,State Representative,8,REP,Leslie Heinemann,159
-Sanborn,2,State Representative,8,REP,Leslie Heinemann,176
-Sanborn,4,State Representative,8,REP,Leslie Heinemann,164
-Sanborn,5,State Representative,8,REP,Leslie Heinemann,170
-Sanborn,Total,State Representative,8,REP,Leslie Heinemann,669
-Sanborn,1,State Representative,8,DEM,Jason Unger,75
-Sanborn,2,State Representative,8,DEM,Jason Unger,79
-Sanborn,4,State Representative,8,DEM,Jason Unger,109
-Sanborn,5,State Representative,8,DEM,Jason Unger,75
-Sanborn,Total,State Representative,8,DEM,Jason Unger,338
-Sanborn,1,State Representative,8,DEM,Kory Rawstern,41
-Sanborn,2,State Representative,8,DEM,Kory Rawstern,62
-Sanborn,4,State Representative,8,DEM,Kory Rawstern,62
-Sanborn,5,State Representative,8,DEM,Kory Rawstern,47
-Sanborn,Total,State Representative,8,DEM,Kory Rawstern,212
+Sanborn,1,President,,Donald J. Trump,REP,193
+Sanborn,2,President,,Donald J. Trump,REP,239
+Sanborn,4,President,,Donald J. Trump,REP,210
+Sanborn,5,President,,Donald J. Trump,REP,177
+Sanborn,Total,President,,Donald J. Trump,REP,819
+Sanborn,1,President,,Gary Johnson,LIB,16
+Sanborn,2,President,,Gary Johnson,LIB,15
+Sanborn,4,President,,Gary Johnson,LIB,14
+Sanborn,5,President,,Gary Johnson,LIB,6
+Sanborn,Total,President,,Gary Johnson,LIB,51
+Sanborn,1,President,,Hillary Clinton,DEM,59
+Sanborn,2,President,,Hillary Clinton,DEM,54
+Sanborn,4,President,,Hillary Clinton,DEM,63
+Sanborn,5,President,,Hillary Clinton,DEM,65
+Sanborn,Total,President,,Hillary Clinton,DEM,241
+Sanborn,1,President,,Darrell L. Castle,CON,3
+Sanborn,2,President,,Darrell L. Castle,CON,5
+Sanborn,4,President,,Darrell L. Castle,CON,2
+Sanborn,5,President,,Darrell L. Castle,CON,2
+Sanborn,Total,President,,Darrell L. Castle,CON,12
+Sanborn,1,U.S. Senate,,John R. Thune,REP,219
+Sanborn,2,U.S. Senate,,John R. Thune,REP,251
+Sanborn,4,U.S. Senate,,John R. Thune,REP,218
+Sanborn,5,U.S. Senate,,John R. Thune,REP,201
+Sanborn,Total,U.S. Senate,,John R. Thune,REP,889
+Sanborn,1,U.S. Senate,,Jay Williams,DEM,51
+Sanborn,2,U.S. Senate,,Jay Williams,DEM,63
+Sanborn,4,U.S. Senate,,Jay Williams,DEM,77
+Sanborn,5,U.S. Senate,,Jay Williams,DEM,53
+Sanborn,Total,U.S. Senate,,Jay Williams,DEM,244
+Sanborn,1,U.S. House,1,Kristi Noem,REP,189
+Sanborn,2,U.S. House,1,Kristi Noem,REP,225
+Sanborn,4,U.S. House,1,Kristi Noem,REP,206
+Sanborn,5,U.S. House,1,Kristi Noem,REP,184
+Sanborn,Total,U.S. House,1,Kristi Noem,REP,804
+Sanborn,1,U.S. House,1,Paula Hawks,DEM,78
+Sanborn,2,U.S. House,1,Paula Hawks,DEM,90
+Sanborn,4,U.S. House,1,Paula Hawks,DEM,87
+Sanborn,5,U.S. House,1,Paula Hawks,DEM,70
+Sanborn,Total,U.S. House,1,Paula Hawks,DEM,325
+Sanborn,1,Public Utilities Commissioner,,Chris Nelson,REP,226
+Sanborn,2,Public Utilities Commissioner,,Chris Nelson,REP,253
+Sanborn,4,Public Utilities Commissioner,,Chris Nelson,REP,236
+Sanborn,5,Public Utilities Commissioner,,Chris Nelson,REP,209
+Sanborn,Total,Public Utilities Commissioner,,Chris Nelson,REP,924
+Sanborn,1,Public Utilities Commissioner,,Henry Red Cloud,DEM,33
+Sanborn,2,Public Utilities Commissioner,,Henry Red Cloud,DEM,48
+Sanborn,4,Public Utilities Commissioner,,Henry Red Cloud,DEM,49
+Sanborn,5,Public Utilities Commissioner,,Henry Red Cloud,DEM,42
+Sanborn,Total,Public Utilities Commissioner,,Henry Red Cloud,DEM,172
+Sanborn,1,State Senate,8,Jordan Youngberg,REP,164
+Sanborn,2,State Senate,8,Jordan Youngberg,REP,179
+Sanborn,4,State Senate,8,Jordan Youngberg,REP,168
+Sanborn,5,State Senate,8,Jordan Youngberg,REP,159
+Sanborn,Total,State Senate,8,Jordan Youngberg,REP,670
+Sanborn,1,State Senate,8,Scott Parsley,DEM,88
+Sanborn,2,State Senate,8,Scott Parsley,DEM,114
+Sanborn,4,State Senate,8,Scott Parsley,DEM,111
+Sanborn,5,State Senate,8,Scott Parsley,DEM,87
+Sanborn,Total,State Senate,8,Scott Parsley,DEM,400
+Sanborn,1,State Representative,8,Mathew Wollman,REP,152
+Sanborn,2,State Representative,8,Mathew Wollman,REP,193
+Sanborn,4,State Representative,8,Mathew Wollman,REP,144
+Sanborn,5,State Representative,8,Mathew Wollman,REP,158
+Sanborn,Total,State Representative,8,Mathew Wollman,REP,647
+Sanborn,1,State Representative,8,Leslie Heinemann,REP,159
+Sanborn,2,State Representative,8,Leslie Heinemann,REP,176
+Sanborn,4,State Representative,8,Leslie Heinemann,REP,164
+Sanborn,5,State Representative,8,Leslie Heinemann,REP,170
+Sanborn,Total,State Representative,8,Leslie Heinemann,REP,669
+Sanborn,1,State Representative,8,Jason Unger,DEM,75
+Sanborn,2,State Representative,8,Jason Unger,DEM,79
+Sanborn,4,State Representative,8,Jason Unger,DEM,109
+Sanborn,5,State Representative,8,Jason Unger,DEM,75
+Sanborn,Total,State Representative,8,Jason Unger,DEM,338
+Sanborn,1,State Representative,8,Kory Rawstern,DEM,41
+Sanborn,2,State Representative,8,Kory Rawstern,DEM,62
+Sanborn,4,State Representative,8,Kory Rawstern,DEM,62
+Sanborn,5,State Representative,8,Kory Rawstern,DEM,47
+Sanborn,Total,State Representative,8,Kory Rawstern,DEM,212
 Spink,1,President,,Donald J. Trump,REP,276
 Spink,3,President,,Donald J. Trump,REP,232
 Spink,4,President,,Donald J. Trump,REP,222
@@ -10116,71 +10116,71 @@ Stanley,1,State Representative,24,Tim Rounds ,REP,812
 Stanley,2,State Representative,24,Tim Rounds ,REP,45
 Stanley,3,State Representative,24,Tim Rounds ,REP,68
 Stanley,TOTAL,State Representative,24,Tim Rounds ,REP,925
-Sully,Absentee Precinct,President,,REP,Donald J. Trump,123
-Sully,Agar Fire Hall,President,,REP,Donald J. Trump,75
-Sully,Bill Floyd Shop,President,,REP,Donald J. Trump,91
-Sully,Phoenix Center,President,,REP,Donald J. Trump,390
-Sully,Total,President,,REP,Donald J. Trump,679
-Sully,Absentee Precinct,President,,LIB,Gary Johnson,9
-Sully,Agar Fire Hall,President,,LIB,Gary Johnson,2
-Sully,Bill Floyd Shop,President,,LIB,Gary Johnson,4
-Sully,Phoenix Center,President,,LIB,Gary Johnson,25
-Sully,Total,President,,LIB,Gary Johnson,40
-Sully,Absentee Precinct,President,,DEM,Hillary Clinton,42
-Sully,Agar Fire Hall,President,,DEM,Hillary Clinton,16
-Sully,Bill Floyd Shop,President,,DEM,Hillary Clinton,16
-Sully,Phoenix Center,President,,DEM,Hillary Clinton,63
-Sully,Total,President,,DEM,Hillary Clinton,137
-Sully,Absentee Precinct,President,,CON,Darrell L. Castle,2
-Sully,Agar Fire Hall,President,,CON,Darrell L. Castle,0
-Sully,Bill Floyd Shop,President,,CON,Darrell L. Castle,0
-Sully,Phoenix Center,President,,CON,Darrell L. Castle,3
-Sully,Total,President,,CON,Darrell L. Castle,5
-Sully,Absentee Precinct,U.S. Senate,,REP,John R. Thune,138
-Sully,Agar Fire Hall,U.S. Senate,,REP,John R. Thune,73
-Sully,Bill Floyd Shop,U.S. Senate,,REP,John R. Thune,90
-Sully,Phoenix Center,U.S. Senate,,REP,John R. Thune,417
-Sully,Total,U.S. Senate,,REP,John R. Thune,718
-Sully,Absentee Precinct,U.S. Senate,,DEM,Jay Williams,36
-Sully,Agar Fire Hall,U.S. Senate,,DEM,Jay Williams,20
-Sully,Bill Floyd Shop,U.S. Senate,,DEM,Jay Williams,13
-Sully,Phoenix Center,U.S. Senate,,DEM,Jay Williams,67
-Sully,Total,U.S. Senate,,DEM,Jay Williams,136
-Sully,Absentee Precinct,U.S. House,1,REP,Kristi Noem,129
-Sully,Agar Fire Hall,U.S. House,1,REP,Kristi Noem,69
-Sully,Bill Floyd Shop,U.S. House,1,REP,Kristi Noem,88
-Sully,Phoenix Center,U.S. House,1,REP,Kristi Noem,382
-Sully,Total,U.S. House,1,REP,Kristi Noem,668
-Sully,Absentee Precinct,U.S. House,1,DEM,Paula Hawks,45
-Sully,Agar Fire Hall,U.S. House,1,DEM,Paula Hawks,24
-Sully,Bill Floyd Shop,U.S. House,1,DEM,Paula Hawks,22
-Sully,Phoenix Center,U.S. House,1,DEM,Paula Hawks,100
-Sully,Total,U.S. House,1,DEM,Paula Hawks,191
-Sully,Absentee Precinct,Public Utilities Commissioner,,REP,Chris Nelson,145
-Sully,Agar Fire Hall,Public Utilities Commissioner,,REP,Chris Nelson,80
-Sully,Bill Floyd Shop,Public Utilities Commissioner,,REP,Chris Nelson,96
-Sully,Phoenix Center,Public Utilities Commissioner,,REP,Chris Nelson,413
-Sully,Total,Public Utilities Commissioner,,REP,Chris Nelson,734
-Sully,Absentee Precinct,Public Utilities Commissioner,,DEM,Henry Red Cloud,26
-Sully,Agar Fire Hall,Public Utilities Commissioner,,DEM,Henry Red Cloud,11
-Sully,Bill Floyd Shop,Public Utilities Commissioner,,DEM,Henry Red Cloud,12
-Sully,Phoenix Center,Public Utilities Commissioner,,DEM,Henry Red Cloud,58
-Sully,Total,Public Utilities Commissioner,,DEM,Henry Red Cloud,107
-Sully,Absentee Precinct,State Senate,24,REP,Jeff Monroe,134
-Sully,Agar Fire Hall,State Senate,24,REP,Jeff Monroe,75
-Sully,Bill Floyd Shop,State Senate,24,REP,Jeff Monroe,89
-Sully,Phoenix Center,State Senate,24,REP,Jeff Monroe,367
-Sully,Total,State Senate,24,REP,Jeff Monroe,665
-Sully,Absentee Precinct,State House,24,REP,Mary Duvall,97
-Sully,Agar Fire Hall,State House,24,REP,Mary Duvall,50
-Sully,Bill Floyd Shop,State House,24,REP,Mary Duvall,76
-Sully,Phoenix Center,State House,24,REP,Mary Duvall,255
-Sully,Total,State House,24,REP,Mary Duvall,478
-Sully,Absentee Precinct,State House,24,REP,Tim Rounds,106
-Sully,Agar Fire Hall,State House,24,REP,Tim Rounds,61
-Sully,Bill Floyd Shop,State House,24,REP,Tim Rounds,68
-Sully,Phoenix Center,State House,24,REP,Tim Rounds,331
-Sully,Total,State House,24,REP,Tim Rounds,566
+Sully,Absentee Precinct,President,,Donald J. Trump,REP,123
+Sully,Agar Fire Hall,President,,Donald J. Trump,REP,75
+Sully,Bill Floyd Shop,President,,Donald J. Trump,REP,91
+Sully,Phoenix Center,President,,Donald J. Trump,REP,390
+Sully,Total,President,,Donald J. Trump,REP,679
+Sully,Absentee Precinct,President,,Gary Johnson,LIB,9
+Sully,Agar Fire Hall,President,,Gary Johnson,LIB,2
+Sully,Bill Floyd Shop,President,,Gary Johnson,LIB,4
+Sully,Phoenix Center,President,,Gary Johnson,LIB,25
+Sully,Total,President,,Gary Johnson,LIB,40
+Sully,Absentee Precinct,President,,Hillary Clinton,DEM,42
+Sully,Agar Fire Hall,President,,Hillary Clinton,DEM,16
+Sully,Bill Floyd Shop,President,,Hillary Clinton,DEM,16
+Sully,Phoenix Center,President,,Hillary Clinton,DEM,63
+Sully,Total,President,,Hillary Clinton,DEM,137
+Sully,Absentee Precinct,President,,Darrell L. Castle,CON,2
+Sully,Agar Fire Hall,President,,Darrell L. Castle,CON,0
+Sully,Bill Floyd Shop,President,,Darrell L. Castle,CON,0
+Sully,Phoenix Center,President,,Darrell L. Castle,CON,3
+Sully,Total,President,,Darrell L. Castle,CON,5
+Sully,Absentee Precinct,U.S. Senate,,John R. Thune,REP,138
+Sully,Agar Fire Hall,U.S. Senate,,John R. Thune,REP,73
+Sully,Bill Floyd Shop,U.S. Senate,,John R. Thune,REP,90
+Sully,Phoenix Center,U.S. Senate,,John R. Thune,REP,417
+Sully,Total,U.S. Senate,,John R. Thune,REP,718
+Sully,Absentee Precinct,U.S. Senate,,Jay Williams,DEM,36
+Sully,Agar Fire Hall,U.S. Senate,,Jay Williams,DEM,20
+Sully,Bill Floyd Shop,U.S. Senate,,Jay Williams,DEM,13
+Sully,Phoenix Center,U.S. Senate,,Jay Williams,DEM,67
+Sully,Total,U.S. Senate,,Jay Williams,DEM,136
+Sully,Absentee Precinct,U.S. House,1,Kristi Noem,REP,129
+Sully,Agar Fire Hall,U.S. House,1,Kristi Noem,REP,69
+Sully,Bill Floyd Shop,U.S. House,1,Kristi Noem,REP,88
+Sully,Phoenix Center,U.S. House,1,Kristi Noem,REP,382
+Sully,Total,U.S. House,1,Kristi Noem,REP,668
+Sully,Absentee Precinct,U.S. House,1,Paula Hawks,DEM,45
+Sully,Agar Fire Hall,U.S. House,1,Paula Hawks,DEM,24
+Sully,Bill Floyd Shop,U.S. House,1,Paula Hawks,DEM,22
+Sully,Phoenix Center,U.S. House,1,Paula Hawks,DEM,100
+Sully,Total,U.S. House,1,Paula Hawks,DEM,191
+Sully,Absentee Precinct,Public Utilities Commissioner,,Chris Nelson,REP,145
+Sully,Agar Fire Hall,Public Utilities Commissioner,,Chris Nelson,REP,80
+Sully,Bill Floyd Shop,Public Utilities Commissioner,,Chris Nelson,REP,96
+Sully,Phoenix Center,Public Utilities Commissioner,,Chris Nelson,REP,413
+Sully,Total,Public Utilities Commissioner,,Chris Nelson,REP,734
+Sully,Absentee Precinct,Public Utilities Commissioner,,Henry Red Cloud,DEM,26
+Sully,Agar Fire Hall,Public Utilities Commissioner,,Henry Red Cloud,DEM,11
+Sully,Bill Floyd Shop,Public Utilities Commissioner,,Henry Red Cloud,DEM,12
+Sully,Phoenix Center,Public Utilities Commissioner,,Henry Red Cloud,DEM,58
+Sully,Total,Public Utilities Commissioner,,Henry Red Cloud,DEM,107
+Sully,Absentee Precinct,State Senate,24,Jeff Monroe,REP,134
+Sully,Agar Fire Hall,State Senate,24,Jeff Monroe,REP,75
+Sully,Bill Floyd Shop,State Senate,24,Jeff Monroe,REP,89
+Sully,Phoenix Center,State Senate,24,Jeff Monroe,REP,367
+Sully,Total,State Senate,24,Jeff Monroe,REP,665
+Sully,Absentee Precinct,State House,24,Mary Duvall,REP,97
+Sully,Agar Fire Hall,State House,24,Mary Duvall,REP,50
+Sully,Bill Floyd Shop,State House,24,Mary Duvall,REP,76
+Sully,Phoenix Center,State House,24,Mary Duvall,REP,255
+Sully,Total,State House,24,Mary Duvall,REP,478
+Sully,Absentee Precinct,State House,24,Tim Rounds,REP,106
+Sully,Agar Fire Hall,State House,24,Tim Rounds,REP,61
+Sully,Bill Floyd Shop,State House,24,Tim Rounds,REP,68
+Sully,Phoenix Center,State House,24,Tim Rounds,REP,331
+Sully,Total,State House,24,Tim Rounds,REP,566
 Todd,Bordeaux,President,,Donald J. Trump,REP,12
 Todd,Jeanette,President,,Donald J. Trump,REP,68
 Todd,Lakeview,President,,Donald J. Trump,REP,90


### PR DESCRIPTION
- remove some random 'county' strings on end of lines
- standardize on 'candidate,party' column order (current version is mixed on a county basis, which results in incorrect data for some counties)
- remove commas and quotes in vote totals, e.g. "2,123" -> 2123