### PR TITLE
Results for Day, Edmunds, Grant, and Gregory counties

### DIFF
--- a/2018/20181106__sd__general__day__precinct.csv
+++ b/2018/20181106__sd__general__day__precinct.csv
@@ -1,0 +1,323 @@
+votes,district,candidate,office,county,party,precinct
+Day,1,U.S. House,1,LIB,George D. Hendrickson,6
+Day,2,U.S. House,1,LIB,George D. Hendrickson,3
+Day,3,U.S. House,1,LIB,George D. Hendrickson,0
+Day,4,U.S. House,1,LIB,George D. Hendrickson,4
+Day,5,U.S. House,1,LIB,George D. Hendrickson,2
+Day,6,U.S. House,1,LIB,George D. Hendrickson,2
+Day,7,U.S. House,1,LIB,George D. Hendrickson,4
+Day,8,U.S. House,1,LIB,George D. Hendrickson,2
+Day,9,U.S. House,1,LIB,George D. Hendrickson,0
+Day,10,U.S. House,1,LIB,George D. Hendrickson,1
+Day,11,U.S. House,1,LIB,George D. Hendrickson,4
+Day,12,U.S. House,1,LIB,George D. Hendrickson,4
+Day,13,U.S. House,1,LIB,George D. Hendrickson,3
+Day,14,U.S. House,1,LIB,George D. Hendrickson,1
+Day,1,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",141
+Day,2,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",153
+Day,3,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",89
+Day,4,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",110
+Day,5,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",95
+Day,6,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",139
+Day,7,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",101
+Day,8,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",77
+Day,9,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",132
+Day,10,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",54
+Day,11,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",103
+Day,12,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",111
+Day,13,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",100
+Day,14,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",136
+Day,1,U.S. House,1,DEM,Tim Bjorkman,95
+Day,2,U.S. House,1,DEM,Tim Bjorkman,91
+Day,3,U.S. House,1,DEM,Tim Bjorkman,69
+Day,4,U.S. House,1,DEM,Tim Bjorkman,65
+Day,5,U.S. House,1,DEM,Tim Bjorkman,74
+Day,6,U.S. House,1,DEM,Tim Bjorkman,113
+Day,7,U.S. House,1,DEM,Tim Bjorkman,70
+Day,8,U.S. House,1,DEM,Tim Bjorkman,53
+Day,9,U.S. House,1,DEM,Tim Bjorkman,57
+Day,10,U.S. House,1,DEM,Tim Bjorkman,34
+Day,11,U.S. House,1,DEM,Tim Bjorkman,87
+Day,12,U.S. House,1,DEM,Tim Bjorkman,91
+Day,13,U.S. House,1,DEM,Tim Bjorkman,88
+Day,14,U.S. House,1,DEM,Tim Bjorkman,85
+Day,1,U.S. House,1,IND,Ron Wieczorek,2
+Day,2,U.S. House,1,IND,Ron Wieczorek,6
+Day,3,U.S. House,1,IND,Ron Wieczorek,4
+Day,4,U.S. House,1,IND,Ron Wieczorek,2
+Day,5,U.S. House,1,IND,Ron Wieczorek,10
+Day,6,U.S. House,1,IND,Ron Wieczorek,7
+Day,7,U.S. House,1,IND,Ron Wieczorek,7
+Day,8,U.S. House,1,IND,Ron Wieczorek,2
+Day,9,U.S. House,1,IND,Ron Wieczorek,1
+Day,10,U.S. House,1,IND,Ron Wieczorek,1
+Day,11,U.S. House,1,IND,Ron Wieczorek,13
+Day,12,U.S. House,1,IND,Ron Wieczorek,4
+Day,13,U.S. House,1,IND,Ron Wieczorek,3
+Day,14,U.S. House,1,IND,Ron Wieczorek,6
+Day,1,Governor,,LIB,Kurt Evans,3
+Day,2,Governor,,LIB,Kurt Evans,4
+Day,3,Governor,,LIB,Kurt Evans,3
+Day,4,Governor,,LIB,Kurt Evans,2
+Day,5,Governor,,LIB,Kurt Evans,5
+Day,6,Governor,,LIB,Kurt Evans,0
+Day,7,Governor,,LIB,Kurt Evans,1
+Day,8,Governor,,LIB,Kurt Evans,2
+Day,9,Governor,,LIB,Kurt Evans,2
+Day,10,Governor,,LIB,Kurt Evans,2
+Day,11,Governor,,LIB,Kurt Evans,9
+Day,12,Governor,,LIB,Kurt Evans,3
+Day,13,Governor,,LIB,Kurt Evans,1
+Day,14,Governor,,LIB,Kurt Evans,2
+Day,1,Governor,,REP,Kristi Noem,128
+Day,2,Governor,,REP,Kristi Noem,112
+Day,3,Governor,,REP,Kristi Noem,76
+Day,4,Governor,,REP,Kristi Noem,86
+Day,5,Governor,,REP,Kristi Noem,76
+Day,6,Governor,,REP,Kristi Noem,106
+Day,7,Governor,,REP,Kristi Noem,85
+Day,8,Governor,,REP,Kristi Noem,56
+Day,9,Governor,,REP,Kristi Noem,105
+Day,10,Governor,,REP,Kristi Noem,42
+Day,11,Governor,,REP,Kristi Noem,73
+Day,12,Governor,,REP,Kristi Noem,78
+Day,13,Governor,,REP,Kristi Noem,83
+Day,14,Governor,,REP,Kristi Noem,101
+Day,1,Governor,,DEM,Billie Sutton,122
+Day,2,Governor,,DEM,Billie Sutton,143
+Day,3,Governor,,DEM,Billie Sutton,86
+Day,4,Governor,,DEM,Billie Sutton,101
+Day,5,Governor,,DEM,Billie Sutton,103
+Day,6,Governor,,DEM,Billie Sutton,160
+Day,7,Governor,,DEM,Billie Sutton,99
+Day,8,Governor,,DEM,Billie Sutton,77
+Day,9,Governor,,DEM,Billie Sutton,84
+Day,10,Governor,,DEM,Billie Sutton,46
+Day,11,Governor,,DEM,Billie Sutton,135
+Day,12,Governor,,DEM,Billie Sutton,131
+Day,13,Governor,,DEM,Billie Sutton,114
+Day,14,Governor,,DEM,Billie Sutton,130
+Day,1,Secretary of State,,REP,Steve Barnett,151
+Day,2,Secretary of State,,REP,Steve Barnett,150
+Day,3,Secretary of State,,REP,Steve Barnett,102
+Day,4,Secretary of State,,REP,Steve Barnett,124
+Day,5,Secretary of State,,REP,Steve Barnett,99
+Day,6,Secretary of State,,REP,Steve Barnett,136
+Day,7,Secretary of State,,REP,Steve Barnett,113
+Day,8,Secretary of State,,REP,Steve Barnett,74
+Day,9,Secretary of State,,REP,Steve Barnett,120
+Day,10,Secretary of State,,REP,Steve Barnett,55
+Day,11,Secretary of State,,REP,Steve Barnett,114
+Day,12,Secretary of State,,REP,Steve Barnett,107
+Day,13,Secretary of State,,REP,Steve Barnett,105
+Day,14,Secretary of State,,REP,Steve Barnett,136
+Day,1,Secretary of State,,DEM,Alexandra Frederick,87
+Day,2,Secretary of State,,DEM,Alexandra Frederick,88
+Day,3,Secretary of State,,DEM,Alexandra Frederick,54
+Day,4,Secretary of State,,DEM,Alexandra Frederick,47
+Day,5,Secretary of State,,DEM,Alexandra Frederick,73
+Day,6,Secretary of State,,DEM,Alexandra Frederick,123
+Day,7,Secretary of State,,DEM,Alexandra Frederick,65
+Day,8,Secretary of State,,DEM,Alexandra Frederick,59
+Day,9,Secretary of State,,DEM,Alexandra Frederick,55
+Day,10,Secretary of State,,DEM,Alexandra Frederick,32
+Day,11,Secretary of State,,DEM,Alexandra Frederick,82
+Day,12,Secretary of State,,DEM,Alexandra Frederick,95
+Day,13,Secretary of State,,DEM,Alexandra Frederick,83
+Day,14,Secretary of State,,DEM,Alexandra Frederick,80
+Day,1,Attorney General,,REP,Jason Ravnsborg,128
+Day,2,Attorney General,,REP,Jason Ravnsborg,115
+Day,3,Attorney General,,REP,Jason Ravnsborg,78
+Day,4,Attorney General,,REP,Jason Ravnsborg,77
+Day,5,Attorney General,,REP,Jason Ravnsborg,83
+Day,6,Attorney General,,REP,Jason Ravnsborg,105
+Day,7,Attorney General,,REP,Jason Ravnsborg,91
+Day,8,Attorney General,,REP,Jason Ravnsborg,56
+Day,9,Attorney General,,REP,Jason Ravnsborg,111
+Day,10,Attorney General,,REP,Jason Ravnsborg,44
+Day,11,Attorney General,,REP,Jason Ravnsborg,85
+Day,12,Attorney General,,REP,Jason Ravnsborg,89
+Day,13,Attorney General,,REP,Jason Ravnsborg,85
+Day,14,Attorney General,,REP,Jason Ravnsborg,111
+Day,1,Attorney General,,DEM,Randy Seiler,105
+Day,2,Attorney General,,DEM,Randy Seiler,126
+Day,3,Attorney General,,DEM,Randy Seiler,79
+Day,4,Attorney General,,DEM,Randy Seiler,92
+Day,5,Attorney General,,DEM,Randy Seiler,90
+Day,6,Attorney General,,DEM,Randy Seiler,148
+Day,7,Attorney General,,DEM,Randy Seiler,84
+Day,8,Attorney General,,DEM,Randy Seiler,73
+Day,9,Attorney General,,DEM,Randy Seiler,67
+Day,10,Attorney General,,DEM,Randy Seiler,44
+Day,11,Attorney General,,DEM,Randy Seiler,118
+Day,12,Attorney General,,DEM,Randy Seiler,114
+Day,13,Attorney General,,DEM,Randy Seiler,100
+Day,14,Attorney General,,DEM,Randy Seiler,102
+Day,1,State Auditor,,REP,Rich Sattgast,133
+Day,2,State Auditor,,REP,Rich Sattgast,142
+Day,3,State Auditor,,REP,Rich Sattgast,87
+Day,4,State Auditor,,REP,Rich Sattgast,112
+Day,5,State Auditor,,REP,Rich Sattgast,95
+Day,6,State Auditor,,REP,Rich Sattgast,127
+Day,7,State Auditor,,REP,Rich Sattgast,103
+Day,8,State Auditor,,REP,Rich Sattgast,69
+Day,9,State Auditor,,REP,Rich Sattgast,114
+Day,10,State Auditor,,REP,Rich Sattgast,56
+Day,11,State Auditor,,REP,Rich Sattgast,105
+Day,12,State Auditor,,REP,Rich Sattgast,98
+Day,13,State Auditor,,REP,Rich Sattgast,98
+Day,14,State Auditor,,REP,Rich Sattgast,124
+Day,1,State Auditor,,DEM,Tom Cool,88
+Day,2,State Auditor,,DEM,Tom Cool,89
+Day,3,State Auditor,,DEM,Tom Cool,59
+Day,4,State Auditor,,DEM,Tom Cool,47
+Day,5,State Auditor,,DEM,Tom Cool,70
+Day,6,State Auditor,,DEM,Tom Cool,122
+Day,7,State Auditor,,DEM,Tom Cool,65
+Day,8,State Auditor,,DEM,Tom Cool,59
+Day,9,State Auditor,,DEM,Tom Cool,49
+Day,10,State Auditor,,DEM,Tom Cool,31
+Day,11,State Auditor,,DEM,Tom Cool,90
+Day,12,State Auditor,,DEM,Tom Cool,96
+Day,13,State Auditor,,DEM,Tom Cool,79
+Day,14,State Auditor,,DEM,Tom Cool,80
+Day,1,State Treasurer,,REP,Josh Haeder,119
+Day,2,State Treasurer,,REP,Josh Haeder,140
+Day,3,State Treasurer,,REP,Josh Haeder,87
+Day,4,State Treasurer,,REP,Josh Haeder,98
+Day,5,State Treasurer,,REP,Josh Haeder,84
+Day,6,State Treasurer,,REP,Josh Haeder,120
+Day,7,State Treasurer,,REP,Josh Haeder,95
+Day,8,State Treasurer,,REP,Josh Haeder,65
+Day,9,State Treasurer,,REP,Josh Haeder,105
+Day,10,State Treasurer,,REP,Josh Haeder,53
+Day,11,State Treasurer,,REP,Josh Haeder,82
+Day,12,State Treasurer,,REP,Josh Haeder,92
+Day,13,State Treasurer,,REP,Josh Haeder,90
+Day,14,State Treasurer,,REP,Josh Haeder,118
+Day,1,State Treasurer,,DEM,Aaron Matson,102
+Day,2,State Treasurer,,DEM,Aaron Matson,94
+Day,3,State Treasurer,,DEM,Aaron Matson,61
+Day,4,State Treasurer,,DEM,Aaron Matson,58
+Day,5,State Treasurer,,DEM,Aaron Matson,76
+Day,6,State Treasurer,,DEM,Aaron Matson,124
+Day,7,State Treasurer,,DEM,Aaron Matson,71
+Day,8,State Treasurer,,DEM,Aaron Matson,62
+Day,9,State Treasurer,,DEM,Aaron Matson,53
+Day,10,State Treasurer,,DEM,Aaron Matson,33
+Day,11,State Treasurer,,DEM,Aaron Matson,104
+Day,12,State Treasurer,,DEM,Aaron Matson,101
+Day,13,State Treasurer,,DEM,Aaron Matson,86
+Day,14,State Treasurer,,DEM,Aaron Matson,84
+Day,1,Commissioner of School and Public Lands,,REP,Ryan Brunner,127
+Day,2,Commissioner of School and Public Lands,,REP,Ryan Brunner,132
+Day,3,Commissioner of School and Public Lands,,REP,Ryan Brunner,78
+Day,4,Commissioner of School and Public Lands,,REP,Ryan Brunner,94
+Day,5,Commissioner of School and Public Lands,,REP,Ryan Brunner,90
+Day,6,Commissioner of School and Public Lands,,REP,Ryan Brunner,120
+Day,7,Commissioner of School and Public Lands,,REP,Ryan Brunner,99
+Day,8,Commissioner of School and Public Lands,,REP,Ryan Brunner,59
+Day,9,Commissioner of School and Public Lands,,REP,Ryan Brunner,107
+Day,10,Commissioner of School and Public Lands,,REP,Ryan Brunner,56
+Day,11,Commissioner of School and Public Lands,,REP,Ryan Brunner,83
+Day,12,Commissioner of School and Public Lands,,REP,Ryan Brunner,100
+Day,13,Commissioner of School and Public Lands,,REP,Ryan Brunner,82
+Day,14,Commissioner of School and Public Lands,,REP,Ryan Brunner,118
+Day,1,Commissioner of School and Public Lands,,DEM,Woody Hauser,93
+Day,2,Commissioner of School and Public Lands,,DEM,Woody Hauser,97
+Day,3,Commissioner of School and Public Lands,,DEM,Woody Hauser,67
+Day,4,Commissioner of School and Public Lands,,DEM,Woody Hauser,62
+Day,5,Commissioner of School and Public Lands,,DEM,Woody Hauser,71
+Day,6,Commissioner of School and Public Lands,,DEM,Woody Hauser,121
+Day,7,Commissioner of School and Public Lands,,DEM,Woody Hauser,71
+Day,8,Commissioner of School and Public Lands,,DEM,Woody Hauser,63
+Day,9,Commissioner of School and Public Lands,,DEM,Woody Hauser,50
+Day,10,Commissioner of School and Public Lands,,DEM,Woody Hauser,32
+Day,11,Commissioner of School and Public Lands,,DEM,Woody Hauser,102
+Day,12,Commissioner of School and Public Lands,,DEM,Woody Hauser,96
+Day,13,Commissioner of School and Public Lands,,DEM,Woody Hauser,91
+Day,14,Commissioner of School and Public Lands,,DEM,Woody Hauser,79
+Day,1,Public Utilities Commissioner,,REP,Kristie Fiegen,125
+Day,2,Public Utilities Commissioner,,REP,Kristie Fiegen,134
+Day,3,Public Utilities Commissioner,,REP,Kristie Fiegen,92
+Day,4,Public Utilities Commissioner,,REP,Kristie Fiegen,98
+Day,5,Public Utilities Commissioner,,REP,Kristie Fiegen,86
+Day,6,Public Utilities Commissioner,,REP,Kristie Fiegen,120
+Day,7,Public Utilities Commissioner,,REP,Kristie Fiegen,95
+Day,8,Public Utilities Commissioner,,REP,Kristie Fiegen,66
+Day,9,Public Utilities Commissioner,,REP,Kristie Fiegen,110
+Day,10,Public Utilities Commissioner,,REP,Kristie Fiegen,53
+Day,11,Public Utilities Commissioner,,REP,Kristie Fiegen,92
+Day,12,Public Utilities Commissioner,,REP,Kristie Fiegen,102
+Day,13,Public Utilities Commissioner,,REP,Kristie Fiegen,86
+Day,14,Public Utilities Commissioner,,REP,Kristie Fiegen,126
+Day,1,Public Utilities Commissioner,,DEM,Wayne Frederick,101
+Day,2,Public Utilities Commissioner,,DEM,Wayne Frederick,94
+Day,3,Public Utilities Commissioner,,DEM,Wayne Frederick,56
+Day,4,Public Utilities Commissioner,,DEM,Wayne Frederick,56
+Day,5,Public Utilities Commissioner,,DEM,Wayne Frederick,76
+Day,6,Public Utilities Commissioner,,DEM,Wayne Frederick,124
+Day,7,Public Utilities Commissioner,,DEM,Wayne Frederick,74
+Day,8,Public Utilities Commissioner,,DEM,Wayne Frederick,62
+Day,9,Public Utilities Commissioner,,DEM,Wayne Frederick,49
+Day,10,Public Utilities Commissioner,,DEM,Wayne Frederick,33
+Day,11,Public Utilities Commissioner,,DEM,Wayne Frederick,95
+Day,12,Public Utilities Commissioner,,DEM,Wayne Frederick,91
+Day,13,Public Utilities Commissioner,,DEM,Wayne Frederick,84
+Day,14,Public Utilities Commissioner,,DEM,Wayne Frederick,75
+Day,1,State Senate,1,DEM,Susan M. Wismer,134
+Day,2,State Senate,1,DEM,Susan M. Wismer,144
+Day,3,State Senate,1,DEM,Susan M. Wismer,90
+Day,4,State Senate,1,DEM,Susan M. Wismer,104
+Day,5,State Senate,1,DEM,Susan M. Wismer,95
+Day,6,State Senate,1,DEM,Susan M. Wismer,153
+Day,7,State Senate,1,DEM,Susan M. Wismer,112
+Day,8,State Senate,1,DEM,Susan M. Wismer,72
+Day,9,State Senate,1,DEM,Susan M. Wismer,83
+Day,10,State Senate,1,DEM,Susan M. Wismer,55
+Day,11,State Senate,1,DEM,Susan M. Wismer,138
+Day,12,State Senate,1,DEM,Susan M. Wismer,135
+Day,13,State Senate,1,DEM,Susan M. Wismer,115
+Day,14,State Senate,1,DEM,Susan M. Wismer,136
+Day,1,State House,1,REP,Tamara St John,110
+Day,2,State House,1,REP,Tamara St John,116
+Day,3,State House,1,REP,Tamara St John,80
+Day,4,State House,1,REP,Tamara St John,90
+Day,5,State House,1,REP,Tamara St John,86
+Day,6,State House,1,REP,Tamara St John,133
+Day,7,State House,1,REP,Tamara St John,87
+Day,8,State House,1,REP,Tamara St John,54
+Day,9,State House,1,REP,Tamara St John,96
+Day,10,State House,1,REP,Tamara St John,37
+Day,11,State House,1,REP,Tamara St John,89
+Day,12,State House,1,REP,Tamara St John,75
+Day,13,State House,1,REP,Tamara St John,85
+Day,14,State House,1,REP,Tamara St John,113
+Day,1,State House,1,DEM,H. Paul Dennert,84
+Day,2,State House,1,DEM,H. Paul Dennert,96
+Day,3,State House,1,DEM,H. Paul Dennert,59
+Day,4,State House,1,DEM,H. Paul Dennert,70
+Day,5,State House,1,DEM,H. Paul Dennert,55
+Day,6,State House,1,DEM,H. Paul Dennert,93
+Day,7,State House,1,DEM,H. Paul Dennert,75
+Day,8,State House,1,DEM,H. Paul Dennert,67
+Day,9,State House,1,DEM,H. Paul Dennert,56
+Day,10,State House,1,DEM,H. Paul Dennert,52
+Day,11,State House,1,DEM,H. Paul Dennert,94
+Day,12,State House,1,DEM,H. Paul Dennert,117
+Day,13,State House,1,DEM,H. Paul Dennert,74
+Day,14,State House,1,DEM,H. Paul Dennert,106
+Day,1,State House,1,DEM,Steven D. McCleery,95
+Day,2,State House,1,DEM,Steven D. McCleery,103
+Day,3,State House,1,DEM,Steven D. McCleery,55
+Day,4,State House,1,DEM,Steven D. McCleery,74
+Day,5,State House,1,DEM,Steven D. McCleery,70
+Day,6,State House,1,DEM,Steven D. McCleery,98
+Day,7,State House,1,DEM,Steven D. McCleery,71
+Day,8,State House,1,DEM,Steven D. McCleery,58
+Day,9,State House,1,DEM,Steven D. McCleery,54
+Day,10,State House,1,DEM,Steven D. McCleery,40
+Day,11,State House,1,DEM,Steven D. McCleery,91
+Day,12,State House,1,DEM,Steven D. McCleery,74
+Day,13,State House,1,DEM,Steven D. McCleery,83
+Day,14,State House,1,DEM,Steven D. McCleery,79

--- a/2018/20181106__sd__general__edmunds__precinct.csv
+++ b/2018/20181106__sd__general__edmunds__precinct.csv
@@ -1,0 +1,151 @@
+votes,district,candidate,office,county,party,precinct
+Edmunds,1,U.S. House,1,LIB,George D. Hendrickson,3
+Edmunds,2,U.S. House,1,LIB,George D. Hendrickson,3
+Edmunds,3,U.S. House,1,LIB,George D. Hendrickson,1
+Edmunds,4,U.S. House,1,LIB,George D. Hendrickson,1
+Edmunds,5,U.S. House,1,LIB,George D. Hendrickson,3
+Edmunds,6,U.S. House,1,LIB,George D. Hendrickson,3
+Edmunds,1,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",286
+Edmunds,2,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",224
+Edmunds,3,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",181
+Edmunds,4,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",125
+Edmunds,5,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",239
+Edmunds,6,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",92
+Edmunds,1,U.S. House,1,DEM,Tim Bjorkman,116
+Edmunds,2,U.S. House,1,DEM,Tim Bjorkman,95
+Edmunds,3,U.S. House,1,DEM,Tim Bjorkman,66
+Edmunds,4,U.S. House,1,DEM,Tim Bjorkman,87
+Edmunds,5,U.S. House,1,DEM,Tim Bjorkman,78
+Edmunds,6,U.S. House,1,DEM,Tim Bjorkman,46
+Edmunds,1,U.S. House,1,IND,Ron Wieczorek,10
+Edmunds,2,U.S. House,1,IND,Ron Wieczorek,5
+Edmunds,3,U.S. House,1,IND,Ron Wieczorek,7
+Edmunds,4,U.S. House,1,IND,Ron Wieczorek,3
+Edmunds,5,U.S. House,1,IND,Ron Wieczorek,9
+Edmunds,6,U.S. House,1,IND,Ron Wieczorek,2
+Edmunds,1,Governor,,LIB,Kurt Evans,5
+Edmunds,2,Governor,,LIB,Kurt Evans,6
+Edmunds,3,Governor,,LIB,Kurt Evans,2
+Edmunds,4,Governor,,LIB,Kurt Evans,0
+Edmunds,5,Governor,,LIB,Kurt Evans,3
+Edmunds,6,Governor,,LIB,Kurt Evans,3
+Edmunds,1,Governor,,REP,Kristi Noem,258
+Edmunds,2,Governor,,REP,Kristi Noem,180
+Edmunds,3,Governor,,REP,Kristi Noem,167
+Edmunds,4,Governor,,REP,Kristi Noem,123
+Edmunds,5,Governor,,REP,Kristi Noem,211
+Edmunds,6,Governor,,REP,Kristi Noem,79
+Edmunds,1,Governor,,DEM,Billie Sutton,154
+Edmunds,2,Governor,,DEM,Billie Sutton,143
+Edmunds,3,Governor,,DEM,Billie Sutton,95
+Edmunds,4,Governor,,DEM,Billie Sutton,99
+Edmunds,5,Governor,,DEM,Billie Sutton,118
+Edmunds,6,Governor,,DEM,Billie Sutton,62
+Edmunds,1,Secretary of State,,REP,Steve Barnett,308
+Edmunds,2,Secretary of State,,REP,Steve Barnett,243
+Edmunds,3,Secretary of State,,REP,Steve Barnett,189
+Edmunds,4,Secretary of State,,REP,Steve Barnett,148
+Edmunds,5,Secretary of State,,REP,Steve Barnett,272
+Edmunds,6,Secretary of State,,REP,Steve Barnett,98
+Edmunds,1,Secretary of State,,DEM,Alexandra Frederick,99
+Edmunds,2,Secretary of State,,DEM,Alexandra Frederick,76
+Edmunds,3,Secretary of State,,DEM,Alexandra Frederick,54
+Edmunds,4,Secretary of State,,DEM,Alexandra Frederick,58
+Edmunds,5,Secretary of State,,DEM,Alexandra Frederick,47
+Edmunds,6,Secretary of State,,DEM,Alexandra Frederick,38
+Edmunds,1,Attorney General,,REP,Jason Ravnsborg,256
+Edmunds,2,Attorney General,,REP,Jason Ravnsborg,197
+Edmunds,3,Attorney General,,REP,Jason Ravnsborg,161
+Edmunds,4,Attorney General,,REP,Jason Ravnsborg,109
+Edmunds,5,Attorney General,,REP,Jason Ravnsborg,213
+Edmunds,6,Attorney General,,REP,Jason Ravnsborg,80
+Edmunds,1,Attorney General,,DEM,Randy Seiler,149
+Edmunds,2,Attorney General,,DEM,Randy Seiler,121
+Edmunds,3,Attorney General,,DEM,Randy Seiler,79
+Edmunds,4,Attorney General,,DEM,Randy Seiler,95
+Edmunds,5,Attorney General,,DEM,Randy Seiler,109
+Edmunds,6,Attorney General,,DEM,Randy Seiler,54
+Edmunds,1,State Auditor,,REP,Rich Sattgast,292
+Edmunds,2,State Auditor,,REP,Rich Sattgast,202
+Edmunds,3,State Auditor,,REP,Rich Sattgast,172
+Edmunds,4,State Auditor,,REP,Rich Sattgast,124
+Edmunds,5,State Auditor,,REP,Rich Sattgast,246
+Edmunds,6,State Auditor,,REP,Rich Sattgast,88
+Edmunds,1,State Auditor,,DEM,Tom Cool,101
+Edmunds,2,State Auditor,,DEM,Tom Cool,103
+Edmunds,3,State Auditor,,DEM,Tom Cool,57
+Edmunds,4,State Auditor,,DEM,Tom Cool,70
+Edmunds,5,State Auditor,,DEM,Tom Cool,63
+Edmunds,6,State Auditor,,DEM,Tom Cool,41
+Edmunds,1,State Treasurer,,REP,Josh Haeder,274
+Edmunds,2,State Treasurer,,REP,Josh Haeder,206
+Edmunds,3,State Treasurer,,REP,Josh Haeder,169
+Edmunds,4,State Treasurer,,REP,Josh Haeder,124
+Edmunds,5,State Treasurer,,REP,Josh Haeder,242
+Edmunds,6,State Treasurer,,REP,Josh Haeder,85
+Edmunds,1,State Treasurer,,DEM,Aaron Matson,115
+Edmunds,2,State Treasurer,,DEM,Aaron Matson,93
+Edmunds,3,State Treasurer,,DEM,Aaron Matson,61
+Edmunds,4,State Treasurer,,DEM,Aaron Matson,74
+Edmunds,5,State Treasurer,,DEM,Aaron Matson,67
+Edmunds,6,State Treasurer,,DEM,Aaron Matson,41
+Edmunds,1,Commissioner of School and Public Lands,,REP,Ryan Brunner,268
+Edmunds,2,Commissioner of School and Public Lands,,REP,Ryan Brunner,201
+Edmunds,3,Commissioner of School and Public Lands,,REP,Ryan Brunner,161
+Edmunds,4,Commissioner of School and Public Lands,,REP,Ryan Brunner,125
+Edmunds,5,Commissioner of School and Public Lands,,REP,Ryan Brunner,240
+Edmunds,6,Commissioner of School and Public Lands,,REP,Ryan Brunner,83
+Edmunds,1,Commissioner of School and Public Lands,,DEM,Woody Hauser,119
+Edmunds,2,Commissioner of School and Public Lands,,DEM,Woody Hauser,96
+Edmunds,3,Commissioner of School and Public Lands,,DEM,Woody Hauser,61
+Edmunds,4,Commissioner of School and Public Lands,,DEM,Woody Hauser,70
+Edmunds,5,Commissioner of School and Public Lands,,DEM,Woody Hauser,68
+Edmunds,6,Commissioner of School and Public Lands,,DEM,Woody Hauser,43
+Edmunds,1,Public Utilities Commissioner,,REP,Kristie Fiegen,289
+Edmunds,2,Public Utilities Commissioner,,REP,Kristie Fiegen,205
+Edmunds,3,Public Utilities Commissioner,,REP,Kristie Fiegen,176
+Edmunds,4,Public Utilities Commissioner,,REP,Kristie Fiegen,124
+Edmunds,5,Public Utilities Commissioner,,REP,Kristie Fiegen,245
+Edmunds,6,Public Utilities Commissioner,,REP,Kristie Fiegen,96
+Edmunds,1,Public Utilities Commissioner,,DEM,Wayne Frederick,101
+Edmunds,2,Public Utilities Commissioner,,DEM,Wayne Frederick,97
+Edmunds,3,Public Utilities Commissioner,,DEM,Wayne Frederick,55
+Edmunds,4,Public Utilities Commissioner,,DEM,Wayne Frederick,68
+Edmunds,5,Public Utilities Commissioner,,DEM,Wayne Frederick,64
+Edmunds,6,Public Utilities Commissioner,,DEM,Wayne Frederick,31
+Edmunds,1,State Senate,23,REP,Justin R. Cronin,293
+Edmunds,2,State Senate,23,REP,Justin R. Cronin,232
+Edmunds,3,State Senate,23,REP,Justin R. Cronin,189
+Edmunds,4,State Senate,23,REP,Justin R. Cronin,140
+Edmunds,5,State Senate,23,REP,Justin R. Cronin,271
+Edmunds,6,State Senate,23,REP,Justin R. Cronin,98
+Edmunds,1,State Senate,23,DEM,Joe Yracheta,100
+Edmunds,2,State Senate,23,DEM,Joe Yracheta,70
+Edmunds,3,State Senate,23,DEM,Joe Yracheta,47
+Edmunds,4,State Senate,23,DEM,Joe Yracheta,52
+Edmunds,5,State Senate,23,DEM,Joe Yracheta,43
+Edmunds,6,State Senate,23,DEM,Joe Yracheta,35
+Edmunds,1,State House,23,REP,Spencer Gosch,276
+Edmunds,2,State House,23,REP,Spencer Gosch,204
+Edmunds,3,State House,23,REP,Spencer Gosch,173
+Edmunds,4,State House,23,REP,Spencer Gosch,140
+Edmunds,5,State House,23,REP,Spencer Gosch,267
+Edmunds,6,State House,23,REP,Spencer Gosch,102
+Edmunds,1,State House,23,REP,John A. Lake,233
+Edmunds,2,State House,23,REP,John A. Lake,186
+Edmunds,3,State House,23,REP,John A. Lake,147
+Edmunds,4,State House,23,REP,John A. Lake,107
+Edmunds,5,State House,23,REP,John A. Lake,219
+Edmunds,6,State House,23,REP,John A. Lake,69
+Edmunds,1,State House,23,DEM,Eleanor Iverson,104
+Edmunds,2,State House,23,DEM,Eleanor Iverson,82
+Edmunds,3,State House,23,DEM,Eleanor Iverson,50
+Edmunds,4,State House,23,DEM,Eleanor Iverson,54
+Edmunds,5,State House,23,DEM,Eleanor Iverson,50
+Edmunds,6,State House,23,DEM,Eleanor Iverson,30
+Edmunds,1,State House,23,DEM,Margaret Ann Walsh,104
+Edmunds,2,State House,23,DEM,Margaret Ann Walsh,77
+Edmunds,3,State House,23,DEM,Margaret Ann Walsh,47
+Edmunds,4,State House,23,DEM,Margaret Ann Walsh,48
+Edmunds,5,State House,23,DEM,Margaret Ann Walsh,42
+Edmunds,6,State House,23,DEM,Margaret Ann Walsh,34

--- a/2018/20181106__sd__general__grant__precinct.csv
+++ b/2018/20181106__sd__general__grant__precinct.csv
@@ -1,0 +1,469 @@
+votes,district,candidate,office,county,party,precinct
+Grant,11,U.S. House,1,LIB,George D. Hendrickson,8
+Grant,12,U.S. House,1,LIB,George D. Hendrickson,1
+Grant,21,U.S. House,1,LIB,George D. Hendrickson,7
+Grant,22,U.S. House,1,LIB,George D. Hendrickson,8
+Grant,31,U.S. House,1,LIB,George D. Hendrickson,0
+Grant,32,U.S. House,1,LIB,George D. Hendrickson,2
+Grant,33,U.S. House,1,LIB,George D. Hendrickson,2
+Grant,41,U.S. House,1,LIB,George D. Hendrickson,3
+Grant,42,U.S. House,1,LIB,George D. Hendrickson,2
+Grant,43,U.S. House,1,LIB,George D. Hendrickson,3
+Grant,44,U.S. House,1,LIB,George D. Hendrickson,1
+Grant,45,U.S. House,1,LIB,George D. Hendrickson,6
+Grant,46,U.S. House,1,LIB,George D. Hendrickson,3
+Grant,47,U.S. House,1,LIB,George D. Hendrickson,1
+Grant,49,U.S. House,1,LIB,George D. Hendrickson,4
+Grant,52,U.S. House,1,LIB,George D. Hendrickson,5
+Grant,53,U.S. House,1,LIB,George D. Hendrickson,0
+Grant,54,U.S. House,1,LIB,George D. Hendrickson,4
+Grant,11,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",180
+Grant,12,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",44
+Grant,21,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",57
+Grant,22,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",227
+Grant,31,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",33
+Grant,32,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",60
+Grant,33,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",243
+Grant,41,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",126
+Grant,42,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",185
+Grant,43,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",237
+Grant,44,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",82
+Grant,45,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",99
+Grant,46,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",131
+Grant,47,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",167
+Grant,49,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",67
+Grant,52,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",48
+Grant,53,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",31
+Grant,54,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",104
+Grant,11,U.S. House,1,DEM,Tim Bjorkman,72
+Grant,12,U.S. House,1,DEM,Tim Bjorkman,15
+Grant,21,U.S. House,1,DEM,Tim Bjorkman,26
+Grant,22,U.S. House,1,DEM,Tim Bjorkman,108
+Grant,31,U.S. House,1,DEM,Tim Bjorkman,22
+Grant,32,U.S. House,1,DEM,Tim Bjorkman,31
+Grant,33,U.S. House,1,DEM,Tim Bjorkman,115
+Grant,41,U.S. House,1,DEM,Tim Bjorkman,89
+Grant,42,U.S. House,1,DEM,Tim Bjorkman,70
+Grant,43,U.S. House,1,DEM,Tim Bjorkman,104
+Grant,44,U.S. House,1,DEM,Tim Bjorkman,33
+Grant,45,U.S. House,1,DEM,Tim Bjorkman,48
+Grant,46,U.S. House,1,DEM,Tim Bjorkman,59
+Grant,47,U.S. House,1,DEM,Tim Bjorkman,36
+Grant,49,U.S. House,1,DEM,Tim Bjorkman,28
+Grant,52,U.S. House,1,DEM,Tim Bjorkman,17
+Grant,53,U.S. House,1,DEM,Tim Bjorkman,15
+Grant,54,U.S. House,1,DEM,Tim Bjorkman,57
+Grant,11,U.S. House,1,IND,Ron Wieczorek,9
+Grant,12,U.S. House,1,IND,Ron Wieczorek,1
+Grant,21,U.S. House,1,IND,Ron Wieczorek,1
+Grant,22,U.S. House,1,IND,Ron Wieczorek,8
+Grant,31,U.S. House,1,IND,Ron Wieczorek,2
+Grant,32,U.S. House,1,IND,Ron Wieczorek,0
+Grant,33,U.S. House,1,IND,Ron Wieczorek,3
+Grant,41,U.S. House,1,IND,Ron Wieczorek,7
+Grant,42,U.S. House,1,IND,Ron Wieczorek,8
+Grant,43,U.S. House,1,IND,Ron Wieczorek,6
+Grant,44,U.S. House,1,IND,Ron Wieczorek,2
+Grant,45,U.S. House,1,IND,Ron Wieczorek,4
+Grant,46,U.S. House,1,IND,Ron Wieczorek,5
+Grant,47,U.S. House,1,IND,Ron Wieczorek,1
+Grant,49,U.S. House,1,IND,Ron Wieczorek,0
+Grant,52,U.S. House,1,IND,Ron Wieczorek,2
+Grant,53,U.S. House,1,IND,Ron Wieczorek,1
+Grant,54,U.S. House,1,IND,Ron Wieczorek,3
+Grant,11,Governor,,LIB,Kurt Evans,9
+Grant,12,Governor,,LIB,Kurt Evans,1
+Grant,21,Governor,,LIB,Kurt Evans,5
+Grant,22,Governor,,LIB,Kurt Evans,4
+Grant,31,Governor,,LIB,Kurt Evans,2
+Grant,32,Governor,,LIB,Kurt Evans,0
+Grant,33,Governor,,LIB,Kurt Evans,2
+Grant,41,Governor,,LIB,Kurt Evans,5
+Grant,42,Governor,,LIB,Kurt Evans,1
+Grant,43,Governor,,LIB,Kurt Evans,7
+Grant,44,Governor,,LIB,Kurt Evans,0
+Grant,45,Governor,,LIB,Kurt Evans,5
+Grant,46,Governor,,LIB,Kurt Evans,0
+Grant,47,Governor,,LIB,Kurt Evans,1
+Grant,49,Governor,,LIB,Kurt Evans,2
+Grant,52,Governor,,LIB,Kurt Evans,4
+Grant,53,Governor,,LIB,Kurt Evans,0
+Grant,54,Governor,,LIB,Kurt Evans,4
+Grant,11,Governor,,REP,Kristi Noem,149
+Grant,12,Governor,,REP,Kristi Noem,32
+Grant,21,Governor,,REP,Kristi Noem,47
+Grant,22,Governor,,REP,Kristi Noem,188
+Grant,31,Governor,,REP,Kristi Noem,27
+Grant,32,Governor,,REP,Kristi Noem,54
+Grant,33,Governor,,REP,Kristi Noem,200
+Grant,41,Governor,,REP,Kristi Noem,106
+Grant,42,Governor,,REP,Kristi Noem,167
+Grant,43,Governor,,REP,Kristi Noem,218
+Grant,44,Governor,,REP,Kristi Noem,76
+Grant,45,Governor,,REP,Kristi Noem,71
+Grant,46,Governor,,REP,Kristi Noem,107
+Grant,47,Governor,,REP,Kristi Noem,128
+Grant,49,Governor,,REP,Kristi Noem,58
+Grant,52,Governor,,REP,Kristi Noem,37
+Grant,53,Governor,,REP,Kristi Noem,28
+Grant,54,Governor,,REP,Kristi Noem,87
+Grant,11,Governor,,DEM,Billie Sutton,117
+Grant,12,Governor,,DEM,Billie Sutton,29
+Grant,21,Governor,,DEM,Billie Sutton,40
+Grant,22,Governor,,DEM,Billie Sutton,162
+Grant,31,Governor,,DEM,Billie Sutton,28
+Grant,32,Governor,,DEM,Billie Sutton,39
+Grant,33,Governor,,DEM,Billie Sutton,167
+Grant,41,Governor,,DEM,Billie Sutton,116
+Grant,42,Governor,,DEM,Billie Sutton,102
+Grant,43,Governor,,DEM,Billie Sutton,127
+Grant,44,Governor,,DEM,Billie Sutton,44
+Grant,45,Governor,,DEM,Billie Sutton,84
+Grant,46,Governor,,DEM,Billie Sutton,90
+Grant,47,Governor,,DEM,Billie Sutton,77
+Grant,49,Governor,,DEM,Billie Sutton,40
+Grant,52,Governor,,DEM,Billie Sutton,31
+Grant,53,Governor,,DEM,Billie Sutton,19
+Grant,54,Governor,,DEM,Billie Sutton,76
+Grant,11,Secretary of State,,REP,Steve Barnett,180
+Grant,12,Secretary of State,,REP,Steve Barnett,42
+Grant,21,Secretary of State,,REP,Steve Barnett,63
+Grant,22,Secretary of State,,REP,Steve Barnett,225
+Grant,31,Secretary of State,,REP,Steve Barnett,38
+Grant,32,Secretary of State,,REP,Steve Barnett,62
+Grant,33,Secretary of State,,REP,Steve Barnett,254
+Grant,41,Secretary of State,,REP,Steve Barnett,122
+Grant,42,Secretary of State,,REP,Steve Barnett,187
+Grant,43,Secretary of State,,REP,Steve Barnett,241
+Grant,44,Secretary of State,,REP,Steve Barnett,85
+Grant,45,Secretary of State,,REP,Steve Barnett,96
+Grant,46,Secretary of State,,REP,Steve Barnett,138
+Grant,47,Secretary of State,,REP,Steve Barnett,159
+Grant,49,Secretary of State,,REP,Steve Barnett,62
+Grant,52,Secretary of State,,REP,Steve Barnett,45
+Grant,53,Secretary of State,,REP,Steve Barnett,31
+Grant,54,Secretary of State,,REP,Steve Barnett,104
+Grant,11,Secretary of State,,DEM,Alexandra Frederick,76
+Grant,12,Secretary of State,,DEM,Alexandra Frederick,19
+Grant,21,Secretary of State,,DEM,Alexandra Frederick,21
+Grant,22,Secretary of State,,DEM,Alexandra Frederick,105
+Grant,31,Secretary of State,,DEM,Alexandra Frederick,18
+Grant,32,Secretary of State,,DEM,Alexandra Frederick,27
+Grant,33,Secretary of State,,DEM,Alexandra Frederick,98
+Grant,41,Secretary of State,,DEM,Alexandra Frederick,90
+Grant,42,Secretary of State,,DEM,Alexandra Frederick,66
+Grant,43,Secretary of State,,DEM,Alexandra Frederick,93
+Grant,44,Secretary of State,,DEM,Alexandra Frederick,28
+Grant,45,Secretary of State,,DEM,Alexandra Frederick,48
+Grant,46,Secretary of State,,DEM,Alexandra Frederick,52
+Grant,47,Secretary of State,,DEM,Alexandra Frederick,37
+Grant,49,Secretary of State,,DEM,Alexandra Frederick,32
+Grant,52,Secretary of State,,DEM,Alexandra Frederick,22
+Grant,53,Secretary of State,,DEM,Alexandra Frederick,14
+Grant,54,Secretary of State,,DEM,Alexandra Frederick,54
+Grant,11,Attorney General,,REP,Jason Ravnsborg,166
+Grant,12,Attorney General,,REP,Jason Ravnsborg,42
+Grant,21,Attorney General,,REP,Jason Ravnsborg,59
+Grant,22,Attorney General,,REP,Jason Ravnsborg,197
+Grant,31,Attorney General,,REP,Jason Ravnsborg,35
+Grant,32,Attorney General,,REP,Jason Ravnsborg,59
+Grant,33,Attorney General,,REP,Jason Ravnsborg,209
+Grant,41,Attorney General,,REP,Jason Ravnsborg,109
+Grant,42,Attorney General,,REP,Jason Ravnsborg,167
+Grant,43,Attorney General,,REP,Jason Ravnsborg,216
+Grant,44,Attorney General,,REP,Jason Ravnsborg,72
+Grant,45,Attorney General,,REP,Jason Ravnsborg,82
+Grant,46,Attorney General,,REP,Jason Ravnsborg,117
+Grant,47,Attorney General,,REP,Jason Ravnsborg,142
+Grant,49,Attorney General,,REP,Jason Ravnsborg,62
+Grant,52,Attorney General,,REP,Jason Ravnsborg,38
+Grant,53,Attorney General,,REP,Jason Ravnsborg,27
+Grant,54,Attorney General,,REP,Jason Ravnsborg,91
+Grant,11,Attorney General,,DEM,Randy Seiler,94
+Grant,12,Attorney General,,DEM,Randy Seiler,18
+Grant,21,Attorney General,,DEM,Randy Seiler,31
+Grant,22,Attorney General,,DEM,Randy Seiler,131
+Grant,31,Attorney General,,DEM,Randy Seiler,21
+Grant,32,Attorney General,,DEM,Randy Seiler,30
+Grant,33,Attorney General,,DEM,Randy Seiler,142
+Grant,41,Attorney General,,DEM,Randy Seiler,103
+Grant,42,Attorney General,,DEM,Randy Seiler,89
+Grant,43,Attorney General,,DEM,Randy Seiler,121
+Grant,44,Attorney General,,DEM,Randy Seiler,41
+Grant,45,Attorney General,,DEM,Randy Seiler,61
+Grant,46,Attorney General,,DEM,Randy Seiler,74
+Grant,47,Attorney General,,DEM,Randy Seiler,53
+Grant,49,Attorney General,,DEM,Randy Seiler,32
+Grant,52,Attorney General,,DEM,Randy Seiler,30
+Grant,53,Attorney General,,DEM,Randy Seiler,17
+Grant,54,Attorney General,,DEM,Randy Seiler,68
+Grant,11,State Auditor,,REP,Rich Sattgast,176
+Grant,12,State Auditor,,REP,Rich Sattgast,45
+Grant,21,State Auditor,,REP,Rich Sattgast,59
+Grant,22,State Auditor,,REP,Rich Sattgast,216
+Grant,31,State Auditor,,REP,Rich Sattgast,34
+Grant,32,State Auditor,,REP,Rich Sattgast,59
+Grant,33,State Auditor,,REP,Rich Sattgast,236
+Grant,41,State Auditor,,REP,Rich Sattgast,116
+Grant,42,State Auditor,,REP,Rich Sattgast,182
+Grant,43,State Auditor,,REP,Rich Sattgast,230
+Grant,44,State Auditor,,REP,Rich Sattgast,82
+Grant,45,State Auditor,,REP,Rich Sattgast,92
+Grant,46,State Auditor,,REP,Rich Sattgast,127
+Grant,47,State Auditor,,REP,Rich Sattgast,145
+Grant,49,State Auditor,,REP,Rich Sattgast,65
+Grant,52,State Auditor,,REP,Rich Sattgast,42
+Grant,53,State Auditor,,REP,Rich Sattgast,28
+Grant,54,State Auditor,,REP,Rich Sattgast,102
+Grant,11,State Auditor,,DEM,Tom Cool,76
+Grant,12,State Auditor,,DEM,Tom Cool,17
+Grant,21,State Auditor,,DEM,Tom Cool,23
+Grant,22,State Auditor,,DEM,Tom Cool,106
+Grant,31,State Auditor,,DEM,Tom Cool,22
+Grant,32,State Auditor,,DEM,Tom Cool,26
+Grant,33,State Auditor,,DEM,Tom Cool,106
+Grant,41,State Auditor,,DEM,Tom Cool,85
+Grant,42,State Auditor,,DEM,Tom Cool,67
+Grant,43,State Auditor,,DEM,Tom Cool,95
+Grant,44,State Auditor,,DEM,Tom Cool,25
+Grant,45,State Auditor,,DEM,Tom Cool,46
+Grant,46,State Auditor,,DEM,Tom Cool,55
+Grant,47,State Auditor,,DEM,Tom Cool,46
+Grant,49,State Auditor,,DEM,Tom Cool,25
+Grant,52,State Auditor,,DEM,Tom Cool,22
+Grant,53,State Auditor,,DEM,Tom Cool,12
+Grant,54,State Auditor,,DEM,Tom Cool,50
+Grant,11,State Treasurer,,REP,Josh Haeder,168
+Grant,12,State Treasurer,,REP,Josh Haeder,42
+Grant,21,State Treasurer,,REP,Josh Haeder,57
+Grant,22,State Treasurer,,REP,Josh Haeder,209
+Grant,31,State Treasurer,,REP,Josh Haeder,29
+Grant,32,State Treasurer,,REP,Josh Haeder,57
+Grant,33,State Treasurer,,REP,Josh Haeder,228
+Grant,41,State Treasurer,,REP,Josh Haeder,105
+Grant,42,State Treasurer,,REP,Josh Haeder,175
+Grant,43,State Treasurer,,REP,Josh Haeder,226
+Grant,44,State Treasurer,,REP,Josh Haeder,78
+Grant,45,State Treasurer,,REP,Josh Haeder,82
+Grant,46,State Treasurer,,REP,Josh Haeder,119
+Grant,47,State Treasurer,,REP,Josh Haeder,145
+Grant,49,State Treasurer,,REP,Josh Haeder,59
+Grant,52,State Treasurer,,REP,Josh Haeder,43
+Grant,53,State Treasurer,,REP,Josh Haeder,28
+Grant,54,State Treasurer,,REP,Josh Haeder,91
+Grant,11,State Treasurer,,DEM,Aaron Matson,81
+Grant,12,State Treasurer,,DEM,Aaron Matson,19
+Grant,21,State Treasurer,,DEM,Aaron Matson,27
+Grant,22,State Treasurer,,DEM,Aaron Matson,107
+Grant,31,State Treasurer,,DEM,Aaron Matson,26
+Grant,32,State Treasurer,,DEM,Aaron Matson,28
+Grant,33,State Treasurer,,DEM,Aaron Matson,114
+Grant,41,State Treasurer,,DEM,Aaron Matson,98
+Grant,42,State Treasurer,,DEM,Aaron Matson,70
+Grant,43,State Treasurer,,DEM,Aaron Matson,102
+Grant,44,State Treasurer,,DEM,Aaron Matson,32
+Grant,45,State Treasurer,,DEM,Aaron Matson,55
+Grant,46,State Treasurer,,DEM,Aaron Matson,67
+Grant,47,State Treasurer,,DEM,Aaron Matson,41
+Grant,49,State Treasurer,,DEM,Aaron Matson,28
+Grant,52,State Treasurer,,DEM,Aaron Matson,21
+Grant,53,State Treasurer,,DEM,Aaron Matson,14
+Grant,54,State Treasurer,,DEM,Aaron Matson,57
+Grant,11,Commissioner of School and Public Lands,,REP,Ryan Brunner,166
+Grant,12,Commissioner of School and Public Lands,,REP,Ryan Brunner,41
+Grant,21,Commissioner of School and Public Lands,,REP,Ryan Brunner,61
+Grant,22,Commissioner of School and Public Lands,,REP,Ryan Brunner,205
+Grant,31,Commissioner of School and Public Lands,,REP,Ryan Brunner,32
+Grant,32,Commissioner of School and Public Lands,,REP,Ryan Brunner,54
+Grant,33,Commissioner of School and Public Lands,,REP,Ryan Brunner,229
+Grant,41,Commissioner of School and Public Lands,,REP,Ryan Brunner,108
+Grant,42,Commissioner of School and Public Lands,,REP,Ryan Brunner,173
+Grant,43,Commissioner of School and Public Lands,,REP,Ryan Brunner,226
+Grant,44,Commissioner of School and Public Lands,,REP,Ryan Brunner,74
+Grant,45,Commissioner of School and Public Lands,,REP,Ryan Brunner,84
+Grant,46,Commissioner of School and Public Lands,,REP,Ryan Brunner,120
+Grant,47,Commissioner of School and Public Lands,,REP,Ryan Brunner,146
+Grant,49,Commissioner of School and Public Lands,,REP,Ryan Brunner,61
+Grant,52,Commissioner of School and Public Lands,,REP,Ryan Brunner,42
+Grant,53,Commissioner of School and Public Lands,,REP,Ryan Brunner,29
+Grant,54,Commissioner of School and Public Lands,,REP,Ryan Brunner,94
+Grant,11,Commissioner of School and Public Lands,,DEM,Woody Hauser,80
+Grant,12,Commissioner of School and Public Lands,,DEM,Woody Hauser,19
+Grant,21,Commissioner of School and Public Lands,,DEM,Woody Hauser,22
+Grant,22,Commissioner of School and Public Lands,,DEM,Woody Hauser,110
+Grant,31,Commissioner of School and Public Lands,,DEM,Woody Hauser,22
+Grant,32,Commissioner of School and Public Lands,,DEM,Woody Hauser,27
+Grant,33,Commissioner of School and Public Lands,,DEM,Woody Hauser,111
+Grant,41,Commissioner of School and Public Lands,,DEM,Woody Hauser,91
+Grant,42,Commissioner of School and Public Lands,,DEM,Woody Hauser,70
+Grant,43,Commissioner of School and Public Lands,,DEM,Woody Hauser,99
+Grant,44,Commissioner of School and Public Lands,,DEM,Woody Hauser,29
+Grant,45,Commissioner of School and Public Lands,,DEM,Woody Hauser,53
+Grant,46,Commissioner of School and Public Lands,,DEM,Woody Hauser,64
+Grant,47,Commissioner of School and Public Lands,,DEM,Woody Hauser,42
+Grant,49,Commissioner of School and Public Lands,,DEM,Woody Hauser,27
+Grant,52,Commissioner of School and Public Lands,,DEM,Woody Hauser,22
+Grant,53,Commissioner of School and Public Lands,,DEM,Woody Hauser,13
+Grant,54,Commissioner of School and Public Lands,,DEM,Woody Hauser,57
+Grant,11,Public Utilities Commissioner,,REP,Kristie Fiegen,164
+Grant,12,Public Utilities Commissioner,,REP,Kristie Fiegen,46
+Grant,21,Public Utilities Commissioner,,REP,Kristie Fiegen,59
+Grant,22,Public Utilities Commissioner,,REP,Kristie Fiegen,224
+Grant,31,Public Utilities Commissioner,,REP,Kristie Fiegen,35
+Grant,32,Public Utilities Commissioner,,REP,Kristie Fiegen,56
+Grant,33,Public Utilities Commissioner,,REP,Kristie Fiegen,241
+Grant,41,Public Utilities Commissioner,,REP,Kristie Fiegen,112
+Grant,42,Public Utilities Commissioner,,REP,Kristie Fiegen,186
+Grant,43,Public Utilities Commissioner,,REP,Kristie Fiegen,229
+Grant,44,Public Utilities Commissioner,,REP,Kristie Fiegen,78
+Grant,45,Public Utilities Commissioner,,REP,Kristie Fiegen,88
+Grant,46,Public Utilities Commissioner,,REP,Kristie Fiegen,129
+Grant,47,Public Utilities Commissioner,,REP,Kristie Fiegen,155
+Grant,49,Public Utilities Commissioner,,REP,Kristie Fiegen,66
+Grant,52,Public Utilities Commissioner,,REP,Kristie Fiegen,44
+Grant,53,Public Utilities Commissioner,,REP,Kristie Fiegen,30
+Grant,54,Public Utilities Commissioner,,REP,Kristie Fiegen,95
+Grant,11,Public Utilities Commissioner,,DEM,Wayne Frederick,82
+Grant,12,Public Utilities Commissioner,,DEM,Wayne Frederick,15
+Grant,21,Public Utilities Commissioner,,DEM,Wayne Frederick,25
+Grant,22,Public Utilities Commissioner,,DEM,Wayne Frederick,101
+Grant,31,Public Utilities Commissioner,,DEM,Wayne Frederick,19
+Grant,32,Public Utilities Commissioner,,DEM,Wayne Frederick,28
+Grant,33,Public Utilities Commissioner,,DEM,Wayne Frederick,100
+Grant,41,Public Utilities Commissioner,,DEM,Wayne Frederick,92
+Grant,42,Public Utilities Commissioner,,DEM,Wayne Frederick,68
+Grant,43,Public Utilities Commissioner,,DEM,Wayne Frederick,99
+Grant,44,Public Utilities Commissioner,,DEM,Wayne Frederick,33
+Grant,45,Public Utilities Commissioner,,DEM,Wayne Frederick,49
+Grant,46,Public Utilities Commissioner,,DEM,Wayne Frederick,62
+Grant,47,Public Utilities Commissioner,,DEM,Wayne Frederick,30
+Grant,49,Public Utilities Commissioner,,DEM,Wayne Frederick,24
+Grant,52,Public Utilities Commissioner,,DEM,Wayne Frederick,23
+Grant,53,Public Utilities Commissioner,,DEM,Wayne Frederick,11
+Grant,54,Public Utilities Commissioner,,DEM,Wayne Frederick,58
+Grant,11,State Senate,4,REP,John Wiik,184
+Grant,12,State Senate,4,REP,John Wiik,47
+Grant,21,State Senate,4,REP,John Wiik,65
+Grant,22,State Senate,4,REP,John Wiik,226
+Grant,31,State Senate,4,REP,John Wiik,37
+Grant,32,State Senate,4,REP,John Wiik,62
+Grant,33,State Senate,4,REP,John Wiik,244
+Grant,41,State Senate,4,REP,John Wiik,119
+Grant,42,State Senate,4,REP,John Wiik,198
+Grant,43,State Senate,4,REP,John Wiik,226
+Grant,44,State Senate,4,REP,John Wiik,77
+Grant,45,State Senate,4,REP,John Wiik,94
+Grant,46,State Senate,4,REP,John Wiik,135
+Grant,47,State Senate,4,REP,John Wiik,147
+Grant,49,State Senate,4,REP,John Wiik,66
+Grant,52,State Senate,4,REP,John Wiik,42
+Grant,53,State Senate,4,REP,John Wiik,29
+Grant,54,State Senate,4,REP,John Wiik,94
+Grant,11,State Senate,4,DEM,Dennis Evenson,83
+Grant,12,State Senate,4,DEM,Dennis Evenson,15
+Grant,21,State Senate,4,DEM,Dennis Evenson,22
+Grant,22,State Senate,4,DEM,Dennis Evenson,117
+Grant,31,State Senate,4,DEM,Dennis Evenson,16
+Grant,32,State Senate,4,DEM,Dennis Evenson,28
+Grant,33,State Senate,4,DEM,Dennis Evenson,110
+Grant,41,State Senate,4,DEM,Dennis Evenson,100
+Grant,42,State Senate,4,DEM,Dennis Evenson,69
+Grant,43,State Senate,4,DEM,Dennis Evenson,115
+Grant,44,State Senate,4,DEM,Dennis Evenson,31
+Grant,45,State Senate,4,DEM,Dennis Evenson,57
+Grant,46,State Senate,4,DEM,Dennis Evenson,60
+Grant,47,State Senate,4,DEM,Dennis Evenson,53
+Grant,49,State Senate,4,DEM,Dennis Evenson,27
+Grant,52,State Senate,4,DEM,Dennis Evenson,29
+Grant,53,State Senate,4,DEM,Dennis Evenson,14
+Grant,54,State Senate,4,DEM,Dennis Evenson,68
+Grant,11,State House,4,LIB,Daryl Lamar Root,15
+Grant,12,State House,4,LIB,Daryl Lamar Root,0
+Grant,21,State House,4,LIB,Daryl Lamar Root,5
+Grant,22,State House,4,LIB,Daryl Lamar Root,12
+Grant,31,State House,4,LIB,Daryl Lamar Root,1
+Grant,32,State House,4,LIB,Daryl Lamar Root,3
+Grant,33,State House,4,LIB,Daryl Lamar Root,7
+Grant,41,State House,4,LIB,Daryl Lamar Root,10
+Grant,42,State House,4,LIB,Daryl Lamar Root,6
+Grant,43,State House,4,LIB,Daryl Lamar Root,8
+Grant,44,State House,4,LIB,Daryl Lamar Root,3
+Grant,45,State House,4,LIB,Daryl Lamar Root,4
+Grant,46,State House,4,LIB,Daryl Lamar Root,3
+Grant,47,State House,4,LIB,Daryl Lamar Root,4
+Grant,49,State House,4,LIB,Daryl Lamar Root,1
+Grant,52,State House,4,LIB,Daryl Lamar Root,8
+Grant,53,State House,4,LIB,Daryl Lamar Root,0
+Grant,54,State House,4,LIB,Daryl Lamar Root,8
+Grant,11,State House,4,REP,Fred Deutsch,152
+Grant,12,State House,4,REP,Fred Deutsch,45
+Grant,21,State House,4,REP,Fred Deutsch,53
+Grant,22,State House,4,REP,Fred Deutsch,203
+Grant,31,State House,4,REP,Fred Deutsch,32
+Grant,32,State House,4,REP,Fred Deutsch,59
+Grant,33,State House,4,REP,Fred Deutsch,224
+Grant,41,State House,4,REP,Fred Deutsch,103
+Grant,42,State House,4,REP,Fred Deutsch,179
+Grant,43,State House,4,REP,Fred Deutsch,222
+Grant,44,State House,4,REP,Fred Deutsch,74
+Grant,45,State House,4,REP,Fred Deutsch,87
+Grant,46,State House,4,REP,Fred Deutsch,125
+Grant,47,State House,4,REP,Fred Deutsch,135
+Grant,49,State House,4,REP,Fred Deutsch,50
+Grant,52,State House,4,REP,Fred Deutsch,38
+Grant,53,State House,4,REP,Fred Deutsch,24
+Grant,54,State House,4,REP,Fred Deutsch,80
+Grant,11,State House,4,REP,John Mills,139
+Grant,12,State House,4,REP,John Mills,34
+Grant,21,State House,4,REP,John Mills,55
+Grant,22,State House,4,REP,John Mills,170
+Grant,31,State House,4,REP,John Mills,25
+Grant,32,State House,4,REP,John Mills,46
+Grant,33,State House,4,REP,John Mills,194
+Grant,41,State House,4,REP,John Mills,95
+Grant,42,State House,4,REP,John Mills,149
+Grant,43,State House,4,REP,John Mills,165
+Grant,44,State House,4,REP,John Mills,56
+Grant,45,State House,4,REP,John Mills,75
+Grant,46,State House,4,REP,John Mills,114
+Grant,47,State House,4,REP,John Mills,121
+Grant,49,State House,4,REP,John Mills,42
+Grant,52,State House,4,REP,John Mills,30
+Grant,53,State House,4,REP,John Mills,19
+Grant,54,State House,4,REP,John Mills,79
+Grant,11,State House,4,DEM,Jim Chilson,62
+Grant,12,State House,4,DEM,Jim Chilson,13
+Grant,21,State House,4,DEM,Jim Chilson,18
+Grant,22,State House,4,DEM,Jim Chilson,89
+Grant,31,State House,4,DEM,Jim Chilson,15
+Grant,32,State House,4,DEM,Jim Chilson,17
+Grant,33,State House,4,DEM,Jim Chilson,88
+Grant,41,State House,4,DEM,Jim Chilson,70
+Grant,42,State House,4,DEM,Jim Chilson,62
+Grant,43,State House,4,DEM,Jim Chilson,76
+Grant,44,State House,4,DEM,Jim Chilson,32
+Grant,45,State House,4,DEM,Jim Chilson,45
+Grant,46,State House,4,DEM,Jim Chilson,48
+Grant,47,State House,4,DEM,Jim Chilson,34
+Grant,49,State House,4,DEM,Jim Chilson,20
+Grant,52,State House,4,DEM,Jim Chilson,19
+Grant,53,State House,4,DEM,Jim Chilson,12
+Grant,54,State House,4,DEM,Jim Chilson,46
+Grant,11,State House,4,DEM,Kathy Tyler,104
+Grant,12,State House,4,DEM,Kathy Tyler,18
+Grant,21,State House,4,DEM,Kathy Tyler,36
+Grant,22,State House,4,DEM,Kathy Tyler,140
+Grant,31,State House,4,DEM,Kathy Tyler,30
+Grant,32,State House,4,DEM,Kathy Tyler,36
+Grant,33,State House,4,DEM,Kathy Tyler,141
+Grant,41,State House,4,DEM,Kathy Tyler,114
+Grant,42,State House,4,DEM,Kathy Tyler,89
+Grant,43,State House,4,DEM,Kathy Tyler,136
+Grant,44,State House,4,DEM,Kathy Tyler,36
+Grant,45,State House,4,DEM,Kathy Tyler,74
+Grant,46,State House,4,DEM,Kathy Tyler,74
+Grant,47,State House,4,DEM,Kathy Tyler,75
+Grant,49,State House,4,DEM,Kathy Tyler,42
+Grant,52,State House,4,DEM,Kathy Tyler,32
+Grant,53,State House,4,DEM,Kathy Tyler,20
+Grant,54,State House,4,DEM,Kathy Tyler,75

--- a/2018/20181106__sd__general__gregory__precinct.csv
+++ b/2018/20181106__sd__general__gregory__precinct.csv
@@ -1,0 +1,76 @@
+votes,district,candidate,office,county,party,precinct
+Gregory,1,U.S. House,1,LIB,George D. Hendrickson,3
+Gregory,2,U.S. House,1,LIB,George D. Hendrickson,8
+Gregory,3,U.S. House,1,LIB,George D. Hendrickson,2
+Gregory,1,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",699
+Gregory,2,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",521
+Gregory,3,U.S. House,1,REP,"Dustin ""Dusty"" Johnson",264
+Gregory,1,U.S. House,1,DEM,Tim Bjorkman,254
+Gregory,2,U.S. House,1,DEM,Tim Bjorkman,240
+Gregory,3,U.S. House,1,DEM,Tim Bjorkman,92
+Gregory,1,U.S. House,1,IND,Ron Wieczorek,17
+Gregory,2,U.S. House,1,IND,Ron Wieczorek,18
+Gregory,3,U.S. House,1,IND,Ron Wieczorek,4
+Gregory,1,Governor,,LIB,Kurt Evans,8
+Gregory,2,Governor,,LIB,Kurt Evans,8
+Gregory,3,Governor,,LIB,Kurt Evans,1
+Gregory,1,Governor,,REP,Kristi Noem,513
+Gregory,2,Governor,,REP,Kristi Noem,356
+Gregory,3,Governor,,REP,Kristi Noem,238
+Gregory,1,Governor,,DEM,Billie Sutton,457
+Gregory,2,Governor,,DEM,Billie Sutton,446
+Gregory,3,Governor,,DEM,Billie Sutton,126
+Gregory,1,Secretary of State,,REP,Steve Barnett,699
+Gregory,2,Secretary of State,,REP,Steve Barnett,561
+Gregory,3,Secretary of State,,REP,Steve Barnett,258
+Gregory,1,Secretary of State,,DEM,Alexandra Frederick,224
+Gregory,2,Secretary of State,,DEM,Alexandra Frederick,203
+Gregory,3,Secretary of State,,DEM,Alexandra Frederick,78
+Gregory,1,Attorney General,,REP,Jason Ravnsborg,571
+Gregory,2,Attorney General,,REP,Jason Ravnsborg,436
+Gregory,3,Attorney General,,REP,Jason Ravnsborg,232
+Gregory,1,Attorney General,,DEM,Randy Seiler,354
+Gregory,2,Attorney General,,DEM,Randy Seiler,317
+Gregory,3,Attorney General,,DEM,Randy Seiler,106
+Gregory,1,State Auditor,,REP,Rich Sattgast,653
+Gregory,2,State Auditor,,REP,Rich Sattgast,507
+Gregory,3,State Auditor,,REP,Rich Sattgast,246
+Gregory,1,State Auditor,,DEM,Tom Cool,258
+Gregory,2,State Auditor,,DEM,Tom Cool,236
+Gregory,3,State Auditor,,DEM,Tom Cool,85
+Gregory,1,State Treasurer,,REP,Josh Haeder,613
+Gregory,2,State Treasurer,,REP,Josh Haeder,489
+Gregory,3,State Treasurer,,REP,Josh Haeder,228
+Gregory,1,State Treasurer,,DEM,Aaron Matson,286
+Gregory,2,State Treasurer,,DEM,Aaron Matson,252
+Gregory,3,State Treasurer,,DEM,Aaron Matson,86
+Gregory,1,Commissioner of School and Public Lands,,REP,Ryan Brunner,617
+Gregory,2,Commissioner of School and Public Lands,,REP,Ryan Brunner,488
+Gregory,3,Commissioner of School and Public Lands,,REP,Ryan Brunner,234
+Gregory,1,Commissioner of School and Public Lands,,DEM,Woody Hauser,272
+Gregory,2,Commissioner of School and Public Lands,,DEM,Woody Hauser,250
+Gregory,3,Commissioner of School and Public Lands,,DEM,Woody Hauser,79
+Gregory,1,Public Utilities Commissioner,,REP,Kristie Fiegen,637
+Gregory,2,Public Utilities Commissioner,,REP,Kristie Fiegen,515
+Gregory,3,Public Utilities Commissioner,,REP,Kristie Fiegen,230
+Gregory,1,Public Utilities Commissioner,,DEM,Wayne Frederick,257
+Gregory,2,Public Utilities Commissioner,,DEM,Wayne Frederick,218
+Gregory,3,Public Utilities Commissioner,,DEM,Wayne Frederick,78
+Gregory,1,State Senate,21,REP,Rocky Dale Blare,492
+Gregory,2,State Senate,21,REP,Rocky Dale Blare,381
+Gregory,3,State Senate,21,REP,Rocky Dale Blare,193
+Gregory,1,State Senate,21,DEM,Julie Bartling,473
+Gregory,2,State Senate,21,DEM,Julie Bartling,416
+Gregory,3,State Senate,21,DEM,Julie Bartling,162
+Gregory,1,State House,21,REP,Caleb Finck,492
+Gregory,2,State House,21,REP,Caleb Finck,377
+Gregory,3,State House,21,REP,Caleb Finck,199
+Gregory,1,State House,21,REP,Lee Qualm,577
+Gregory,2,State House,21,REP,Lee Qualm,471
+Gregory,3,State House,21,REP,Lee Qualm,237
+Gregory,1,State House,21,DEM,Faith Spotted Eagle,140
+Gregory,2,State House,21,DEM,Faith Spotted Eagle,127
+Gregory,3,State House,21,DEM,Faith Spotted Eagle,58
+Gregory,1,State House,21,DEM,Anna Kerner Andersson,420
+Gregory,2,State House,21,DEM,Anna Kerner Andersson,373
+Gregory,3,State House,21,DEM,Anna Kerner Andersson,110

--- a/scripts/tabula_to_csv_2018.py
+++ b/scripts/tabula_to_csv_2018.py
@@ -66,8 +66,8 @@ with open(tabula_file) as csvfile:
                     candidates.append({
                         'name': 'Unknown Candidate #{0}'.format(n),
                         'party': 'PARTY{0}'.format(n),
-                        'office': 'Uknown Office #{0}'.format(n),
-                        'district': 'DIST{0}'.format(n),
+                        'office': 'Uknown Office #{0}'.format(race_index),
+                        'district': 'DIST{0}'.format(race_index),
                         'votes': [],
                     })
                 candidates[cand_index]['votes'].append(row[i + 1])


### PR DESCRIPTION
This PR adds 2018 general results for a few more counties where the precincts are numbered.

It also makes a small tweak to the python script that converts from tabula to csv.

I'd like to do Haakon, Hamlin, Hanson, Harding, and Hutchinson next, since those follow this same pattern.