### PR TITLE
Fix incorrect value in 2016 primary file

### DIFF
--- a/2016/20160607__sd__primary__county.csv
+++ b/2016/20160607__sd__primary__county.csv
@@ -546,7 +546,7 @@ South Dakota,Lawrence,State House,31,Michael E. Weyrich,REP,"1,000"
 South Dakota,Total,State House,31,Michael E. Weyrich,REP,"1,000"
 South Dakota,Pennington,State House,32,Craig Ericks,REP,"1,147"
 South Dakota,Total,State House,32,Craig Ericks,REP,"1,147"
-South Dakota,Pennington,State House,32,Sean McPherson,REP,1.372
+South Dakota,Pennington,State House,32,Sean McPherson,REP,1372
 South Dakota,Total,State House,32,Sean McPherson,REP,"1,372"
 South Dakota,Pennington,State House,32,Kristin A. Conzet,REP,"1,245"
 South Dakota,Total,State House,32,Kristin A. Conzet,REP,"1,245"


### PR DESCRIPTION
This fixes a parsing error that resulted in a non-integer vote value.  According to the [source file](https://github.com/openelections/openelections-sources-sd/blob/75a293318d41621a36fe1474ef06909fff0be39f/2016/Pennington%20SD%2020160607JurisdictionalCanvass.pdf), Sean McPherson received `1,372` votes:

![image](https://user-images.githubusercontent.com/17345532/129389773-f812f0bb-186f-4979-a694-8871c8b35a9a.png)

This should fix the failure introduced in pull request #34.