### PR TITLE
2024 primary precinct results

### DIFF
--- a/2024/20240604__sd__primary__county.csv
+++ b/2024/20240604__sd__primary__county.csv
@@ -171,14 +171,14 @@ Marshall,President,,DEM,Marianne Williamson,14
 Marshall,President,,DEM,Joseph R Biden Jr,97
 Marshall,President,,DEM,Dean Phillips,19
 Marshall,President,,DEM,Armando Perez-Serrato,6
-Mccook,President,,DEM,Marianne Williamson,9
-Mccook,President,,DEM,Joseph R Biden Jr,65
-Mccook,President,,DEM,Dean Phillips,16
-Mccook,President,,DEM,Armando Perez-Serrato,4
-Mcpherson,President,,DEM,Marianne Williamson,5
-Mcpherson,President,,DEM,Joseph R Biden Jr,25
-Mcpherson,President,,DEM,Dean Phillips,5
-Mcpherson,President,,DEM,Armando Perez-Serrato,3
+McCook,President,,DEM,Marianne Williamson,9
+McCook,President,,DEM,Joseph R Biden Jr,65
+McCook,President,,DEM,Dean Phillips,16
+McCook,President,,DEM,Armando Perez-Serrato,4
+McPherson,President,,DEM,Marianne Williamson,5
+McPherson,President,,DEM,Joseph R Biden Jr,25
+McPherson,President,,DEM,Dean Phillips,5
+McPherson,President,,DEM,Armando Perez-Serrato,3
 Meade,President,,DEM,Marianne Williamson,72
 Meade,President,,DEM,Joseph R Biden Jr,353
 Meade,President,,DEM,Dean Phillips,51
@@ -321,8 +321,8 @@ Faulk,State Senate,23,REP,Steven Ray Roseland,393
 Faulk,State Senate,23,REP,Mark Lapka,155
 Hand,State Senate,23,REP,Steven Ray Roseland,271
 Hand,State Senate,23,REP,Mark Lapka,243
-Mcpherson,State Senate,23,REP,Steven Ray Roseland,84
-Mcpherson,State Senate,23,REP,Mark Lapka,553
+McPherson,State Senate,23,REP,Steven Ray Roseland,84
+McPherson,State Senate,23,REP,Mark Lapka,553
 Potter,State Senate,23,REP,Steven Ray Roseland,372
 Potter,State Senate,23,REP,Mark Lapka,143
 Walworth,State Senate,23,REP,Steven Ray Roseland,302
@@ -496,9 +496,9 @@ Hanson,State House,19,REP,Jessica Bahmuller,444
 Hutchinson,State House,19,REP,Drew Peterson,451
 Hutchinson,State House,19,REP,Steven Mettler,509
 Hutchinson,State House,19,REP,Jessica Bahmuller,708
-Mccook,State House,19,REP,Drew Peterson,367
-Mccook,State House,19,REP,Steven Mettler,252
-Mccook,State House,19,REP,Jessica Bahmuller,478
+McCook,State House,19,REP,Drew Peterson,367
+McCook,State House,19,REP,Steven Mettler,252
+McCook,State House,19,REP,Jessica Bahmuller,478
 Turner,State House,19,REP,Drew Peterson,26
 Turner,State House,19,REP,Steven Mettler,34
 Turner,State House,19,REP,Jessica Bahmuller,35
@@ -541,9 +541,9 @@ Faulk,State House,23,REP,James D. Wangsness,236
 Hand,State House,23,REP,Spencer Gosch,289
 Hand,State House,23,REP,Scott Moore,411
 Hand,State House,23,REP,James D. Wangsness,235
-Mcpherson,State House,23,REP,Spencer Gosch,500
-Mcpherson,State House,23,REP,Scott Moore,538
-Mcpherson,State House,23,REP,James D. Wangsness,110
+McPherson,State House,23,REP,Spencer Gosch,500
+McPherson,State House,23,REP,Scott Moore,538
+McPherson,State House,23,REP,James D. Wangsness,110
 Potter,State House,23,REP,Spencer Gosch,247
 Potter,State House,23,REP,Scott Moore,313
 Potter,State House,23,REP,James D. Wangsness,271

--- a/2024/counties/20240604__sd__primary__aurora__precinct.csv
+++ b/2024/counties/20240604__sd__primary__aurora__precinct.csv
@@ -1,0 +1,50 @@
+county,precinct,office,district,candidate,party,votes
+Aurora,1,President,,Marianne Williamson,DEM,0
+Aurora,1,President,,Joseph R Biden Jr,DEM,5
+Aurora,1,President,,Dean Phillips,DEM,3
+Aurora,1,President,,Armando Perez-Serrato,DEM,1
+Aurora,2,President,,Marianne Williamson,DEM,1
+Aurora,2,President,,Joseph R Biden Jr,DEM,2
+Aurora,2,President,,Dean Phillips,DEM,1
+Aurora,2,President,,Armando Perez-Serrato,DEM,0
+Aurora,3,President,,Marianne Williamson,DEM,6
+Aurora,3,President,,Joseph R Biden Jr,DEM,5
+Aurora,3,President,,Dean Phillips,DEM,6
+Aurora,3,President,,Armando Perez-Serrato,DEM,1
+Aurora,5,President,,Marianne Williamson,DEM,4
+Aurora,5,President,,Joseph R Biden Jr,DEM,3
+Aurora,5,President,,Dean Phillips,DEM,1
+Aurora,5,President,,Armando Perez-Serrato,DEM,0
+Aurora,7,President,,Marianne Williamson,DEM,5
+Aurora,7,President,,Joseph R Biden Jr,DEM,6
+Aurora,7,President,,Dean Phillips,DEM,5
+Aurora,7,President,,Armando Perez-Serrato,DEM,1
+Aurora,1,State Senate,21,Erin Tobin,REP,33
+Aurora,1,State Senate,21,Mykala Voita,REP,49
+Aurora,2,State Senate,21,Erin Tobin,REP,14
+Aurora,2,State Senate,21,Mykala Voita,REP,25
+Aurora,3,State Senate,21,Erin Tobin,REP,27
+Aurora,3,State Senate,21,Mykala Voita,REP,26
+Aurora,5,State Senate,21,Erin Tobin,REP,8
+Aurora,5,State Senate,21,Mykala Voita,REP,5
+Aurora,7,State Senate,21,Erin Tobin,REP,36
+Aurora,7,State Senate,21,Mykala Voita,REP,10
+Aurora,1,State House,21,Lee Qualm,REP,63
+Aurora,1,State House,21,Marty Overweg,REP,71
+Aurora,1,State House,21,Jim Halverson,REP,11
+Aurora,2,State House,21,Lee Qualm,REP,30
+Aurora,2,State House,21,Marty Overweg,REP,37
+Aurora,2,State House,21,Jim Halverson,REP,6
+Aurora,3,State House,21,Lee Qualm,REP,41
+Aurora,3,State House,21,Marty Overweg,REP,50
+Aurora,3,State House,21,Jim Halverson,REP,8
+Aurora,5,State House,21,Lee Qualm,REP,6
+Aurora,5,State House,21,Marty Overweg,REP,9
+Aurora,5,State House,21,Jim Halverson,REP,5
+Aurora,7,State House,21,Lee Qualm,REP,29
+Aurora,7,State House,21,Marty Overweg,REP,29
+Aurora,7,State House,21,Jim Halverson,REP,24
+Aurora,3,School Board Member,Kimball School District 7-2,Hillary Leiferman,,0
+Aurora,3,School Board Member,Kimball School District 7-2,Joshua Krier,,0
+Aurora,3,School Board Member,Kimball School District 7-2,Justin Blasius,,0
+Aurora,3,School Board Member,Kimball School District 7-2,James Hoing,,0

--- a/2024/counties/20240604__sd__primary__beadle__precinct.csv
+++ b/2024/counties/20240604__sd__primary__beadle__precinct.csv
@@ -1,0 +1,68 @@
+county,precinct,office,district,candidate,party,votes
+Beadle,1,President,,Marianne Williamson,DEM,9
+Beadle,1,President,,Joseph R Biden Jr,DEM,28
+Beadle,1,President,,Dean Phillips,DEM,5
+Beadle,1,President,,Armando Perez-Serrato,DEM,4
+Beadle,2,President,,Marianne Williamson,DEM,5
+Beadle,2,President,,Joseph R Biden Jr,DEM,8
+Beadle,2,President,,Dean Phillips,DEM,5
+Beadle,2,President,,Armando Perez-Serrato,DEM,0
+Beadle,3,President,,Marianne Williamson,DEM,2
+Beadle,3,President,,Joseph R Biden Jr,DEM,26
+Beadle,3,President,,Dean Phillips,DEM,1
+Beadle,3,President,,Armando Perez-Serrato,DEM,1
+Beadle,4,President,,Marianne Williamson,DEM,2
+Beadle,4,President,,Joseph R Biden Jr,DEM,20
+Beadle,4,President,,Dean Phillips,DEM,2
+Beadle,4,President,,Armando Perez-Serrato,DEM,0
+Beadle,5,President,,Marianne Williamson,DEM,5
+Beadle,5,President,,Joseph R Biden Jr,DEM,35
+Beadle,5,President,,Dean Phillips,DEM,7
+Beadle,5,President,,Armando Perez-Serrato,DEM,3
+Beadle,6,President,,Marianne Williamson,DEM,6
+Beadle,6,President,,Joseph R Biden Jr,DEM,16
+Beadle,6,President,,Dean Phillips,DEM,1
+Beadle,6,President,,Armando Perez-Serrato,DEM,1
+Beadle,8,President,,Marianne Williamson,DEM,0
+Beadle,8,President,,Joseph R Biden Jr,DEM,4
+Beadle,8,President,,Dean Phillips,DEM,0
+Beadle,8,President,,Armando Perez-Serrato,DEM,1
+Beadle,9,President,,Marianne Williamson,DEM,1
+Beadle,9,President,,Joseph R Biden Jr,DEM,6
+Beadle,9,President,,Dean Phillips,DEM,1
+Beadle,9,President,,Armando Perez-Serrato,DEM,1
+Beadle,7,President,,Marianne Williamson,DEM,3
+Beadle,7,President,,Joseph R Biden Jr,DEM,11
+Beadle,7,President,,Dean Phillips,DEM,14
+Beadle,7,President,,Armando Perez-Serrato,DEM,0
+Beadle,1,State House,22,Kevin Van Diepen,REP,92
+Beadle,1,State House,22,Terry Nebelsick,REP,77
+Beadle,1,State House,22,Lana Greenfield,REP,84
+Beadle,2,State House,22,Kevin Van Diepen,REP,98
+Beadle,2,State House,22,Terry Nebelsick,REP,67
+Beadle,2,State House,22,Lana Greenfield,REP,60
+Beadle,3,State House,22,Kevin Van Diepen,REP,92
+Beadle,3,State House,22,Terry Nebelsick,REP,71
+Beadle,3,State House,22,Lana Greenfield,REP,61
+Beadle,4,State House,22,Kevin Van Diepen,REP,98
+Beadle,4,State House,22,Terry Nebelsick,REP,74
+Beadle,4,State House,22,Lana Greenfield,REP,55
+Beadle,5,State House,22,Kevin Van Diepen,REP,135
+Beadle,5,State House,22,Terry Nebelsick,REP,109
+Beadle,5,State House,22,Lana Greenfield,REP,82
+Beadle,6,State House,22,Kevin Van Diepen,REP,74
+Beadle,6,State House,22,Terry Nebelsick,REP,49
+Beadle,6,State House,22,Lana Greenfield,REP,60
+Beadle,8,State House,22,Kevin Van Diepen,REP,34
+Beadle,8,State House,22,Terry Nebelsick,REP,28
+Beadle,8,State House,22,Lana Greenfield,REP,32
+Beadle,9,State House,22,Kevin Van Diepen,REP,20
+Beadle,9,State House,22,Terry Nebelsick,REP,15
+Beadle,9,State House,22,Lana Greenfield,REP,18
+Beadle,7,State House,22,Kevin Van Diepen,REP,95
+Beadle,7,State House,22,Terry Nebelsick,REP,84
+Beadle,7,State House,22,Lana Greenfield,REP,80
+Beadle,6,County Commissioner,Beadle-2,Rick Benson,REP,55
+Beadle,6,County Commissioner,Beadle-2,Jared Zerfoss,REP,41
+Beadle,7,County Commissioner,Beadle-2,Rick Benson,REP,50
+Beadle,7,County Commissioner,Beadle-2,Jared Zerfoss,REP,95

--- a/2024/counties/20240604__sd__primary__bennett__precinct.csv
+++ b/2024/counties/20240604__sd__primary__bennett__precinct.csv
@@ -1,0 +1,53 @@
+county,precinct,office,district,candidate,party,votes
+Bennett,Allen Precinct,President,,Marianne Williamson,DEM,1
+Bennett,Allen Precinct,President,,Joseph R Biden Jr,DEM,12
+Bennett,Allen Precinct,President,,Dean Phillips,DEM,2
+Bennett,Allen Precinct,President,,Armando Perez-Serrato,DEM,1
+Bennett,Martin City Precinct,President,,Marianne Williamson,DEM,6
+Bennett,Martin City Precinct,President,,Joseph R Biden Jr,DEM,17
+Bennett,Martin City Precinct,President,,Dean Phillips,DEM,2
+Bennett,Martin City Precinct,President,,Armando Perez-Serrato,DEM,1
+Bennett,Martin Rural 26/27 Precinct,President,,Marianne Williamson,DEM,2
+Bennett,Martin Rural 26/27 Precinct,President,,Joseph R Biden Jr,DEM,6
+Bennett,Martin Rural 26/27 Precinct,President,,Dean Phillips,DEM,1
+Bennett,Martin Rural 26/27 Precinct,President,,Armando Perez-Serrato,DEM,2
+Bennett,Vetal/Tuthill Precinct,President,,Marianne Williamson,DEM,2
+Bennett,Vetal/Tuthill Precinct,President,,Joseph R Biden Jr,DEM,0
+Bennett,Vetal/Tuthill Precinct,President,,Dean Phillips,DEM,3
+Bennett,Vetal/Tuthill Precinct,President,,Armando Perez-Serrato,DEM,0
+Bennett,Allen Precinct,State Senate,27,Gerald M Cournoyer Jr,DEM,2
+Bennett,Allen Precinct,State Senate,27,Red Dawn Foster,DEM,14
+Bennett,Allen Precinct,State Senate,27,Anthony G. Kathol,REP,7
+Bennett,Allen Precinct,State Senate,27,Bruce Whalen,REP,4
+Bennett,Martin City Precinct,State Senate,27,Gerald M Cournoyer Jr,DEM,9
+Bennett,Martin City Precinct,State Senate,27,Red Dawn Foster,DEM,18
+Bennett,Martin City Precinct,State Senate,27,Anthony G. Kathol,REP,68
+Bennett,Martin City Precinct,State Senate,27,Bruce Whalen,REP,14
+Bennett,Martin Rural 26/27 Precinct,State Senate,27,Gerald M Cournoyer Jr,DEM,7
+Bennett,Martin Rural 26/27 Precinct,State Senate,27,Red Dawn Foster,DEM,5
+Bennett,Martin Rural 26/27 Precinct,State Senate,27,Anthony G. Kathol,REP,87
+Bennett,Martin Rural 26/27 Precinct,State Senate,27,Bruce Whalen,REP,26
+Bennett,Vetal/Tuthill Precinct,State Senate,27,Gerald M Cournoyer Jr,DEM,4
+Bennett,Vetal/Tuthill Precinct,State Senate,27,Red Dawn Foster,DEM,3
+Bennett,Vetal/Tuthill Precinct,State Senate,27,Anthony G. Kathol,REP,51
+Bennett,Vetal/Tuthill Precinct,State Senate,27,Bruce Whalen,REP,10
+Bennett,Allen Precinct,County Commissioner At Large,,Robert TT Scherer,REP,8
+Bennett,Allen Precinct,County Commissioner At Large,,Chase R Strand,REP,1
+Bennett,Allen Precinct,County Commissioner At Large,,Robert L Ceplecha,REP,1
+Bennett,Allen Precinct,County Commissioner At Large,,Judd W Schomp,REP,2
+Bennett,Allen Precinct,County Commissioner At Large,,David L Bakley,REP,7
+Bennett,Martin City Precinct,County Commissioner At Large,,Robert TT Scherer,REP,40
+Bennett,Martin City Precinct,County Commissioner At Large,,Chase R Strand,REP,12
+Bennett,Martin City Precinct,County Commissioner At Large,,Robert L Ceplecha,REP,22
+Bennett,Martin City Precinct,County Commissioner At Large,,Judd W Schomp,REP,21
+Bennett,Martin City Precinct,County Commissioner At Large,,David L Bakley,REP,53
+Bennett,Martin Rural 26/27 Precinct,County Commissioner At Large,,Robert TT Scherer,REP,78
+Bennett,Martin Rural 26/27 Precinct,County Commissioner At Large,,Chase R Strand,REP,18
+Bennett,Martin Rural 26/27 Precinct,County Commissioner At Large,,Robert L Ceplecha,REP,27
+Bennett,Martin Rural 26/27 Precinct,County Commissioner At Large,,Judd W Schomp,REP,19
+Bennett,Martin Rural 26/27 Precinct,County Commissioner At Large,,David L Bakley,REP,70
+Bennett,Vetal/Tuthill Precinct,County Commissioner At Large,,Robert TT Scherer,REP,50
+Bennett,Vetal/Tuthill Precinct,County Commissioner At Large,,Chase R Strand,REP,12
+Bennett,Vetal/Tuthill Precinct,County Commissioner At Large,,Robert L Ceplecha,REP,5
+Bennett,Vetal/Tuthill Precinct,County Commissioner At Large,,Judd W Schomp,REP,4
+Bennett,Vetal/Tuthill Precinct,County Commissioner At Large,,David L Bakley,REP,49

--- a/2024/counties/20240604__sd__primary__bon_homme__precinct.csv
+++ b/2024/counties/20240604__sd__primary__bon_homme__precinct.csv
@@ -1,0 +1,46 @@
+county,precinct,office,district,candidate,party,votes
+Bon Homme,1,President,,Marianne Williamson,DEM,6
+Bon Homme,1,President,,Joseph R Biden Jr,DEM,17
+Bon Homme,1,President,,Dean Phillips,DEM,5
+Bon Homme,1,President,,Armando Perez-Serrato,DEM,1
+Bon Homme,2,President,,Marianne Williamson,DEM,5
+Bon Homme,2,President,,Joseph R Biden Jr,DEM,14
+Bon Homme,2,President,,Dean Phillips,DEM,4
+Bon Homme,2,President,,Armando Perez-Serrato,DEM,0
+Bon Homme,3,President,,Marianne Williamson,DEM,12
+Bon Homme,3,President,,Joseph R Biden Jr,DEM,29
+Bon Homme,3,President,,Dean Phillips,DEM,8
+Bon Homme,3,President,,Armando Perez-Serrato,DEM,0
+Bon Homme,4,President,,Marianne Williamson,DEM,3
+Bon Homme,4,President,,Joseph R Biden Jr,DEM,21
+Bon Homme,4,President,,Dean Phillips,DEM,6
+Bon Homme,4,President,,Armando Perez-Serrato,DEM,1
+Bon Homme,5,President,,Marianne Williamson,DEM,2
+Bon Homme,5,President,,Joseph R Biden Jr,DEM,17
+Bon Homme,5,President,,Dean Phillips,DEM,3
+Bon Homme,5,President,,Armando Perez-Serrato,DEM,0
+Bon Homme,1,State House,19,Drew Peterson,REP,66
+Bon Homme,1,State House,19,Steven Mettler,REP,61
+Bon Homme,1,State House,19,Jessica Bahmuller,REP,83
+Bon Homme,2,State House,19,Drew Peterson,REP,71
+Bon Homme,2,State House,19,Steven Mettler,REP,59
+Bon Homme,2,State House,19,Jessica Bahmuller,REP,94
+Bon Homme,3,State House,19,Drew Peterson,REP,90
+Bon Homme,3,State House,19,Steven Mettler,REP,75
+Bon Homme,3,State House,19,Jessica Bahmuller,REP,130
+Bon Homme,4,State House,19,Drew Peterson,REP,67
+Bon Homme,4,State House,19,Steven Mettler,REP,43
+Bon Homme,4,State House,19,Jessica Bahmuller,REP,71
+Bon Homme,5,State House,19,Drew Peterson,REP,80
+Bon Homme,5,State House,19,Steven Mettler,REP,62
+Bon Homme,5,State House,19,Jessica Bahmuller,REP,122
+Bon Homme,1,States Attorney,,Abigail Monger,REP,96
+Bon Homme,1,States Attorney,,Derrick Johnson,REP,18
+Bon Homme,2,States Attorney,,Abigail Monger,REP,98
+Bon Homme,2,States Attorney,,Derrick Johnson,REP,24
+Bon Homme,3,States Attorney,,Abigail Monger,REP,130
+Bon Homme,3,States Attorney,,Derrick Johnson,REP,42
+Bon Homme,4,States Attorney,,Abigail Monger,REP,90
+Bon Homme,4,States Attorney,,Derrick Johnson,REP,26
+Bon Homme,5,States Attorney,,Abigail Monger,REP,113
+Bon Homme,5,States Attorney,,Derrick Johnson,REP,36

--- a/2024/counties/20240604__sd__primary__brookings__precinct.csv
+++ b/2024/counties/20240604__sd__primary__brookings__precinct.csv
@@ -1,0 +1,261 @@
+county,precinct,office,district,candidate,party,votes
+Brookings,1- Brookings Activity Center,President,,Marianne Williamson,DEM,7
+Brookings,1- Brookings Activity Center,President,,Joseph R Biden Jr,DEM,101
+Brookings,1- Brookings Activity Center,President,,Dean Phillips,DEM,5
+Brookings,1- Brookings Activity Center,President,,Armando Perez-Serrato,DEM,2
+Brookings,2- Bethel Baptist Church Area 1,President,,Marianne Williamson,DEM,7
+Brookings,2- Bethel Baptist Church Area 1,President,,Joseph R Biden Jr,DEM,30
+Brookings,2- Bethel Baptist Church Area 1,President,,Dean Phillips,DEM,1
+Brookings,2- Bethel Baptist Church Area 1,President,,Armando Perez-Serrato,DEM,1
+Brookings,3- Bethel Baptist Church Area 2,President,,Marianne Williamson,DEM,6
+Brookings,3- Bethel Baptist Church Area 2,President,,Joseph R Biden Jr,DEM,30
+Brookings,3- Bethel Baptist Church Area 2,President,,Dean Phillips,DEM,8
+Brookings,3- Bethel Baptist Church Area 2,President,,Armando Perez-Serrato,DEM,1
+Brookings,4- Holy Life Tabernacle,President,,Marianne Williamson,DEM,9
+Brookings,4- Holy Life Tabernacle,President,,Joseph R Biden Jr,DEM,34
+Brookings,4- Holy Life Tabernacle,President,,Dean Phillips,DEM,0
+Brookings,4- Holy Life Tabernacle,President,,Armando Perez-Serrato,DEM,1
+Brookings,5- Aurora Fire Hall,President,,Marianne Williamson,DEM,1
+Brookings,5- Aurora Fire Hall,President,,Joseph R Biden Jr,DEM,15
+Brookings,5- Aurora Fire Hall,President,,Dean Phillips,DEM,3
+Brookings,5- Aurora Fire Hall,President,,Armando Perez-Serrato,DEM,1
+Brookings,6- Elkton Community Center,President,,Marianne Williamson,DEM,2
+Brookings,6- Elkton Community Center,President,,Joseph R Biden Jr,DEM,4
+Brookings,6- Elkton Community Center,President,,Dean Phillips,DEM,3
+Brookings,6- Elkton Community Center,President,,Armando Perez-Serrato,DEM,0
+Brookings,7- White McKnight Hall,President,,Marianne Williamson,DEM,0
+Brookings,7- White McKnight Hall,President,,Joseph R Biden Jr,DEM,9
+Brookings,7- White McKnight Hall,President,,Dean Phillips,DEM,2
+Brookings,7- White McKnight Hall,President,,Armando Perez-Serrato,DEM,1
+Brookings,8- Bruce Community Room,President,,Marianne Williamson,DEM,2
+Brookings,8- Bruce Community Room,President,,Joseph R Biden Jr,DEM,10
+Brookings,8- Bruce Community Room,President,,Dean Phillips,DEM,3
+Brookings,8- Bruce Community Room,President,,Armando Perez-Serrato,DEM,0
+Brookings,9- Volga Community Center,President,,Marianne Williamson,DEM,4
+Brookings,9- Volga Community Center,President,,Joseph R Biden Jr,DEM,19
+Brookings,9- Volga Community Center,President,,Dean Phillips,DEM,3
+Brookings,9- Volga Community Center,President,,Armando Perez-Serrato,DEM,2
+Brookings,Absentee Precinct,President,,Marianne Williamson,DEM,16
+Brookings,Absentee Precinct,President,,Joseph R Biden Jr,DEM,194
+Brookings,Absentee Precinct,President,,Dean Phillips,DEM,10
+Brookings,Absentee Precinct,President,,Armando Perez-Serrato,DEM,4
+Brookings,1- Brookings Activity Center,State Senate,08,Casey Crabtree,REP,13
+Brookings,1- Brookings Activity Center,State Senate,08,Rick Weible,REP,11
+Brookings,2- Bethel Baptist Church Area 1,State Senate,08,Casey Crabtree,REP,1
+Brookings,2- Bethel Baptist Church Area 1,State Senate,08,Rick Weible,REP,3
+Brookings,3- Bethel Baptist Church Area 2,State Senate,08,Casey Crabtree,REP,0
+Brookings,3- Bethel Baptist Church Area 2,State Senate,08,Rick Weible,REP,1
+Brookings,4- Holy Life Tabernacle,State Senate,08,Casey Crabtree,REP,0
+Brookings,4- Holy Life Tabernacle,State Senate,08,Rick Weible,REP,0
+Brookings,5- Aurora Fire Hall,State Senate,08,Casey Crabtree,REP,14
+Brookings,5- Aurora Fire Hall,State Senate,08,Rick Weible,REP,20
+Brookings,6- Elkton Community Center,State Senate,08,Casey Crabtree,REP,31
+Brookings,6- Elkton Community Center,State Senate,08,Rick Weible,REP,22
+Brookings,7- White McKnight Hall,State Senate,08,Casey Crabtree,REP,59
+Brookings,7- White McKnight Hall,State Senate,08,Rick Weible,REP,35
+Brookings,8- Bruce Community Room,State Senate,08,Casey Crabtree,REP,57
+Brookings,8- Bruce Community Room,State Senate,08,Rick Weible,REP,41
+Brookings,9- Volga Community Center,State Senate,08,Casey Crabtree,REP,208
+Brookings,9- Volga Community Center,State Senate,08,Rick Weible,REP,129
+Brookings,Absentee Precinct,State Senate,08,Casey Crabtree,REP,43
+Brookings,Absentee Precinct,State Senate,08,Rick Weible,REP,30
+Brookings,1- Brookings Activity Center,State House,07,Roger DeGroot,REP,142
+Brookings,1- Brookings Activity Center,State House,07,Jeffrey A Struwe,REP,90
+Brookings,1- Brookings Activity Center,State House,07,Mellissa Heermann,REP,158
+Brookings,1- Brookings Activity Center,State House,08,Matt Wagner,REP,19
+Brookings,1- Brookings Activity Center,State House,08,Tim Walburg,REP,7
+Brookings,1- Brookings Activity Center,State House,08,Tim Reisch,REP,9
+Brookings,2- Bethel Baptist Church Area 1,State House,07,Roger DeGroot,REP,99
+Brookings,2- Bethel Baptist Church Area 1,State House,07,Jeffrey A Struwe,REP,75
+Brookings,2- Bethel Baptist Church Area 1,State House,07,Mellissa Heermann,REP,117
+Brookings,2- Bethel Baptist Church Area 1,State House,08,Matt Wagner,REP,2
+Brookings,2- Bethel Baptist Church Area 1,State House,08,Tim Walburg,REP,2
+Brookings,2- Bethel Baptist Church Area 1,State House,08,Tim Reisch,REP,3
+Brookings,3- Bethel Baptist Church Area 2,State House,07,Roger DeGroot,REP,117
+Brookings,3- Bethel Baptist Church Area 2,State House,07,Jeffrey A Struwe,REP,106
+Brookings,3- Bethel Baptist Church Area 2,State House,07,Mellissa Heermann,REP,113
+Brookings,3- Bethel Baptist Church Area 2,State House,08,Matt Wagner,REP,0
+Brookings,3- Bethel Baptist Church Area 2,State House,08,Tim Walburg,REP,1
+Brookings,3- Bethel Baptist Church Area 2,State House,08,Tim Reisch,REP,1
+Brookings,4- Holy Life Tabernacle,State House,07,Roger DeGroot,REP,91
+Brookings,4- Holy Life Tabernacle,State House,07,Jeffrey A Struwe,REP,80
+Brookings,4- Holy Life Tabernacle,State House,07,Mellissa Heermann,REP,120
+Brookings,4- Holy Life Tabernacle,State House,08,Matt Wagner,REP,2
+Brookings,4- Holy Life Tabernacle,State House,08,Tim Walburg,REP,0
+Brookings,4- Holy Life Tabernacle,State House,08,Tim Reisch,REP,0
+Brookings,5- Aurora Fire Hall,State House,07,Roger DeGroot,REP,21
+Brookings,5- Aurora Fire Hall,State House,07,Jeffrey A Struwe,REP,36
+Brookings,5- Aurora Fire Hall,State House,07,Mellissa Heermann,REP,27
+Brookings,5- Aurora Fire Hall,State House,08,Matt Wagner,REP,29
+Brookings,5- Aurora Fire Hall,State House,08,Tim Walburg,REP,10
+Brookings,5- Aurora Fire Hall,State House,08,Tim Reisch,REP,15
+Brookings,6- Elkton Community Center,State House,07,Roger DeGroot,REP,1
+Brookings,6- Elkton Community Center,State House,07,Jeffrey A Struwe,REP,0
+Brookings,6- Elkton Community Center,State House,07,Mellissa Heermann,REP,1
+Brookings,6- Elkton Community Center,State House,08,Matt Wagner,REP,33
+Brookings,6- Elkton Community Center,State House,08,Tim Walburg,REP,17
+Brookings,6- Elkton Community Center,State House,08,Tim Reisch,REP,32
+Brookings,7- White McKnight Hall,State House,07,Roger DeGroot,REP,0
+Brookings,7- White McKnight Hall,State House,07,Jeffrey A Struwe,REP,0
+Brookings,7- White McKnight Hall,State House,07,Mellissa Heermann,REP,0
+Brookings,7- White McKnight Hall,State House,08,Matt Wagner,REP,66
+Brookings,7- White McKnight Hall,State House,08,Tim Walburg,REP,48
+Brookings,7- White McKnight Hall,State House,08,Tim Reisch,REP,40
+Brookings,8- Bruce Community Room,State House,07,Roger DeGroot,REP,0
+Brookings,8- Bruce Community Room,State House,07,Jeffrey A Struwe,REP,0
+Brookings,8- Bruce Community Room,State House,07,Mellissa Heermann,REP,0
+Brookings,8- Bruce Community Room,State House,08,Matt Wagner,REP,92
+Brookings,8- Bruce Community Room,State House,08,Tim Walburg,REP,34
+Brookings,8- Bruce Community Room,State House,08,Tim Reisch,REP,36
+Brookings,9- Volga Community Center,State House,07,Roger DeGroot,REP,9
+Brookings,9- Volga Community Center,State House,07,Jeffrey A Struwe,REP,11
+Brookings,9- Volga Community Center,State House,07,Mellissa Heermann,REP,7
+Brookings,9- Volga Community Center,State House,08,Matt Wagner,REP,318
+Brookings,9- Volga Community Center,State House,08,Tim Walburg,REP,100
+Brookings,9- Volga Community Center,State House,08,Tim Reisch,REP,128
+Brookings,Absentee Precinct,State House,07,Roger DeGroot,REP,232
+Brookings,Absentee Precinct,State House,07,Jeffrey A Struwe,REP,141
+Brookings,Absentee Precinct,State House,07,Mellissa Heermann,REP,238
+Brookings,Absentee Precinct,State House,08,Matt Wagner,REP,58
+Brookings,Absentee Precinct,State House,08,Tim Walburg,REP,20
+Brookings,Absentee Precinct,State House,08,Tim Reisch,REP,35
+Brookings,1- Brookings Activity Center,County Commissioner At Large,,Dave Miller,REP,148
+Brookings,1- Brookings Activity Center,County Commissioner At Large,,Michael D. Bartley,REP,125
+Brookings,1- Brookings Activity Center,County Commissioner At Large,,Doug Post,REP,117
+Brookings,2- Bethel Baptist Church Area 1,County Commissioner At Large,,Dave Miller,REP,98
+Brookings,2- Bethel Baptist Church Area 1,County Commissioner At Large,,Michael D. Bartley,REP,91
+Brookings,2- Bethel Baptist Church Area 1,County Commissioner At Large,,Doug Post,REP,98
+Brookings,3- Bethel Baptist Church Area 2,County Commissioner At Large,,Dave Miller,REP,132
+Brookings,3- Bethel Baptist Church Area 2,County Commissioner At Large,,Michael D. Bartley,REP,84
+Brookings,3- Bethel Baptist Church Area 2,County Commissioner At Large,,Doug Post,REP,107
+Brookings,4- Holy Life Tabernacle,County Commissioner At Large,,Dave Miller,REP,91
+Brookings,4- Holy Life Tabernacle,County Commissioner At Large,,Michael D. Bartley,REP,79
+Brookings,4- Holy Life Tabernacle,County Commissioner At Large,,Doug Post,REP,98
+Brookings,5- Aurora Fire Hall,County Commissioner At Large,,Dave Miller,REP,36
+Brookings,5- Aurora Fire Hall,County Commissioner At Large,,Michael D. Bartley,REP,33
+Brookings,5- Aurora Fire Hall,County Commissioner At Large,,Doug Post,REP,60
+Brookings,6- Elkton Community Center,County Commissioner At Large,,Dave Miller,REP,29
+Brookings,6- Elkton Community Center,County Commissioner At Large,,Michael D. Bartley,REP,19
+Brookings,6- Elkton Community Center,County Commissioner At Large,,Doug Post,REP,33
+Brookings,7- White McKnight Hall,County Commissioner At Large,,Dave Miller,REP,61
+Brookings,7- White McKnight Hall,County Commissioner At Large,,Michael D. Bartley,REP,36
+Brookings,7- White McKnight Hall,County Commissioner At Large,,Doug Post,REP,51
+Brookings,8- Bruce Community Room,County Commissioner At Large,,Dave Miller,REP,42
+Brookings,8- Bruce Community Room,County Commissioner At Large,,Michael D. Bartley,REP,38
+Brookings,8- Bruce Community Room,County Commissioner At Large,,Doug Post,REP,72
+Brookings,9- Volga Community Center,County Commissioner At Large,,Dave Miller,REP,168
+Brookings,9- Volga Community Center,County Commissioner At Large,,Michael D. Bartley,REP,112
+Brookings,9- Volga Community Center,County Commissioner At Large,,Doug Post,REP,264
+Brookings,Absentee Precinct,County Commissioner At Large,,Dave Miller,REP,241
+Brookings,Absentee Precinct,County Commissioner At Large,,Michael D. Bartley,REP,223
+Brookings,Absentee Precinct,County Commissioner At Large,,Doug Post,REP,220
+Brookings,1- Brookings Activity Center,Precinct Committeeman,05,Leon Pesall,REP,4
+Brookings,1- Brookings Activity Center,Precinct Committeeman,05,Jeremiah VanOverbeke,REP,6
+Brookings,1- Brookings Activity Center,Precinct Committeeman,05,Patrick Powers,REP,16
+Brookings,1- Brookings Activity Center,Precinct Committeeman,12,Donald L Jacobsma,REP,2
+Brookings,1- Brookings Activity Center,Precinct Committeeman,12,Regg Neiger,REP,0
+Brookings,1- Brookings Activity Center,Precinct Committeeman,15,Joshua Spilde,REP,1
+Brookings,1- Brookings Activity Center,Precinct Committeeman,15,James Mitchell,REP,1
+Brookings,2- Bethel Baptist Church Area 1,Precinct Committeeman,05,Leon Pesall,REP,6
+Brookings,2- Bethel Baptist Church Area 1,Precinct Committeeman,05,Jeremiah VanOverbeke,REP,17
+Brookings,2- Bethel Baptist Church Area 1,Precinct Committeeman,05,Patrick Powers,REP,37
+Brookings,2- Bethel Baptist Church Area 1,Precinct Committeeman,12,Donald L Jacobsma,REP,1
+Brookings,2- Bethel Baptist Church Area 1,Precinct Committeeman,12,Regg Neiger,REP,0
+Brookings,2- Bethel Baptist Church Area 1,Precinct Committeeman,15,Joshua Spilde,REP,0
+Brookings,2- Bethel Baptist Church Area 1,Precinct Committeeman,15,James Mitchell,REP,0
+Brookings,3- Bethel Baptist Church Area 2,Precinct Committeeman,05,Leon Pesall,REP,13
+Brookings,3- Bethel Baptist Church Area 2,Precinct Committeeman,05,Jeremiah VanOverbeke,REP,27
+Brookings,3- Bethel Baptist Church Area 2,Precinct Committeeman,05,Patrick Powers,REP,28
+Brookings,3- Bethel Baptist Church Area 2,Precinct Committeeman,12,Donald L Jacobsma,REP,1
+Brookings,3- Bethel Baptist Church Area 2,Precinct Committeeman,12,Regg Neiger,REP,0
+Brookings,3- Bethel Baptist Church Area 2,Precinct Committeeman,15,Joshua Spilde,REP,0
+Brookings,3- Bethel Baptist Church Area 2,Precinct Committeeman,15,James Mitchell,REP,0
+Brookings,4- Holy Life Tabernacle,Precinct Committeeman,05,Leon Pesall,REP,2
+Brookings,4- Holy Life Tabernacle,Precinct Committeeman,05,Jeremiah VanOverbeke,REP,3
+Brookings,4- Holy Life Tabernacle,Precinct Committeeman,05,Patrick Powers,REP,9
+Brookings,4- Holy Life Tabernacle,Precinct Committeeman,12,Donald L Jacobsma,REP,0
+Brookings,4- Holy Life Tabernacle,Precinct Committeeman,12,Regg Neiger,REP,0
+Brookings,4- Holy Life Tabernacle,Precinct Committeeman,15,Joshua Spilde,REP,0
+Brookings,4- Holy Life Tabernacle,Precinct Committeeman,15,James Mitchell,REP,0
+Brookings,5- Aurora Fire Hall,Precinct Committeeman,05,Leon Pesall,REP,0
+Brookings,5- Aurora Fire Hall,Precinct Committeeman,05,Jeremiah VanOverbeke,REP,0
+Brookings,5- Aurora Fire Hall,Precinct Committeeman,05,Patrick Powers,REP,0
+Brookings,5- Aurora Fire Hall,Precinct Committeeman,12,Donald L Jacobsma,REP,1
+Brookings,5- Aurora Fire Hall,Precinct Committeeman,12,Regg Neiger,REP,0
+Brookings,5- Aurora Fire Hall,Precinct Committeeman,15,Joshua Spilde,REP,0
+Brookings,5- Aurora Fire Hall,Precinct Committeeman,15,James Mitchell,REP,0
+Brookings,6- Elkton Community Center,Precinct Committeeman,05,Leon Pesall,REP,0
+Brookings,6- Elkton Community Center,Precinct Committeeman,05,Jeremiah VanOverbeke,REP,0
+Brookings,6- Elkton Community Center,Precinct Committeeman,05,Patrick Powers,REP,0
+Brookings,6- Elkton Community Center,Precinct Committeeman,12,Donald L Jacobsma,REP,0
+Brookings,6- Elkton Community Center,Precinct Committeeman,12,Regg Neiger,REP,0
+Brookings,6- Elkton Community Center,Precinct Committeeman,15,Joshua Spilde,REP,0
+Brookings,6- Elkton Community Center,Precinct Committeeman,15,James Mitchell,REP,0
+Brookings,7- White McKnight Hall,Precinct Committeeman,05,Leon Pesall,REP,0
+Brookings,7- White McKnight Hall,Precinct Committeeman,05,Jeremiah VanOverbeke,REP,0
+Brookings,7- White McKnight Hall,Precinct Committeeman,05,Patrick Powers,REP,0
+Brookings,7- White McKnight Hall,Precinct Committeeman,12,Donald L Jacobsma,REP,0
+Brookings,7- White McKnight Hall,Precinct Committeeman,12,Regg Neiger,REP,0
+Brookings,7- White McKnight Hall,Precinct Committeeman,15,Joshua Spilde,REP,0
+Brookings,7- White McKnight Hall,Precinct Committeeman,15,James Mitchell,REP,0
+Brookings,8- Bruce Community Room,Precinct Committeeman,05,Leon Pesall,REP,0
+Brookings,8- Bruce Community Room,Precinct Committeeman,05,Jeremiah VanOverbeke,REP,0
+Brookings,8- Bruce Community Room,Precinct Committeeman,05,Patrick Powers,REP,0
+Brookings,8- Bruce Community Room,Precinct Committeeman,12,Donald L Jacobsma,REP,0
+Brookings,8- Bruce Community Room,Precinct Committeeman,12,Regg Neiger,REP,0
+Brookings,8- Bruce Community Room,Precinct Committeeman,15,Joshua Spilde,REP,4
+Brookings,8- Bruce Community Room,Precinct Committeeman,15,James Mitchell,REP,3
+Brookings,9- Volga Community Center,Precinct Committeeman,05,Leon Pesall,REP,0
+Brookings,9- Volga Community Center,Precinct Committeeman,05,Jeremiah VanOverbeke,REP,0
+Brookings,9- Volga Community Center,Precinct Committeeman,05,Patrick Powers,REP,1
+Brookings,9- Volga Community Center,Precinct Committeeman,12,Donald L Jacobsma,REP,28
+Brookings,9- Volga Community Center,Precinct Committeeman,12,Regg Neiger,REP,16
+Brookings,9- Volga Community Center,Precinct Committeeman,15,Joshua Spilde,REP,5
+Brookings,9- Volga Community Center,Precinct Committeeman,15,James Mitchell,REP,10
+Brookings,Absentee Precinct,Precinct Committeeman,05,Leon Pesall,REP,18
+Brookings,Absentee Precinct,Precinct Committeeman,05,Jeremiah VanOverbeke,REP,16
+Brookings,Absentee Precinct,Precinct Committeeman,05,Patrick Powers,REP,37
+Brookings,Absentee Precinct,Precinct Committeeman,12,Donald L Jacobsma,REP,7
+Brookings,Absentee Precinct,Precinct Committeeman,12,Regg Neiger,REP,0
+Brookings,Absentee Precinct,Precinct Committeeman,15,Joshua Spilde,REP,4
+Brookings,Absentee Precinct,Precinct Committeeman,15,James Mitchell,REP,5
+Brookings,1- Brookings Activity Center,Precinct Committeewoman,05,"Cynthia ""Cindy"" Mydland",REP,13
+Brookings,1- Brookings Activity Center,Precinct Committeewoman,05,Nancy Stewart,REP,13
+Brookings,1- Brookings Activity Center,Precinct Committeewoman,15,Sara Spilde,REP,1
+Brookings,1- Brookings Activity Center,Precinct Committeewoman,15,Marla Mitchell,REP,1
+Brookings,2- Bethel Baptist Church Area 1,Precinct Committeewoman,05,"Cynthia ""Cindy"" Mydland",REP,34
+Brookings,2- Bethel Baptist Church Area 1,Precinct Committeewoman,05,Nancy Stewart,REP,38
+Brookings,2- Bethel Baptist Church Area 1,Precinct Committeewoman,15,Sara Spilde,REP,0
+Brookings,2- Bethel Baptist Church Area 1,Precinct Committeewoman,15,Marla Mitchell,REP,0
+Brookings,3- Bethel Baptist Church Area 2,Precinct Committeewoman,05,"Cynthia ""Cindy"" Mydland",REP,39
+Brookings,3- Bethel Baptist Church Area 2,Precinct Committeewoman,05,Nancy Stewart,REP,43
+Brookings,3- Bethel Baptist Church Area 2,Precinct Committeewoman,15,Sara Spilde,REP,0
+Brookings,3- Bethel Baptist Church Area 2,Precinct Committeewoman,15,Marla Mitchell,REP,0
+Brookings,4- Holy Life Tabernacle,Precinct Committeewoman,05,"Cynthia ""Cindy"" Mydland",REP,7
+Brookings,4- Holy Life Tabernacle,Precinct Committeewoman,05,Nancy Stewart,REP,7
+Brookings,4- Holy Life Tabernacle,Precinct Committeewoman,15,Sara Spilde,REP,0
+Brookings,4- Holy Life Tabernacle,Precinct Committeewoman,15,Marla Mitchell,REP,0
+Brookings,5- Aurora Fire Hall,Precinct Committeewoman,05,"Cynthia ""Cindy"" Mydland",REP,1
+Brookings,5- Aurora Fire Hall,Precinct Committeewoman,05,Nancy Stewart,REP,0
+Brookings,5- Aurora Fire Hall,Precinct Committeewoman,15,Sara Spilde,REP,0
+Brookings,5- Aurora Fire Hall,Precinct Committeewoman,15,Marla Mitchell,REP,0
+Brookings,6- Elkton Community Center,Precinct Committeewoman,05,"Cynthia ""Cindy"" Mydland",REP,0
+Brookings,6- Elkton Community Center,Precinct Committeewoman,05,Nancy Stewart,REP,0
+Brookings,6- Elkton Community Center,Precinct Committeewoman,15,Sara Spilde,REP,0
+Brookings,6- Elkton Community Center,Precinct Committeewoman,15,Marla Mitchell,REP,0
+Brookings,7- White McKnight Hall,Precinct Committeewoman,05,"Cynthia ""Cindy"" Mydland",REP,0
+Brookings,7- White McKnight Hall,Precinct Committeewoman,05,Nancy Stewart,REP,0
+Brookings,7- White McKnight Hall,Precinct Committeewoman,15,Sara Spilde,REP,0
+Brookings,7- White McKnight Hall,Precinct Committeewoman,15,Marla Mitchell,REP,0
+Brookings,8- Bruce Community Room,Precinct Committeewoman,05,"Cynthia ""Cindy"" Mydland",REP,0
+Brookings,8- Bruce Community Room,Precinct Committeewoman,05,Nancy Stewart,REP,0
+Brookings,8- Bruce Community Room,Precinct Committeewoman,15,Sara Spilde,REP,4
+Brookings,8- Bruce Community Room,Precinct Committeewoman,15,Marla Mitchell,REP,3
+Brookings,9- Volga Community Center,Precinct Committeewoman,05,"Cynthia ""Cindy"" Mydland",REP,1
+Brookings,9- Volga Community Center,Precinct Committeewoman,05,Nancy Stewart,REP,1
+Brookings,9- Volga Community Center,Precinct Committeewoman,15,Sara Spilde,REP,5
+Brookings,9- Volga Community Center,Precinct Committeewoman,15,Marla Mitchell,REP,10
+Brookings,Absentee Precinct,Precinct Committeewoman,05,"Cynthia ""Cindy"" Mydland",REP,40
+Brookings,Absentee Precinct,Precinct Committeewoman,05,Nancy Stewart,REP,26
+Brookings,Absentee Precinct,Precinct Committeewoman,15,Sara Spilde,REP,4
+Brookings,Absentee Precinct,Precinct Committeewoman,15,Marla Mitchell,REP,5

--- a/2024/counties/20240604__sd__primary__brown__precinct.csv
+++ b/2024/counties/20240604__sd__primary__brown__precinct.csv
@@ -1,0 +1,243 @@
+county,precinct,office,district,candidate,party,votes
+Brown,Absentee Precinct,President,,Marianne Williamson,DEM,34
+Brown,Absentee Precinct,President,,Joseph R Biden Jr,DEM,198
+Brown,Absentee Precinct,President,,Dean Phillips,DEM,34
+Brown,Absentee Precinct,President,,Armando Perez-Serrato,DEM,9
+Brown,AmericInn Event Center,President,,Marianne Williamson,DEM,16
+Brown,AmericInn Event Center,President,,Joseph R Biden Jr,DEM,75
+Brown,AmericInn Event Center,President,,Dean Phillips,DEM,12
+Brown,AmericInn Event Center,President,,Armando Perez-Serrato,DEM,8
+Brown,Best Western Ramkota Hotel and Convention Center,President,,Marianne Williamson,DEM,11
+Brown,Best Western Ramkota Hotel and Convention Center,President,,Joseph R Biden Jr,DEM,54
+Brown,Best Western Ramkota Hotel and Convention Center,President,,Dean Phillips,DEM,14
+Brown,Best Western Ramkota Hotel and Convention Center,President,,Armando Perez-Serrato,DEM,5
+Brown,Claremont City Hall,President,,Marianne Williamson,DEM,1
+Brown,Claremont City Hall,President,,Joseph R Biden Jr,DEM,7
+Brown,Claremont City Hall,President,,Dean Phillips,DEM,0
+Brown,Claremont City Hall,President,,Armando Perez-Serrato,DEM,0
+Brown,Columbia Legion,President,,Marianne Williamson,DEM,0
+Brown,Columbia Legion,President,,Joseph R Biden Jr,DEM,6
+Brown,Columbia Legion,President,,Dean Phillips,DEM,3
+Brown,Columbia Legion,President,,Armando Perez-Serrato,DEM,0
+Brown,Courthouse Community Room,President,,Marianne Williamson,DEM,25
+Brown,Courthouse Community Room,President,,Joseph R Biden Jr,DEM,122
+Brown,Courthouse Community Room,President,,Dean Phillips,DEM,25
+Brown,Courthouse Community Room,President,,Armando Perez-Serrato,DEM,9
+Brown,Frederick Community Center,President,,Marianne Williamson,DEM,1
+Brown,Frederick Community Center,President,,Joseph R Biden Jr,DEM,7
+Brown,Frederick Community Center,President,,Dean Phillips,DEM,5
+Brown,Frederick Community Center,President,,Armando Perez-Serrato,DEM,0
+Brown,Groton Community Center,President,,Marianne Williamson,DEM,4
+Brown,Groton Community Center,President,,Joseph R Biden Jr,DEM,19
+Brown,Groton Community Center,President,,Dean Phillips,DEM,5
+Brown,Groton Community Center,President,,Armando Perez-Serrato,DEM,2
+Brown,Heda Community Center,President,,Marianne Williamson,DEM,2
+Brown,Heda Community Center,President,,Joseph R Biden Jr,DEM,5
+Brown,Heda Community Center,President,,Dean Phillips,DEM,6
+Brown,Heda Community Center,President,,Armando Perez-Serrato,DEM,2
+Brown,Stratford Community Center,President,,Marianne Williamson,DEM,0
+Brown,Stratford Community Center,President,,Joseph R Biden Jr,DEM,8
+Brown,Stratford Community Center,President,,Dean Phillips,DEM,3
+Brown,Stratford Community Center,President,,Armando Perez-Serrato,DEM,1
+Brown,Warner Community Center,President,,Marianne Williamson,DEM,6
+Brown,Warner Community Center,President,,Joseph R Biden Jr,DEM,14
+Brown,Warner Community Center,President,,Dean Phillips,DEM,3
+Brown,Warner Community Center,President,,Armando Perez-Serrato,DEM,2
+Brown,Westport Town Hall,President,,Marianne Williamson,DEM,5
+Brown,Westport Town Hall,President,,Joseph R Biden Jr,DEM,9
+Brown,Westport Town Hall,President,,Dean Phillips,DEM,1
+Brown,Westport Town Hall,President,,Armando Perez-Serrato,DEM,0
+Brown,Absentee Precinct,State Senate,03,Katherine (Katie) Washnok,REP,427
+Brown,Absentee Precinct,State Senate,03,Carl Perry,REP,426
+Brown,Absentee Precinct,State Senate,23,Steven Ray Roseland,REP,24
+Brown,Absentee Precinct,State Senate,23,Mark Lapka,REP,31
+Brown,AmericInn Event Center,State Senate,03,Katherine (Katie) Washnok,REP,264
+Brown,AmericInn Event Center,State Senate,03,Carl Perry,REP,257
+Brown,AmericInn Event Center,State Senate,23,Steven Ray Roseland,REP,10
+Brown,AmericInn Event Center,State Senate,23,Mark Lapka,REP,6
+Brown,Best Western Ramkota Hotel and Convention Center,State Senate,03,Katherine (Katie) Washnok,REP,158
+Brown,Best Western Ramkota Hotel and Convention Center,State Senate,03,Carl Perry,REP,204
+Brown,Best Western Ramkota Hotel and Convention Center,State Senate,23,Steven Ray Roseland,REP,21
+Brown,Best Western Ramkota Hotel and Convention Center,State Senate,23,Mark Lapka,REP,34
+Brown,Claremont City Hall,State Senate,03,Katherine (Katie) Washnok,REP,0
+Brown,Claremont City Hall,State Senate,03,Carl Perry,REP,0
+Brown,Claremont City Hall,State Senate,23,Steven Ray Roseland,REP,0
+Brown,Claremont City Hall,State Senate,23,Mark Lapka,REP,0
+Brown,Columbia Legion,State Senate,03,Katherine (Katie) Washnok,REP,5
+Brown,Columbia Legion,State Senate,03,Carl Perry,REP,4
+Brown,Columbia Legion,State Senate,23,Steven Ray Roseland,REP,0
+Brown,Columbia Legion,State Senate,23,Mark Lapka,REP,0
+Brown,Courthouse Community Room,State Senate,03,Katherine (Katie) Washnok,REP,340
+Brown,Courthouse Community Room,State Senate,03,Carl Perry,REP,415
+Brown,Courthouse Community Room,State Senate,23,Steven Ray Roseland,REP,20
+Brown,Courthouse Community Room,State Senate,23,Mark Lapka,REP,34
+Brown,Frederick Community Center,State Senate,03,Katherine (Katie) Washnok,REP,0
+Brown,Frederick Community Center,State Senate,03,Carl Perry,REP,3
+Brown,Frederick Community Center,State Senate,23,Steven Ray Roseland,REP,1
+Brown,Frederick Community Center,State Senate,23,Mark Lapka,REP,0
+Brown,Groton Community Center,State Senate,03,Katherine (Katie) Washnok,REP,6
+Brown,Groton Community Center,State Senate,03,Carl Perry,REP,1
+Brown,Groton Community Center,State Senate,23,Steven Ray Roseland,REP,0
+Brown,Groton Community Center,State Senate,23,Mark Lapka,REP,0
+Brown,Hecla Community Center,State Senate,03,Katherine (Katie) Washnok,REP,0
+Brown,Hecla Community Center,State Senate,03,Carl Perry,REP,0
+Brown,Hecla Community Center,State Senate,23,Steven Ray Roseland,REP,0
+Brown,Hecla Community Center,State Senate,23,Mark Lapka,REP,0
+Brown,Stratford Community Center,State Senate,03,Katherine (Katie) Washnok,REP,0
+Brown,Stratford Community Center,State Senate,03,Carl Perry,REP,1
+Brown,Stratford Community Center,State Senate,23,Steven Ray Roseland,REP,0
+Brown,Stratford Community Center,State Senate,23,Mark Lapka,REP,0
+Brown,Warner Community Center,State Senate,03,Katherine (Katie) Washnok,REP,1
+Brown,Warner Community Center,State Senate,03,Carl Perry,REP,2
+Brown,Warner Community Center,State Senate,23,Steven Ray Roseland,REP,2
+Brown,Warner Community Center,State Senate,23,Mark Lapka,REP,1
+Brown,Westport Town Hall,State Senate,03,Katherine (Katie) Washnok,REP,0
+Brown,Westport Town Hall,State Senate,03,Carl Perry,REP,0
+Brown,Westport Town Hall,State Senate,23,Steven Ray Roseland,REP,0
+Brown,Westport Town Hall,State Senate,23,Mark Lapka,REP,0
+Brown,Absentee Precinct,State House,01,Logan Manhart,REP,106
+Brown,Absentee Precinct,State House,01,Tamara St John,REP,75
+Brown,Absentee Precinct,State House,01,Christopher Reder,REP,100
+Brown,Absentee Precinct,State House,23,Spencer Gosch,REP,39
+Brown,Absentee Precinct,State House,23,Scott Moore,REP,31
+Brown,Absentee Precinct,State House,23,James D. Wangsness,REP,22
+Brown,AmericInn Event Center,State House,01,Logan Manhart,REP,59
+Brown,AmericInn Event Center,State House,01,Tamara St John,REP,36
+Brown,AmericInn Event Center,State House,01,Christopher Reder,REP,37
+Brown,AmericInn Event Center,State House,23,Spencer Gosch,REP,9
+Brown,AmericInn Event Center,State House,23,Scott Moore,REP,10
+Brown,AmericInn Event Center,State House,23,James D. Wangsness,REP,8
+Brown,Best Western Ramkota Hotel and Convention Center,State House,01,Logan Manhart,REP,73
+Brown,Best Western Ramkota Hotel and Convention Center,State House,01,Tamara St John,REP,37
+Brown,Best Western Ramkota Hotel and Convention Center,State House,01,Christopher Reder,REP,57
+Brown,Best Western Ramkota Hotel and Convention Center,State House,23,Spencer Gosch,REP,31
+Brown,Best Western Ramkota Hotel and Convention Center,State House,23,Scott Moore,REP,42
+Brown,Best Western Ramkota Hotel and Convention Center,State House,23,James D. Wangsness,REP,15
+Brown,Claremont City Hall,State House,01,Logan Manhart,REP,18
+Brown,Claremont City Hall,State House,01,Tamara St John,REP,10
+Brown,Claremont City Hall,State House,01,Christopher Reder,REP,18
+Brown,Claremont City Hall,State House,23,Spencer Gosch,REP,0
+Brown,Claremont City Hall,State House,23,Scott Moore,REP,0
+Brown,Claremont City Hall,State House,23,James D. Wangsness,REP,0
+Brown,Columbia Legion,State House,01,Logan Manhart,REP,36
+Brown,Columbia Legion,State House,01,Tamara St John,REP,18
+Brown,Columbia Legion,State House,01,Christopher Reder,REP,32
+Brown,Columbia Legion,State House,23,Spencer Gosch,REP,0
+Brown,Columbia Legion,State House,23,Scott Moore,REP,0
+Brown,Columbia Legion,State House,23,James D. Wangsness,REP,0
+Brown,Courthouse Community Room,State House,01,Logan Manhart,REP,55
+Brown,Courthouse Community Room,State House,01,Tamara St John,REP,21
+Brown,Courthouse Community Room,State House,01,Christopher Reder,REP,57
+Brown,Courthouse Community Room,State House,23,Spencer Gosch,REP,33
+Brown,Courthouse Community Room,State House,23,Scott Moore,REP,35
+Brown,Courthouse Community Room,State House,23,James D. Wangsness,REP,17
+Brown,Frederick Community Center,State House,01,Logan Manhart,REP,29
+Brown,Frederick Community Center,State House,01,Tamara St John,REP,17
+Brown,Frederick Community Center,State House,01,Christopher Reder,REP,23
+Brown,Frederick Community Center,State House,23,Spencer Gosch,REP,1
+Brown,Frederick Community Center,State House,23,Scott Moore,REP,0
+Brown,Frederick Community Center,State House,23,James D. Wangsness,REP,1
+Brown,Groton Community Center,State House,01,Logan Manhart,REP,110
+Brown,Groton Community Center,State House,01,Tamara St John,REP,54
+Brown,Groton Community Center,State House,01,Christopher Reder,REP,101
+Brown,Groton Community Center,State House,23,Spencer Gosch,REP,0
+Brown,Groton Community Center,State House,23,Scott Moore,REP,0
+Brown,Groton Community Center,State House,23,James D. Wangsness,REP,0
+Brown,Hecla Community Center,State House,01,Logan Manhart,REP,27
+Brown,Hecla Community Center,State House,01,Tamara St John,REP,23
+Brown,Hecla Community Center,State House,01,Christopher Reder,REP,19
+Brown,Hecla Community Center,State House,23,Spencer Gosch,REP,0
+Brown,Hecla Community Center,State House,23,Scott Moore,REP,0
+Brown,Hecla Community Center,State House,23,James D. Wangsness,REP,0
+Brown,Stratford Community Center,State House,01,Logan Manhart,REP,15
+Brown,Stratford Community Center,State House,01,Tamara St John,REP,10
+Brown,Stratford Community Center,State House,01,Christopher Reder,REP,20
+Brown,Stratford Community Center,State House,23,Spencer Gosch,REP,0
+Brown,Stratford Community Center,State House,23,Scott Moore,REP,0
+Brown,Stratford Community Center,State House,23,James D. Wangsness,REP,0
+Brown,Warner Community Center,State House,01,Logan Manhart,REP,83
+Brown,Warner Community Center,State House,01,Tamara St John,REP,29
+Brown,Warner Community Center,State House,01,Christopher Reder,REP,81
+Brown,Warner Community Center,State House,23,Spencer Gosch,REP,2
+Brown,Warner Community Center,State House,23,Scott Moore,REP,3
+Brown,Warner Community Center,State House,23,James D. Wangsness,REP,1
+Brown,Westport Town Hall,State House,01,Logan Manhart,REP,44
+Brown,Westport Town Hall,State House,01,Tamara St John,REP,19
+Brown,Westport Town Hall,State House,01,Christopher Reder,REP,31
+Brown,Westport Town Hall,State House,23,Spencer Gosch,REP,0
+Brown,Westport Town Hall,State House,23,Scott Moore,REP,0
+Brown,Westport Town Hall,State House,23,James D. Wangsness,REP,0
+Brown,Absentee Precinct,County Commissioner At Large,,Duane Sutton,REP,664
+Brown,Absentee Precinct,County Commissioner At Large,,Kyler Dinger,REP,602
+Brown,Absentee Precinct,County Commissioner At Large,,Michael W. Carlsen,REP,528
+Brown,AmericInn Event Center,County Commissioner At Large,,Duane Sutton,REP,361
+Brown,AmericInn Event Center,County Commissioner At Large,,Kyler Dinger,REP,412
+Brown,AmericInn Event Center,County Commissioner At Large,,Michael W. Carlsen,REP,270
+Brown,Best Western Ramkota Hotel and Convention Center,County Commissioner At Large,,Duane Sutton,REP,313
+Brown,Best Western Ramkota Hotel and Convention Center,County Commissioner At Large,,Kyler Dinger,REP,344
+Brown,Best Western Ramkota Hotel and Convention Center,County Commissioner At Large,,Michael W. Carlsen,REP,227
+Brown,Claremont City Hall,County Commissioner At Large,,Duane Sutton,REP,22
+Brown,Claremont City Hall,County Commissioner At Large,,Kyler Dinger,REP,21
+Brown,Claremont City Hall,County Commissioner At Large,,Michael W. Carlsen,REP,4
+Brown,Columbia Legion,County Commissioner At Large,,Duane Sutton,REP,21
+Brown,Columbia Legion,County Commissioner At Large,,Kyler Dinger,REP,58
+Brown,Columbia Legion,County Commissioner At Large,,Michael W. Carlsen,REP,15
+Brown,Courthouse Community Room,County Commissioner At Large,,Duane Sutton,REP,491
+Brown,Courthouse Community Room,County Commissioner At Large,,Kyler Dinger,REP,568
+Brown,Courthouse Community Room,County Commissioner At Large,,Michael W. Carlsen,REP,375
+Brown,Frederick Community Center,County Commissioner At Large,,Duane Sutton,REP,24
+Brown,Frederick Community Center,County Commissioner At Large,,Kyler Dinger,REP,35
+Brown,Frederick Community Center,County Commissioner At Large,,Michael W. Carlsen,REP,25
+Brown,Groton Community Center,County Commissioner At Large,,Duane Sutton,REP,90
+Brown,Groton Community Center,County Commissioner At Large,,Kyler Dinger,REP,121
+Brown,Groton Community Center,County Commissioner At Large,,Michael W. Carlsen,REP,60
+Brown,Heda Community Center,County Commissioner At Large,,Duane Sutton,REP,23
+Brown,Heda Community Center,County Commissioner At Large,,Kyler Dinger,REP,29
+Brown,Heda Community Center,County Commissioner At Large,,Michael W. Carlsen,REP,16
+Brown,Stratford Community Center,County Commissioner At Large,,Duane Sutton,REP,19
+Brown,Stratford Community Center,County Commissioner At Large,,Kyler Dinger,REP,20
+Brown,Stratford Community Center,County Commissioner At Large,,Michael W. Carlsen,REP,10
+Brown,Warner Community Center,County Commissioner At Large,,Duane Sutton,REP,75
+Brown,Warner Community Center,County Commissioner At Large,,Kyler Dinger,REP,79
+Brown,Warner Community Center,County Commissioner At Large,,Michael W. Carlsen,REP,43
+Brown,Westport Town Hall,County Commissioner At Large,,Duane Sutton,REP,31
+Brown,Westport Town Hall,County Commissioner At Large,,Kyler Dinger,REP,46
+Brown,Westport Town Hall,County Commissioner At Large,,Michael W. Carlsen,REP,16
+Brown,Absentee Precinct,Precinct Committeewoman,02,Carol Schaunaman,REP,25
+Brown,Absentee Precinct,Precinct Committeewoman,02,Jadynn Marie Donne,REP,4
+Brown,AmericInn Event Center,Precinct Committeewoman,02,Carol Schaunaman,REP,15
+Brown,AmericInn Event Center,Precinct Committeewoman,02,Jadynn Marie Donne,REP,2
+Brown,Best Western Ramkota Hotel and Convention Center,Precinct Committeewoman,02,Carol Schaunaman,REP,27
+Brown,Best Western Ramkota Hotel and Convention Center,Precinct Committeewoman,02,Jadynn Marie Donne,REP,1
+Brown,Claremont City Hall,Precinct Committeewoman,02,Carol Schaunaman,REP,0
+Brown,Claremont City Hall,Precinct Committeewoman,02,Jadynn Marie Donne,REP,0
+Brown,Columbia Legion,Precinct Committeewoman,02,Carol Schaunaman,REP,0
+Brown,Columbia Legion,Precinct Committeewoman,02,Jadynn Marie Donne,REP,0
+Brown,Courthouse Community Room,Precinct Committeewoman,02,Carol Schaunaman,REP,33
+Brown,Courthouse Community Room,Precinct Committeewoman,02,Jadynn Marie Donne,REP,7
+Brown,Frederick Community Center,Precinct Committeewoman,02,Carol Schaunaman,REP,0
+Brown,Frederick Community Center,Precinct Committeewoman,02,Jadynn Marie Donne,REP,0
+Brown,Groton Community Center,Precinct Committeewoman,02,Carol Schaunaman,REP,0
+Brown,Groton Community Center,Precinct Committeewoman,02,Jadynn Marie Donne,REP,1
+Brown,Heda Community Center,Precinct Committeewoman,02,Carol Schaunaman,REP,0
+Brown,Heda Community Center,Precinct Committeewoman,02,Jadynn Marie Donne,REP,0
+Brown,Stratford Community Center,Precinct Committeewoman,02,Carol Schaunaman,REP,0
+Brown,Stratford Community Center,Precinct Committeewoman,02,Jadynn Marie Donne,REP,0
+Brown,Warner Community Center,Precinct Committeewoman,02,Carol Schaunaman,REP,0
+Brown,Warner Community Center,Precinct Committeewoman,02,Jadynn Marie Donne,REP,0
+Brown,Westport Town Hall,Precinct Committeewoman,02,Carol Schaunaman,REP,0
+Brown,Westport Town Hall,Precinct Committeewoman,02,Jadynn Marie Donne,REP,0
+Brown,VC-1 - AmericInn,,,Katherine (Katie) Washnok,,1
+Brown,VC-1 - AmericInn,,,Duane Sutton,,1
+Brown,VC-1 - AmericInn,,,Michael W. Carlsen,,1
+Brown,VC-1 - AmericInn,,,Carol Schaunaman,,1
+Brown,VC-2 - BW Ramkota,,,Katherine (Katie) Washnok,,1
+Brown,VC-2 - BW Ramkota,,,Michael W. Carlsen,,1
+Brown,VC-4 - Columbia Legion,,,Logan Manhart,,1
+Brown,VC-4 - Columbia Legion,,,Christopher Reder,,1
+Brown,VC-4 - Columbia Legion,,,Kyler Dinger,,1
+Brown,VC-4 - Columbia Legion,,,Michael W. Carlsen,,1
+Brown,VC-6 - Warner,,,Logan Manhart,,1
+Brown,VC-6 - Warner,,,Christopher Reder,,1
+Brown,VC-6 - Warner,,,Kyler Dinger,,1
+Brown,VC-6 - Warner,,,Michael W. Carlsen,,1

--- a/2024/counties/20240604__sd__primary__brule__precinct.csv
+++ b/2024/counties/20240604__sd__primary__brule__precinct.csv
@@ -1,0 +1,32 @@
+county,precinct,office,district,candidate,party,votes
+Brule,01,President,,Marianne Williamson,DEM,12
+Brule,01,President,,Joseph R. Biden Jr.,DEM,62
+Brule,01,President,,Dean Phillips,DEM,11
+Brule,01,President,,Armando Perez-Serrato,DEM,3
+Brule,02,President,,Marianne Williamson,DEM,14
+Brule,02,President,,Joseph R. Biden Jr.,DEM,19
+Brule,02,President,,Dean Phillips,DEM,7
+Brule,02,President,,Armando Perez-Serrato,DEM,4
+Brule,03,President,,Marianne Williamson,DEM,1
+Brule,03,President,,Joseph R. Biden Jr.,DEM,8
+Brule,03,President,,Dean Phillips,DEM,4
+Brule,03,President,,Armando Perez-Serrato,DEM,1
+Brule,04,President,,Marianne Williamson,DEM,1
+Brule,04,President,,Joseph R. Biden Jr.,DEM,6
+Brule,04,President,,Dean Phillips,DEM,2
+Brule,04,President,,Armando Perez-Serrato,DEM,0
+Brule,02,School Board Member Kimball School District,7-2,Hillary Leiferman,,84
+Brule,02,School Board Member Kimball School District,7-2,Joshua Krier,,105
+Brule,02,School Board Member Kimball School District,7-2,Justin Blasius,,75
+Brule,02,School Board Member Kimball School District,7-2,James Hoing,,120
+Brule,03,School Board Member Kimball School District,7-2,Hillary Leiferman,,5
+Brule,03,School Board Member Kimball School District,7-2,Joshua Krier,,10
+Brule,03,School Board Member Kimball School District,7-2,Justin Blasius,,13
+Brule,03,School Board Member Kimball School District,7-2,James Hoing,,16
+Brule,04,School Board Member Kimball School District,7-2,Hillary Leiferman,,11
+Brule,04,School Board Member Kimball School District,7-2,Joshua Krier,,9
+Brule,04,School Board Member Kimball School District,7-2,Justin Blasius,,8
+Brule,04,School Board Member Kimball School District,7-2,James Hoing,,8
+Brule,01,City Commissioner Chamberlain,,Dan Hyland,NPA,170
+Brule,01,City Commissioner Chamberlain,,Ronnie Brown,NPA,220
+Brule,01,City Commissioner Chamberlain,,Ron Madison,NPA,114

--- a/2024/counties/20240604__sd__primary__buffalo__precinct.csv
+++ b/2024/counties/20240604__sd__primary__buffalo__precinct.csv
@@ -1,0 +1,17 @@
+county,precinct,office,district,candidate,party,votes
+Buffalo,1,President,,Marianne Williamson,DEM,3
+Buffalo,1,President,,Joseph R Biden Jr,DEM,2
+Buffalo,1,President,,Dean Phillips,DEM,1
+Buffalo,1,President,,Armando Perez-Serrato,DEM,0
+Buffalo,2,President,,Marianne Williamson,DEM,0
+Buffalo,2,President,,Joseph R Biden Jr,DEM,4
+Buffalo,2,President,,Dean Phillips,DEM,1
+Buffalo,2,President,,Armando Perez-Serrato,DEM,3
+Buffalo,3,President,,Marianne Williamson,DEM,3
+Buffalo,3,President,,Joseph R Biden Jr,DEM,14
+Buffalo,3,President,,Dean Phillips,DEM,2
+Buffalo,3,President,,Armando Perez-Serrato,DEM,3
+Buffalo,2,School Board Member,Kimball School District 7-2,Hillary Leiferman,NPA,0
+Buffalo,2,School Board Member,Kimball School District 7-2,Joshua Krier,NPA,0
+Buffalo,2,School Board Member,Kimball School District 7-2,Justin Blasius,NPA,0
+Buffalo,2,School Board Member,Kimball School District 7-2,James Hoing,NPA,0

--- a/2024/counties/20240604__sd__primary__butte__precinct.csv
+++ b/2024/counties/20240604__sd__primary__butte__precinct.csv
@@ -1,0 +1,181 @@
+county,precinct,office,district,candidate,party,votes
+Butte,06,President,,Marianne Williamson,DEM,0
+Butte,06,President,,Joseph R Biden Jr,DEM,0
+Butte,06,President,,Dean Phillips,DEM,1
+Butte,06,President,,Armando Perez-Serrato,DEM,0
+Butte,08,President,,Marianne Williamson,DEM,0
+Butte,08,President,,Joseph R Biden Jr,DEM,0
+Butte,08,President,,Dean Phillips,DEM,0
+Butte,08,President,,Armando Perez-Serrato,DEM,0
+Butte,11,President,,Marianne Williamson,DEM,0
+Butte,11,President,,Joseph R Biden Jr,DEM,0
+Butte,11,President,,Dean Phillips,DEM,0
+Butte,11,President,,Armando Perez-Serrato,DEM,0
+Butte,12,President,,Marianne Williamson,DEM,0
+Butte,12,President,,Joseph R Biden Jr,DEM,2
+Butte,12,President,,Dean Phillips,DEM,0
+Butte,12,President,,Armando Perez-Serrato,DEM,0
+Butte,13,President,,Marianne Williamson,DEM,0
+Butte,13,President,,Joseph R Biden Jr,DEM,1
+Butte,13,President,,Dean Phillips,DEM,2
+Butte,13,President,,Armando Perez-Serrato,DEM,0
+Butte,14,President,,Marianne Williamson,DEM,5
+Butte,14,President,,Joseph R Biden Jr,DEM,3
+Butte,14,President,,Dean Phillips,DEM,1
+Butte,14,President,,Armando Perez-Serrato,DEM,0
+Butte,16,President,,Marianne Williamson,DEM,2
+Butte,16,President,,Joseph R Biden Jr,DEM,12
+Butte,16,President,,Dean Phillips,DEM,0
+Butte,16,President,,Armando Perez-Serrato,DEM,3
+Butte,17,President,,Marianne Williamson,DEM,1
+Butte,17,President,,Joseph R Biden Jr,DEM,6
+Butte,17,President,,Dean Phillips,DEM,5
+Butte,17,President,,Armando Perez-Serrato,DEM,1
+Butte,18,President,,Marianne Williamson,DEM,6
+Butte,18,President,,Joseph R Biden Jr,DEM,6
+Butte,18,President,,Dean Phillips,DEM,0
+Butte,18,President,,Armando Perez-Serrato,DEM,3
+Butte,20,President,,Marianne Williamson,DEM,1
+Butte,20,President,,Joseph R Biden Jr,DEM,9
+Butte,20,President,,Dean Phillips,DEM,6
+Butte,20,President,,Armando Perez-Serrato,DEM,3
+Butte,21,President,,Marianne Williamson,DEM,2
+Butte,21,President,,Joseph R Biden Jr,DEM,12
+Butte,21,President,,Dean Phillips,DEM,3
+Butte,21,President,,Armando Perez-Serrato,DEM,2
+Butte,22,President,,Marianne Williamson,DEM,3
+Butte,22,President,,Joseph R Biden Jr,DEM,2
+Butte,22,President,,Dean Phillips,DEM,3
+Butte,22,President,,Armando Perez-Serrato,DEM,1
+Butte,23,President,,Marianne Williamson,DEM,1
+Butte,23,President,,Joseph R Biden Jr,DEM,8
+Butte,23,President,,Dean Phillips,DEM,1
+Butte,23,President,,Armando Perez-Serrato,DEM,1
+Butte,24,President,,Marianne Williamson,DEM,2
+Butte,24,President,,Joseph R Biden Jr,DEM,7
+Butte,24,President,,Dean Phillips,DEM,0
+Butte,24,President,,Armando Perez-Serrato,DEM,2
+Butte,25,President,,Marianne Williamson,DEM,4
+Butte,25,President,,Joseph R Biden Jr,DEM,7
+Butte,25,President,,Dean Phillips,DEM,3
+Butte,25,President,,Armando Perez-Serrato,DEM,0
+Butte,26,President,,Marianne Williamson,DEM,3
+Butte,26,President,,Joseph R Biden Jr,DEM,7
+Butte,26,President,,Dean Phillips,DEM,1
+Butte,26,President,,Armando Perez-Serrato,DEM,1
+Butte,27,President,,Marianne Williamson,DEM,3
+Butte,27,President,,Joseph R Biden Jr,DEM,9
+Butte,27,President,,Dean Phillips,DEM,0
+Butte,27,President,,Armando Perez-Serrato,DEM,1
+Butte,28,President,,Marianne Williamson,DEM,8
+Butte,28,President,,Joseph R Biden Jr,DEM,15
+Butte,28,President,,Dean Phillips,DEM,2
+Butte,28,President,,Armando Perez-Serrato,DEM,0
+Butte,06,State Senate,28,Susan M. Peterson,REP,3
+Butte,06,State Senate,28,Sam Marty,REP,21
+Butte,08,State Senate,28,Susan M. Peterson,REP,1
+Butte,08,State Senate,28,Sam Marty,REP,11
+Butte,11,State Senate,28,Susan M. Peterson,REP,14
+Butte,11,State Senate,28,Sam Marty,REP,19
+Butte,12,State Senate,28,Susan M. Peterson,REP,9
+Butte,12,State Senate,28,Sam Marty,REP,29
+Butte,13,State Senate,28,Susan M. Peterson,REP,41
+Butte,13,State Senate,28,Sam Marty,REP,72
+Butte,14,State Senate,28,Susan M. Peterson,REP,31
+Butte,14,State Senate,28,Sam Marty,REP,51
+Butte,16,State Senate,28,Susan M. Peterson,REP,136
+Butte,16,State Senate,28,Sam Marty,REP,109
+Butte,17,State Senate,28,Susan M. Peterson,REP,78
+Butte,17,State Senate,28,Sam Marty,REP,77
+Butte,18,State Senate,28,Susan M. Peterson,REP,14
+Butte,18,State Senate,28,Sam Marty,REP,22
+Butte,20,State Senate,28,Susan M. Peterson,REP,30
+Butte,20,State Senate,28,Sam Marty,REP,48
+Butte,21,State Senate,28,Susan M. Peterson,REP,31
+Butte,21,State Senate,28,Sam Marty,REP,22
+Butte,22,State Senate,28,Susan M. Peterson,REP,26
+Butte,22,State Senate,28,Sam Marty,REP,21
+Butte,23,State Senate,28,Susan M. Peterson,REP,38
+Butte,23,State Senate,28,Sam Marty,REP,28
+Butte,24,State Senate,28,Susan M. Peterson,REP,70
+Butte,24,State Senate,28,Sam Marty,REP,47
+Butte,25,State Senate,28,Susan M. Peterson,REP,100
+Butte,25,State Senate,28,Sam Marty,REP,51
+Butte,26,State Senate,28,Susan M. Peterson,REP,40
+Butte,26,State Senate,28,Sam Marty,REP,24
+Butte,27,State Senate,28,Susan M. Peterson,REP,56
+Butte,27,State Senate,28,Sam Marty,REP,25
+Butte,28,State Senate,28,Susan M. Peterson,REP,87
+Butte,28,State Senate,28,Sam Marty,REP,46
+Butte,06,State House,28B,Travis Ismay,REP,22
+Butte,06,State House,28B,Travis W. Martin,REP,2
+Butte,08,State House,28B,Travis Ismay,REP,11
+Butte,08,State House,28B,Travis W. Martin,REP,1
+Butte,11,State House,28B,Travis Ismay,REP,18
+Butte,11,State House,28B,Travis W. Martin,REP,17
+Butte,12,State House,28B,Travis Ismay,REP,24
+Butte,12,State House,28B,Travis W. Martin,REP,15
+Butte,13,State House,28B,Travis Ismay,REP,77
+Butte,13,State House,28B,Travis W. Martin,REP,36
+Butte,14,State House,28B,Travis Ismay,REP,53
+Butte,14,State House,28B,Travis W. Martin,REP,30
+Butte,16,State House,28B,Travis Ismay,REP,136
+Butte,16,State House,28B,Travis W. Martin,REP,113
+Butte,17,State House,28B,Travis Ismay,REP,76
+Butte,17,State House,28B,Travis W. Martin,REP,75
+Butte,18,State House,28B,Travis Ismay,REP,27
+Butte,18,State House,28B,Travis W. Martin,REP,9
+Butte,20,State House,28B,Travis Ismay,REP,42
+Butte,20,State House,28B,Travis W. Martin,REP,38
+Butte,21,State House,28B,Travis Ismay,REP,30
+Butte,21,State House,28B,Travis W. Martin,REP,20
+Butte,22,State House,28B,Travis Ismay,REP,28
+Butte,22,State House,28B,Travis W. Martin,REP,21
+Butte,23,State House,28B,Travis Ismay,REP,22
+Butte,23,State House,28B,Travis W. Martin,REP,39
+Butte,24,State House,28B,Travis Ismay,REP,55
+Butte,24,State House,28B,Travis W. Martin,REP,61
+Butte,25,State House,28B,Travis Ismay,REP,71
+Butte,25,State House,28B,Travis W. Martin,REP,76
+Butte,26,State House,28B,Travis Ismay,REP,21
+Butte,26,State House,28B,Travis W. Martin,REP,44
+Butte,27,State House,28B,Travis Ismay,REP,38
+Butte,27,State House,28B,Travis W. Martin,REP,46
+Butte,28,State House,28B,Travis Ismay,REP,46
+Butte,28,State House,28B,Travis W. Martin,REP,85
+Butte,16,County Commissioner,2,Thomas J Brunner,REP,0
+Butte,16,County Commissioner,2,William O'Dea,REP,0
+Butte,16,County Commissioner,4,Sue Broadhurst,REP,5
+Butte,16,County Commissioner,4,Terry Batterman,REP,5
+Butte,17,County Commissioner,2,Thomas J Brunner,REP,96
+Butte,17,County Commissioner,2,William O'Dea,REP,59
+Butte,17,County Commissioner,4,Sue Broadhurst,REP,0
+Butte,17,County Commissioner,4,Terry Batterman,REP,1
+Butte,18,County Commissioner,2,Thomas J Brunner,REP,31
+Butte,18,County Commissioner,2,William O'Dea,REP,6
+Butte,18,County Commissioner,4,Sue Broadhurst,REP,0
+Butte,18,County Commissioner,4,Terry Batterman,REP,0
+Butte,24,County Commissioner,2,Thomas J Brunner,REP,0
+Butte,24,County Commissioner,2,William O'Dea,REP,0
+Butte,24,County Commissioner,4,Sue Broadhurst,REP,47
+Butte,24,County Commissioner,4,Terry Batterman,REP,52
+Butte,25,County Commissioner,2,Thomas J Brunner,REP,0
+Butte,25,County Commissioner,2,William O'Dea,REP,0
+Butte,25,County Commissioner,4,Sue Broadhurst,REP,12
+Butte,25,County Commissioner,4,Terry Batterman,REP,9
+Butte,26,County Commissioner,2,Thomas J Brunner,REP,0
+Butte,26,County Commissioner,2,William O'Dea,REP,0
+Butte,26,County Commissioner,4,Sue Broadhurst,REP,37
+Butte,26,County Commissioner,4,Terry Batterman,REP,29
+Butte,27,County Commissioner,2,Thomas J Brunner,REP,1
+Butte,27,County Commissioner,2,William O'Dea,REP,1
+Butte,27,County Commissioner,4,Sue Broadhurst,REP,37
+Butte,27,County Commissioner,4,Terry Batterman,REP,43
+Butte,28,County Commissioner,2,Thomas J Brunner,REP,74
+Butte,28,County Commissioner,2,William O'Dea,REP,57
+Butte,28,County Commissioner,4,Sue Broadhurst,REP,0
+Butte,28,County Commissioner,4,Terry Batterman,REP,0
+Butte,13,Precinct Committeeman,13,Daniel I Rhoden,REP,49
+Butte,13,Precinct Committeeman,13,John Deighton,REP,54
+Butte,13,Precinct Committeewoman,13,Lori Deighton,REP,50
+Butte,13,Precinct Committeewoman,13,Kathryn Rhoden,REP,52

--- a/2024/counties/20240604__sd__primary__campbell__precinct.csv
+++ b/2024/counties/20240604__sd__primary__campbell__precinct.csv
@@ -1,0 +1,46 @@
+county,precinct,office,district,candidate,party,votes
+Campbell,1,President,,Marianne Williamson,DEM,0
+Campbell,1,President,,Joseph R Biden Jr,DEM,4
+Campbell,1,President,,Dean Phillips,DEM,0
+Campbell,1,President,,Armando Perez-Serrato,DEM,0
+Campbell,2,President,,Marianne Williamson,DEM,2
+Campbell,2,President,,Joseph R Biden Jr,DEM,2
+Campbell,2,President,,Dean Phillips,DEM,1
+Campbell,2,President,,Armando Perez-Serrato,DEM,1
+Campbell,3,President,,Marianne Williamson,DEM,0
+Campbell,3,President,,Joseph R Biden Jr,DEM,4
+Campbell,3,President,,Dean Phillips,DEM,0
+Campbell,3,President,,Armando Perez-Serrato,DEM,1
+Campbell,4,President,,Marianne Williamson,DEM,0
+Campbell,4,President,,Joseph R Biden Jr,DEM,5
+Campbell,4,President,,Dean Phillips,DEM,0
+Campbell,4,President,,Armando Perez-Serrato,DEM,0
+Campbell,5,President,,Marianne Williamson,DEM,2
+Campbell,5,President,,Joseph R Biden Jr,DEM,2
+Campbell,5,President,,Dean Phillips,DEM,1
+Campbell,5,President,,Armando Perez-Serrato,DEM,0
+Campbell,1,State Senate,23,Steven Ray Roseland,REP,7
+Campbell,1,State Senate,23,Mark Lapka,REP,54
+Campbell,2,State Senate,23,Steven Ray Roseland,REP,17
+Campbell,2,State Senate,23,Mark Lapka,REP,27
+Campbell,3,State Senate,23,Steven Ray Roseland,REP,8
+Campbell,3,State Senate,23,Mark Lapka,REP,35
+Campbell,4,State Senate,23,Steven Ray Roseland,REP,13
+Campbell,4,State Senate,23,Mark Lapka,REP,41
+Campbell,5,State Senate,23,Steven Ray Roseland,REP,18
+Campbell,5,State Senate,23,Mark Lapka,REP,53
+Campbell,1,State House,23,Spencer Gosch,REP,55
+Campbell,1,State House,23,Scott Moore,REP,26
+Campbell,1,State House,23,James D. Wangsness,REP,8
+Campbell,2,State House,23,Spencer Gosch,REP,24
+Campbell,2,State House,23,Scott Moore,REP,36
+Campbell,2,State House,23,James D. Wangsness,REP,21
+Campbell,3,State House,23,Spencer Gosch,REP,42
+Campbell,3,State House,23,Scott Moore,REP,20
+Campbell,3,State House,23,James D. Wangsness,REP,5
+Campbell,4,State House,23,Spencer Gosch,REP,46
+Campbell,4,State House,23,Scott Moore,REP,38
+Campbell,4,State House,23,James D. Wangsness,REP,15
+Campbell,5,State House,23,Spencer Gosch,REP,53
+Campbell,5,State House,23,Scott Moore,REP,52
+Campbell,5,State House,23,James D. Wangsness,REP,13

--- a/2024/counties/20240604__sd__primary__charles_mix__precinct.csv
+++ b/2024/counties/20240604__sd__primary__charles_mix__precinct.csv
@@ -1,0 +1,139 @@
+county,precinct,office,district,candidate,party,votes
+Charles Mix,01,President,,Marianne Williamson,DEM,2
+Charles Mix,01,President,,Joseph R Biden Jr,DEM,7
+Charles Mix,01,President,,Dean Phillips,DEM,6
+Charles Mix,01,President,,Armando Perez-Serrato,DEM,0
+Charles Mix,02,President,,Marianne Williamson,DEM,0
+Charles Mix,02,President,,Joseph R Biden Jr,DEM,10
+Charles Mix,02,President,,Dean Phillips,DEM,0
+Charles Mix,02,President,,Armando Perez-Serrato,DEM,1
+Charles Mix,03,President,,Marianne Williamson,DEM,3
+Charles Mix,03,President,,Joseph R Biden Jr,DEM,10
+Charles Mix,03,President,,Dean Phillips,DEM,4
+Charles Mix,03,President,,Armando Perez-Serrato,DEM,3
+Charles Mix,04,President,,Marianne Williamson,DEM,1
+Charles Mix,04,President,,Joseph R Biden Jr,DEM,3
+Charles Mix,04,President,,Dean Phillips,DEM,0
+Charles Mix,04,President,,Armando Perez-Serrato,DEM,2
+Charles Mix,05,President,,Marianne Williamson,DEM,5
+Charles Mix,05,President,,Joseph R Biden Jr,DEM,8
+Charles Mix,05,President,,Dean Phillips,DEM,4
+Charles Mix,05,President,,Armando Perez-Serrato,DEM,1
+Charles Mix,06,President,,Marianne Williamson,DEM,4
+Charles Mix,06,President,,Joseph R Biden Jr,DEM,10
+Charles Mix,06,President,,Dean Phillips,DEM,2
+Charles Mix,06,President,,Armando Perez-Serrato,DEM,0
+Charles Mix,07,President,,Marianne Williamson,DEM,2
+Charles Mix,07,President,,Joseph R Biden Jr,DEM,13
+Charles Mix,07,President,,Dean Phillips,DEM,0
+Charles Mix,07,President,,Armando Perez-Serrato,DEM,0
+Charles Mix,08,President,,Marianne Williamson,DEM,2
+Charles Mix,08,President,,Joseph R Biden Jr,DEM,6
+Charles Mix,08,President,,Dean Phillips,DEM,3
+Charles Mix,08,President,,Armando Perez-Serrato,DEM,0
+Charles Mix,09,President,,Marianne Williamson,DEM,2
+Charles Mix,09,President,,Joseph R Biden Jr,DEM,8
+Charles Mix,09,President,,Dean Phillips,DEM,2
+Charles Mix,09,President,,Armando Perez-Serrato,DEM,2
+Charles Mix,10,President,,Marianne Williamson,DEM,0
+Charles Mix,10,President,,Joseph R Biden Jr,DEM,4
+Charles Mix,10,President,,Dean Phillips,DEM,1
+Charles Mix,10,President,,Armando Perez-Serrato,DEM,0
+Charles Mix,11,President,,Marianne Williamson,DEM,5
+Charles Mix,11,President,,Joseph R Biden Jr,DEM,18
+Charles Mix,11,President,,Dean Phillips,DEM,4
+Charles Mix,11,President,,Armando Perez-Serrato,DEM,1
+Charles Mix,12,President,,Marianne Williamson,DEM,2
+Charles Mix,12,President,,Joseph R Biden Jr,DEM,2
+Charles Mix,12,President,,Dean Phillips,DEM,3
+Charles Mix,12,President,,Armando Perez-Serrato,DEM,0
+Charles Mix,13,President,,Marianne Williamson,DEM,1
+Charles Mix,13,President,,Joseph R Biden Jr,DEM,4
+Charles Mix,13,President,,Dean Phillips,DEM,1
+Charles Mix,13,President,,Armando Perez-Serrato,DEM,0
+Charles Mix,01,State Senate,21,Erin Tobin,REP,43
+Charles Mix,01,State Senate,21,Mykala Voita,REP,44
+Charles Mix,02,State Senate,21,Erin Tobin,REP,11
+Charles Mix,02,State Senate,21,Mykala Voita,REP,11
+Charles Mix,03,State Senate,21,Erin Tobin,REP,30
+Charles Mix,03,State Senate,21,Mykala Voita,REP,26
+Charles Mix,04,State Senate,21,Erin Tobin,REP,13
+Charles Mix,04,State Senate,21,Mykala Voita,REP,13
+Charles Mix,05,State Senate,21,Erin Tobin,REP,23
+Charles Mix,05,State Senate,21,Mykala Voita,REP,29
+Charles Mix,06,State Senate,21,Erin Tobin,REP,5
+Charles Mix,06,State Senate,21,Mykala Voita,REP,14
+Charles Mix,07,State Senate,21,Erin Tobin,REP,18
+Charles Mix,07,State Senate,21,Mykala Voita,REP,21
+Charles Mix,08,State Senate,21,Erin Tobin,REP,27
+Charles Mix,08,State Senate,21,Mykala Voita,REP,24
+Charles Mix,09,State Senate,21,Erin Tobin,REP,70
+Charles Mix,09,State Senate,21,Mykala Voita,REP,97
+Charles Mix,10,State Senate,21,Erin Tobin,REP,19
+Charles Mix,10,State Senate,21,Mykala Voita,REP,43
+Charles Mix,11,State Senate,21,Erin Tobin,REP,136
+Charles Mix,11,State Senate,21,Mykala Voita,REP,128
+Charles Mix,12,State Senate,21,Erin Tobin,REP,19
+Charles Mix,12,State Senate,21,Mykala Voita,REP,5
+Charles Mix,13,State Senate,21,Erin Tobin,REP,4
+Charles Mix,13,State Senate,21,Mykala Voita,REP,5
+Charles Mix,01,State House,21,Lee Qualm,REP,50
+Charles Mix,01,State House,21,Marty Overweg,REP,70
+Charles Mix,01,State House,21,Jim Halverson,REP,31
+Charles Mix,02,State House,21,Lee Qualm,REP,12
+Charles Mix,02,State House,21,Marty Overweg,REP,17
+Charles Mix,02,State House,21,Jim Halverson,REP,4
+Charles Mix,03,State House,21,Lee Qualm,REP,37
+Charles Mix,03,State House,21,Marty Overweg,REP,31
+Charles Mix,03,State House,21,Jim Halverson,REP,23
+Charles Mix,04,State House,21,Lee Qualm,REP,17
+Charles Mix,04,State House,21,Marty Overweg,REP,21
+Charles Mix,04,State House,21,Jim Halverson,REP,9
+Charles Mix,05,State House,21,Lee Qualm,REP,29
+Charles Mix,05,State House,21,Marty Overweg,REP,35
+Charles Mix,05,State House,21,Jim Halverson,REP,21
+Charles Mix,06,State House,21,Lee Qualm,REP,10
+Charles Mix,06,State House,21,Marty Overweg,REP,16
+Charles Mix,06,State House,21,Jim Halverson,REP,7
+Charles Mix,07,State House,21,Lee Qualm,REP,18
+Charles Mix,07,State House,21,Marty Overweg,REP,29
+Charles Mix,07,State House,21,Jim Halverson,REP,13
+Charles Mix,08,State House,21,Lee Qualm,REP,26
+Charles Mix,08,State House,21,Marty Overweg,REP,44
+Charles Mix,08,State House,21,Jim Halverson,REP,20
+Charles Mix,09,State House,21,Lee Qualm,REP,72
+Charles Mix,09,State House,21,Marty Overweg,REP,151
+Charles Mix,09,State House,21,Jim Halverson,REP,67
+Charles Mix,10,State House,21,Lee Qualm,REP,44
+Charles Mix,10,State House,21,Marty Overweg,REP,47
+Charles Mix,10,State House,21,Jim Halverson,REP,14
+Charles Mix,11,State House,21,Lee Qualm,REP,119
+Charles Mix,11,State House,21,Marty Overweg,REP,244
+Charles Mix,11,State House,21,Jim Halverson,REP,118
+Charles Mix,12,State House,21,Lee Qualm,REP,10
+Charles Mix,12,State House,21,Marty Overweg,REP,16
+Charles Mix,12,State House,21,Jim Halverson,REP,7
+Charles Mix,13,State House,21,Lee Qualm,REP,6
+Charles Mix,13,State House,21,Marty Overweg,REP,7
+Charles Mix,13,State House,21,Jim Halverson,REP,3
+Charles Mix,05,County Commissioner,3,David M Spier,REP,3
+Charles Mix,05,County Commissioner,3,Kory Standy,REP,5
+Charles Mix,05,County Commissioner,3,Heath Knudson,REP,3
+Charles Mix,07,County Commissioner,3,David M Spier,REP,4
+Charles Mix,07,County Commissioner,3,Kory Standy,REP,13
+Charles Mix,07,County Commissioner,3,Heath Knudson,REP,11
+Charles Mix,08,County Commissioner,3,David M Spier,REP,9
+Charles Mix,08,County Commissioner,3,Kory Standy,REP,29
+Charles Mix,08,County Commissioner,3,Heath Knudson,REP,9
+Charles Mix,09,County Commissioner,3,David M Spier,REP,66
+Charles Mix,09,County Commissioner,3,Kory Standy,REP,75
+Charles Mix,09,County Commissioner,3,Heath Knudson,REP,23
+Charles Mix,10,County Commissioner,3,David M Spier,REP,38
+Charles Mix,10,County Commissioner,3,Kory Standy,REP,22
+Charles Mix,10,County Commissioner,3,Heath Knudson,REP,3
+Charles Mix,11,County Commissioner,3,David M Spier,REP,94
+Charles Mix,11,County Commissioner,3,Kory Standy,REP,116
+Charles Mix,11,County Commissioner,3,Heath Knudson,REP,40
+Charles Mix,12,County Commissioner,3,David M Spier,REP,0
+Charles Mix,12,County Commissioner,3,Kory Standy,REP,17
+Charles Mix,12,County Commissioner,3,Heath Knudson,REP,7

--- a/2024/counties/20240604__sd__primary__clark__precinct.csv
+++ b/2024/counties/20240604__sd__primary__clark__precinct.csv
@@ -1,0 +1,130 @@
+county,precinct,office,district,candidate,party,votes
+Clark,01,President,,Marianne Williamson,DEM,3
+Clark,01,President,,Joseph R Biden Jr,DEM,1
+Clark,01,President,,Dean Phillips,DEM,3
+Clark,01,President,,Armando Perez-Serrato,DEM,2
+Clark,02,President,,Marianne Williamson,DEM,2
+Clark,02,President,,Joseph R Biden Jr,DEM,1
+Clark,02,President,,Dean Phillips,DEM,1
+Clark,02,President,,Armando Perez-Serrato,DEM,0
+Clark,03,President,,Marianne Williamson,DEM,0
+Clark,03,President,,Joseph R Biden Jr,DEM,6
+Clark,03,President,,Dean Phillips,DEM,1
+Clark,03,President,,Armando Perez-Serrato,DEM,0
+Clark,04,President,,Marianne Williamson,DEM,1
+Clark,04,President,,Joseph R Biden Jr,DEM,1
+Clark,04,President,,Dean Phillips,DEM,0
+Clark,04,President,,Armando Perez-Serrato,DEM,0
+Clark,06,President,,Marianne Williamson,DEM,1
+Clark,06,President,,Joseph R Biden Jr,DEM,3
+Clark,06,President,,Dean Phillips,DEM,0
+Clark,06,President,,Armando Perez-Serrato,DEM,0
+Clark,07,President,,Marianne Williamson,DEM,1
+Clark,07,President,,Joseph R Biden Jr,DEM,0
+Clark,07,President,,Dean Phillips,DEM,2
+Clark,07,President,,Armando Perez-Serrato,DEM,0
+Clark,08,President,,Marianne Williamson,DEM,2
+Clark,08,President,,Joseph R Biden Jr,DEM,5
+Clark,08,President,,Dean Phillips,DEM,3
+Clark,08,President,,Armando Perez-Serrato,DEM,3
+Clark,09,President,,Marianne Williamson,DEM,1
+Clark,09,President,,Joseph R Biden Jr,DEM,7
+Clark,09,President,,Dean Phillips,DEM,0
+Clark,09,President,,Armando Perez-Serrato,DEM,0
+Clark,10,President,,Marianne Williamson,DEM,0
+Clark,10,President,,Joseph R Biden Jr,DEM,1
+Clark,10,President,,Dean Phillips,DEM,1
+Clark,10,President,,Armando Perez-Serrato,DEM,0
+Clark,11,President,,Marianne Williamson,DEM,1
+Clark,11,President,,Joseph R Biden Jr,DEM,5
+Clark,11,President,,Dean Phillips,DEM,3
+Clark,11,President,,Armando Perez-Serrato,DEM,0
+Clark,12,President,,Marianne Williamson,DEM,1
+Clark,12,President,,Joseph R Biden Jr,DEM,10
+Clark,12,President,,Dean Phillips,DEM,0
+Clark,12,President,,Armando Perez-Serrato,DEM,0
+Clark,13,President,,Marianne Williamson,DEM,2
+Clark,13,President,,Joseph R Biden Jr,DEM,4
+Clark,13,President,,Dean Phillips,DEM,1
+Clark,13,President,,Armando Perez-Serrato,DEM,1
+Clark,01,State House,04,Dylan C. Jordan,REP,11
+Clark,01,State House,04,Vanessa Namken,REP,14
+Clark,01,State House,04,Barbara Guenette,REP,9
+Clark,01,State House,04,Kent Roe,REP,24
+Clark,02,State House,04,Dylan C. Jordan,REP,14
+Clark,02,State House,04,Vanessa Namken,REP,15
+Clark,02,State House,04,Barbara Guenette,REP,5
+Clark,02,State House,04,Kent Roe,REP,14
+Clark,03,State House,04,Dylan C. Jordan,REP,2
+Clark,03,State House,04,Vanessa Namken,REP,3
+Clark,03,State House,04,Barbara Guenette,REP,2
+Clark,03,State House,04,Kent Roe,REP,2
+Clark,03,State House,22,Kevin Van Diepen,REP,7
+Clark,03,State House,22,Terry Nebelsick,REP,4
+Clark,03,State House,22,Lana Greenfield,REP,11
+Clark,04,State House,04,Dylan C. Jordan,REP,5
+Clark,04,State House,04,Vanessa Namken,REP,6
+Clark,04,State House,04,Barbara Guenette,REP,16
+Clark,04,State House,04,Kent Roe,REP,20
+Clark,06,State House,04,Dylan C. Jordan,REP,17
+Clark,06,State House,04,Vanessa Namken,REP,16
+Clark,06,State House,04,Barbara Guenette,REP,20
+Clark,06,State House,04,Kent Roe,REP,32
+Clark,07,State House,04,Dylan C. Jordan,REP,47
+Clark,07,State House,04,Vanessa Namken,REP,62
+Clark,07,State House,04,Barbara Guenette,REP,22
+Clark,07,State House,04,Kent Roe,REP,38
+Clark,08,State House,04,Dylan C. Jordan,REP,14
+Clark,08,State House,04,Vanessa Namken,REP,15
+Clark,08,State House,04,Barbara Guenette,REP,12
+Clark,08,State House,04,Kent Roe,REP,33
+Clark,09,State House,04,Dylan C. Jordan,REP,10
+Clark,09,State House,04,Vanessa Namken,REP,4
+Clark,09,State House,04,Barbara Guenette,REP,8
+Clark,09,State House,04,Kent Roe,REP,13
+Clark,09,State House,22,Kevin Van Diepen,REP,13
+Clark,09,State House,22,Terry Nebelsick,REP,16
+Clark,09,State House,22,Lana Greenfield,REP,7
+Clark,10,State House,04,Dylan C. Jordan,REP,4
+Clark,10,State House,04,Vanessa Namken,REP,4
+Clark,10,State House,04,Barbara Guenette,REP,4
+Clark,10,State House,04,Kent Roe,REP,12
+Clark,10,State House,22,Kevin Van Diepen,REP,0
+Clark,10,State House,22,Terry Nebelsick,REP,0
+Clark,10,State House,22,Lana Greenfield,REP,4
+Clark,11,State House,04,Dylan C. Jordan,REP,12
+Clark,11,State House,04,Vanessa Namken,REP,12
+Clark,11,State House,04,Barbara Guenette,REP,13
+Clark,11,State House,04,Kent Roe,REP,21
+Clark,12,State House,04,Dylan C. Jordan,REP,21
+Clark,12,State House,04,Vanessa Namken,REP,13
+Clark,12,State House,04,Barbara Guenette,REP,19
+Clark,12,State House,04,Kent Roe,REP,19
+Clark,13,State House,04,Dylan C. Jordan,REP,18
+Clark,13,State House,04,Vanessa Namken,REP,17
+Clark,13,State House,04,Barbara Guenette,REP,21
+Clark,13,State House,04,Kent Roe,REP,31
+Clark,01,State Senate,04,Fred Deutsch,REP,13
+Clark,01,State Senate,04,Stephanie Sauder,REP,21
+Clark,02,State Senate,04,Fred Deutsch,REP,14
+Clark,02,State Senate,04,Stephanie Sauder,REP,11
+Clark,03,State Senate,04,Fred Deutsch,REP,2
+Clark,03,State Senate,04,Stephanie Sauder,REP,3
+Clark,04,State Senate,04,Fred Deutsch,REP,16
+Clark,04,State Senate,04,Stephanie Sauder,REP,13
+Clark,06,State Senate,04,Fred Deutsch,REP,18
+Clark,06,State Senate,04,Stephanie Sauder,REP,30
+Clark,07,State Senate,04,Fred Deutsch,REP,55
+Clark,07,State Senate,04,Stephanie Sauder,REP,42
+Clark,08,State Senate,04,Fred Deutsch,REP,9
+Clark,08,State Senate,04,Stephanie Sauder,REP,37
+Clark,09,State Senate,04,Fred Deutsch,REP,6
+Clark,09,State Senate,04,Stephanie Sauder,REP,15
+Clark,10,State Senate,04,Fred Deutsch,REP,5
+Clark,10,State Senate,04,Stephanie Sauder,REP,11
+Clark,11,State Senate,04,Fred Deutsch,REP,14
+Clark,11,State Senate,04,Stephanie Sauder,REP,21
+Clark,12,State Senate,04,Fred Deutsch,REP,22
+Clark,12,State Senate,04,Stephanie Sauder,REP,17
+Clark,13,State Senate,04,Fred Deutsch,REP,15
+Clark,13,State Senate,04,Stephanie Sauder,REP,32

--- a/2024/counties/20240604__sd__primary__clay__precinct.csv
+++ b/2024/counties/20240604__sd__primary__clay__precinct.csv
@@ -1,0 +1,104 @@
+county,precinct,office,district,candidate,party,votes
+Clay,01,President,,Marianne Williamson,DEM,0
+Clay,01,President,,Joseph R Biden Jr,DEM,16
+Clay,01,President,,Dean Phillips,DEM,0
+Clay,01,President,,Armando Perez-Serrato,DEM,0
+Clay,02,President,,Marianne Williamson,DEM,0
+Clay,02,President,,Joseph R Biden Jr,DEM,14
+Clay,02,President,,Dean Phillips,DEM,1
+Clay,02,President,,Armando Perez-Serrato,DEM,0
+Clay,03,President,,Marianne Williamson,DEM,8
+Clay,03,President,,Joseph R Biden Jr,DEM,89
+Clay,03,President,,Dean Phillips,DEM,6
+Clay,03,President,,Armando Perez-Serrato,DEM,1
+Clay,C1 (Precinct-C2),President,,Marianne Williamson,DEM,4
+Clay,C1 (Precinct-C2),President,,Joseph R Biden Jr,DEM,120
+Clay,C1 (Precinct-C2),President,,Dean Phillips,DEM,5
+Clay,C1 (Precinct-C2),President,,Armando Perez-Serrato,DEM,5
+Clay,E1 (Precinct-E2),President,,Marianne Williamson,DEM,4
+Clay,E1 (Precinct-E2),President,,Joseph R Biden Jr,DEM,69
+Clay,E1 (Precinct-E2),President,,Dean Phillips,DEM,2
+Clay,E1 (Precinct-E2),President,,Armando Perez-Serrato,DEM,2
+Clay,S1,President,,Marianne Williamson,DEM,8
+Clay,S1,President,,Joseph R Biden Jr,DEM,178
+Clay,S1,President,,Dean Phillips,DEM,6
+Clay,S1,President,,Armando Perez-Serrato,DEM,0
+Clay,S2,President,,Marianne Williamson,DEM,3
+Clay,S2,President,,Joseph R Biden Jr,DEM,135
+Clay,S2,President,,Dean Phillips,DEM,4
+Clay,S2,President,,Armando Perez-Serrato,DEM,1
+Clay,W1 (Precinct-W2),President,,Marianne Williamson,DEM,17
+Clay,W1 (Precinct-W2),President,,Joseph R Biden Jr,DEM,169
+Clay,W1 (Precinct-W2),President,,Dean Phillips,DEM,8
+Clay,W1 (Precinct-W2),President,,Armando Perez-Serrato,DEM,4
+Clay,01,State Senate,17,Sydney Davis,REP,50
+Clay,01,State Senate,17,Jeffrey Church,REP,32
+Clay,02,State Senate,18,Lauren Nelson,REP,35
+Clay,02,State Senate,18,Jean M. Hunhoff,REP,16
+Clay,03,State Senate,17,Sydney Davis,REP,113
+Clay,03,State Senate,17,Jeffrey Church,REP,72
+Clay,C1 (Precinct-C2),State Senate,17,Sydney Davis,REP,15
+Clay,C1 (Precinct-C2),State Senate,17,Jeffrey Church,REP,15
+Clay,E1 (Precinct-E2),State Senate,17,Sydney Davis,REP,33
+Clay,E1 (Precinct-E2),State Senate,17,Jeffrey Church,REP,33
+Clay,S1,State Senate,17,Sydney Davis,REP,117
+Clay,S1,State Senate,17,Jeffrey Church,REP,35
+Clay,S2,State Senate,17,Sydney Davis,REP,61
+Clay,S2,State Senate,17,Jeffrey Church,REP,20
+Clay,W1 (Precinct-W2),State Senate,17,Sydney Davis,REP,97
+Clay,W1 (Precinct-W2),State Senate,17,Jeffrey Church,REP,43
+Clay,01,State House,17,William (Bill) Shorma,REP,54
+Clay,01,State House,17,Chris Kassin,REP,55
+Clay,01,State House,17,Robin J. Schiro,REP,12
+Clay,02,State House,18,Mike Stevens,REP,24
+Clay,02,State House,18,Julie Auch,REP,38
+Clay,02,State House,18,John R Marquardt,REP,14
+Clay,03,State House,17,William (Bill) Shorma,REP,115
+Clay,03,State House,17,Chris Kassin,REP,150
+Clay,03,State House,17,Robin J. Schiro,REP,34
+Clay,C1 (Precinct-C2),State House,17,William (Bill) Shorma,REP,19
+Clay,C1 (Precinct-C2),State House,17,Chris Kassin,REP,26
+Clay,C1 (Precinct-C2),State House,17,Robin J. Schiro,REP,5
+Clay,E1 (Precinct-E2),State House,17,William (Bill) Shorma,REP,43
+Clay,E1 (Precinct-E2),State House,17,Chris Kassin,REP,51
+Clay,E1 (Precinct-E2),State House,17,Robin J. Schiro,REP,9
+Clay,S1,State House,17,William (Bill) Shorma,REP,96
+Clay,S1,State House,17,Chris Kassin,REP,142
+Clay,S1,State House,17,Robin J. Schiro,REP,15
+Clay,S2,State House,17,William (Bill) Shorma,REP,52
+Clay,S2,State House,17,Chris Kassin,REP,78
+Clay,S2,State House,17,Robin J. Schiro,REP,6
+Clay,W1 (Precinct-W2),State House,17,William (Bill) Shorma,REP,88
+Clay,W1 (Precinct-W2),State House,17,Chris Kassin,REP,124
+Clay,W1 (Precinct-W2),State House,17,Robin J. Schiro,REP,18
+Clay,S1,Precinct Committeeman,S1,Jan Berkhout,REP,20
+Clay,S1,Precinct Committeeman,S1,Arthur Rusch,REP,122
+Clay,01,School Board Member Vermillion School,13-1,Michael Phelan,,5
+Clay,01,School Board Member Vermillion School,13-1,Corey L Thomason,,0
+Clay,01,School Board Member Vermillion School,13-1,Rachel E Olson,,8
+Clay,03,School Board Member Vermillion School,13-1,Michael Phelan,,115
+Clay,03,School Board Member Vermillion School,13-1,Corey L Thomason,,96
+Clay,03,School Board Member Vermillion School,13-1,Rachel E Olson,,221
+Clay,C1 (Precinct-C2),School Board Member Vermillion School,13-1,Michael Phelan,,134
+Clay,C1 (Precinct-C2),School Board Member Vermillion School,13-1,Corey L Thomason,,52
+Clay,C1 (Precinct-C2),School Board Member Vermillion School,13-1,Rachel E Olson,,97
+Clay,E1 (Precinct-E2),School Board Member Vermillion School,13-1,Michael Phelan,,84
+Clay,E1 (Precinct-E2),School Board Member Vermillion School,13-1,Corey L Thomason,,52
+Clay,E1 (Precinct-E2),School Board Member Vermillion School,13-1,Rachel E Olson,,102
+Clay,S1,School Board Member Vermillion School,13-1,Michael Phelan,,217
+Clay,S1,School Board Member Vermillion School,13-1,Corey L Thomason,,113
+Clay,S1,School Board Member Vermillion School,13-1,Rachel E Olson,,298
+Clay,S2,School Board Member Vermillion School,13-1,Michael Phelan,,140
+Clay,S2,School Board Member Vermillion School,13-1,Corey L Thomason,,52
+Clay,S2,School Board Member Vermillion School,13-1,Rachel E Olson,,182
+Clay,W1 (Precinct-W2),School Board Member Vermillion School,13-1,Michael Phelan,,187
+Clay,W1 (Precinct-W2),School Board Member Vermillion School,13-1,Corey L Thomason,,124
+Clay,W1 (Precinct-W2),School Board Member Vermillion School,13-1,Rachel E Olson,,239
+Clay,E1 (Precinct-E2),Alderman Vermillion Ward -SE,,Jay Thaler,,88
+Clay,E1 (Precinct-E2),Alderman Vermillion Ward -SE,,Ryan Church,,45
+Clay,S1,Alderman Vermillion Ward -NW,,Al Leber,,216
+Clay,S1,Alderman Vermillion Ward -SE,,Jeff Gilbertson,,175
+Clay,S2,Alderman Vermillion Ward -NW,,Al Leber,,154
+Clay,S2,Alderman Vermillion Ward -SE,,Jeff Gilbertson,,82
+Clay,W1 (Precinct-W2),Alderman Vermillion Ward -NW,,Brian Humphrey,,151
+Clay,W1 (Precinct-W2),Alderman Vermillion Ward -NW,,Gary Cheeseman,,217

--- a/2024/counties/20240604__sd__primary__corson__precinct.csv
+++ b/2024/counties/20240604__sd__primary__corson__precinct.csv
@@ -1,0 +1,73 @@
+county,precinct,office,district,candidate,party,votes
+Corson,Bullhead Precinct,President,,Marianne Williamson,DEM,1
+Corson,Bullhead Precinct,President,,Joseph R Biden Jr,DEM,8
+Corson,Bullhead Precinct,President,,Dean Phillips,DEM,0
+Corson,Bullhead Precinct,President,,Armando Perez-Serrato,DEM,0
+Corson,Kenel Precinct,President,,Marianne Williamson,DEM,3
+Corson,Kenel Precinct,President,,Joseph R Biden Jr,DEM,4
+Corson,Kenel Precinct,President,,Dean Phillips,DEM,1
+Corson,Kenel Precinct,President,,Armando Perez-Serrato,DEM,3
+Corson,Lincoln Precinct,President,,Marianne Williamson,DEM,1
+Corson,Lincoln Precinct,President,,Joseph R Biden Jr,DEM,5
+Corson,Lincoln Precinct,President,,Dean Phillips,DEM,1
+Corson,Lincoln Precinct,President,,Armando Perez-Serrato,DEM,0
+Corson,Little Eagle Precinct,President,,Marianne Williamson,DEM,5
+Corson,Little Eagle Precinct,President,,Joseph R Biden Jr,DEM,4
+Corson,Little Eagle Precinct,President,,Dean Phillips,DEM,0
+Corson,Little Eagle Precinct,President,,Armando Perez-Serrato,DEM,3
+Corson,McIntosh Precinct,President,,Marianne Williamson,DEM,1
+Corson,McIntosh Precinct,President,,Joseph R Biden Jr,DEM,0
+Corson,McIntosh Precinct,President,,Dean Phillips,DEM,0
+Corson,McIntosh Precinct,President,,Armando Perez-Serrato,DEM,0
+Corson,McLaughlin Precinct,President,,Marianne Williamson,DEM,4
+Corson,McLaughlin Precinct,President,,Joseph R Biden Jr,DEM,10
+Corson,McLaughlin Precinct,President,,Dean Phillips,DEM,0
+Corson,McLaughlin Precinct,President,,Armando Perez-Serrato,DEM,1
+Corson,Morristown Precinct,President,,Marianne Williamson,DEM,0
+Corson,Morristown Precinct,President,,Joseph R Biden Jr,DEM,3
+Corson,Morristown Precinct,President,,Dean Phillips,DEM,0
+Corson,Morristown Precinct,President,,Armando Perez-Serrato,DEM,0
+Corson,Ridgeland Precinct,President,,Marianne Williamson,DEM,1
+Corson,Ridgeland Precinct,President,,Joseph R Biden Jr,DEM,0
+Corson,Ridgeland Precinct,President,,Dean Phillips,DEM,2
+Corson,Ridgeland Precinct,President,,Armando Perez-Serrato,DEM,0
+Corson,Wakpala Precinct,President,,Marianne Williamson,DEM,6
+Corson,Wakpala Precinct,President,,Joseph R Biden Jr,DEM,20
+Corson,Wakpala Precinct,President,,Dean Phillips,DEM,6
+Corson,Wakpala Precinct,President,,Armando Perez-Serrato,DEM,2
+Corson,Bullhead Precinct,State Senate,28,Susan M. Peterson,REP,0
+Corson,Bullhead Precinct,State Senate,28,Sam Marty,REP,0
+Corson,Kenel Precinct,State Senate,28,Susan M. Peterson,REP,0
+Corson,Kenel Precinct,State Senate,28,Sam Marty,REP,1
+Corson,Lincoln Precinct,State Senate,28,Susan M. Peterson,REP,6
+Corson,Lincoln Precinct,State Senate,28,Sam Marty,REP,10
+Corson,Little Eagle Precinct,State Senate,28,Susan M. Peterson,REP,2
+Corson,Little Eagle Precinct,State Senate,28,Sam Marty,REP,4
+Corson,McIntosh Precinct,State Senate,28,Susan M. Peterson,REP,27
+Corson,McIntosh Precinct,State Senate,28,Sam Marty,REP,28
+Corson,McLaughlin Precinct,State Senate,28,Susan M. Peterson,REP,10
+Corson,McLaughlin Precinct,State Senate,28,Sam Marty,REP,6
+Corson,Morristown Precinct,State Senate,28,Susan M. Peterson,REP,7
+Corson,Morristown Precinct,State Senate,28,Sam Marty,REP,39
+Corson,Ridgeland Precinct,State Senate,28,Susan M. Peterson,REP,8
+Corson,Ridgeland Precinct,State Senate,28,Sam Marty,REP,9
+Corson,Wakpala Precinct,State Senate,28,Susan M. Peterson,REP,3
+Corson,Wakpala Precinct,State Senate,28,Sam Marty,REP,4
+Corson,Bullhead Precinct,State House,28A,Ryan Maher,REP,0
+Corson,Bullhead Precinct,State House,28A,Jana Hunt,REP,0
+Corson,Kenel Precinct,State House,28A,Ryan Maher,REP,0
+Corson,Kenel Precinct,State House,28A,Jana Hunt,REP,1
+Corson,Lincoln Precinct,State House,28A,Ryan Maher,REP,6
+Corson,Lincoln Precinct,State House,28A,Jana Hunt,REP,10
+Corson,Little Eagle Precinct,State House,28A,Ryan Maher,REP,3
+Corson,Little Eagle Precinct,State House,28A,Jana Hunt,REP,3
+Corson,McIntosh Precinct,State House,28A,Ryan Maher,REP,28
+Corson,McIntosh Precinct,State House,28A,Jana Hunt,REP,30
+Corson,McLaughlin Precinct,State House,28A,Ryan Maher,REP,8
+Corson,McLaughlin Precinct,State House,28A,Jana Hunt,REP,11
+Corson,Morristown Precinct,State House,28A,Ryan Maher,REP,10
+Corson,Morristown Precinct,State House,28A,Jana Hunt,REP,38
+Corson,Ridgeland Precinct,State House,28A,Ryan Maher,REP,12
+Corson,Ridgeland Precinct,State House,28A,Jana Hunt,REP,8
+Corson,Wakpala Precinct,State House,28A,Ryan Maher,REP,4
+Corson,Wakpala Precinct,State House,28A,Jana Hunt,REP,3

--- a/2024/counties/20240604__sd__primary__custer__precinct.csv
+++ b/2024/counties/20240604__sd__primary__custer__precinct.csv
@@ -1,0 +1,173 @@
+county,precinct,office,district,candidate,party,votes
+Custer,01,President,,Marianne Williamson,DEM,5
+Custer,01,President,,Joseph R Biden Jr,DEM,20
+Custer,01,President,,Dean Phillips,DEM,1
+Custer,01,President,,Armando Perez-Serrato,DEM,1
+Custer,02,President,,Marianne Williamson,DEM,1
+Custer,02,President,,Joseph R Biden Jr,DEM,5
+Custer,02,President,,Dean Phillips,DEM,1
+Custer,02,President,,Armando Perez-Serrato,DEM,0
+Custer,03,President,,Marianne Williamson,DEM,1
+Custer,03,President,,Joseph R Biden Jr,DEM,10
+Custer,03,President,,Dean Phillips,DEM,0
+Custer,03,President,,Armando Perez-Serrato,DEM,0
+Custer,04,President,,Marianne Williamson,DEM,2
+Custer,04,President,,Joseph R Biden Jr,DEM,13
+Custer,04,President,,Dean Phillips,DEM,1
+Custer,04,President,,Armando Perez-Serrato,DEM,2
+Custer,05,President,,Marianne Williamson,DEM,0
+Custer,05,President,,Joseph R Biden Jr,DEM,20
+Custer,05,President,,Dean Phillips,DEM,0
+Custer,05,President,,Armando Perez-Serrato,DEM,1
+Custer,06,President,,Marianne Williamson,DEM,8
+Custer,06,President,,Joseph R Biden Jr,DEM,37
+Custer,06,President,,Dean Phillips,DEM,2
+Custer,06,President,,Armando Perez-Serrato,DEM,1
+Custer,07,President,,Marianne Williamson,DEM,0
+Custer,07,President,,Joseph R Biden Jr,DEM,14
+Custer,07,President,,Dean Phillips,DEM,3
+Custer,07,President,,Armando Perez-Serrato,DEM,0
+Custer,08,President,,Marianne Williamson,DEM,2
+Custer,08,President,,Joseph R Biden Jr,DEM,38
+Custer,08,President,,Dean Phillips,DEM,2
+Custer,08,President,,Armando Perez-Serrato,DEM,0
+Custer,09,President,,Marianne Williamson,DEM,5
+Custer,09,President,,Joseph R Biden Jr,DEM,55
+Custer,09,President,,Dean Phillips,DEM,7
+Custer,09,President,,Armando Perez-Serrato,DEM,1
+Custer,10,President,,Marianne Williamson,DEM,1
+Custer,10,President,,Joseph R Biden Jr,DEM,6
+Custer,10,President,,Dean Phillips,DEM,3
+Custer,10,President,,Armando Perez-Serrato,DEM,0
+Custer,01,State Senate,30,Amber Hulse,REP,163
+Custer,01,State Senate,30,Forrest Foster,REP,50
+Custer,01,State Senate,30,Julie Frye-Mueller,REP,170
+Custer,02,State Senate,30,Amber Hulse,REP,13
+Custer,02,State Senate,30,Forrest Foster,REP,8
+Custer,02,State Senate,30,Julie Frye-Mueller,REP,39
+Custer,03,State Senate,30,Amber Hulse,REP,20
+Custer,03,State Senate,30,Forrest Foster,REP,8
+Custer,03,State Senate,30,Julie Frye-Mueller,REP,34
+Custer,04,State Senate,30,Amber Hulse,REP,107
+Custer,04,State Senate,30,Forrest Foster,REP,27
+Custer,04,State Senate,30,Julie Frye-Mueller,REP,89
+Custer,05,State Senate,30,Amber Hulse,REP,147
+Custer,05,State Senate,30,Forrest Foster,REP,20
+Custer,05,State Senate,30,Julie Frye-Mueller,REP,86
+Custer,06,State Senate,30,Amber Hulse,REP,63
+Custer,06,State Senate,30,Forrest Foster,REP,10
+Custer,06,State Senate,30,Julie Frye-Mueller,REP,43
+Custer,07,State Senate,30,Amber Hulse,REP,35
+Custer,07,State Senate,30,Forrest Foster,REP,6
+Custer,07,State Senate,30,Julie Frye-Mueller,REP,23
+Custer,08,State Senate,30,Amber Hulse,REP,96
+Custer,08,State Senate,30,Forrest Foster,REP,19
+Custer,08,State Senate,30,Julie Frye-Mueller,REP,63
+Custer,09,State Senate,30,Amber Hulse,REP,256
+Custer,09,State Senate,30,Forrest Foster,REP,44
+Custer,09,State Senate,30,Julie Frye-Mueller,REP,208
+Custer,10,State Senate,30,Amber Hulse,REP,30
+Custer,10,State Senate,30,Forrest Foster,REP,9
+Custer,10,State Senate,30,Julie Frye-Mueller,REP,33
+Custer,01,State House,30,Pat Baumann,REP,105
+Custer,01,State House,30,Matt Smith,REP,189
+Custer,01,State House,30,Trish Ladner,REP,133
+Custer,01,State House,30,Stephen Saint,REP,23
+Custer,01,State House,30,Tim Goodwin,REP,164
+Custer,01,State House,30,Matthew Monfore,REP,30
+Custer,02,State House,30,Pat Baumann,REP,9
+Custer,02,State House,30,Matt Smith,REP,39
+Custer,02,State House,30,Trish Ladner,REP,27
+Custer,02,State House,30,Stephen Saint,REP,8
+Custer,02,State House,30,Tim Goodwin,REP,23
+Custer,02,State House,30,Matthew Monfore,REP,4
+Custer,03,State House,30,Pat Baumann,REP,17
+Custer,03,State House,30,Matt Smith,REP,22
+Custer,03,State House,30,Trish Ladner,REP,29
+Custer,03,State House,30,Stephen Saint,REP,7
+Custer,03,State House,30,Tim Goodwin,REP,20
+Custer,03,State House,30,Matthew Monfore,REP,5
+Custer,04,State House,30,Pat Baumann,REP,93
+Custer,04,State House,30,Matt Smith,REP,72
+Custer,04,State House,30,Trish Ladner,REP,80
+Custer,04,State House,30,Stephen Saint,REP,27
+Custer,04,State House,30,Tim Goodwin,REP,78
+Custer,04,State House,30,Matthew Monfore,REP,22
+Custer,05,State House,30,Pat Baumann,REP,118
+Custer,05,State House,30,Matt Smith,REP,69
+Custer,05,State House,30,Trish Ladner,REP,101
+Custer,05,State House,30,Stephen Saint,REP,37
+Custer,05,State House,30,Tim Goodwin,REP,115
+Custer,05,State House,30,Matthew Monfore,REP,6
+Custer,06,State House,30,Pat Baumann,REP,67
+Custer,06,State House,30,Matt Smith,REP,32
+Custer,06,State House,30,Trish Ladner,REP,43
+Custer,06,State House,30,Stephen Saint,REP,13
+Custer,06,State House,30,Tim Goodwin,REP,46
+Custer,06,State House,30,Matthew Monfore,REP,3
+Custer,07,State House,30,Pat Baumann,REP,42
+Custer,07,State House,30,Matt Smith,REP,16
+Custer,07,State House,30,Trish Ladner,REP,23
+Custer,07,State House,30,Stephen Saint,REP,7
+Custer,07,State House,30,Tim Goodwin,REP,27
+Custer,07,State House,30,Matthew Monfore,REP,1
+Custer,08,State House,30,Pat Baumann,REP,92
+Custer,08,State House,30,Matt Smith,REP,42
+Custer,08,State House,30,Trish Ladner,REP,80
+Custer,08,State House,30,Stephen Saint,REP,25
+Custer,08,State House,30,Tim Goodwin,REP,78
+Custer,08,State House,30,Matthew Monfore,REP,7
+Custer,09,State House,30,Pat Baumann,REP,264
+Custer,09,State House,30,Matt Smith,REP,154
+Custer,09,State House,30,Trish Ladner,REP,213
+Custer,09,State House,30,Stephen Saint,REP,82
+Custer,09,State House,30,Tim Goodwin,REP,184
+Custer,09,State House,30,Matthew Monfore,REP,23
+Custer,10,State House,30,Pat Baumann,REP,38
+Custer,10,State House,30,Matt Smith,REP,28
+Custer,10,State House,30,Trish Ladner,REP,27
+Custer,10,State House,30,Stephen Saint,REP,6
+Custer,10,State House,30,Tim Goodwin,REP,26
+Custer,10,State House,30,Matthew Monfore,REP,3
+Custer,01,School Board Member Custer School,16-1,Jeffery L Prior,,108
+Custer,01,School Board Member Custer School,16-1,Heath Reindl,,195
+Custer,01,School Board Member Custer School,16-1,Jeff Barnes,,186
+Custer,02,School Board Member Custer School,16-1,Jeffery L Prior,,21
+Custer,02,School Board Member Custer School,16-1,Heath Reindl,,39
+Custer,02,School Board Member Custer School,16-1,Jeff Barnes,,36
+Custer,03,School Board Member Custer School,16-1,Jeffery L Prior,,0
+Custer,03,School Board Member Custer School,16-1,Heath Reindl,,7
+Custer,03,School Board Member Custer School,16-1,Jeff Barnes,,3
+Custer,04,School Board Member Custer School,16-1,Jeffery L Prior,,88
+Custer,04,School Board Member Custer School,16-1,Heath Reindl,,113
+Custer,04,School Board Member Custer School,16-1,Jeff Barnes,,88
+Custer,05,School Board Member Custer School,16-1,Jeffery L Prior,,142
+Custer,05,School Board Member Custer School,16-1,Heath Reindl,,148
+Custer,05,School Board Member Custer School,16-1,Jeff Barnes,,132
+Custer,06,School Board Member Custer School,16-1,Jeffery L Prior,,80
+Custer,06,School Board Member Custer School,16-1,Heath Reindl,,99
+Custer,06,School Board Member Custer School,16-1,Jeff Barnes,,104
+Custer,07,School Board Member Custer School,16-1,Jeffery L Prior,,43
+Custer,07,School Board Member Custer School,16-1,Heath Reindl,,46
+Custer,07,School Board Member Custer School,16-1,Jeff Barnes,,43
+Custer,08,School Board Member Custer School,16-1,Jeffery L Prior,,107
+Custer,08,School Board Member Custer School,16-1,Heath Reindl,,128
+Custer,08,School Board Member Custer School,16-1,Jeff Barnes,,121
+Custer,09,School Board Member Custer School,16-1,Jeffery L Prior,,289
+Custer,09,School Board Member Custer School,16-1,Heath Reindl,,325
+Custer,09,School Board Member Custer School,16-1,Jeff Barnes,,246
+Custer,10,School Board Member Custer School,16-1,Jeffery L Prior,,0
+Custer,10,School Board Member Custer School,16-1,Heath Reindl,,0
+Custer,10,School Board Member Custer School,16-1,Jeff Barnes,,2
+Custer,06,City Council Member,1,Bruce Miller,NPA,67
+Custer,06,City Council Member,1,Dixie Whittaker,NPA,97
+Custer,01,Trustee Hermosa,,Aaron Serviss,,50
+Custer,01,Trustee Hermosa,,Kelburn Koontz,,53
+Custer,1,State Senate,30,Amber Hulse,,1
+Custer,1,State House,30,Pat Baumann,,1
+Custer,1,State House,30,Tim Goodwin,,1
+Custer,1,School Board Member Custer School District,,Heath Reindl,,1
+Custer,9,State Senate,30,Amber Hulse,,1
+Custer,9,State House,30,Trish Ladner,,1
+Custer,9,State House,30,Stephen Saint,,1
+Custer,9,School Board Member Custer School District,,Jeff Barnes,,1

--- a/2024/counties/20240604__sd__primary__davison__precinct.csv
+++ b/2024/counties/20240604__sd__primary__davison__precinct.csv
@@ -1,0 +1,183 @@
+county,precinct,office,district,candidate,party,votes
+Davison,01,President,,Marianne Williamson,DEM,3
+Davison,01,President,,Joseph R Biden Jr,DEM,3
+Davison,01,President,,Dean Phillips,DEM,2
+Davison,01,President,,Armando Perez-Serrato,DEM,0
+Davison,02,President,,Marianne Williamson,DEM,1
+Davison,02,President,,Joseph R Biden Jr,DEM,5
+Davison,02,President,,Dean Phillips,DEM,2
+Davison,02,President,,Armando Perez-Serrato,DEM,1
+Davison,03,President,,Marianne Williamson,DEM,1
+Davison,03,President,,Joseph R Biden Jr,DEM,19
+Davison,03,President,,Dean Phillips,DEM,0
+Davison,03,President,,Armando Perez-Serrato,DEM,1
+Davison,04,President,,Marianne Williamson,DEM,0
+Davison,04,President,,Joseph R Biden Jr,DEM,13
+Davison,04,President,,Dean Phillips,DEM,1
+Davison,04,President,,Armando Perez-Serrato,DEM,1
+Davison,05,President,,Marianne Williamson,DEM,1
+Davison,05,President,,Joseph R Biden Jr,DEM,3
+Davison,05,President,,Dean Phillips,DEM,0
+Davison,05,President,,Armando Perez-Serrato,DEM,0
+Davison,06,President,,Marianne Williamson,DEM,1
+Davison,06,President,,Joseph R Biden Jr,DEM,68
+Davison,06,President,,Dean Phillips,DEM,3
+Davison,06,President,,Armando Perez-Serrato,DEM,4
+Davison,07,President,,Marianne Williamson,DEM,13
+Davison,07,President,,Joseph R Biden Jr,DEM,74
+Davison,07,President,,Dean Phillips,DEM,3
+Davison,07,President,,Armando Perez-Serrato,DEM,2
+Davison,08,President,,Marianne Williamson,DEM,8
+Davison,08,President,,Joseph R Biden Jr,DEM,49
+Davison,08,President,,Dean Phillips,DEM,5
+Davison,08,President,,Armando Perez-Serrato,DEM,3
+Davison,09,President,,Marianne Williamson,DEM,8
+Davison,09,President,,Joseph R Biden Jr,DEM,38
+Davison,09,President,,Dean Phillips,DEM,11
+Davison,09,President,,Armando Perez-Serrato,DEM,2
+Davison,10,President,,Marianne Williamson,DEM,6
+Davison,10,President,,Joseph R Biden Jr,DEM,56
+Davison,10,President,,Dean Phillips,DEM,5
+Davison,10,President,,Armando Perez-Serrato,DEM,2
+Davison,11,President,,Marianne Williamson,DEM,8
+Davison,11,President,,Joseph R Biden Jr,DEM,45
+Davison,11,President,,Dean Phillips,DEM,3
+Davison,11,President,,Armando Perez-Serrato,DEM,3
+Davison,12,President,,Marianne Williamson,DEM,7
+Davison,12,President,,Joseph R Biden Jr,DEM,55
+Davison,12,President,,Dean Phillips,DEM,5
+Davison,12,President,,Armando Perez-Serrato,DEM,3
+Davison,13,President,,Marianne Williamson,DEM,5
+Davison,13,President,,Joseph R Biden Jr,DEM,16
+Davison,13,President,,Dean Phillips,DEM,2
+Davison,13,President,,Armando Perez-Serrato,DEM,0
+Davison,14,President,,Marianne Williamson,DEM,8
+Davison,14,President,,Joseph R Biden Jr,DEM,41
+Davison,14,President,,Dean Phillips,DEM,4
+Davison,14,President,,Armando Perez-Serrato,DEM,1
+Davison,15,President,,Marianne Williamson,DEM,7
+Davison,15,President,,Joseph R Biden Jr,DEM,77
+Davison,15,President,,Dean Phillips,DEM,11
+Davison,15,President,,Armando Perez-Serrato,DEM,3
+Davison,16,President,,Marianne Williamson,DEM,11
+Davison,16,President,,Joseph R Biden Jr,DEM,43
+Davison,16,President,,Dean Phillips,DEM,6
+Davison,16,President,,Armando Perez-Serrato,DEM,2
+Davison,18,President,,Marianne Williamson,DEM,6
+Davison,18,President,,Joseph R Biden Jr,DEM,39
+Davison,18,President,,Dean Phillips,DEM,3
+Davison,18,President,,Armando Perez-Serrato,DEM,5
+Davison,19,President,,Marianne Williamson,DEM,7
+Davison,19,President,,Joseph R Biden Jr,DEM,61
+Davison,19,President,,Dean Phillips,DEM,14
+Davison,19,President,,Armando Perez-Serrato,DEM,3
+Davison,20,President,,Marianne Williamson,DEM,11
+Davison,20,President,,Joseph R Biden Jr,DEM,91
+Davison,20,President,,Dean Phillips,DEM,12
+Davison,20,President,,Armando Perez-Serrato,DEM,3
+Davison,06,Precinct Committeeman,06,Boyd A Reimnitz,REP,44
+Davison,06,Precinct Committeeman,06,Michael Vehle,REP,235
+Davison,13,Precinct Committeeman,13,Larry A Mathis,REP,36
+Davison,13,Precinct Committeeman,13,Mike Lauritsen,REP,31
+Davison,06,Precinct Committeewoman,,Tona Rozum,REP,230
+Davison,06,Precinct Committeewoman,,Kay Reimnitz,REP,36
+Davison,06,Mayor City of Mitchell,,Bob Everson,,139
+Davison,06,Mayor City of Mitchell,,Jordan Hanson,,101
+Davison,06,Mayor City of Mitchell,,Terry Sabers,,206
+Davison,07,Mayor City of Mitchell,,Bob Everson,,85
+Davison,07,Mayor City of Mitchell,,Jordan Hanson,,97
+Davison,07,Mayor City of Mitchell,,Terry Sabers,,225
+Davison,08,Mayor City of Mitchell,,Bob Everson,,53
+Davison,08,Mayor City of Mitchell,,Jordan Hanson,,144
+Davison,08,Mayor City of Mitchell,,Terry Sabers,,108
+Davison,09,Mayor City of Mitchell,,Bob Everson,,34
+Davison,09,Mayor City of Mitchell,,Jordan Hanson,,172
+Davison,09,Mayor City of Mitchell,,Terry Sabers,,57
+Davison,10,Mayor City of Mitchell,,Bob Everson,,48
+Davison,10,Mayor City of Mitchell,,Jordan Hanson,,149
+Davison,10,Mayor City of Mitchell,,Terry Sabers,,84
+Davison,11,Mayor City of Mitchell,,Bob Everson,,63
+Davison,11,Mayor City of Mitchell,,Jordan Hanson,,95
+Davison,11,Mayor City of Mitchell,,Terry Sabers,,108
+Davison,12,Mayor City of Mitchell,,Bob Everson,,61
+Davison,12,Mayor City of Mitchell,,Jordan Hanson,,111
+Davison,12,Mayor City of Mitchell,,Terry Sabers,,148
+Davison,13,Mayor City of Mitchell,,Bob Everson,,24
+Davison,13,Mayor City of Mitchell,,Jordan Hanson,,46
+Davison,13,Mayor City of Mitchell,,Terry Sabers,,53
+Davison,14,Mayor City of Mitchell,,Bob Everson,,29
+Davison,14,Mayor City of Mitchell,,Jordan Hanson,,131
+Davison,14,Mayor City of Mitchell,,Terry Sabers,,72
+Davison,15,Mayor City of Mitchell,,Bob Everson,,68
+Davison,15,Mayor City of Mitchell,,Jordan Hanson,,183
+Davison,15,Mayor City of Mitchell,,Terry Sabers,,211
+Davison,16,Mayor City of Mitchell,,Bob Everson,,32
+Davison,16,Mayor City of Mitchell,,Jordan Hanson,,108
+Davison,16,Mayor City of Mitchell,,Terry Sabers,,69
+Davison,18,Mayor City of Mitchell,,Bob Everson,,40
+Davison,18,Mayor City of Mitchell,,Jordan Hanson,,100
+Davison,18,Mayor City of Mitchell,,Terry Sabers,,61
+Davison,19,Mayor City of Mitchell,,Bob Everson,,43
+Davison,19,Mayor City of Mitchell,,Jordan Hanson,,154
+Davison,19,Mayor City of Mitchell,,Terry Sabers,,91
+Davison,20,Mayor City of Mitchell,,Bob Everson,,82
+Davison,20,Mayor City of Mitchell,,Jordan Hanson,,190
+Davison,20,Mayor City of Mitchell,,Terry Sabers,,231
+Davison,06,Alderman Mitchell Ward,004,Don Everson,NPA,105
+Davison,06,Alderman Mitchell Ward,004,Montana Walcott,NPA,23
+Davison,06,Alderman Mitchell Ward,004,Jeff Smith,NPA,312
+Davison,07,Alderman Mitchell Ward,004,Don Everson,NPA,152
+Davison,07,Alderman Mitchell Ward,004,Montana Walcott,NPA,21
+Davison,07,Alderman Mitchell Ward,004,Jeff Smith,NPA,227
+Davison,08,Alderman Mitchell Ward,004,Don Everson,NPA,139
+Davison,08,Alderman Mitchell Ward,004,Montana Walcott,NPA,32
+Davison,08,Alderman Mitchell Ward,004,Jeff Smith,NPA,116
+Davison,09,Alderman Mitchell Ward,004,Don Everson,NPA,144
+Davison,09,Alderman Mitchell Ward,004,Montana Walcott,NPA,37
+Davison,09,Alderman Mitchell Ward,004,Jeff Smith,NPA,67
+Davison,10,Alderman Mitchell Ward,001,Dan Sabers,NPA,96
+Davison,10,Alderman Mitchell Ward,001,Sarah Deakins,NPA,127
+Davison,10,Alderman Mitchell Ward,001,Jesse Stroud,NPA,50
+Davison,11,Alderman Mitchell Ward,001,Dan Sabers,NPA,118
+Davison,11,Alderman Mitchell Ward,001,Sarah Deakins,NPA,101
+Davison,11,Alderman Mitchell Ward,001,Jesse Stroud,NPA,30
+Davison,12,Alderman Mitchell Ward,001,Dan Sabers,NPA,158
+Davison,12,Alderman Mitchell Ward,001,Sarah Deakins,NPA,108
+Davison,12,Alderman Mitchell Ward,001,Jesse Stroud,NPA,29
+Davison,13,Alderman Mitchell Ward,001,Dan Sabers,NPA,76
+Davison,13,Alderman Mitchell Ward,001,Sarah Deakins,NPA,26
+Davison,13,Alderman Mitchell Ward,001,Jesse Stroud,NPA,13
+Davison,14,Alderman Mitchell Ward,002,Shaun Davis,NPA,103
+Davison,14,Alderman Mitchell Ward,002,Kevin Mccardle,NPA,110
+Davison,15,Alderman Mitchell Ward,002,Shaun Davis,NPA,173
+Davison,15,Alderman Mitchell Ward,002,Kevin Mccardle,NPA,271
+Davison,16,Alderman Mitchell Ward,002,Shaun Davis,NPA,91
+Davison,16,Alderman Mitchell Ward,002,Kevin Mccardle,NPA,108
+Davison,06,Bond Issue : City Of Mitchell,,Yes,,356
+Davison,06,Bond Issue : City Of Mitchell,,No,,92
+Davison,07,Bond Issue : City Of Mitchell,,Yes,,240
+Davison,07,Bond Issue : City Of Mitchell,,No,,170
+Davison,08,Bond Issue : City Of Mitchell,,Yes,,132
+Davison,08,Bond Issue : City Of Mitchell,,No,,175
+Davison,09,Bond Issue : City Of Mitchell,,Yes,,89
+Davison,09,Bond Issue : City Of Mitchell,,No,,171
+Davison,10,Bond Issue : City Of Mitchell,,Yes,,131
+Davison,10,Bond Issue : City Of Mitchell,,No,,155
+Davison,11,Bond Issue : City Of Mitchell,,Yes,,142
+Davison,11,Bond Issue : City Of Mitchell,,No,,126
+Davison,12,Bond Issue : City Of Mitchell,,Yes,,147
+Davison,12,Bond Issue : City Of Mitchell,,No,,174
+Davison,13,Bond Issue : City Of Mitchell,,Yes,,68
+Davison,13,Bond Issue : City Of Mitchell,,No,,55
+Davison,14,Bond Issue : City Of Mitchell,,Yes,,87
+Davison,14,Bond Issue : City Of Mitchell,,No,,145
+Davison,15,Bond Issue : City Of Mitchell,,Yes,,214
+Davison,15,Bond Issue : City Of Mitchell,,No,,250
+Davison,16,Bond Issue : City Of Mitchell,,Yes,,83
+Davison,16,Bond Issue : City Of Mitchell,,No,,127
+Davison,18,Bond Issue : City Of Mitchell,,Yes,,104
+Davison,18,Bond Issue : City Of Mitchell,,No,,101
+Davison,19,Bond Issue : City Of Mitchell,,Yes,,122
+Davison,19,Bond Issue : City Of Mitchell,,No,,164
+Davison,20,Bond Issue : City Of Mitchell,,Yes,,262
+Davison,20,Bond Issue : City Of Mitchell,,No,,242

--- a/2024/counties/20240604__sd__primary__day__precinct.csv
+++ b/2024/counties/20240604__sd__primary__day__precinct.csv
@@ -1,0 +1,82 @@
+county,precinct,office,district,candidate,party,votes
+Day,01,President,,Marianne Williamson,DEM,4
+Day,01,President,,Joseph R Biden Jr,DEM,14
+Day,01,President,,Dean Phillips,DEM,1
+Day,01,President,,Armando Perez-Serrato,DEM,0
+Day,02,President,,Marianne Williamson,DEM,0
+Day,02,President,,Joseph R Biden Jr,DEM,7
+Day,02,President,,Dean Phillips,DEM,1
+Day,02,President,,Armando Perez-Serrato,DEM,0
+Day,03,President,,Marianne Williamson,DEM,0
+Day,03,President,,Joseph R Biden Jr,DEM,13
+Day,03,President,,Dean Phillips,DEM,2
+Day,03,President,,Armando Perez-Serrato,DEM,0
+Day,04,President,,Marianne Williamson,DEM,5
+Day,04,President,,Joseph R Biden Jr,DEM,17
+Day,04,President,,Dean Phillips,DEM,0
+Day,04,President,,Armando Perez-Serrato,DEM,1
+Day,05,President,,Marianne Williamson,DEM,0
+Day,05,President,,Joseph R Biden Jr,DEM,25
+Day,05,President,,Dean Phillips,DEM,1
+Day,05,President,,Armando Perez-Serrato,DEM,0
+Day,06,President,,Marianne Williamson,DEM,2
+Day,06,President,,Joseph R Biden Jr,DEM,2
+Day,06,President,,Dean Phillips,DEM,1
+Day,06,President,,Armando Perez-Serrato,DEM,0
+Day,07,President,,Marianne Williamson,DEM,3
+Day,07,President,,Joseph R Biden Jr,DEM,9
+Day,07,President,,Dean Phillips,DEM,5
+Day,07,President,,Armando Perez-Serrato,DEM,2
+Day,08,President,,Marianne Williamson,DEM,0
+Day,08,President,,Joseph R Biden Jr,DEM,13
+Day,08,President,,Dean Phillips,DEM,3
+Day,08,President,,Armando Perez-Serrato,DEM,0
+Day,09,President,,Marianne Williamson,DEM,0
+Day,09,President,,Joseph R Biden Jr,DEM,4
+Day,09,President,,Dean Phillips,DEM,2
+Day,09,President,,Armando Perez-Serrato,DEM,0
+Day,10,President,,Marianne Williamson,DEM,2
+Day,10,President,,Joseph R Biden Jr,DEM,0
+Day,10,President,,Dean Phillips,DEM,0
+Day,10,President,,Armando Perez-Serrato,DEM,0
+Day,11,President,,Marianne Williamson,DEM,1
+Day,11,President,,Joseph R Biden Jr,DEM,15
+Day,11,President,,Dean Phillips,DEM,5
+Day,11,President,,Armando Perez-Serrato,DEM,1
+Day,01,State House,01,Logan Manhart,REP,17
+Day,01,State House,01,Tamara St John,REP,28
+Day,01,State House,01,Christopher Reder,REP,21
+Day,02,State House,01,Logan Manhart,REP,25
+Day,02,State House,01,Tamara St John,REP,27
+Day,02,State House,01,Christopher Reder,REP,18
+Day,03,State House,01,Logan Manhart,REP,29
+Day,03,State House,01,Tamara St John,REP,35
+Day,03,State House,01,Christopher Reder,REP,24
+Day,04,State House,01,Logan Manhart,REP,27
+Day,04,State House,01,Tamara St John,REP,39
+Day,04,State House,01,Christopher Reder,REP,23
+Day,05,State House,01,Logan Manhart,REP,45
+Day,05,State House,01,Tamara St John,REP,52
+Day,05,State House,01,Christopher Reder,REP,33
+Day,06,State House,01,Logan Manhart,REP,21
+Day,06,State House,01,Tamara St John,REP,12
+Day,06,State House,01,Christopher Reder,REP,14
+Day,07,State House,01,Logan Manhart,REP,16
+Day,07,State House,01,Tamara St John,REP,23
+Day,07,State House,01,Christopher Reder,REP,19
+Day,08,State House,01,Logan Manhart,REP,23
+Day,08,State House,01,Tamara St John,REP,9
+Day,08,State House,01,Christopher Reder,REP,24
+Day,09,State House,01,Logan Manhart,REP,16
+Day,09,State House,01,Tamara St John,REP,4
+Day,09,State House,01,Christopher Reder,REP,10
+Day,10,State House,01,Logan Manhart,REP,8
+Day,10,State House,01,Tamara St John,REP,2
+Day,10,State House,01,Christopher Reder,REP,7
+Day,11,State House,01,Logan Manhart,REP,30
+Day,11,State House,01,Tamara St John,REP,19
+Day,11,State House,01,Christopher Reder,REP,28
+Day,04,County Commissioner,4,Roy Aldrich,REP,34
+Day,04,County Commissioner,4,Jim Walter,REP,24
+Day,05,County Commissioner,4,Roy Aldrich,REP,68
+Day,05,County Commissioner,4,Jim Walter,REP,29

--- a/2024/counties/20240604__sd__primary__deuel__precinct.csv
+++ b/2024/counties/20240604__sd__primary__deuel__precinct.csv
@@ -1,0 +1,101 @@
+county,precinct,office,district,candidate,party,votes
+Deuel,01,President,,Marianne Williamson,DEM,0
+Deuel,01,President,,Joseph R Biden Jr,DEM,2
+Deuel,01,President,,Dean Phillips,DEM,1
+Deuel,01,President,,Armando Perez-Serrato,DEM,1
+Deuel,03,President,,Marianne Williamson,DEM,1
+Deuel,03,President,,Joseph R Biden Jr,DEM,3
+Deuel,03,President,,Dean Phillips,DEM,0
+Deuel,03,President,,Armando Perez-Serrato,DEM,1
+Deuel,04,President,,Marianne Williamson,DEM,2
+Deuel,04,President,,Joseph R Biden Jr,DEM,7
+Deuel,04,President,,Dean Phillips,DEM,2
+Deuel,04,President,,Armando Perez-Serrato,DEM,1
+Deuel,05,President,,Marianne Williamson,DEM,0
+Deuel,05,President,,Joseph R Biden Jr,DEM,6
+Deuel,05,President,,Dean Phillips,DEM,1
+Deuel,05,President,,Armando Perez-Serrato,DEM,0
+Deuel,06,President,,Marianne Williamson,DEM,1
+Deuel,06,President,,Joseph R Biden Jr,DEM,3
+Deuel,06,President,,Dean Phillips,DEM,1
+Deuel,06,President,,Armando Perez-Serrato,DEM,0
+Deuel,07,President,,Marianne Williamson,DEM,1
+Deuel,07,President,,Joseph R Biden Jr,DEM,0
+Deuel,07,President,,Dean Phillips,DEM,2
+Deuel,07,President,,Armando Perez-Serrato,DEM,1
+Deuel,08,President,,Marianne Williamson,DEM,1
+Deuel,08,President,,Joseph R Biden Jr,DEM,9
+Deuel,08,President,,Dean Phillips,DEM,2
+Deuel,08,President,,Armando Perez-Serrato,DEM,1
+Deuel,09,President,,Marianne Williamson,DEM,0
+Deuel,09,President,,Joseph R Biden Jr,DEM,5
+Deuel,09,President,,Dean Phillips,DEM,0
+Deuel,09,President,,Armando Perez-Serrato,DEM,0
+Deuel,10,President,,Marianne Williamson,DEM,1
+Deuel,10,President,,Joseph R Biden Jr,DEM,2
+Deuel,10,President,,Dean Phillips,DEM,0
+Deuel,10,President,,Armando Perez-Serrato,DEM,0
+Deuel,11,President,,Marianne Williamson,DEM,1
+Deuel,11,President,,Joseph R Biden Jr,DEM,4
+Deuel,11,President,,Dean Phillips,DEM,2
+Deuel,11,President,,Armando Perez-Serrato,DEM,0
+Deuel,01,State Senate,04,Fred Deutsch,REP,18
+Deuel,01,State Senate,04,Stephanie Sauder,REP,12
+Deuel,03,State Senate,04,Fred Deutsch,REP,22
+Deuel,03,State Senate,04,Stephanie Sauder,REP,17
+Deuel,04,State Senate,04,Fred Deutsch,REP,13
+Deuel,04,State Senate,04,Stephanie Sauder,REP,9
+Deuel,05,State Senate,04,Fred Deutsch,REP,25
+Deuel,05,State Senate,04,Stephanie Sauder,REP,15
+Deuel,06,State Senate,04,Fred Deutsch,REP,32
+Deuel,06,State Senate,04,Stephanie Sauder,REP,21
+Deuel,07,State Senate,04,Fred Deutsch,REP,37
+Deuel,07,State Senate,04,Stephanie Sauder,REP,21
+Deuel,08,State Senate,04,Fred Deutsch,REP,62
+Deuel,08,State Senate,04,Stephanie Sauder,REP,24
+Deuel,09,State Senate,04,Fred Deutsch,REP,45
+Deuel,09,State Senate,04,Stephanie Sauder,REP,27
+Deuel,10,State Senate,04,Fred Deutsch,REP,17
+Deuel,10,State Senate,04,Stephanie Sauder,REP,20
+Deuel,11,State Senate,04,Fred Deutsch,REP,23
+Deuel,11,State Senate,04,Stephanie Sauder,REP,12
+Deuel,01,State House,04,Dylan C. Jordan,REP,13
+Deuel,01,State House,04,Vanessa Namken,REP,13
+Deuel,01,State House,04,Barbara Guenette,REP,9
+Deuel,01,State House,04,Kent Roe,REP,16
+Deuel,03,State House,04,Dylan C. Jordan,REP,22
+Deuel,03,State House,04,Vanessa Namken,REP,18
+Deuel,03,State House,04,Barbara Guenette,REP,13
+Deuel,03,State House,04,Kent Roe,REP,20
+Deuel,04,State House,04,Dylan C. Jordan,REP,12
+Deuel,04,State House,04,Vanessa Namken,REP,10
+Deuel,04,State House,04,Barbara Guenette,REP,5
+Deuel,04,State House,04,Kent Roe,REP,12
+Deuel,05,State House,04,Dylan C. Jordan,REP,29
+Deuel,05,State House,04,Vanessa Namken,REP,20
+Deuel,05,State House,04,Barbara Guenette,REP,9
+Deuel,05,State House,04,Kent Roe,REP,14
+Deuel,06,State House,04,Dylan C. Jordan,REP,32
+Deuel,06,State House,04,Vanessa Namken,REP,26
+Deuel,06,State House,04,Barbara Guenette,REP,15
+Deuel,06,State House,04,Kent Roe,REP,24
+Deuel,07,State House,04,Dylan C. Jordan,REP,34
+Deuel,07,State House,04,Vanessa Namken,REP,29
+Deuel,07,State House,04,Barbara Guenette,REP,13
+Deuel,07,State House,04,Kent Roe,REP,22
+Deuel,08,State House,04,Dylan C. Jordan,REP,53
+Deuel,08,State House,04,Vanessa Namken,REP,48
+Deuel,08,State House,04,Barbara Guenette,REP,20
+Deuel,08,State House,04,Kent Roe,REP,35
+Deuel,09,State House,04,Dylan C. Jordan,REP,44
+Deuel,09,State House,04,Vanessa Namken,REP,38
+Deuel,09,State House,04,Barbara Guenette,REP,15
+Deuel,09,State House,04,Kent Roe,REP,25
+Deuel,10,State House,04,Dylan C. Jordan,REP,8
+Deuel,10,State House,04,Vanessa Namken,REP,8
+Deuel,10,State House,04,Barbara Guenette,REP,20
+Deuel,10,State House,04,Kent Roe,REP,28
+Deuel,11,State House,04,Dylan C. Jordan,REP,16
+Deuel,11,State House,04,Vanessa Namken,REP,13
+Deuel,11,State House,04,Barbara Guenette,REP,10
+Deuel,11,State House,04,Kent Roe,REP,21

--- a/2024/counties/20240604__sd__primary__dewey__precinct.csv
+++ b/2024/counties/20240604__sd__primary__dewey__precinct.csv
@@ -1,0 +1,89 @@
+county,precinct,office,district,candidate,party,votes
+Dewey,02 Trail City,President,,Marianne Williamson,DEM,1
+Dewey,02 Trail City,President,,Joseph R Biden Jr,DEM,0
+Dewey,02 Trail City,President,,Dean Phillips,DEM,0
+Dewey,02 Trail City,President,,Armando Perez-Serrato,DEM,0
+Dewey,04 Timber Lake,President,,Marianne Williamson,DEM,24
+Dewey,04 Timber Lake,President,,Joseph R Biden Jr,DEM,25
+Dewey,04 Timber Lake,President,,Dean Phillips,DEM,13
+Dewey,04 Timber Lake,President,,Armando Perez-Serrato,DEM,5
+Dewey,05 Firesteel,President,,Marianne Williamson,DEM,0
+Dewey,05 Firesteel,President,,Joseph R Biden Jr,DEM,2
+Dewey,05 Firesteel,President,,Dean Phillips,DEM,1
+Dewey,05 Firesteel,President,,Armando Perez-Serrato,DEM,1
+Dewey,06 Isabel,President,,Marianne Williamson,DEM,1
+Dewey,06 Isabel,President,,Joseph R Biden Jr,DEM,4
+Dewey,06 Isabel,President,,Dean Phillips,DEM,1
+Dewey,06 Isabel,President,,Armando Perez-Serrato,DEM,1
+Dewey,07 Eagle Butte East,President,,Marianne Williamson,DEM,0
+Dewey,07 Eagle Butte East,President,,Joseph R Biden Jr,DEM,15
+Dewey,07 Eagle Butte East,President,,Dean Phillips,DEM,1
+Dewey,07 Eagle Butte East,President,,Armando Perez-Serrato,DEM,2
+Dewey,08 White Horse,President,,Marianne Williamson,DEM,2
+Dewey,08 White Horse,President,,Joseph R Biden Jr,DEM,10
+Dewey,08 White Horse,President,,Dean Phillips,DEM,2
+Dewey,08 White Horse,President,,Armando Perez-Serrato,DEM,0
+Dewey,09 Promise,President,,Marianne Williamson,DEM,1
+Dewey,09 Promise,President,,Joseph R Biden Jr,DEM,15
+Dewey,09 Promise,President,,Dean Phillips,DEM,2
+Dewey,09 Promise,President,,Armando Perez-Serrato,DEM,1
+Dewey,11 Swiftbird/LaPlant,President,,Marianne Williamson,DEM,0
+Dewey,11 Swiftbird/LaPlant,President,,Joseph R Biden Jr,DEM,1
+Dewey,11 Swiftbird/LaPlant,President,,Dean Phillips,DEM,0
+Dewey,11 Swiftbird/LaPlant,President,,Armando Perez-Serrato,DEM,0
+Dewey,12 Eagle Butte North (Precinct-13 Eagle Butte North),President,,Marianne Williamson,DEM,0
+Dewey,12 Eagle Butte North (Precinct-13 Eagle Butte North),President,,Joseph R Biden Jr,DEM,13
+Dewey,12 Eagle Butte North (Precinct-13 Eagle Butte North),President,,Dean Phillips,DEM,0
+Dewey,12 Eagle Butte North (Precinct-13 Eagle Butte North),President,,Armando Perez-Serrato,DEM,0
+Dewey,14 Eagle Butte South,President,,Marianne Williamson,DEM,6
+Dewey,14 Eagle Butte South,President,,Joseph R Biden Jr,DEM,18
+Dewey,14 Eagle Butte South,President,,Dean Phillips,DEM,3
+Dewey,14 Eagle Butte South,President,,Armando Perez-Serrato,DEM,2
+Dewey,15 Eagle Butte West,President,,Marianne Williamson,DEM,3
+Dewey,15 Eagle Butte West,President,,Joseph R Biden Jr,DEM,9
+Dewey,15 Eagle Butte West,President,,Dean Phillips,DEM,0
+Dewey,15 Eagle Butte West,President,,Armando Perez-Serrato,DEM,1
+Dewey,02 Trail City,State Senate,28,Susan M. Peterson,REP,12
+Dewey,02 Trail City,State Senate,28,Sam Marty,REP,7
+Dewey,04 Timber Lake,State Senate,28,Susan M. Peterson,REP,59
+Dewey,04 Timber Lake,State Senate,28,Sam Marty,REP,26
+Dewey,05 Firesteel,State Senate,28,Susan M. Peterson,REP,10
+Dewey,05 Firesteel,State Senate,28,Sam Marty,REP,9
+Dewey,06 Isabel,State Senate,28,Susan M. Peterson,REP,33
+Dewey,06 Isabel,State Senate,28,Sam Marty,REP,21
+Dewey,07 Eagle Butte East,State Senate,28,Susan M. Peterson,REP,3
+Dewey,07 Eagle Butte East,State Senate,28,Sam Marty,REP,1
+Dewey,08 White Horse,State Senate,28,Susan M. Peterson,REP,1
+Dewey,08 White Horse,State Senate,28,Sam Marty,REP,2
+Dewey,09 Promise,State Senate,28,Susan M. Peterson,REP,5
+Dewey,09 Promise,State Senate,28,Sam Marty,REP,2
+Dewey,11 Swiftbird/LaPlant,State Senate,28,Susan M. Peterson,REP,0
+Dewey,11 Swiftbird/LaPlant,State Senate,28,Sam Marty,REP,2
+Dewey,12 Eagle Butte North (Precinct-13 Eagle Butte North),State Senate,28,Susan M. Peterson,REP,10
+Dewey,12 Eagle Butte North (Precinct-13 Eagle Butte North),State Senate,28,Sam Marty,REP,8
+Dewey,14 Eagle Butte South,State Senate,28,Susan M. Peterson,REP,4
+Dewey,14 Eagle Butte South,State Senate,28,Sam Marty,REP,8
+Dewey,15 Eagle Butte West,State Senate,28,Susan M. Peterson,REP,7
+Dewey,15 Eagle Butte West,State Senate,28,Sam Marty,REP,6
+Dewey,02 Trail City,State House,28A,Ryan Maher,REP,7
+Dewey,02 Trail City,State House,28A,Jana Hunt,REP,14
+Dewey,04 Timber Lake,State House,28A,Ryan Maher,REP,71
+Dewey,04 Timber Lake,State House,28A,Jana Hunt,REP,26
+Dewey,05 Firesteel,State House,28A,Ryan Maher,REP,13
+Dewey,05 Firesteel,State House,28A,Jana Hunt,REP,7
+Dewey,06 Isabel,State House,28A,Ryan Maher,REP,41
+Dewey,06 Isabel,State House,28A,Jana Hunt,REP,20
+Dewey,07 Eagle Butte East,State House,28A,Ryan Maher,REP,2
+Dewey,07 Eagle Butte East,State House,28A,Jana Hunt,REP,3
+Dewey,08 White Horse,State House,28A,Ryan Maher,REP,3
+Dewey,08 White Horse,State House,28A,Jana Hunt,REP,3
+Dewey,09 Promise,State House,28A,Ryan Maher,REP,4
+Dewey,09 Promise,State House,28A,Jana Hunt,REP,5
+Dewey,11 Swiftbird/LaPlant,State House,28A,Ryan Maher,REP,2
+Dewey,11 Swiftbird/LaPlant,State House,28A,Jana Hunt,REP,0
+Dewey,12 Eagle Butte North (Precinct-13 Eagle Butte North),State House,28A,Ryan Maher,REP,12
+Dewey,12 Eagle Butte North (Precinct-13 Eagle Butte North),State House,28A,Jana Hunt,REP,7
+Dewey,14 Eagle Butte South,State House,28A,Ryan Maher,REP,7
+Dewey,14 Eagle Butte South,State House,28A,Jana Hunt,REP,6
+Dewey,15 Eagle Butte West,State House,28A,Ryan Maher,REP,11
+Dewey,15 Eagle Butte West,State House,28A,Jana Hunt,REP,6

--- a/2024/counties/20240604__sd__primary__douglas__precinct.csv
+++ b/2024/counties/20240604__sd__primary__douglas__precinct.csv
@@ -1,0 +1,55 @@
+county,precinct,office,district,candidate,party,votes
+Douglas,Absentee Precinct,President,,Marianne Williamson,DEM,1
+Douglas,Absentee Precinct,President,,Joseph R Biden Jr,DEM,10
+Douglas,Absentee Precinct,President,,Dean Phillips,DEM,0
+Douglas,Absentee Precinct,President,,Armando Perez-Serrato,DEM,0
+Douglas,1,President,,Marianne Williamson,DEM,0
+Douglas,1,President,,Joseph R Biden Jr,DEM,1
+Douglas,1,President,,Dean Phillips,DEM,1
+Douglas,1,President,,Armando Perez-Serrato,DEM,0
+Douglas,2,President,,Marianne Williamson,DEM,1
+Douglas,2,President,,Joseph R Biden Jr,DEM,6
+Douglas,2,President,,Dean Phillips,DEM,1
+Douglas,2,President,,Armando Perez-Serrato,DEM,0
+Douglas,3,President,,Marianne Williamson,DEM,0
+Douglas,3,President,,Joseph R Biden Jr,DEM,2
+Douglas,3,President,,Dean Phillips,DEM,1
+Douglas,3,President,,Armando Perez-Serrato,DEM,0
+Douglas,4,President,,Marianne Williamson,DEM,0
+Douglas,4,President,,Joseph R Biden Jr,DEM,6
+Douglas,4,President,,Dean Phillips,DEM,0
+Douglas,4,President,,Armando Perez-Serrato,DEM,0
+Douglas,5,President,,Marianne Williamson,DEM,1
+Douglas,5,President,,Joseph R Biden Jr,DEM,0
+Douglas,5,President,,Dean Phillips,DEM,0
+Douglas,5,President,,Armando Perez-Serrato,DEM,0
+Douglas,Absentee Precinct,State Senate,21,Erin Tobin,REP,34
+Douglas,Absentee Precinct,State Senate,21,Mykala Voita,REP,12
+Douglas,1,State Senate,21,Erin Tobin,REP,36
+Douglas,1,State Senate,21,Mykala Voita,REP,131
+Douglas,2,State Senate,21,Erin Tobin,REP,47
+Douglas,2,State Senate,21,Mykala Voita,REP,57
+Douglas,3,State Senate,21,Erin Tobin,REP,44
+Douglas,3,State Senate,21,Mykala Voita,REP,37
+Douglas,4,State Senate,21,Erin Tobin,REP,46
+Douglas,4,State Senate,21,Mykala Voita,REP,50
+Douglas,5,State Senate,21,Erin Tobin,REP,24
+Douglas,5,State Senate,21,Mykala Voita,REP,67
+Douglas,Absentee Precinct,State House,21,Lee Qualm,REP,26
+Douglas,Absentee Precinct,State House,21,Marty Overweg,REP,45
+Douglas,Absentee Precinct,State House,21,Jim Halverson,REP,16
+Douglas,1,State House,21,Lee Qualm,REP,75
+Douglas,1,State House,21,Marty Overweg,REP,166
+Douglas,1,State House,21,Jim Halverson,REP,35
+Douglas,2,State House,21,Lee Qualm,REP,54
+Douglas,2,State House,21,Marty Overweg,REP,103
+Douglas,2,State House,21,Jim Halverson,REP,20
+Douglas,3,State House,21,Lee Qualm,REP,44
+Douglas,3,State House,21,Marty Overweg,REP,65
+Douglas,3,State House,21,Jim Halverson,REP,24
+Douglas,4,State House,21,Lee Qualm,REP,38
+Douglas,4,State House,21,Marty Overweg,REP,88
+Douglas,4,State House,21,Jim Halverson,REP,35
+Douglas,5,State House,21,Lee Qualm,REP,47
+Douglas,5,State House,21,Marty Overweg,REP,87
+Douglas,5,State House,21,Jim Halverson,REP,24

--- a/2024/counties/20240604__sd__primary__edmunds__precinct.csv
+++ b/2024/counties/20240604__sd__primary__edmunds__precinct.csv
@@ -1,0 +1,55 @@
+county,precinct,office,district,candidate,party,votes
+Edmunds,1,President,,Marianne Williamson,DEM,5
+Edmunds,1,President,,Joseph R Biden Jr,DEM,9
+Edmunds,1,President,,Dean Phillips,DEM,5
+Edmunds,1,President,,Armando Perez-Serrato,DEM,1
+Edmunds,2,President,,Marianne Williamson,DEM,2
+Edmunds,2,President,,Joseph R Biden Jr,DEM,12
+Edmunds,2,President,,Dean Phillips,DEM,4
+Edmunds,2,President,,Armando Perez-Serrato,DEM,1
+Edmunds,3,President,,Marianne Williamson,DEM,5
+Edmunds,3,President,,Joseph R Biden Jr,DEM,4
+Edmunds,3,President,,Dean Phillips,DEM,2
+Edmunds,3,President,,Armando Perez-Serrato,DEM,1
+Edmunds,4,President,,Marianne Williamson,DEM,3
+Edmunds,4,President,,Joseph R Biden Jr,DEM,11
+Edmunds,4,President,,Dean Phillips,DEM,2
+Edmunds,4,President,,Armando Perez-Serrato,DEM,3
+Edmunds,5,President,,Marianne Williamson,DEM,1
+Edmunds,5,President,,Joseph R Biden Jr,DEM,3
+Edmunds,5,President,,Dean Phillips,DEM,6
+Edmunds,5,President,,Armando Perez-Serrato,DEM,0
+Edmunds,6,President,,Marianne Williamson,DEM,2
+Edmunds,6,President,,Joseph R Biden Jr,DEM,7
+Edmunds,6,President,,Dean Phillips,DEM,4
+Edmunds,6,President,,Armando Perez-Serrato,DEM,2
+Edmunds,1,State Senate,23,Steven Ray Roseland,REP,63
+Edmunds,1,State Senate,23,Mark Lapka,REP,71
+Edmunds,2,State Senate,23,Steven Ray Roseland,REP,35
+Edmunds,2,State Senate,23,Mark Lapka,REP,70
+Edmunds,3,State Senate,23,Steven Ray Roseland,REP,33
+Edmunds,3,State Senate,23,Mark Lapka,REP,81
+Edmunds,4,State Senate,23,Steven Ray Roseland,REP,18
+Edmunds,4,State Senate,23,Mark Lapka,REP,44
+Edmunds,5,State Senate,23,Steven Ray Roseland,REP,34
+Edmunds,5,State Senate,23,Mark Lapka,REP,50
+Edmunds,6,State Senate,23,Steven Ray Roseland,REP,10
+Edmunds,6,State Senate,23,Mark Lapka,REP,40
+Edmunds,1,State House,23,Spencer Gosch,REP,79
+Edmunds,1,State House,23,Scott Moore,REP,114
+Edmunds,1,State House,23,James D. Wangsness,REP,44
+Edmunds,2,State House,23,Spencer Gosch,REP,63
+Edmunds,2,State House,23,Scott Moore,REP,88
+Edmunds,2,State House,23,James D. Wangsness,REP,39
+Edmunds,3,State House,23,Spencer Gosch,REP,54
+Edmunds,3,State House,23,Scott Moore,REP,99
+Edmunds,3,State House,23,James D. Wangsness,REP,42
+Edmunds,4,State House,23,Spencer Gosch,REP,40
+Edmunds,4,State House,23,Scott Moore,REP,52
+Edmunds,4,State House,23,James D. Wangsness,REP,24
+Edmunds,5,State House,23,Spencer Gosch,REP,55
+Edmunds,5,State House,23,Scott Moore,REP,67
+Edmunds,5,State House,23,James D. Wangsness,REP,25
+Edmunds,6,State House,23,Spencer Gosch,REP,24
+Edmunds,6,State House,23,Scott Moore,REP,45
+Edmunds,6,State House,23,James D. Wangsness,REP,21

--- a/2024/counties/20240604__sd__primary__fall_river__precinct.csv
+++ b/2024/counties/20240604__sd__primary__fall_river__precinct.csv
@@ -1,0 +1,183 @@
+county,precinct,office,district,candidate,party,votes
+Fall River,BEA,President,,Marianne Williamson,DEM,0
+Fall River,BEA,President,,Joseph R Biden Jr,DEM,2
+Fall River,BEA,President,,Dean Phillips,DEM,2
+Fall River,BEA,President,,Armando Perez-Serrato,DEM,1
+Fall River,CAS,President,,Marianne Williamson,DEM,0
+Fall River,CAS,President,,Joseph R Biden Jr,DEM,4
+Fall River,CAS,President,,Dean Phillips,DEM,2
+Fall River,CAS,President,,Armando Perez-Serrato,DEM,0
+Fall River,EDA,President,,Marianne Williamson,DEM,1
+Fall River,EDA,President,,Joseph R Biden Jr,DEM,9
+Fall River,EDA,President,,Dean Phillips,DEM,4
+Fall River,EDA,President,,Armando Perez-Serrato,DEM,1
+Fall River,HS 1,President,,Marianne Williamson,DEM,4
+Fall River,HS 1,President,,Joseph R Biden Jr,DEM,26
+Fall River,HS 1,President,,Dean Phillips,DEM,5
+Fall River,HS 1,President,,Armando Perez-Serrato,DEM,2
+Fall River,HS 2,President,,Marianne Williamson,DEM,5
+Fall River,HS 2,President,,Joseph R Biden Jr,DEM,19
+Fall River,HS 2,President,,Dean Phillips,DEM,2
+Fall River,HS 2,President,,Armando Perez-Serrato,DEM,1
+Fall River,HS 3,President,,Marianne Williamson,DEM,1
+Fall River,HS 3,President,,Joseph R Biden Jr,DEM,17
+Fall River,HS 3,President,,Dean Phillips,DEM,4
+Fall River,HS 3,President,,Armando Perez-Serrato,DEM,1
+Fall River,HS 4,President,,Marianne Williamson,DEM,2
+Fall River,HS 4,President,,Joseph R Biden Jr,DEM,30
+Fall River,HS 4,President,,Dean Phillips,DEM,4
+Fall River,HS 4,President,,Armando Perez-Serrato,DEM,1
+Fall River,JAC,President,,Marianne Williamson,DEM,1
+Fall River,JAC,President,,Joseph R Biden Jr,DEM,26
+Fall River,JAC,President,,Dean Phillips,DEM,6
+Fall River,JAC,President,,Armando Perez-Serrato,DEM,2
+Fall River,Oelrichs Area,President,,Marianne Williamson,DEM,0
+Fall River,Oelrichs Area,President,,Joseph R Biden Jr,DEM,7
+Fall River,Oelrichs Area,President,,Dean Phillips,DEM,0
+Fall River,Oelrichs Area,President,,Armando Perez-Serrato,DEM,0
+Fall River,BEA,State Senate,30,Amber Hulse,REP,20
+Fall River,BEA,State Senate,30,Forrest Foster,REP,39
+Fall River,BEA,State Senate,30,Julie Frye-Mueller,REP,27
+Fall River,CAS,State Senate,30,Amber Hulse,REP,40
+Fall River,CAS,State Senate,30,Forrest Foster,REP,7
+Fall River,CAS,State Senate,30,Julie Frye-Mueller,REP,29
+Fall River,EDA,State Senate,30,Amber Hulse,REP,84
+Fall River,EDA,State Senate,30,Forrest Foster,REP,14
+Fall River,EDA,State Senate,30,Julie Frye-Mueller,REP,120
+Fall River,HS 1,State Senate,30,Amber Hulse,REP,75
+Fall River,HS 1,State Senate,30,Forrest Foster,REP,15
+Fall River,HS 1,State Senate,30,Julie Frye-Mueller,REP,72
+Fall River,HS 2,State Senate,30,Amber Hulse,REP,79
+Fall River,HS 2,State Senate,30,Forrest Foster,REP,24
+Fall River,HS 2,State Senate,30,Julie Frye-Mueller,REP,56
+Fall River,HS 3,State Senate,30,Amber Hulse,REP,64
+Fall River,HS 3,State Senate,30,Forrest Foster,REP,11
+Fall River,HS 3,State Senate,30,Julie Frye-Mueller,REP,55
+Fall River,HS 4,State Senate,30,Amber Hulse,REP,76
+Fall River,HS 4,State Senate,30,Forrest Foster,REP,15
+Fall River,HS 4,State Senate,30,Julie Frye-Mueller,REP,39
+Fall River,JAC,State Senate,30,Amber Hulse,REP,228
+Fall River,JAC,State Senate,30,Forrest Foster,REP,37
+Fall River,JAC,State Senate,30,Julie Frye-Mueller,REP,165
+Fall River,Oelrichs Area,State Senate,30,Amber Hulse,REP,21
+Fall River,Oelrichs Area,State Senate,30,Forrest Foster,REP,20
+Fall River,Oelrichs Area,State Senate,30,Julie Frye-Mueller,REP,73
+Fall River,BEA,State House,30,Pat Baumann,REP,29
+Fall River,BEA,State House,30,Matt Smith,REP,26
+Fall River,BEA,State House,30,Trish Ladner,REP,40
+Fall River,BEA,State House,30,Stephen Saint,REP,9
+Fall River,BEA,State House,30,Tim Goodwin,REP,43
+Fall River,BEA,State House,30,Matthew Monfore,REP,5
+Fall River,CAS,State House,30,Pat Baumann,REP,25
+Fall River,CAS,State House,30,Matt Smith,REP,29
+Fall River,CAS,State House,30,Trish Ladner,REP,29
+Fall River,CAS,State House,30,Stephen Saint,REP,9
+Fall River,CAS,State House,30,Tim Goodwin,REP,27
+Fall River,CAS,State House,30,Matthew Monfore,REP,8
+Fall River,EDA,State House,30,Pat Baumann,REP,90
+Fall River,EDA,State House,30,Matt Smith,REP,93
+Fall River,EDA,State House,30,Trish Ladner,REP,94
+Fall River,EDA,State House,30,Stephen Saint,REP,11
+Fall River,EDA,State House,30,Tim Goodwin,REP,70
+Fall River,EDA,State House,30,Matthew Monfore,REP,13
+Fall River,HS 1,State House,30,Pat Baumann,REP,66
+Fall River,HS 1,State House,30,Matt Smith,REP,65
+Fall River,HS 1,State House,30,Trish Ladner,REP,67
+Fall River,HS 1,State House,30,Stephen Saint,REP,9
+Fall River,HS 1,State House,30,Tim Goodwin,REP,46
+Fall River,HS 1,State House,30,Matthew Monfore,REP,23
+Fall River,HS 2,State House,30,Pat Baumann,REP,45
+Fall River,HS 2,State House,30,Matt Smith,REP,58
+Fall River,HS 2,State House,30,Trish Ladner,REP,75
+Fall River,HS 2,State House,30,Stephen Saint,REP,12
+Fall River,HS 2,State House,30,Tim Goodwin,REP,63
+Fall River,HS 2,State House,30,Matthew Monfore,REP,17
+Fall River,HS 3,State House,30,Pat Baumann,REP,54
+Fall River,HS 3,State House,30,Matt Smith,REP,47
+Fall River,HS 3,State House,30,Trish Ladner,REP,62
+Fall River,HS 3,State House,30,Stephen Saint,REP,8
+Fall River,HS 3,State House,30,Tim Goodwin,REP,39
+Fall River,HS 3,State House,30,Matthew Monfore,REP,12
+Fall River,HS 4,State House,30,Pat Baumann,REP,49
+Fall River,HS 4,State House,30,Matt Smith,REP,43
+Fall River,HS 4,State House,30,Trish Ladner,REP,62
+Fall River,HS 4,State House,30,Stephen Saint,REP,9
+Fall River,HS 4,State House,30,Tim Goodwin,REP,44
+Fall River,HS 4,State House,30,Matthew Monfore,REP,19
+Fall River,JAC,State House,30,Pat Baumann,REP,143
+Fall River,JAC,State House,30,Matt Smith,REP,122
+Fall River,JAC,State House,30,Trish Ladner,REP,236
+Fall River,JAC,State House,30,Stephen Saint,REP,29
+Fall River,JAC,State House,30,Tim Goodwin,REP,157
+Fall River,JAC,State House,30,Matthew Monfore,REP,29
+Fall River,Oelrichs Area,State House,30,Pat Baumann,REP,26
+Fall River,Oelrichs Area,State House,30,Matt Smith,REP,49
+Fall River,Oelrichs Area,State House,30,Trish Ladner,REP,48
+Fall River,Oelrichs Area,State House,30,Stephen Saint,REP,5
+Fall River,Oelrichs Area,State House,30,Tim Goodwin,REP,38
+Fall River,Oelrichs Area,State House,30,Matthew Monfore,REP,10
+Fall River,BEA,County Commissioner At Large,,John Staben,REP,45
+Fall River,BEA,County Commissioner At Large,,Jeannine M Lecy,REP,17
+Fall River,BEA,County Commissioner At Large,,Trudy Valenzuela,REP,8
+Fall River,BEA,County Commissioner At Large,,Les Cope,REP,43
+Fall River,BEA,County Commissioner At Large,,Joe Allen,REP,46
+Fall River,BEA,County Commissioner At Large,,Heath Greenough,REP,38
+Fall River,BEA,County Commissioner At Large,,Sandra Wahlert,REP,37
+Fall River,CAS,County Commissioner At Large,,John Staben,REP,26
+Fall River,CAS,County Commissioner At Large,,Jeannine M Lecy,REP,23
+Fall River,CAS,County Commissioner At Large,,Trudy Valenzuela,REP,11
+Fall River,CAS,County Commissioner At Large,,Les Cope,REP,17
+Fall River,CAS,County Commissioner At Large,,Joe Allen,REP,32
+Fall River,CAS,County Commissioner At Large,,Heath Greenough,REP,12
+Fall River,CAS,County Commissioner At Large,,Sandra Wahlert,REP,35
+Fall River,EDA,County Commissioner At Large,,John Staben,REP,89
+Fall River,EDA,County Commissioner At Large,,Jeannine M Lecy,REP,35
+Fall River,EDA,County Commissioner At Large,,Trudy Valenzuela,REP,13
+Fall River,EDA,County Commissioner At Large,,Les Cope,REP,132
+Fall River,EDA,County Commissioner At Large,,Joe Allen,REP,81
+Fall River,EDA,County Commissioner At Large,,Heath Greenough,REP,77
+Fall River,EDA,County Commissioner At Large,,Sandra Wahlert,REP,68
+Fall River,HS 1,County Commissioner At Large,,John Staben,REP,62
+Fall River,HS 1,County Commissioner At Large,,Jeannine M Lecy,REP,49
+Fall River,HS 1,County Commissioner At Large,,Trudy Valenzuela,REP,29
+Fall River,HS 1,County Commissioner At Large,,Les Cope,REP,46
+Fall River,HS 1,County Commissioner At Large,,Joe Allen,REP,72
+Fall River,HS 1,County Commissioner At Large,,Heath Greenough,REP,53
+Fall River,HS 1,County Commissioner At Large,,Sandra Wahlert,REP,72
+Fall River,HS 2,County Commissioner At Large,,John Staben,REP,58
+Fall River,HS 2,County Commissioner At Large,,Jeannine M Lecy,REP,46
+Fall River,HS 2,County Commissioner At Large,,Trudy Valenzuela,REP,30
+Fall River,HS 2,County Commissioner At Large,,Les Cope,REP,55
+Fall River,HS 2,County Commissioner At Large,,Joe Allen,REP,76
+Fall River,HS 2,County Commissioner At Large,,Heath Greenough,REP,46
+Fall River,HS 2,County Commissioner At Large,,Sandra Wahlert,REP,68
+Fall River,HS 3,County Commissioner At Large,,John Staben,REP,53
+Fall River,HS 3,County Commissioner At Large,,Jeannine M Lecy,REP,30
+Fall River,HS 3,County Commissioner At Large,,Trudy Valenzuela,REP,17
+Fall River,HS 3,County Commissioner At Large,,Les Cope,REP,52
+Fall River,HS 3,County Commissioner At Large,,Joe Allen,REP,59
+Fall River,HS 3,County Commissioner At Large,,Heath Greenough,REP,45
+Fall River,HS 3,County Commissioner At Large,,Sandra Wahlert,REP,53
+Fall River,HS 4,County Commissioner At Large,,John Staben,REP,58
+Fall River,HS 4,County Commissioner At Large,,Jeannine M Lecy,REP,37
+Fall River,HS 4,County Commissioner At Large,,Trudy Valenzuela,REP,19
+Fall River,HS 4,County Commissioner At Large,,Les Cope,REP,54
+Fall River,HS 4,County Commissioner At Large,,Joe Allen,REP,60
+Fall River,HS 4,County Commissioner At Large,,Heath Greenough,REP,42
+Fall River,HS 4,County Commissioner At Large,,Sandra Wahlert,REP,48
+Fall River,JAC,County Commissioner At Large,,John Staben,REP,157
+Fall River,JAC,County Commissioner At Large,,Jeannine M Lecy,REP,112
+Fall River,JAC,County Commissioner At Large,,Trudy Valenzuela,REP,63
+Fall River,JAC,County Commissioner At Large,,Les Cope,REP,162
+Fall River,JAC,County Commissioner At Large,,Joe Allen,REP,187
+Fall River,JAC,County Commissioner At Large,,Heath Greenough,REP,137
+Fall River,JAC,County Commissioner At Large,,Sandra Wahlert,REP,164
+Fall River,Oelrichs Area,County Commissioner At Large,,John Staben,REP,40
+Fall River,Oelrichs Area,County Commissioner At Large,,Jeannine M Lecy,REP,14
+Fall River,Oelrichs Area,County Commissioner At Large,,Trudy Valenzuela,REP,7
+Fall River,Oelrichs Area,County Commissioner At Large,,Les Cope,REP,82
+Fall River,Oelrichs Area,County Commissioner At Large,,Joe Allen,REP,28
+Fall River,Oelrichs Area,County Commissioner At Large,,Heath Greenough,REP,84
+Fall River,Oelrichs Area,County Commissioner At Large,,Sandra Wahlert,REP,44
+Fall River,EDA,Precinct Committeewoman,,Jessica Tubbs,REP,98
+Fall River,EDA,Precinct Committeewoman,,Amber Hulse,REP,95

--- a/2024/counties/20240604__sd__primary__faulk__precinct.csv
+++ b/2024/counties/20240604__sd__primary__faulk__precinct.csv
@@ -1,0 +1,85 @@
+county,precinct,office,district,candidate,party,votes
+Faulk,1,President,,Marianne Williamson,DEM,2
+Faulk,1,President,,Joseph R Biden Jr,DEM,9
+Faulk,1,President,,Dean Phillips,DEM,3
+Faulk,1,President,,Armando Perez-Serrato,DEM,0
+Faulk,2,President,,Marianne Williamson,DEM,3
+Faulk,2,President,,Joseph R Biden Jr,DEM,0
+Faulk,2,President,,Dean Phillips,DEM,0
+Faulk,2,President,,Armando Perez-Serrato,DEM,1
+Faulk,3,President,,Marianne Williamson,DEM,0
+Faulk,3,President,,Joseph R Biden Jr,DEM,2
+Faulk,3,President,,Dean Phillips,DEM,3
+Faulk,3,President,,Armando Perez-Serrato,DEM,0
+Faulk,4,President,,Marianne Williamson,DEM,1
+Faulk,4,President,,Joseph R Biden Jr,DEM,4
+Faulk,4,President,,Dean Phillips,DEM,0
+Faulk,4,President,,Armando Perez-Serrato,DEM,0
+Faulk,5,President,,Marianne Williamson,DEM,0
+Faulk,5,President,,Joseph R Biden Jr,DEM,1
+Faulk,5,President,,Dean Phillips,DEM,1
+Faulk,5,President,,Armando Perez-Serrato,DEM,2
+Faulk,6,President,,Marianne Williamson,DEM,2
+Faulk,6,President,,Joseph R Biden Jr,DEM,4
+Faulk,6,President,,Dean Phillips,DEM,2
+Faulk,6,President,,Armando Perez-Serrato,DEM,0
+Faulk,7,President,,Marianne Williamson,DEM,5
+Faulk,7,President,,Joseph R Biden Jr,DEM,10
+Faulk,7,President,,Dean Phillips,DEM,3
+Faulk,7,President,,Armando Perez-Serrato,DEM,1
+Faulk,1,State Senate,23,Steven Ray Roseland,REP,33
+Faulk,1,State Senate,23,Mark Lapka,REP,23
+Faulk,2,State Senate,23,Steven Ray Roseland,REP,28
+Faulk,2,State Senate,23,Mark Lapka,REP,20
+Faulk,3,State Senate,23,Steven Ray Roseland,REP,48
+Faulk,3,State Senate,23,Mark Lapka,REP,30
+Faulk,4,State Senate,23,Steven Ray Roseland,REP,36
+Faulk,4,State Senate,23,Mark Lapka,REP,14
+Faulk,5,State Senate,23,Steven Ray Roseland,REP,24
+Faulk,5,State Senate,23,Mark Lapka,REP,21
+Faulk,6,State Senate,23,Steven Ray Roseland,REP,99
+Faulk,6,State Senate,23,Mark Lapka,REP,29
+Faulk,7,State Senate,23,Steven Ray Roseland,REP,125
+Faulk,7,State Senate,23,Mark Lapka,REP,18
+Faulk,1,State House,23,Spencer Gosch,REP,20
+Faulk,1,State House,23,Scott Moore,REP,36
+Faulk,1,State House,23,James D. Wangsness,REP,27
+Faulk,2,State House,23,Spencer Gosch,REP,19
+Faulk,2,State House,23,Scott Moore,REP,39
+Faulk,2,State House,23,James D. Wangsness,REP,9
+Faulk,3,State House,23,Spencer Gosch,REP,40
+Faulk,3,State House,23,Scott Moore,REP,59
+Faulk,3,State House,23,James D. Wangsness,REP,37
+Faulk,4,State House,23,Spencer Gosch,REP,26
+Faulk,4,State House,23,Scott Moore,REP,38
+Faulk,4,State House,23,James D. Wangsness,REP,20
+Faulk,5,State House,23,Spencer Gosch,REP,24
+Faulk,5,State House,23,Scott Moore,REP,31
+Faulk,5,State House,23,James D. Wangsness,REP,13
+Faulk,6,State House,23,Spencer Gosch,REP,57
+Faulk,6,State House,23,Scott Moore,REP,92
+Faulk,6,State House,23,James D. Wangsness,REP,62
+Faulk,7,State House,23,Spencer Gosch,REP,65
+Faulk,7,State House,23,Scott Moore,REP,96
+Faulk,7,State House,23,James D. Wangsness,REP,68
+Faulk,1,County Commissioner At Large,,Lee A. Hansen,REP,23
+Faulk,1,County Commissioner At Large,,Bruce Edgar,REP,32
+Faulk,1,County Commissioner At Large,,Alexander Thomas,REP,22
+Faulk,2,County Commissioner At Large,,Lee A. Hansen,REP,30
+Faulk,2,County Commissioner At Large,,Bruce Edgar,REP,35
+Faulk,2,County Commissioner At Large,,Alexander Thomas,REP,22
+Faulk,3,County Commissioner At Large,,Lee A. Hansen,REP,30
+Faulk,3,County Commissioner At Large,,Bruce Edgar,REP,46
+Faulk,3,County Commissioner At Large,,Alexander Thomas,REP,50
+Faulk,4,County Commissioner At Large,,Lee A. Hansen,REP,34
+Faulk,4,County Commissioner At Large,,Bruce Edgar,REP,42
+Faulk,4,County Commissioner At Large,,Alexander Thomas,REP,15
+Faulk,5,County Commissioner At Large,,Lee A. Hansen,REP,20
+Faulk,5,County Commissioner At Large,,Bruce Edgar,REP,41
+Faulk,5,County Commissioner At Large,,Alexander Thomas,REP,11
+Faulk,6,County Commissioner At Large,,Lee A. Hansen,REP,79
+Faulk,6,County Commissioner At Large,,Bruce Edgar,REP,110
+Faulk,6,County Commissioner At Large,,Alexander Thomas,REP,40
+Faulk,7,County Commissioner At Large,,Lee A. Hansen,REP,104
+Faulk,7,County Commissioner At Large,,Bruce Edgar,REP,121
+Faulk,7,County Commissioner At Large,,Alexander Thomas,REP,35

--- a/2024/counties/20240604__sd__primary__grant__precinct.csv
+++ b/2024/counties/20240604__sd__primary__grant__precinct.csv
@@ -1,0 +1,217 @@
+county,precinct,office,district,candidate,party,votes
+Grant,11,President,,Marianne Williamson,DEM,3
+Grant,11,President,,Joseph R Biden Jr,DEM,21
+Grant,11,President,,Dean Phillips,DEM,6
+Grant,11,President,,Armando Perez-Serrato,DEM,0
+Grant,12,President,,Marianne Williamson,DEM,0
+Grant,12,President,,Joseph R Biden Jr,DEM,3
+Grant,12,President,,Dean Phillips,DEM,0
+Grant,12,President,,Armando Perez-Serrato,DEM,0
+Grant,21,President,,Marianne Williamson,DEM,0
+Grant,21,President,,Joseph R Biden Jr,DEM,8
+Grant,21,President,,Dean Phillips,DEM,2
+Grant,21,President,,Armando Perez-Serrato,DEM,0
+Grant,22,President,,Marianne Williamson,DEM,0
+Grant,22,President,,Joseph R Biden Jr,DEM,22
+Grant,22,President,,Dean Phillips,DEM,2
+Grant,22,President,,Armando Perez-Serrato,DEM,0
+Grant,31,President,,Marianne Williamson,DEM,0
+Grant,31,President,,Joseph R Biden Jr,DEM,1
+Grant,31,President,,Dean Phillips,DEM,1
+Grant,31,President,,Armando Perez-Serrato,DEM,0
+Grant,32,President,,Marianne Williamson,DEM,0
+Grant,32,President,,Joseph R Biden Jr,DEM,3
+Grant,32,President,,Dean Phillips,DEM,0
+Grant,32,President,,Armando Perez-Serrato,DEM,0
+Grant,33,President,,Marianne Williamson,DEM,6
+Grant,33,President,,Joseph R Biden Jr,DEM,24
+Grant,33,President,,Dean Phillips,DEM,1
+Grant,33,President,,Armando Perez-Serrato,DEM,2
+Grant,41,President,,Marianne Williamson,DEM,4
+Grant,41,President,,Joseph R Biden Jr,DEM,12
+Grant,41,President,,Dean Phillips,DEM,0
+Grant,41,President,,Armando Perez-Serrato,DEM,1
+Grant,42,President,,Marianne Williamson,DEM,1
+Grant,42,President,,Joseph R Biden Jr,DEM,6
+Grant,42,President,,Dean Phillips,DEM,1
+Grant,42,President,,Armando Perez-Serrato,DEM,0
+Grant,43,President,,Marianne Williamson,DEM,3
+Grant,43,President,,Joseph R Biden Jr,DEM,18
+Grant,43,President,,Dean Phillips,DEM,4
+Grant,43,President,,Armando Perez-Serrato,DEM,1
+Grant,44,President,,Marianne Williamson,DEM,0
+Grant,44,President,,Joseph R Biden Jr,DEM,7
+Grant,44,President,,Dean Phillips,DEM,3
+Grant,44,President,,Armando Perez-Serrato,DEM,1
+Grant,45,President,,Marianne Williamson,DEM,0
+Grant,45,President,,Joseph R Biden Jr,DEM,9
+Grant,45,President,,Dean Phillips,DEM,2
+Grant,45,President,,Armando Perez-Serrato,DEM,0
+Grant,46,President,,Marianne Williamson,DEM,0
+Grant,46,President,,Joseph R Biden Jr,DEM,9
+Grant,46,President,,Dean Phillips,DEM,0
+Grant,46,President,,Armando Perez-Serrato,DEM,1
+Grant,47,President,,Marianne Williamson,DEM,2
+Grant,47,President,,Joseph R Biden Jr,DEM,2
+Grant,47,President,,Dean Phillips,DEM,1
+Grant,47,President,,Armando Perez-Serrato,DEM,1
+Grant,49,President,,Marianne Williamson,DEM,1
+Grant,49,President,,Joseph R Biden Jr,DEM,1
+Grant,49,President,,Dean Phillips,DEM,0
+Grant,49,President,,Armando Perez-Serrato,DEM,0
+Grant,52,President,,Marianne Williamson,DEM,1
+Grant,52,President,,Joseph R Biden Jr,DEM,3
+Grant,52,President,,Dean Phillips,DEM,1
+Grant,52,President,,Armando Perez-Serrato,DEM,1
+Grant,53,President,,Marianne Williamson,DEM,1
+Grant,53,President,,Joseph R Biden Jr,DEM,0
+Grant,53,President,,Dean Phillips,DEM,0
+Grant,53,President,,Armando Perez-Serrato,DEM,1
+Grant,54,President,,Marianne Williamson,DEM,3
+Grant,54,President,,Joseph R Biden Jr,DEM,3
+Grant,54,President,,Dean Phillips,DEM,3
+Grant,54,President,,Armando Perez-Serrato,DEM,0
+Grant,11,State Senate,04,Fred Deutsch,REP,52
+Grant,11,State Senate,04,Stephanie Sauder,REP,34
+Grant,12,State Senate,04,Fred Deutsch,REP,17
+Grant,12,State Senate,04,Stephanie Sauder,REP,8
+Grant,21,State Senate,04,Fred Deutsch,REP,18
+Grant,21,State Senate,04,Stephanie Sauder,REP,17
+Grant,22,State Senate,04,Fred Deutsch,REP,45
+Grant,22,State Senate,04,Stephanie Sauder,REP,39
+Grant,31,State Senate,04,Fred Deutsch,REP,11
+Grant,31,State Senate,04,Stephanie Sauder,REP,8
+Grant,32,State Senate,04,Fred Deutsch,REP,15
+Grant,32,State Senate,04,Stephanie Sauder,REP,5
+Grant,33,State Senate,04,Fred Deutsch,REP,67
+Grant,33,State Senate,04,Stephanie Sauder,REP,50
+Grant,41,State Senate,04,Fred Deutsch,REP,35
+Grant,41,State Senate,04,Stephanie Sauder,REP,22
+Grant,42,State Senate,04,Fred Deutsch,REP,50
+Grant,42,State Senate,04,Stephanie Sauder,REP,26
+Grant,43,State Senate,04,Fred Deutsch,REP,62
+Grant,43,State Senate,04,Stephanie Sauder,REP,43
+Grant,44,State Senate,04,Fred Deutsch,REP,20
+Grant,44,State Senate,04,Stephanie Sauder,REP,15
+Grant,45,State Senate,04,Fred Deutsch,REP,29
+Grant,45,State Senate,04,Stephanie Sauder,REP,27
+Grant,46,State Senate,04,Fred Deutsch,REP,38
+Grant,46,State Senate,04,Stephanie Sauder,REP,18
+Grant,47,State Senate,04,Fred Deutsch,REP,47
+Grant,47,State Senate,04,Stephanie Sauder,REP,24
+Grant,49,State Senate,04,Fred Deutsch,REP,18
+Grant,49,State Senate,04,Stephanie Sauder,REP,9
+Grant,52,State Senate,04,Fred Deutsch,REP,11
+Grant,52,State Senate,04,Stephanie Sauder,REP,4
+Grant,53,State Senate,04,Fred Deutsch,REP,9
+Grant,53,State Senate,04,Stephanie Sauder,REP,5
+Grant,54,State Senate,04,Fred Deutsch,REP,20
+Grant,54,State Senate,04,Stephanie Sauder,REP,14
+Grant,11,State House,04,Dylan C. Jordan,REP,53
+Grant,11,State House,04,Vanessa Namken,REP,37
+Grant,11,State House,04,Barbara Guenette,REP,25
+Grant,11,State House,04,Kent Roe,REP,17
+Grant,12,State House,04,Dylan C. Jordan,REP,14
+Grant,12,State House,04,Vanessa Namken,REP,5
+Grant,12,State House,04,Barbara Guenette,REP,12
+Grant,12,State House,04,Kent Roe,REP,13
+Grant,21,State House,04,Dylan C. Jordan,REP,11
+Grant,21,State House,04,Vanessa Namken,REP,7
+Grant,21,State House,04,Barbara Guenette,REP,15
+Grant,21,State House,04,Kent Roe,REP,15
+Grant,22,State House,04,Dylan C. Jordan,REP,36
+Grant,22,State House,04,Vanessa Namken,REP,23
+Grant,22,State House,04,Barbara Guenette,REP,34
+Grant,22,State House,04,Kent Roe,REP,42
+Grant,31,State House,04,Dylan C. Jordan,REP,10
+Grant,31,State House,04,Vanessa Namken,REP,9
+Grant,31,State House,04,Barbara Guenette,REP,5
+Grant,31,State House,04,Kent Roe,REP,5
+Grant,32,State House,04,Dylan C. Jordan,REP,11
+Grant,32,State House,04,Vanessa Namken,REP,6
+Grant,32,State House,04,Barbara Guenette,REP,4
+Grant,32,State House,04,Kent Roe,REP,8
+Grant,33,State House,04,Dylan C. Jordan,REP,56
+Grant,33,State House,04,Vanessa Namken,REP,52
+Grant,33,State House,04,Barbara Guenette,REP,46
+Grant,33,State House,04,Kent Roe,REP,52
+Grant,41,State House,04,Dylan C. Jordan,REP,31
+Grant,41,State House,04,Vanessa Namken,REP,32
+Grant,41,State House,04,Barbara Guenette,REP,14
+Grant,41,State House,04,Kent Roe,REP,21
+Grant,42,State House,04,Dylan C. Jordan,REP,40
+Grant,42,State House,04,Vanessa Namken,REP,24
+Grant,42,State House,04,Barbara Guenette,REP,29
+Grant,42,State House,04,Kent Roe,REP,35
+Grant,43,State House,04,Dylan C. Jordan,REP,58
+Grant,43,State House,04,Vanessa Namken,REP,28
+Grant,43,State House,04,Barbara Guenette,REP,40
+Grant,43,State House,04,Kent Roe,REP,48
+Grant,44,State House,04,Dylan C. Jordan,REP,7
+Grant,44,State House,04,Vanessa Namken,REP,19
+Grant,44,State House,04,Barbara Guenette,REP,11
+Grant,44,State House,04,Kent Roe,REP,20
+Grant,45,State House,04,Dylan C. Jordan,REP,29
+Grant,45,State House,04,Vanessa Namken,REP,24
+Grant,45,State House,04,Barbara Guenette,REP,22
+Grant,45,State House,04,Kent Roe,REP,27
+Grant,46,State House,04,Dylan C. Jordan,REP,34
+Grant,46,State House,04,Vanessa Namken,REP,28
+Grant,46,State House,04,Barbara Guenette,REP,9
+Grant,46,State House,04,Kent Roe,REP,21
+Grant,47,State House,04,Dylan C. Jordan,REP,41
+Grant,47,State House,04,Vanessa Namken,REP,38
+Grant,47,State House,04,Barbara Guenette,REP,14
+Grant,47,State House,04,Kent Roe,REP,26
+Grant,49,State House,04,Dylan C. Jordan,REP,11
+Grant,49,State House,04,Vanessa Namken,REP,13
+Grant,49,State House,04,Barbara Guenette,REP,12
+Grant,49,State House,04,Kent Roe,REP,13
+Grant,52,State House,04,Dylan C. Jordan,REP,5
+Grant,52,State House,04,Vanessa Namken,REP,8
+Grant,52,State House,04,Barbara Guenette,REP,6
+Grant,52,State House,04,Kent Roe,REP,9
+Grant,53,State House,04,Dylan C. Jordan,REP,8
+Grant,53,State House,04,Vanessa Namken,REP,8
+Grant,53,State House,04,Barbara Guenette,REP,3
+Grant,53,State House,04,Kent Roe,REP,3
+Grant,54,State House,04,Dylan C. Jordan,REP,22
+Grant,54,State House,04,Vanessa Namken,REP,14
+Grant,54,State House,04,Barbara Guenette,REP,10
+Grant,54,State House,04,Kent Roe,REP,15
+Grant,11,Bond Issue,,Yes,,94
+Grant,11,Bond Issue,,No,,37
+Grant,12,Bond Issue,,Yes,,25
+Grant,12,Bond Issue,,No,,8
+Grant,21,Bond Issue,,Yes,,43
+Grant,21,Bond Issue,,No,,6
+Grant,22,Bond Issue,,Yes,,86
+Grant,22,Bond Issue,,No,,34
+Grant,31,Bond Issue,,Yes,,22
+Grant,31,Bond Issue,,No,,3
+Grant,32,Bond Issue,,Yes,,19
+Grant,32,Bond Issue,,No,,6
+Grant,33,Bond Issue,,Yes,,136
+Grant,33,Bond Issue,,No,,29
+Grant,41,Bond Issue,,Yes,,66
+Grant,41,Bond Issue,,No,,24
+Grant,42,Bond Issue,,Yes,,68
+Grant,42,Bond Issue,,No,,22
+Grant,43,Bond Issue,,Yes,,112
+Grant,43,Bond Issue,,No,,45
+Grant,44,Bond Issue,,Yes,,35
+Grant,44,Bond Issue,,No,,13
+Grant,45,Bond Issue,,Yes,,64
+Grant,45,Bond Issue,,No,,10
+Grant,46,Bond Issue,,Yes,,52
+Grant,46,Bond Issue,,No,,18
+Grant,47,Bond Issue,,Yes,,78
+Grant,47,Bond Issue,,No,,15
+Grant,49,Bond Issue,,Yes,,28
+Grant,49,Bond Issue,,No,,1
+Grant,52,Bond Issue,,Yes,,23
+Grant,52,Bond Issue,,No,,2
+Grant,53,Bond Issue,,Yes,,14
+Grant,53,Bond Issue,,No,,6
+Grant,54,Bond Issue,,Yes,,37
+Grant,54,Bond Issue,,No,,14

--- a/2024/counties/20240604__sd__primary__gregory__precinct.csv
+++ b/2024/counties/20240604__sd__primary__gregory__precinct.csv
@@ -1,0 +1,36 @@
+county,precinct,office,district,candidate,party,votes
+Gregory,1,President,,Marianne Williamson,DEM,10
+Gregory,1,President,,Joseph R Biden Jr,DEM,54
+Gregory,1,President,,Dean Phillips,DEM,17
+Gregory,1,President,,Armando Perez-Serrato,DEM,5
+Gregory,2,President,,Marianne Williamson,DEM,6
+Gregory,2,President,,Joseph R Biden Jr,DEM,57
+Gregory,2,President,,Dean Phillips,DEM,11
+Gregory,2,President,,Armando Perez-Serrato,DEM,1
+Gregory,3,President,,Marianne Williamson,DEM,2
+Gregory,3,President,,Joseph R Biden Jr,DEM,19
+Gregory,3,President,,Dean Phillips,DEM,1
+Gregory,3,President,,Armando Perez-Serrato,DEM,0
+Gregory,1,State Senate,21,Erin Tobin,REP,178
+Gregory,1,State Senate,21,Mykala Voita,REP,211
+Gregory,2,State Senate,21,Erin Tobin,REP,135
+Gregory,2,State Senate,21,Mykala Voita,REP,176
+Gregory,3,State Senate,21,Erin Tobin,REP,52
+Gregory,3,State Senate,21,Mykala Voita,REP,69
+Gregory,1,State House,21,Lee Qualm,REP,199
+Gregory,1,State House,21,Marty Overweg,REP,193
+Gregory,1,State House,21,Jim Halverson,REP,229
+Gregory,2,State House,21,Lee Qualm,REP,168
+Gregory,2,State House,21,Marty Overweg,REP,182
+Gregory,2,State House,21,Jim Halverson,REP,169
+Gregory,3,State House,21,Lee Qualm,REP,88
+Gregory,3,State House,21,Marty Overweg,REP,59
+Gregory,3,State House,21,Jim Halverson,REP,53
+Gregory,2,Precinct Committeewoman,2,Erika Van Nieuwenhuyse,REP,137
+Gregory,2,Precinct Committeewoman,2,Juli Anne Peppel,REP,143
+Gregory,1,Initiated Measure 1,,Yes,,271
+Gregory,1,Initiated Measure 1,,No,,249
+Gregory,2,Initiated Measure 1,,Yes,,166
+Gregory,2,Initiated Measure 1,,No,,255
+Gregory,3,Initiated Measure 1,,Yes,,72
+Gregory,3,Initiated Measure 1,,No,,83

--- a/2024/counties/20240604__sd__primary__haakon__precinct.csv
+++ b/2024/counties/20240604__sd__primary__haakon__precinct.csv
@@ -1,0 +1,41 @@
+county,precinct,office,district,candidate,party,votes
+Haakon,Absentee Precinct,Initiated Measure 2024,,Yes,,12
+Haakon,Absentee Precinct,Initiated Measure 2024,,No,,31
+Haakon,Courthouse Community Room,Initiated Measure 2024,,Yes,,99
+Haakon,Courthouse Community Room,Initiated Measure 2024,,No,,166
+Haakon,Deep Creek Church,Initiated Measure 2024,,Yes,,6
+Haakon,Deep Creek Church,Initiated Measure 2024,,No,,12
+Haakon,Midland Fire Hall,Initiated Measure 2024,,Yes,,42
+Haakon,Midland Fire Hall,Initiated Measure 2024,,No,,40
+Haakon,Milesville Hall,Initiated Measure 2024,,Yes,,18
+Haakon,Milesville Hall,Initiated Measure 2024,,No,,27
+Haakon,Absentee Precinct,Sheriff,,Dillon Armour,REP,20
+Haakon,Absentee Precinct,Sheriff,,Tim Quinn,REP,24
+Haakon,Courthouse Community Room,Sheriff,,Dillon Armour,REP,129
+Haakon,Courthouse Community Room,Sheriff,,Tim Quinn,REP,121
+Haakon,Deep Creek Church,Sheriff,,Dillon Armour,REP,13
+Haakon,Deep Creek Church,Sheriff,,Tim Quinn,REP,3
+Haakon,Midland Fire Hall,Sheriff,,Dillon Armour,REP,29
+Haakon,Midland Fire Hall,Sheriff,,Tim Quinn,REP,48
+Haakon,Milesville Hall,Sheriff,,Dillon Armour,REP,11
+Haakon,Milesville Hall,Sheriff,,Tim Quinn,REP,32
+Haakon,Absentee Precinct,President,,Marianne Williamson,DEM,0
+Haakon,Absentee Precinct,President,,Joseph R Biden Jr,DEM,1
+Haakon,Absentee Precinct,President,,Dean Phillips,DEM,0
+Haakon,Absentee Precinct,President,,Armando Perez-Serrato,DEM,0
+Haakon,Courthouse Community Room,President,,Marianne Williamson,DEM,4
+Haakon,Courthouse Community Room,President,,Joseph R Biden Jr,DEM,10
+Haakon,Courthouse Community Room,President,,Dean Phillips,DEM,2
+Haakon,Courthouse Community Room,President,,Armando Perez-Serrato,DEM,0
+Haakon,Deep Creek Church,President,,Marianne Williamson,DEM,0
+Haakon,Deep Creek Church,President,,Joseph R Biden Jr,DEM,2
+Haakon,Deep Creek Church,President,,Dean Phillips,DEM,1
+Haakon,Deep Creek Church,President,,Armando Perez-Serrato,DEM,1
+Haakon,Midland Fire Hall,President,,Marianne Williamson,DEM,1
+Haakon,Midland Fire Hall,President,,Joseph R Biden Jr,DEM,1
+Haakon,Midland Fire Hall,President,,Dean Phillips,DEM,0
+Haakon,Midland Fire Hall,President,,Armando Perez-Serrato,DEM,0
+Haakon,Milesville Hall,President,,Marianne Williamson,DEM,0
+Haakon,Milesville Hall,President,,Joseph R Biden Jr,DEM,1
+Haakon,Milesville Hall,President,,Dean Phillips,DEM,0
+Haakon,Milesville Hall,President,,Armando Perez-Serrato,DEM,1

--- a/2024/counties/20240604__sd__primary__hamlin__precinct.csv
+++ b/2024/counties/20240604__sd__primary__hamlin__precinct.csv
@@ -1,0 +1,85 @@
+county,precinct,office,district,candidate,party,votes
+Hamlin,02,State House,04,Dylan C. Jordan,REP,24
+Hamlin,02,State House,04,Vanessa Namken,REP,34
+Hamlin,02,State House,04,Barbara Guenette,REP,46
+Hamlin,02,State House,04,Kent Roe,REP,70
+Hamlin,21,State House,04,Dylan C. Jordan,REP,92
+Hamlin,21,State House,04,Vanessa Namken,REP,93
+Hamlin,21,State House,04,Barbara Guenette,REP,56
+Hamlin,21,State House,04,Kent Roe,REP,117
+Hamlin,22,State House,04,Dylan C. Jordan,REP,38
+Hamlin,22,State House,04,Vanessa Namken,REP,43
+Hamlin,22,State House,04,Barbara Guenette,REP,48
+Hamlin,22,State House,04,Kent Roe,REP,55
+Hamlin,23,State House,04,Dylan C. Jordan,REP,35
+Hamlin,23,State House,04,Vanessa Namken,REP,52
+Hamlin,23,State House,04,Barbara Guenette,REP,58
+Hamlin,23,State House,04,Kent Roe,REP,103
+Hamlin,24,State House,04,Dylan C. Jordan,REP,68
+Hamlin,24,State House,04,Vanessa Namken,REP,95
+Hamlin,24,State House,04,Barbara Guenette,REP,107
+Hamlin,24,State House,04,Kent Roe,REP,166
+Hamlin,25,State House,04,Dylan C. Jordan,REP,25
+Hamlin,25,State House,04,Vanessa Namken,REP,17
+Hamlin,25,State House,04,Barbara Guenette,REP,40
+Hamlin,25,State House,04,Kent Roe,REP,65
+Hamlin,26,State House,04,Dylan C. Jordan,REP,63
+Hamlin,26,State House,04,Vanessa Namken,REP,82
+Hamlin,26,State House,04,Barbara Guenette,REP,102
+Hamlin,26,State House,04,Kent Roe,REP,172
+Hamlin,02,State Senate,04,Fred Deutsch,REP,30
+Hamlin,02,State Senate,04,Stephanie Sauder,REP,68
+Hamlin,21,State Senate,04,Fred Deutsch,REP,87
+Hamlin,21,State Senate,04,Stephanie Sauder,REP,113
+Hamlin,22,State Senate,04,Fred Deutsch,REP,48
+Hamlin,22,State Senate,04,Stephanie Sauder,REP,52
+Hamlin,23,State Senate,04,Fred Deutsch,REP,42
+Hamlin,23,State Senate,04,Stephanie Sauder,REP,110
+Hamlin,24,State Senate,04,Fred Deutsch,REP,73
+Hamlin,24,State Senate,04,Stephanie Sauder,REP,182
+Hamlin,25,State Senate,04,Fred Deutsch,REP,26
+Hamlin,25,State Senate,04,Stephanie Sauder,REP,60
+Hamlin,26,State Senate,04,Fred Deutsch,REP,81
+Hamlin,26,State Senate,04,Stephanie Sauder,REP,161
+Hamlin,02,County Commissioner,2,Randall L Taschner,REP,39
+Hamlin,02,County Commissioner,2,Scott C Popham,REP,58
+Hamlin,22,County Commissioner,2,Randall L Taschner,REP,35
+Hamlin,22,County Commissioner,2,Scott C Popham,REP,63
+Hamlin,23,County Commissioner,3,Riley John Buck,REP,105
+Hamlin,23,County Commissioner,3,Douglas L Noem,REP,41
+Hamlin,24,County Commissioner,3,Riley John Buck,REP,33
+Hamlin,24,County Commissioner,3,Douglas L Noem,REP,38
+Hamlin,26,County Commissioner,2,Randall L Taschner,REP,73
+Hamlin,26,County Commissioner,2,Scott C Popham,REP,96
+Hamlin,26,County Commissioner,3,Riley John Buck,REP,44
+Hamlin,26,County Commissioner,3,Douglas L Noem,REP,20
+Hamlin,22,Precinct Committeewoman,,Barbara Gayle Guenette,REP,53
+Hamlin,22,Precinct Committeewoman,,Vanessa L Namken,REP,47
+Hamlin,02,President,,Marianne Williamson,DEM,1
+Hamlin,02,President,,Joseph R Biden Jr,DEM,0
+Hamlin,02,President,,Dean Phillips,DEM,2
+Hamlin,02,President,,Armando Perez-Serrato,DEM,0
+Hamlin,21,President,,Marianne Williamson,DEM,5
+Hamlin,21,President,,Joseph R Biden Jr,DEM,9
+Hamlin,21,President,,Dean Phillips,DEM,1
+Hamlin,21,President,,Armando Perez-Serrato,DEM,0
+Hamlin,22,President,,Marianne Williamson,DEM,0
+Hamlin,22,President,,Joseph R Biden Jr,DEM,1
+Hamlin,22,President,,Dean Phillips,DEM,0
+Hamlin,22,President,,Armando Perez-Serrato,DEM,1
+Hamlin,23,President,,Marianne Williamson,DEM,0
+Hamlin,23,President,,Joseph R Biden Jr,DEM,4
+Hamlin,23,President,,Dean Phillips,DEM,0
+Hamlin,23,President,,Armando Perez-Serrato,DEM,0
+Hamlin,24,President,,Marianne Williamson,DEM,2
+Hamlin,24,President,,Joseph R Biden Jr,DEM,12
+Hamlin,24,President,,Dean Phillips,DEM,0
+Hamlin,24,President,,Armando Perez-Serrato,DEM,1
+Hamlin,25,President,,Marianne Williamson,DEM,4
+Hamlin,25,President,,Joseph R Biden Jr,DEM,11
+Hamlin,25,President,,Dean Phillips,DEM,3
+Hamlin,25,President,,Armando Perez-Serrato,DEM,2
+Hamlin,26,President,,Marianne Williamson,DEM,0
+Hamlin,26,President,,Joseph R Biden Jr,DEM,3
+Hamlin,26,President,,Dean Phillips,DEM,0
+Hamlin,26,President,,Armando Perez-Serrato,DEM,0

--- a/2024/counties/20240604__sd__primary__hand__precinct.csv
+++ b/2024/counties/20240604__sd__primary__hand__precinct.csv
@@ -1,0 +1,46 @@
+county,precinct,office,district,candidate,party,votes
+Hand,01,President,,Marianne Williamson,DEM,2
+Hand,01,President,,Joseph R Biden Jr,DEM,6
+Hand,01,President,,Dean Phillips,DEM,0
+Hand,01,President,,Armando Perez-Serrato,DEM,0
+Hand,02,President,,Marianne Williamson,DEM,1
+Hand,02,President,,Joseph R Biden Jr,DEM,8
+Hand,02,President,,Dean Phillips,DEM,2
+Hand,02,President,,Armando Perez-Serrato,DEM,1
+Hand,03,President,,Marianne Williamson,DEM,2
+Hand,03,President,,Joseph R Biden Jr,DEM,10
+Hand,03,President,,Dean Phillips,DEM,3
+Hand,03,President,,Armando Perez-Serrato,DEM,0
+Hand,04,President,,Marianne Williamson,DEM,0
+Hand,04,President,,Joseph R Biden Jr,DEM,4
+Hand,04,President,,Dean Phillips,DEM,1
+Hand,04,President,,Armando Perez-Serrato,DEM,0
+Hand,05,President,,Marianne Williamson,DEM,2
+Hand,05,President,,Joseph R Biden Jr,DEM,5
+Hand,05,President,,Dean Phillips,DEM,0
+Hand,05,President,,Armando Perez-Serrato,DEM,2
+Hand,01,State Senate,23,Steven Ray Roseland,REP,40
+Hand,01,State Senate,23,Mark Lapka,REP,35
+Hand,02,State Senate,23,Steven Ray Roseland,REP,60
+Hand,02,State Senate,23,Mark Lapka,REP,41
+Hand,03,State Senate,23,Steven Ray Roseland,REP,69
+Hand,03,State Senate,23,Mark Lapka,REP,41
+Hand,04,State Senate,23,Steven Ray Roseland,REP,40
+Hand,04,State Senate,23,Mark Lapka,REP,62
+Hand,05,State Senate,23,Steven Ray Roseland,REP,62
+Hand,05,State Senate,23,Mark Lapka,REP,64
+Hand,01,State House,23,Spencer Gosch,REP,37
+Hand,01,State House,23,Scott Moore,REP,59
+Hand,01,State House,23,James D. Wangsness,REP,35
+Hand,02,State House,23,Spencer Gosch,REP,39
+Hand,02,State House,23,Scott Moore,REP,77
+Hand,02,State House,23,James D. Wangsness,REP,69
+Hand,03,State House,23,Spencer Gosch,REP,51
+Hand,03,State House,23,Scott Moore,REP,88
+Hand,03,State House,23,James D. Wangsness,REP,65
+Hand,04,State House,23,Spencer Gosch,REP,77
+Hand,04,State House,23,Scott Moore,REP,88
+Hand,04,State House,23,James D. Wangsness,REP,29
+Hand,05,State House,23,Spencer Gosch,REP,85
+Hand,05,State House,23,Scott Moore,REP,99
+Hand,05,State House,23,James D. Wangsness,REP,37

--- a/2024/counties/20240604__sd__primary__hanson__precinct.csv
+++ b/2024/counties/20240604__sd__primary__hanson__precinct.csv
@@ -1,0 +1,38 @@
+county,precinct,office,district,candidate,party,votes
+Hanson,1,President,,Marianne Williamson,DEM,1
+Hanson,1,President,,Joseph R Biden Jr,DEM,20
+Hanson,1,President,,Dean Phillips,DEM,2
+Hanson,1,President,,Armando Perez-Serrato,DEM,3
+Hanson,2,President,,Marianne Williamson,DEM,7
+Hanson,2,President,,Joseph R Biden Jr,DEM,27
+Hanson,2,President,,Dean Phillips,DEM,13
+Hanson,2,President,,Armando Perez-Serrato,DEM,5
+Hanson,3,President,,Marianne Williamson,DEM,2
+Hanson,3,President,,Joseph R Biden Jr,DEM,10
+Hanson,3,President,,Dean Phillips,DEM,7
+Hanson,3,President,,Armando Perez-Serrato,DEM,1
+Hanson,4,President,,Marianne Williamson,DEM,2
+Hanson,4,President,,Joseph R Biden Jr,DEM,1
+Hanson,4,President,,Dean Phillips,DEM,5
+Hanson,4,President,,Armando Perez-Serrato,DEM,0
+Hanson,5,President,,Marianne Williamson,DEM,4
+Hanson,5,President,,Joseph R Biden Jr,DEM,3
+Hanson,5,President,,Dean Phillips,DEM,5
+Hanson,5,President,,Armando Perez-Serrato,DEM,1
+Hanson,1,State House,19,Drew Peterson,REP,52
+Hanson,1,State House,19,Steven Mettler,REP,47
+Hanson,1,State House,19,Jessica Bahmuller,REP,95
+Hanson,2,State House,19,Drew Peterson,REP,65
+Hanson,2,State House,19,Steven Mettler,REP,26
+Hanson,2,State House,19,Jessica Bahmuller,REP,153
+Hanson,3,State House,19,Drew Peterson,REP,33
+Hanson,3,State House,19,Steven Mettler,REP,32
+Hanson,3,State House,19,Jessica Bahmuller,REP,78
+Hanson,4,State House,19,Drew Peterson,REP,26
+Hanson,4,State House,19,Steven Mettler,REP,23
+Hanson,4,State House,19,Jessica Bahmuller,REP,38
+Hanson,5,State House,19,Drew Peterson,REP,41
+Hanson,5,State House,19,Steven Mettler,REP,20
+Hanson,5,State House,19,Jessica Bahmuller,REP,80
+Hanson,2,County Commissioner,Hanson-2,Chad Pearson,REP,52
+Hanson,2,County Commissioner,Hanson-2,Richard J Waldera,REP,108

--- a/2024/counties/20240604__sd__primary__harding__precinct.csv
+++ b/2024/counties/20240604__sd__primary__harding__precinct.csv
@@ -1,0 +1,89 @@
+county,precinct,office,district,candidate,party,votes
+Harding,01,President,,Marianne Williamson,DEM,0
+Harding,01,President,,Joseph R Biden Jr,DEM,5
+Harding,01,President,,Dean Phillips,DEM,1
+Harding,01,President,,Armando Perez-Serrato,DEM,0
+Harding,02,President,,Marianne Williamson,DEM,2
+Harding,02,President,,Joseph R Biden Jr,DEM,3
+Harding,02,President,,Dean Phillips,DEM,1
+Harding,02,President,,Armando Perez-Serrato,DEM,1
+Harding,03,President,,Marianne Williamson,DEM,0
+Harding,03,President,,Joseph R Biden Jr,DEM,1
+Harding,03,President,,Dean Phillips,DEM,0
+Harding,03,President,,Armando Perez-Serrato,DEM,0
+Harding,05,President,,Marianne Williamson,DEM,2
+Harding,05,President,,Joseph R Biden Jr,DEM,2
+Harding,05,President,,Dean Phillips,DEM,1
+Harding,05,President,,Armando Perez-Serrato,DEM,1
+Harding,06,President,,Marianne Williamson,DEM,0
+Harding,06,President,,Joseph R Biden Jr,DEM,0
+Harding,06,President,,Dean Phillips,DEM,0
+Harding,06,President,,Armando Perez-Serrato,DEM,0
+Harding,07,President,,Marianne Williamson,DEM,0
+Harding,07,President,,Joseph R Biden Jr,DEM,1
+Harding,07,President,,Dean Phillips,DEM,0
+Harding,07,President,,Armando Perez-Serrato,DEM,1
+Harding,08,President,,Marianne Williamson,DEM,0
+Harding,08,President,,Joseph R Biden Jr,DEM,0
+Harding,08,President,,Dean Phillips,DEM,0
+Harding,08,President,,Armando Perez-Serrato,DEM,0
+Harding,09,President,,Marianne Williamson,DEM,0
+Harding,09,President,,Joseph R Biden Jr,DEM,0
+Harding,09,President,,Dean Phillips,DEM,0
+Harding,09,President,,Armando Perez-Serrato,DEM,1
+Harding,01,State Senate,28,Susan M. Peterson,REP,18
+Harding,01,State Senate,28,Sam Marty,REP,55
+Harding,02,State Senate,28,Susan M. Peterson,REP,12
+Harding,02,State Senate,28,Sam Marty,REP,44
+Harding,03,State Senate,28,Susan M. Peterson,REP,5
+Harding,03,State Senate,28,Sam Marty,REP,19
+Harding,05,State Senate,28,Susan M. Peterson,REP,30
+Harding,05,State Senate,28,Sam Marty,REP,42
+Harding,06,State Senate,28,Susan M. Peterson,REP,4
+Harding,06,State Senate,28,Sam Marty,REP,6
+Harding,07,State Senate,28,Susan M. Peterson,REP,6
+Harding,07,State Senate,28,Sam Marty,REP,17
+Harding,08,State Senate,28,Susan M. Peterson,REP,16
+Harding,08,State Senate,28,Sam Marty,REP,19
+Harding,09,State Senate,28,Susan M. Peterson,REP,7
+Harding,09,State Senate,28,Sam Marty,REP,62
+Harding,01,State House,28B,Travis Ismay,REP,37
+Harding,01,State House,28B,Travis W. Martin,REP,36
+Harding,02,State House,28B,Travis Ismay,REP,31
+Harding,02,State House,28B,Travis W. Martin,REP,22
+Harding,03,State House,28B,Travis Ismay,REP,17
+Harding,03,State House,28B,Travis W. Martin,REP,6
+Harding,05,State House,28B,Travis Ismay,REP,32
+Harding,05,State House,28B,Travis W. Martin,REP,37
+Harding,06,State House,28B,Travis Ismay,REP,7
+Harding,06,State House,28B,Travis W. Martin,REP,3
+Harding,07,State House,28B,Travis Ismay,REP,16
+Harding,07,State House,28B,Travis W. Martin,REP,5
+Harding,08,State House,28B,Travis Ismay,REP,17
+Harding,08,State House,28B,Travis W. Martin,REP,18
+Harding,09,State House,28B,Travis Ismay,REP,61
+Harding,09,State House,28B,Travis W. Martin,REP,7
+Harding,01,School Board Member,31-1,Nathan Wagner,,38
+Harding,01,School Board Member,31-1,Taz Olson,,48
+Harding,01,School Board Member,31-1,Clint Doll,,68
+Harding,02,School Board Member,31-1,Nathan Wagner,,32
+Harding,02,School Board Member,31-1,Taz Olson,,27
+Harding,02,School Board Member,31-1,Clint Doll,,51
+Harding,03,School Board Member,31-1,Nathan Wagner,,4
+Harding,03,School Board Member,31-1,Taz Olson,,22
+Harding,03,School Board Member,31-1,Clint Doll,,23
+Harding,05,School Board Member,31-1,Nathan Wagner,,26
+Harding,05,School Board Member,31-1,Taz Olson,,49
+Harding,05,School Board Member,31-1,Clint Doll,,71
+Harding,06,School Board Member,31-1,Nathan Wagner,,11
+Harding,06,School Board Member,31-1,Taz Olson,,1
+Harding,06,School Board Member,31-1,Clint Doll,,7
+Harding,07,School Board Member,31-1,Nathan Wagner,,17
+Harding,07,School Board Member,31-1,Taz Olson,,6
+Harding,07,School Board Member,31-1,Clint Doll,,25
+Harding,08,School Board Member,31-1,Nathan Wagner,,10
+Harding,08,School Board Member,31-1,Taz Olson,,28
+Harding,08,School Board Member,31-1,Clint Doll,,33
+Harding,09,School Board Member,31-1,Nathan Wagner,,11
+Harding,09,School Board Member,31-1,Taz Olson,,48
+Harding,09,School Board Member,31-1,Clint Doll,,64

--- a/2024/counties/20240604__sd__primary__hughes__precinct.csv
+++ b/2024/counties/20240604__sd__primary__hughes__precinct.csv
@@ -1,0 +1,49 @@
+county,precinct,office,district,candidate,party,votes
+Hughes,Absentee Precinct,President,,Marianne Williamson,DEM,3
+Hughes,Absentee Precinct,President,,Joseph R Biden Jr,DEM,25
+Hughes,Absentee Precinct,President,,Dean Phillips,DEM,0
+Hughes,Absentee Precinct,President,,Armando Perez-Serrato,DEM,0
+Hughes,Blunt City Hall,President,,Marianne Williamson,DEM,2
+Hughes,Blunt City Hall,President,,Joseph R Biden Jr,DEM,5
+Hughes,Blunt City Hall,President,,Dean Phillips,DEM,4
+Hughes,Blunt City Hall,President,,Armando Perez-Serrato,DEM,2
+Hughes,Capitol Lake Visitors Center,President,,Marianne Williamson,DEM,5
+Hughes,Capitol Lake Visitors Center,President,,Joseph R Biden Jr,DEM,19
+Hughes,Capitol Lake Visitors Center,President,,Dean Phillips,DEM,1
+Hughes,Capitol Lake Visitors Center,President,,Armando Perez-Serrato,DEM,2
+Hughes,Faith Lutheran Church,President,,Marianne Williamson,DEM,4
+Hughes,Faith Lutheran Church,President,,Joseph R Biden Jr,DEM,37
+Hughes,Faith Lutheran Church,President,,Dean Phillips,DEM,1
+Hughes,Faith Lutheran Church,President,,Armando Perez-Serrato,DEM,3
+Hughes,Harrold City Auditorium,President,,Marianne Williamson,DEM,0
+Hughes,Harrold City Auditorium,President,,Joseph R Biden Jr,DEM,1
+Hughes,Harrold City Auditorium,President,,Dean Phillips,DEM,0
+Hughes,Harrold City Auditorium,President,,Armando Perez-Serrato,DEM,0
+Hughes,New Life Assembly of God Church,President,,Marianne Williamson,DEM,2
+Hughes,New Life Assembly of God Church,President,,Joseph R Biden Jr,DEM,38
+Hughes,New Life Assembly of God Church,President,,Dean Phillips,DEM,3
+Hughes,New Life Assembly of God Church,President,,Armando Perez-Serrato,DEM,1
+Hughes,Absentee Precinct,Precinct Committeeman,11,Jeff Monroe,REP,8
+Hughes,Absentee Precinct,Precinct Committeeman,11,Craig Ambach,REP,3
+Hughes,Absentee Precinct,Precinct Committeeman,28,Tom Strubel,REP,3
+Hughes,Absentee Precinct,Precinct Committeeman,28,Jamie Huizenga,REP,1
+Hughes,Blunt City Hall,Precinct Committeeman,11,Jeff Monroe,REP,0
+Hughes,Blunt City Hall,Precinct Committeeman,11,Craig Ambach,REP,0
+Hughes,Blunt City Hall,Precinct Committeeman,28,Tom Strubel,REP,0
+Hughes,Blunt City Hall,Precinct Committeeman,28,Jamie Huizenga,REP,0
+Hughes,Capitol Lake Visitors Center,Precinct Committeeman,11,Jeff Monroe,REP,5
+Hughes,Capitol Lake Visitors Center,Precinct Committeeman,11,Craig Ambach,REP,1
+Hughes,Capitol Lake Visitors Center,Precinct Committeeman,28,Tom Strubel,REP,3
+Hughes,Capitol Lake Visitors Center,Precinct Committeeman,28,Jamie Huizenga,REP,4
+Hughes,Faith Lutheran Church,Precinct Committeeman,11,Jeff Monroe,REP,15
+Hughes,Faith Lutheran Church,Precinct Committeeman,11,Craig Ambach,REP,19
+Hughes,Faith Lutheran Church,Precinct Committeeman,28,Tom Strubel,REP,5
+Hughes,Faith Lutheran Church,Precinct Committeeman,28,Jamie Huizenga,REP,20
+Hughes,Harrold City Auditorium,Precinct Committeeman,11,Jeff Monroe,REP,0
+Hughes,Harrold City Auditorium,Precinct Committeeman,11,Craig Ambach,REP,0
+Hughes,Harrold City Auditorium,Precinct Committeeman,28,Tom Strubel,REP,0
+Hughes,Harrold City Auditorium,Precinct Committeeman,28,Jamie Huizenga,REP,0
+Hughes,New Life Assembly of God Church,Precinct Committeeman,11,Jeff Monroe,REP,39
+Hughes,New Life Assembly of God Church,Precinct Committeeman,11,Craig Ambach,REP,8
+Hughes,New Life Assembly of God Church,Precinct Committeeman,28,Tom Strubel,REP,3
+Hughes,New Life Assembly of God Church,Precinct Committeeman,28,Jamie Huizenga,REP,5

--- a/2024/counties/20240604__sd__primary__hutchinson__precinct.csv
+++ b/2024/counties/20240604__sd__primary__hutchinson__precinct.csv
@@ -1,0 +1,51 @@
+county,precinct,office,district,candidate,party,votes
+Hutchinson,01,President,,Marianne Williamson,DEM,0
+Hutchinson,01,President,,Joseph R Biden Jr,DEM,9
+Hutchinson,01,President,,Dean Phillips,DEM,4
+Hutchinson,01,President,,Armando Perez-Serrato,DEM,0
+Hutchinson,02,President,,Marianne Williamson,DEM,7
+Hutchinson,02,President,,Joseph R Biden Jr,DEM,21
+Hutchinson,02,President,,Dean Phillips,DEM,4
+Hutchinson,02,President,,Armando Perez-Serrato,DEM,2
+Hutchinson,03,President,,Marianne Williamson,DEM,2
+Hutchinson,03,President,,Joseph R Biden Jr,DEM,6
+Hutchinson,03,President,,Dean Phillips,DEM,3
+Hutchinson,03,President,,Armando Perez-Serrato,DEM,0
+Hutchinson,04,President,,Marianne Williamson,DEM,1
+Hutchinson,04,President,,Joseph R Biden Jr,DEM,17
+Hutchinson,04,President,,Dean Phillips,DEM,2
+Hutchinson,04,President,,Armando Perez-Serrato,DEM,1
+Hutchinson,05,President,,Marianne Williamson,DEM,2
+Hutchinson,05,President,,Joseph R Biden Jr,DEM,5
+Hutchinson,05,President,,Dean Phillips,DEM,1
+Hutchinson,05,President,,Armando Perez-Serrato,DEM,0
+Hutchinson,06,President,,Marianne Williamson,DEM,1
+Hutchinson,06,President,,Joseph R Biden Jr,DEM,1
+Hutchinson,06,President,,Dean Phillips,DEM,1
+Hutchinson,06,President,,Armando Perez-Serrato,DEM,0
+Hutchinson,01,State House,19,Drew Peterson,REP,78
+Hutchinson,01,State House,19,Steven Mettler,REP,171
+Hutchinson,01,State House,19,Jessica Bahmuller,REP,154
+Hutchinson,02,State House,19,Drew Peterson,REP,128
+Hutchinson,02,State House,19,Steven Mettler,REP,143
+Hutchinson,02,State House,19,Jessica Bahmuller,REP,196
+Hutchinson,03,State House,19,Drew Peterson,REP,56
+Hutchinson,03,State House,19,Steven Mettler,REP,24
+Hutchinson,03,State House,19,Jessica Bahmuller,REP,80
+Hutchinson,04,State House,19,Drew Peterson,REP,94
+Hutchinson,04,State House,19,Steven Mettler,REP,59
+Hutchinson,04,State House,19,Jessica Bahmuller,REP,114
+Hutchinson,05,State House,19,Drew Peterson,REP,61
+Hutchinson,05,State House,19,Steven Mettler,REP,60
+Hutchinson,05,State House,19,Jessica Bahmuller,REP,96
+Hutchinson,06,State House,19,Drew Peterson,REP,34
+Hutchinson,06,State House,19,Steven Mettler,REP,52
+Hutchinson,06,State House,19,Jessica Bahmuller,REP,68
+Hutchinson,02,County Commissioner,,Steven Friesen,REP,148
+Hutchinson,02,County Commissioner,,Charles Gering,REP,78
+Hutchinson,04,,,William D Hoffman,REP,109
+Hutchinson,04,,,Michael T. Boyle,REP,45
+Hutchinson,06,,,Kyle Schoenfish,REP,28
+Hutchinson,06,,,Daniel Hauck,REP,57
+Hutchinson,04,,,Isabel Boyle,REP,38
+Hutchinson,04,,,Elizabeth A Hoffman,REP,115

--- a/2024/counties/20240604__sd__primary__hyde__precinct.csv
+++ b/2024/counties/20240604__sd__primary__hyde__precinct.csv
@@ -1,0 +1,7 @@
+county,precinct,office,district,candidate,party,votes
+Hyde,Hyde County Memorial Auditorium-East Wing,President,,Marianne Williamson,DEM,10
+Hyde,Hyde County Memorial Auditorium-East Wing,President,,Joseph R Biden Jr,DEM,12
+Hyde,Hyde County Memorial Auditorium-East Wing,President,,Dean Phillips,DEM,1
+Hyde,Hyde County Memorial Auditorium-East Wing,President,,Armando Perez-Serrato,DEM,0
+Hyde,Hyde County Memorial Auditorium-East Wing,County Commissioner,4,Tod Kroeplin,REP,23
+Hyde,Hyde County Memorial Auditorium-East Wing,County Commissioner,4,Michael S Cowan,REP,17

--- a/2024/counties/20240604__sd__primary__jackson__precinct.csv
+++ b/2024/counties/20240604__sd__primary__jackson__precinct.csv
@@ -1,0 +1,81 @@
+county,precinct,office,district,candidate,party,votes
+Jackson,1,President,,Marianne Williamson,DEM,0
+Jackson,1,President,,Joseph R Biden Jr,DEM,0
+Jackson,1,President,,Dean Phillips,DEM,0
+Jackson,1,President,,Armando Perez-Serrato,DEM,0
+Jackson,2,President,,Marianne Williamson,DEM,1
+Jackson,2,President,,Joseph R Biden Jr,DEM,5
+Jackson,2,President,,Dean Phillips,DEM,0
+Jackson,2,President,,Armando Perez-Serrato,DEM,0
+Jackson,3,President,,Marianne Williamson,DEM,2
+Jackson,3,President,,Joseph R Biden Jr,DEM,4
+Jackson,3,President,,Dean Phillips,DEM,2
+Jackson,3,President,,Armando Perez-Serrato,DEM,1
+Jackson,4,President,,Marianne Williamson,DEM,0
+Jackson,4,President,,Joseph R Biden Jr,DEM,5
+Jackson,4,President,,Dean Phillips,DEM,1
+Jackson,4,President,,Armando Perez-Serrato,DEM,0
+Jackson,5,President,,Marianne Williamson,DEM,0
+Jackson,5,President,,Joseph R Biden Jr,DEM,2
+Jackson,5,President,,Dean Phillips,DEM,0
+Jackson,5,President,,Armando Perez-Serrato,DEM,0
+Jackson,6,President,,Marianne Williamson,DEM,0
+Jackson,6,President,,Joseph R Biden Jr,DEM,3
+Jackson,6,President,,Dean Phillips,DEM,0
+Jackson,6,President,,Armando Perez-Serrato,DEM,0
+Jackson,7,President,,Marianne Williamson,DEM,2
+Jackson,7,President,,Joseph R Biden Jr,DEM,18
+Jackson,7,President,,Dean Phillips,DEM,2
+Jackson,7,President,,Armando Perez-Serrato,DEM,1
+Jackson,8,President,,Marianne Williamson,DEM,0
+Jackson,8,President,,Joseph R Biden Jr,DEM,1
+Jackson,8,President,,Dean Phillips,DEM,0
+Jackson,8,President,,Armando Perez-Serrato,DEM,0
+Jackson,1,State Senate,27,Gerald M Cournoyer Jr,DEM,0
+Jackson,1,State Senate,27,Red Dawn Foster,DEM,0
+Jackson,1,State Senate,27,Anthony G. Kathol,REP,5
+Jackson,1,State Senate,27,Bruce Whalen,REP,5
+Jackson,2,State Senate,27,Gerald M Cournoyer Jr,DEM,2
+Jackson,2,State Senate,27,Red Dawn Foster,DEM,3
+Jackson,2,State Senate,27,Anthony G. Kathol,REP,18
+Jackson,2,State Senate,27,Bruce Whalen,REP,9
+Jackson,3,State Senate,27,Gerald M Cournoyer Jr,DEM,6
+Jackson,3,State Senate,27,Red Dawn Foster,DEM,4
+Jackson,3,State Senate,27,Anthony G. Kathol,REP,60
+Jackson,3,State Senate,27,Bruce Whalen,REP,32
+Jackson,4,State Senate,27,Gerald M Cournoyer Jr,DEM,1
+Jackson,4,State Senate,27,Red Dawn Foster,DEM,7
+Jackson,4,State Senate,27,Anthony G. Kathol,REP,32
+Jackson,4,State Senate,27,Bruce Whalen,REP,17
+Jackson,5,State Senate,27,Gerald M Cournoyer Jr,DEM,0
+Jackson,5,State Senate,27,Red Dawn Foster,DEM,2
+Jackson,5,State Senate,27,Anthony G. Kathol,REP,15
+Jackson,5,State Senate,27,Bruce Whalen,REP,19
+Jackson,6,State Senate,27,Gerald M Cournoyer Jr,DEM,0
+Jackson,6,State Senate,27,Red Dawn Foster,DEM,3
+Jackson,6,State Senate,27,Anthony G. Kathol,REP,19
+Jackson,6,State Senate,27,Bruce Whalen,REP,11
+Jackson,7,State Senate,27,Gerald M Cournoyer Jr,DEM,3
+Jackson,7,State Senate,27,Red Dawn Foster,DEM,20
+Jackson,7,State Senate,27,Anthony G. Kathol,REP,0
+Jackson,7,State Senate,27,Bruce Whalen,REP,2
+Jackson,8,State Senate,27,Gerald M Cournoyer Jr,DEM,0
+Jackson,8,State Senate,27,Red Dawn Foster,DEM,1
+Jackson,8,State Senate,27,Anthony G. Kathol,REP,7
+Jackson,8,State Senate,27,Bruce Whalen,REP,3
+Jackson,1,States Attorney,,Daniel Van Gorp,REP,4
+Jackson,1,States Attorney,,Cassie J. Wendt,REP,7
+Jackson,2,States Attorney,,Daniel Van Gorp,REP,11
+Jackson,2,States Attorney,,Cassie J. Wendt,REP,17
+Jackson,3,States Attorney,,Daniel Van Gorp,REP,45
+Jackson,3,States Attorney,,Cassie J. Wendt,REP,56
+Jackson,4,States Attorney,,Daniel Van Gorp,REP,23
+Jackson,4,States Attorney,,Cassie J. Wendt,REP,31
+Jackson,5,States Attorney,,Daniel Van Gorp,REP,10
+Jackson,5,States Attorney,,Cassie J. Wendt,REP,26
+Jackson,6,States Attorney,,Daniel Van Gorp,REP,10
+Jackson,6,States Attorney,,Cassie J. Wendt,REP,17
+Jackson,7,States Attorney,,Daniel Van Gorp,REP,1
+Jackson,7,States Attorney,,Cassie J. Wendt,REP,4
+Jackson,8,States Attorney,,Daniel Van Gorp,REP,2
+Jackson,8,States Attorney,,Cassie J. Wendt,REP,7

--- a/2024/counties/20240604__sd__primary__jerauld__precinct.csv
+++ b/2024/counties/20240604__sd__primary__jerauld__precinct.csv
@@ -1,0 +1,35 @@
+county,precinct,office,district,candidate,party,votes
+Jerauld,1,President,,Marianne Williamson,DEM,7
+Jerauld,1,President,,Joseph R Biden Jr,DEM,20
+Jerauld,1,President,,Dean Phillips,DEM,3
+Jerauld,1,President,,Armando Perez-Serrato,DEM,0
+Jerauld,2,President,,Marianne Williamson,DEM,0
+Jerauld,2,President,,Joseph R Biden Jr,DEM,5
+Jerauld,2,President,,Dean Phillips,DEM,0
+Jerauld,2,President,,Armando Perez-Serrato,DEM,0
+Jerauld,3,President,,Marianne Williamson,DEM,0
+Jerauld,3,President,,Joseph R Biden Jr,DEM,2
+Jerauld,3,President,,Dean Phillips,DEM,0
+Jerauld,3,President,,Armando Perez-Serrato,DEM,2
+Jerauld,4,President,,Marianne Williamson,DEM,0
+Jerauld,4,President,,Joseph R Biden Jr,DEM,3
+Jerauld,4,President,,Dean Phillips,DEM,0
+Jerauld,4,President,,Armando Perez-Serrato,DEM,0
+Jerauld,5,President,,Marianne Williamson,DEM,1
+Jerauld,5,President,,Joseph R Biden Jr,DEM,3
+Jerauld,5,President,,Dean Phillips,DEM,0
+Jerauld,5,President,,Armando Perez-Serrato,DEM,0
+Jerauld,1,County Treasurer,,Shelby Schooler,REP,38
+Jerauld,1,County Treasurer,,Tara Peterson,REP,54
+Jerauld,2,County Treasurer,,Shelby Schooler,REP,18
+Jerauld,2,County Treasurer,,Tara Peterson,REP,11
+Jerauld,3,County Treasurer,,Shelby Schooler,REP,6
+Jerauld,3,County Treasurer,,Tara Peterson,REP,9
+Jerauld,4,County Treasurer,,Shelby Schooler,REP,4
+Jerauld,4,County Treasurer,,Tara Peterson,REP,2
+Jerauld,5,County Treasurer,,Shelby Schooler,REP,10
+Jerauld,5,County Treasurer,,Tara Peterson,REP,12
+Jerauld,5,School Board Member,Kimball School District 7-2,Hillary Leiferman,,0
+Jerauld,5,School Board Member,Kimball School District 7-2,Joshua Krier,,0
+Jerauld,5,School Board Member,Kimball School District 7-2,Justin Blasius,,0
+Jerauld,5,School Board Member,Kimball School District 7-2,James Hoing,,0

--- a/2024/counties/20240604__sd__primary__jones__precinct.csv
+++ b/2024/counties/20240604__sd__primary__jones__precinct.csv
@@ -1,0 +1,13 @@
+county,precinct,office,district,candidate,party,votes
+Jones,1,County Commissioner,,Rodney Mann,REP,32
+Jones,1,County Commissioner,,Steven W. Iwan,REP,29
+Jones,2,County Commissioner,,Rodney Mann,REP,85
+Jones,2,County Commissioner,,Steven W. Iwan,REP,89
+Jones,1,President,,Marianne Williamson,DEM,1
+Jones,1,President,,Joseph R Biden Jr,DEM,3
+Jones,1,President,,Dean Phillips,DEM,0
+Jones,1,President,,Armando Perez-Serrato,DEM,1
+Jones,2,President,,Marianne Williamson,DEM,4
+Jones,2,President,,Joseph R Biden Jr,DEM,8
+Jones,2,President,,Dean Phillips,DEM,2
+Jones,2,President,,Armando Perez-Serrato,DEM,4

--- a/2024/counties/20240604__sd__primary__kingsbury__precinct.csv
+++ b/2024/counties/20240604__sd__primary__kingsbury__precinct.csv
@@ -1,0 +1,67 @@
+county,precinct,office,district,candidate,party,votes
+Kingsbury,Arlington Precinct,President,,Marianne Williamson,DEM,5
+Kingsbury,Arlington Precinct,President,,Joseph R Biden Jr,DEM,21
+Kingsbury,Arlington Precinct,President,,Dean Phillips,DEM,1
+Kingsbury,Arlington Precinct,President,,Armando Perez-Serrato,DEM,1
+Kingsbury,Badger Precinct,President,,Marianne Williamson,DEM,3
+Kingsbury,Badger Precinct,President,,Joseph R Biden Jr,DEM,0
+Kingsbury,Badger Precinct,President,,Dean Phillips,DEM,2
+Kingsbury,Badger Precinct,President,,Armando Perez-Serrato,DEM,0
+Kingsbury,De Smet Precinct,President,,Marianne Williamson,DEM,1
+Kingsbury,De Smet Precinct,President,,Joseph R Biden Jr,DEM,28
+Kingsbury,De Smet Precinct,President,,Dean Phillips,DEM,0
+Kingsbury,De Smet Precinct,President,,Armando Perez-Serrato,DEM,1
+Kingsbury,Iroquois Precinct,President,,Marianne Williamson,DEM,0
+Kingsbury,Iroquois Precinct,President,,Joseph R Biden Jr,DEM,14
+Kingsbury,Iroquois Precinct,President,,Dean Phillips,DEM,1
+Kingsbury,Iroquois Precinct,President,,Armando Perez-Serrato,DEM,1
+Kingsbury,Lake Preston Precinct,President,,Marianne Williamson,DEM,0
+Kingsbury,Lake Preston Precinct,President,,Joseph R Biden Jr,DEM,13
+Kingsbury,Lake Preston Precinct,President,,Dean Phillips,DEM,0
+Kingsbury,Lake Preston Precinct,President,,Armando Perez-Serrato,DEM,0
+Kingsbury,Oldham Precinct,President,,Marianne Williamson,DEM,1
+Kingsbury,Oldham Precinct,President,,Joseph R Biden Jr,DEM,4
+Kingsbury,Oldham Precinct,President,,Dean Phillips,DEM,2
+Kingsbury,Oldham Precinct,President,,Armando Perez-Serrato,DEM,0
+Kingsbury,Arlington Precinct,State Senate,08,Casey Crabtree,REP,100
+Kingsbury,Arlington Precinct,State Senate,08,Rick Weible,REP,40
+Kingsbury,Badger Precinct,State Senate,08,Casey Crabtree,REP,46
+Kingsbury,Badger Precinct,State Senate,08,Rick Weible,REP,25
+Kingsbury,De Smet Precinct,State Senate,08,Casey Crabtree,REP,141
+Kingsbury,De Smet Precinct,State Senate,08,Rick Weible,REP,36
+Kingsbury,Iroquois Precinct,State Senate,08,Casey Crabtree,REP,29
+Kingsbury,Iroquois Precinct,State Senate,08,Rick Weible,REP,13
+Kingsbury,Lake Preston Precinct,State Senate,08,Casey Crabtree,REP,78
+Kingsbury,Lake Preston Precinct,State Senate,08,Rick Weible,REP,24
+Kingsbury,Oldham Precinct,State Senate,08,Casey Crabtree,REP,41
+Kingsbury,Oldham Precinct,State Senate,08,Rick Weible,REP,11
+Kingsbury,Arlington Precinct,State House,08,Matt Wagner,REP,77
+Kingsbury,Arlington Precinct,State House,08,Tim Walburg,REP,66
+Kingsbury,Arlington Precinct,State House,08,Tim Reisch,REP,82
+Kingsbury,Badger Precinct,State House,08,Matt Wagner,REP,41
+Kingsbury,Badger Precinct,State House,08,Tim Walburg,REP,43
+Kingsbury,Badger Precinct,State House,08,Tim Reisch,REP,33
+Kingsbury,De Smet Precinct,State House,08,Matt Wagner,REP,95
+Kingsbury,De Smet Precinct,State House,08,Tim Walburg,REP,88
+Kingsbury,De Smet Precinct,State House,08,Tim Reisch,REP,135
+Kingsbury,Iroquois Precinct,State House,08,Matt Wagner,REP,23
+Kingsbury,Iroquois Precinct,State House,08,Tim Walburg,REP,21
+Kingsbury,Iroquois Precinct,State House,08,Tim Reisch,REP,27
+Kingsbury,Lake Preston Precinct,State House,08,Matt Wagner,REP,51
+Kingsbury,Lake Preston Precinct,State House,08,Tim Walburg,REP,47
+Kingsbury,Lake Preston Precinct,State House,08,Tim Reisch,REP,63
+Kingsbury,Oldham Precinct,State House,08,Matt Wagner,REP,32
+Kingsbury,Oldham Precinct,State House,08,Tim Walburg,REP,26
+Kingsbury,Oldham Precinct,State House,08,Tim Reisch,REP,28
+Kingsbury,Arlington Precinct,Coroner,,Steven A Strande,REP,76
+Kingsbury,Arlington Precinct,Coroner,,Garth Johnson,REP,64
+Kingsbury,Badger Precinct,Coroner,,Steven A Strande,REP,43
+Kingsbury,Badger Precinct,Coroner,,Garth Johnson,REP,28
+Kingsbury,De Smet Precinct,Coroner,,Steven A Strande,REP,121
+Kingsbury,De Smet Precinct,Coroner,,Garth Johnson,REP,60
+Kingsbury,Iroquois Precinct,Coroner,,Steven A Strande,REP,29
+Kingsbury,Iroquois Precinct,Coroner,,Garth Johnson,REP,12
+Kingsbury,Lake Preston Precinct,Coroner,,Steven A Strande,REP,78
+Kingsbury,Lake Preston Precinct,Coroner,,Garth Johnson,REP,23
+Kingsbury,Oldham Precinct,Coroner,,Steven A Strande,REP,32
+Kingsbury,Oldham Precinct,Coroner,,Garth Johnson,REP,22

--- a/2024/counties/20240604__sd__primary__lake__precinct.csv
+++ b/2024/counties/20240604__sd__primary__lake__precinct.csv
@@ -1,0 +1,151 @@
+county,precinct,office,district,candidate,party,votes
+Lake,Chester-Franklin,State Senate,08,Casey Crabtree,REP,79
+Lake,Chester-Franklin,State Senate,08,Rick Weible,REP,44
+Lake,Wentworth-Rutland,State Senate,08,Casey Crabtree,REP,101
+Lake,Wentworth-Rutland,State Senate,08,Rick Weible,REP,38
+Lake,Nunda-Summit,State Senate,08,Casey Crabtree,REP,32
+Lake,Nunda-Summit,State Senate,08,Rick Weible,REP,22
+Lake,Concord-Badus-Wayne/Ramona,State Senate,08,Casey Crabtree,REP,55
+Lake,Concord-Badus-Wayne/Ramona,State Senate,08,Rick Weible,REP,14
+Lake,Herman-Winfred,State Senate,08,Casey Crabtree,REP,102
+Lake,Herman-Winfred,State Senate,08,Rick Weible,REP,20
+Lake,Farmington-Leroy-Clarno-Orland,State Senate,08,Casey Crabtree,REP,64
+Lake,Farmington-Leroy-Clarno-Orland,State Senate,08,Rick Weible,REP,11
+Lake,Lakeview,State Senate,08,Casey Crabtree,REP,104
+Lake,Lakeview,State Senate,08,Rick Weible,REP,22
+Lake,Ward One,State Senate,08,Casey Crabtree,REP,266
+Lake,Ward One,State Senate,08,Rick Weible,REP,52
+Lake,Ward Two,State Senate,08,Casey Crabtree,REP,122
+Lake,Ward Two,State Senate,08,Rick Weible,REP,36
+Lake,Ward Three,State Senate,08,Casey Crabtree,REP,103
+Lake,Ward Three,State Senate,08,Rick Weible,REP,28
+Lake,Chester-Franklin,State House,08,Matt Wagner,REP,64
+Lake,Chester-Franklin,State House,08,Tim Walburg,REP,91
+Lake,Chester-Franklin,State House,08,Tim Reisch,REP,62
+Lake,Wentworth-Rutland,State House,08,Matt Wagner,REP,52
+Lake,Wentworth-Rutland,State House,08,Tim Walburg,REP,118
+Lake,Wentworth-Rutland,State House,08,Tim Reisch,REP,73
+Lake,Nunda-Summit,State House,08,Matt Wagner,REP,34
+Lake,Nunda-Summit,State House,08,Tim Walburg,REP,46
+Lake,Nunda-Summit,State House,08,Tim Reisch,REP,18
+Lake,Concord-Badus-Wayne/Ramona,State House,08,Matt Wagner,REP,24
+Lake,Concord-Badus-Wayne/Ramona,State House,08,Tim Walburg,REP,55
+Lake,Concord-Badus-Wayne/Ramona,State House,08,Tim Reisch,REP,42
+Lake,Herman-Winfred,State House,08,Matt Wagner,REP,31
+Lake,Herman-Winfred,State House,08,Tim Walburg,REP,102
+Lake,Herman-Winfred,State House,08,Tim Reisch,REP,85
+Lake,Farmington-Leroy-Clarno-Orland,State House,08,Matt Wagner,REP,23
+Lake,Farmington-Leroy-Clarno-Orland,State House,08,Tim Walburg,REP,61
+Lake,Farmington-Leroy-Clarno-Orland,State House,08,Tim Reisch,REP,53
+Lake,Lakeview,State House,08,Matt Wagner,REP,25
+Lake,Lakeview,State House,08,Tim Walburg,REP,111
+Lake,Lakeview,State House,08,Tim Reisch,REP,102
+Lake,Ward One,State House,08,Matt Wagner,REP,78
+Lake,Ward One,State House,08,Tim Walburg,REP,261
+Lake,Ward One,State House,08,Tim Reisch,REP,244
+Lake,Ward Two,State House,08,Matt Wagner,REP,68
+Lake,Ward Two,State House,08,Tim Walburg,REP,114
+Lake,Ward Two,State House,08,Tim Reisch,REP,108
+Lake,Ward Three,State House,08,Matt Wagner,REP,47
+Lake,Ward Three,State House,08,Tim Walburg,REP,105
+Lake,Ward Three,State House,08,Tim Reisch,REP,96
+Lake,Chester-Franklin,States Attorney,,Aaron Francis McGowan,REP,58
+Lake,Chester-Franklin,States Attorney,,Wendy Kloeppner,REP,50
+Lake,Wentworth-Rutland,States Attorney,,Aaron Francis McGowan,REP,68
+Lake,Wentworth-Rutland,States Attorney,,Wendy Kloeppner,REP,48
+Lake,Nunda-Summit,States Attorney,,Aaron Francis McGowan,REP,31
+Lake,Nunda-Summit,States Attorney,,Wendy Kloeppner,REP,16
+Lake,Concord-Badus-Wayne/Ramona,States Attorney,,Aaron Francis McGowan,REP,37
+Lake,Concord-Badus-Wayne/Ramona,States Attorney,,Wendy Kloeppner,REP,32
+Lake,Herman-Winfred,States Attorney,,Aaron Francis McGowan,REP,83
+Lake,Herman-Winfred,States Attorney,,Wendy Kloeppner,REP,28
+Lake,Farmington-Leroy-Clarno-Orland,States Attorney,,Aaron Francis McGowan,REP,49
+Lake,Farmington-Leroy-Clarno-Orland,States Attorney,,Wendy Kloeppner,REP,23
+Lake,Lakeview,States Attorney,,Aaron Francis McGowan,REP,75
+Lake,Lakeview,States Attorney,,Wendy Kloeppner,REP,41
+Lake,Ward One,States Attorney,,Aaron Francis McGowan,REP,229
+Lake,Ward One,States Attorney,,Wendy Kloeppner,REP,68
+Lake,Ward Two,States Attorney,,Aaron Francis McGowan,REP,93
+Lake,Ward Two,States Attorney,,Wendy Kloeppner,REP,66
+Lake,Ward Three,States Attorney,,Aaron Francis McGowan,REP,99
+Lake,Ward Three,States Attorney,,Wendy Kloeppner,REP,35
+Lake,Chester-Franklin,County Commissioner At Large,,Ryan J Gebauer,REP,50
+Lake,Chester-Franklin,County Commissioner At Large,,Adam Leighton,REP,74
+Lake,Chester-Franklin,County Commissioner At Large,,Deb Reinicke,REP,81
+Lake,Chester-Franklin,County Commissioner At Large,,Dennis Slaughter,REP,74
+Lake,Wentworth-Rutland,County Commissioner At Large,,Ryan J Gebauer,REP,56
+Lake,Wentworth-Rutland,County Commissioner At Large,,Adam Leighton,REP,103
+Lake,Wentworth-Rutland,County Commissioner At Large,,Deb Reinicke,REP,92
+Lake,Wentworth-Rutland,County Commissioner At Large,,Dennis Slaughter,REP,69
+Lake,Nunda-Summit,County Commissioner At Large,,Ryan J Gebauer,REP,26
+Lake,Nunda-Summit,County Commissioner At Large,,Adam Leighton,REP,43
+Lake,Nunda-Summit,County Commissioner At Large,,Deb Reinicke,REP,26
+Lake,Nunda-Summit,County Commissioner At Large,,Dennis Slaughter,REP,34
+Lake,Concord-Badus-Wayne/Ramona,County Commissioner At Large,,Ryan J Gebauer,REP,27
+Lake,Concord-Badus-Wayne/Ramona,County Commissioner At Large,,Adam Leighton,REP,48
+Lake,Concord-Badus-Wayne/Ramona,County Commissioner At Large,,Deb Reinicke,REP,41
+Lake,Concord-Badus-Wayne/Ramona,County Commissioner At Large,,Dennis Slaughter,REP,53
+Lake,Herman-Winfred,County Commissioner At Large,,Ryan J Gebauer,REP,41
+Lake,Herman-Winfred,County Commissioner At Large,,Adam Leighton,REP,96
+Lake,Herman-Winfred,County Commissioner At Large,,Deb Reinicke,REP,78
+Lake,Herman-Winfred,County Commissioner At Large,,Dennis Slaughter,REP,89
+Lake,Farmington-Leroy-Clarno-Orland,County Commissioner At Large,,Ryan J Gebauer,REP,20
+Lake,Farmington-Leroy-Clarno-Orland,County Commissioner At Large,,Adam Leighton,REP,58
+Lake,Farmington-Leroy-Clarno-Orland,County Commissioner At Large,,Deb Reinicke,REP,49
+Lake,Farmington-Leroy-Clarno-Orland,County Commissioner At Large,,Dennis Slaughter,REP,50
+Lake,Lakeview,County Commissioner At Large,,Ryan J Gebauer,REP,62
+Lake,Lakeview,County Commissioner At Large,,Adam Leighton,REP,90
+Lake,Lakeview,County Commissioner At Large,,Deb Reinicke,REP,66
+Lake,Lakeview,County Commissioner At Large,,Dennis Slaughter,REP,88
+Lake,Ward One,County Commissioner At Large,,Ryan J Gebauer,REP,119
+Lake,Ward One,County Commissioner At Large,,Adam Leighton,REP,250
+Lake,Ward One,County Commissioner At Large,,Deb Reinicke,REP,185
+Lake,Ward One,County Commissioner At Large,,Dennis Slaughter,REP,218
+Lake,Ward Two,County Commissioner At Large,,Ryan J Gebauer,REP,71
+Lake,Ward Two,County Commissioner At Large,,Adam Leighton,REP,121
+Lake,Ward Two,County Commissioner At Large,,Deb Reinicke,REP,94
+Lake,Ward Two,County Commissioner At Large,,Dennis Slaughter,REP,121
+Lake,Ward Three,County Commissioner At Large,,Ryan J Gebauer,REP,53
+Lake,Ward Three,County Commissioner At Large,,Adam Leighton,REP,105
+Lake,Ward Three,County Commissioner At Large,,Deb Reinicke,REP,82
+Lake,Ward Three,County Commissioner At Large,,Dennis Slaughter,REP,91
+Lake,Chester-Franklin,President,,Marianne Williamson,DEM,3
+Lake,Chester-Franklin,President,,Joseph R Biden Jr,DEM,12
+Lake,Chester-Franklin,President,,Dean Phillips,DEM,0
+Lake,Chester-Franklin,President,,Armando Perez-Serrato,DEM,1
+Lake,Wentworth – Rutland,President,,Marianne Williamson,DEM,3
+Lake,Wentworth – Rutland,President,,Joseph R Biden Jr,DEM,16
+Lake,Wentworth – Rutland,President,,Dean Phillips,DEM,3
+Lake,Wentworth – Rutland,President,,Armando Perez-Serrato,DEM,1
+Lake,Nunda-Summit,President,,Marianne Williamson,DEM,1
+Lake,Nunda-Summit,President,,Joseph R Biden Jr,DEM,2
+Lake,Nunda-Summit,President,,Dean Phillips,DEM,4
+Lake,Nunda-Summit,President,,Armando Perez-Serrato,DEM,0
+Lake,Concord-Badus-Wayne/Ramona,President,,Marianne Williamson,DEM,1
+Lake,Concord-Badus-Wayne/Ramona,President,,Joseph R Biden Jr,DEM,9
+Lake,Concord-Badus-Wayne/Ramona,President,,Dean Phillips,DEM,2
+Lake,Concord-Badus-Wayne/Ramona,President,,Armando Perez-Serrato,DEM,0
+Lake,Herman-Winfred,President,,Marianne Williamson,DEM,3
+Lake,Herman-Winfred,President,,Joseph R Biden Jr,DEM,11
+Lake,Herman-Winfred,President,,Dean Phillips,DEM,5
+Lake,Herman-Winfred,President,,Armando Perez-Serrato,DEM,0
+Lake,Farmington-Leroy-Clarno-Orland,President,,Marianne Williamson,DEM,2
+Lake,Farmington-Leroy-Clarno-Orland,President,,Joseph R Biden Jr,DEM,6
+Lake,Farmington-Leroy-Clarno-Orland,President,,Dean Phillips,DEM,2
+Lake,Farmington-Leroy-Clarno-Orland,President,,Armando Perez-Serrato,DEM,0
+Lake,Lakeview,President,,Marianne Williamson,DEM,1
+Lake,Lakeview,President,,Joseph R Biden Jr,DEM,14
+Lake,Lakeview,President,,Dean Phillips,DEM,1
+Lake,Lakeview,President,,Armando Perez-Serrato,DEM,0
+Lake,Ward One,President,,Marianne Williamson,DEM,6
+Lake,Ward One,President,,Joseph R Biden Jr,DEM,41
+Lake,Ward One,President,,Dean Phillips,DEM,5
+Lake,Ward One,President,,Armando Perez-Serrato,DEM,0
+Lake,Ward Two,President,,Marianne Williamson,DEM,2
+Lake,Ward Two,President,,Joseph R Biden Jr,DEM,21
+Lake,Ward Two,President,,Dean Phillips,DEM,4
+Lake,Ward Two,President,,Armando Perez-Serrato,DEM,2
+Lake,Ward Three,President,,Marianne Williamson,DEM,4
+Lake,Ward Three,President,,Joseph R Biden Jr,DEM,20
+Lake,Ward Three,President,,Dean Phillips,DEM,7
+Lake,Ward Three,President,,Armando Perez-Serrato,DEM,2

--- a/2024/counties/20240604__sd__primary__lawrence__precinct.csv
+++ b/2024/counties/20240604__sd__primary__lawrence__precinct.csv
@@ -1,0 +1,235 @@
+county,precinct,office,district,candidate,party,votes
+Lawrence,Absentee Precinct,President,,Marianne Williamson,DEM,15
+Lawrence,Absentee Precinct,President,,Joseph R Biden Jr,DEM,189
+Lawrence,Absentee Precinct,President,,Dean Phillips,DEM,4
+Lawrence,Absentee Precinct,President,,Armando Perez-Serrato,DEM,3
+Lawrence,01,President,,Marianne Williamson,DEM,8
+Lawrence,01,President,,Joseph R Biden Jr,DEM,51
+Lawrence,01,President,,Dean Phillips,DEM,9
+Lawrence,01,President,,Armando Perez-Serrato,DEM,4
+Lawrence,02,President,,Marianne Williamson,DEM,7
+Lawrence,02,President,,Joseph R Biden Jr,DEM,52
+Lawrence,02,President,,Dean Phillips,DEM,5
+Lawrence,02,President,,Armando Perez-Serrato,DEM,2
+Lawrence,03,President,,Marianne Williamson,DEM,8
+Lawrence,03,President,,Joseph R Biden Jr,DEM,82
+Lawrence,03,President,,Dean Phillips,DEM,5
+Lawrence,03,President,,Armando Perez-Serrato,DEM,1
+Lawrence,04,President,,Marianne Williamson,DEM,3
+Lawrence,04,President,,Joseph R Biden Jr,DEM,38
+Lawrence,04,President,,Dean Phillips,DEM,3
+Lawrence,04,President,,Armando Perez-Serrato,DEM,2
+Lawrence,05,President,,Marianne Williamson,DEM,0
+Lawrence,05,President,,Joseph R Biden Jr,DEM,22
+Lawrence,05,President,,Dean Phillips,DEM,0
+Lawrence,05,President,,Armando Perez-Serrato,DEM,4
+Lawrence,06,President,,Marianne Williamson,DEM,2
+Lawrence,06,President,,Joseph R Biden Jr,DEM,6
+Lawrence,06,President,,Dean Phillips,DEM,2
+Lawrence,06,President,,Armando Perez-Serrato,DEM,0
+Lawrence,07,President,,Marianne Williamson,DEM,3
+Lawrence,07,President,,Joseph R Biden Jr,DEM,26
+Lawrence,07,President,,Dean Phillips,DEM,3
+Lawrence,07,President,,Armando Perez-Serrato,DEM,1
+Lawrence,08,President,,Marianne Williamson,DEM,2
+Lawrence,08,President,,Joseph R Biden Jr,DEM,6
+Lawrence,08,President,,Dean Phillips,DEM,0
+Lawrence,08,President,,Armando Perez-Serrato,DEM,0
+Lawrence,09,President,,Marianne Williamson,DEM,10
+Lawrence,09,President,,Joseph R Biden Jr,DEM,26
+Lawrence,09,President,,Dean Phillips,DEM,4
+Lawrence,09,President,,Armando Perez-Serrato,DEM,2
+Lawrence,10,President,,Marianne Williamson,DEM,11
+Lawrence,10,President,,Joseph R Biden Jr,DEM,44
+Lawrence,10,President,,Dean Phillips,DEM,4
+Lawrence,10,President,,Armando Perez-Serrato,DEM,2
+Lawrence,Absentee Precinct,State Senate,31,Randy Deibert,REP,452
+Lawrence,Absentee Precinct,State Senate,31,Kate Crowley-Johnson,REP,265
+Lawrence,01,State Senate,31,Randy Deibert,REP,182
+Lawrence,01,State Senate,31,Kate Crowley-Johnson,REP,103
+Lawrence,02,State Senate,31,Randy Deibert,REP,178
+Lawrence,02,State Senate,31,Kate Crowley-Johnson,REP,104
+Lawrence,03,State Senate,31,Randy Deibert,REP,267
+Lawrence,03,State Senate,31,Kate Crowley-Johnson,REP,135
+Lawrence,04,State Senate,31,Randy Deibert,REP,107
+Lawrence,04,State Senate,31,Kate Crowley-Johnson,REP,57
+Lawrence,05,State Senate,31,Randy Deibert,REP,58
+Lawrence,05,State Senate,31,Kate Crowley-Johnson,REP,31
+Lawrence,06,State Senate,31,Randy Deibert,REP,19
+Lawrence,06,State Senate,31,Kate Crowley-Johnson,REP,24
+Lawrence,07,State Senate,31,Randy Deibert,REP,113
+Lawrence,07,State Senate,31,Kate Crowley-Johnson,REP,97
+Lawrence,08,State Senate,31,Randy Deibert,REP,45
+Lawrence,08,State Senate,31,Kate Crowley-Johnson,REP,25
+Lawrence,09,State Senate,31,Randy Deibert,REP,116
+Lawrence,09,State Senate,31,Kate Crowley-Johnson,REP,143
+Lawrence,10,State Senate,31,Randy Deibert,REP,287
+Lawrence,10,State Senate,31,Kate Crowley-Johnson,REP,264
+Lawrence,Absentee Precinct,State House,31,Mark Mowry,REP,298
+Lawrence,Absentee Precinct,State House,31,Mary J Fitzgerald,REP,387
+Lawrence,Absentee Precinct,State House,31,Scott Odenbach,REP,534
+Lawrence,01,State House,31,Mark Mowry,REP,112
+Lawrence,01,State House,31,Mary J Fitzgerald,REP,161
+Lawrence,01,State House,31,Scott Odenbach,REP,217
+Lawrence,02,State House,31,Mark Mowry,REP,123
+Lawrence,02,State House,31,Mary J Fitzgerald,REP,164
+Lawrence,02,State House,31,Scott Odenbach,REP,199
+Lawrence,03,State House,31,Mark Mowry,REP,162
+Lawrence,03,State House,31,Mary J Fitzgerald,REP,216
+Lawrence,03,State House,31,Scott Odenbach,REP,332
+Lawrence,04,State House,31,Mark Mowry,REP,65
+Lawrence,04,State House,31,Mary J Fitzgerald,REP,99
+Lawrence,04,State House,31,Scott Odenbach,REP,126
+Lawrence,05,State House,31,Mark Mowry,REP,42
+Lawrence,05,State House,31,Mary J Fitzgerald,REP,46
+Lawrence,05,State House,31,Scott Odenbach,REP,53
+Lawrence,06,State House,31,Mark Mowry,REP,18
+Lawrence,06,State House,31,Mary J Fitzgerald,REP,17
+Lawrence,06,State House,31,Scott Odenbach,REP,32
+Lawrence,07,State House,31,Mark Mowry,REP,105
+Lawrence,07,State House,31,Mary J Fitzgerald,REP,100
+Lawrence,07,State House,31,Scott Odenbach,REP,152
+Lawrence,08,State House,31,Mark Mowry,REP,34
+Lawrence,08,State House,31,Mary J Fitzgerald,REP,34
+Lawrence,08,State House,31,Scott Odenbach,REP,41
+Lawrence,09,State House,31,Mark Mowry,REP,153
+Lawrence,09,State House,31,Mary J Fitzgerald,REP,92
+Lawrence,09,State House,31,Scott Odenbach,REP,198
+Lawrence,10,State House,31,Mark Mowry,REP,294
+Lawrence,10,State House,31,Mary J Fitzgerald,REP,243
+Lawrence,10,State House,31,Scott Odenbach,REP,437
+Lawrence,Absentee Precinct,County Commissioner At Large,,Bob Ewing,REP,444
+Lawrence,Absentee Precinct,County Commissioner At Large,,Rick Tysdal,REP,389
+Lawrence,Absentee Precinct,County Commissioner At Large,,Erica Douglas,REP,339
+Lawrence,01,County Commissioner At Large,,Bob Ewing,REP,164
+Lawrence,01,County Commissioner At Large,,Rick Tysdal,REP,178
+Lawrence,01,County Commissioner At Large,,Erica Douglas,REP,131
+Lawrence,02,County Commissioner At Large,,Bob Ewing,REP,183
+Lawrence,02,County Commissioner At Large,,Rick Tysdal,REP,173
+Lawrence,02,County Commissioner At Large,,Erica Douglas,REP,116
+Lawrence,03,County Commissioner At Large,,Bob Ewing,REP,246
+Lawrence,03,County Commissioner At Large,,Rick Tysdal,REP,229
+Lawrence,03,County Commissioner At Large,,Erica Douglas,REP,184
+Lawrence,04,County Commissioner At Large,,Bob Ewing,REP,101
+Lawrence,04,County Commissioner At Large,,Rick Tysdal,REP,90
+Lawrence,04,County Commissioner At Large,,Erica Douglas,REP,85
+Lawrence,05,County Commissioner At Large,,Bob Ewing,REP,47
+Lawrence,05,County Commissioner At Large,,Rick Tysdal,REP,37
+Lawrence,05,County Commissioner At Large,,Erica Douglas,REP,51
+Lawrence,06,County Commissioner At Large,,Bob Ewing,REP,21
+Lawrence,06,County Commissioner At Large,,Rick Tysdal,REP,20
+Lawrence,06,County Commissioner At Large,,Erica Douglas,REP,30
+Lawrence,07,County Commissioner At Large,,Bob Ewing,REP,105
+Lawrence,07,County Commissioner At Large,,Rick Tysdal,REP,86
+Lawrence,07,County Commissioner At Large,,Erica Douglas,REP,133
+Lawrence,08,County Commissioner At Large,,Bob Ewing,REP,40
+Lawrence,08,County Commissioner At Large,,Rick Tysdal,REP,30
+Lawrence,08,County Commissioner At Large,,Erica Douglas,REP,33
+Lawrence,09,County Commissioner At Large,,Bob Ewing,REP,129
+Lawrence,09,County Commissioner At Large,,Rick Tysdal,REP,98
+Lawrence,09,County Commissioner At Large,,Erica Douglas,REP,163
+Lawrence,10,County Commissioner At Large,,Bob Ewing,REP,331
+Lawrence,10,County Commissioner At Large,,Rick Tysdal,REP,284
+Lawrence,10,County Commissioner At Large,,Erica Douglas,REP,292
+Lawrence,Absentee Precinct,Delegates To State Convention,,Naomi Merchant,REP,332
+Lawrence,Absentee Precinct,Delegates To State Convention,,David L. Gross,REP,269
+Lawrence,Absentee Precinct,Delegates To State Convention,,Ellen L. Gross,REP,259
+Lawrence,Absentee Precinct,Delegates To State Convention,,Meta Halverson,REP,270
+Lawrence,01,Delegates To State Convention,,Naomi Merchant,REP,118
+Lawrence,01,Delegates To State Convention,,David L. Gross,REP,97
+Lawrence,01,Delegates To State Convention,,Ellen L. Gross,REP,89
+Lawrence,01,Delegates To State Convention,,Meta Halverson,REP,93
+Lawrence,02,Delegates To State Convention,,Naomi Merchant,REP,130
+Lawrence,02,Delegates To State Convention,,David L. Gross,REP,102
+Lawrence,02,Delegates To State Convention,,Ellen L. Gross,REP,93
+Lawrence,02,Delegates To State Convention,,Meta Halverson,REP,100
+Lawrence,03,Delegates To State Convention,,Naomi Merchant,REP,181
+Lawrence,03,Delegates To State Convention,,David L. Gross,REP,150
+Lawrence,03,Delegates To State Convention,,Ellen L. Gross,REP,122
+Lawrence,03,Delegates To State Convention,,Meta Halverson,REP,141
+Lawrence,04,Delegates To State Convention,,Naomi Merchant,REP,89
+Lawrence,04,Delegates To State Convention,,David L. Gross,REP,77
+Lawrence,04,Delegates To State Convention,,Ellen L. Gross,REP,68
+Lawrence,04,Delegates To State Convention,,Meta Halverson,REP,69
+Lawrence,05,Delegates To State Convention,,Naomi Merchant,REP,40
+Lawrence,05,Delegates To State Convention,,David L. Gross,REP,34
+Lawrence,05,Delegates To State Convention,,Ellen L. Gross,REP,31
+Lawrence,05,Delegates To State Convention,,Meta Halverson,REP,27
+Lawrence,06,Delegates To State Convention,,Naomi Merchant,REP,26
+Lawrence,06,Delegates To State Convention,,David L. Gross,REP,15
+Lawrence,06,Delegates To State Convention,,Ellen L. Gross,REP,9
+Lawrence,06,Delegates To State Convention,,Meta Halverson,REP,21
+Lawrence,07,Delegates To State Convention,,Naomi Merchant,REP,92
+Lawrence,07,Delegates To State Convention,,David L. Gross,REP,86
+Lawrence,07,Delegates To State Convention,,Ellen L. Gross,REP,77
+Lawrence,07,Delegates To State Convention,,Meta Halverson,REP,84
+Lawrence,08,Delegates To State Convention,,Naomi Merchant,REP,29
+Lawrence,08,Delegates To State Convention,,David L. Gross,REP,30
+Lawrence,08,Delegates To State Convention,,Ellen L. Gross,REP,29
+Lawrence,08,Delegates To State Convention,,Meta Halverson,REP,22
+Lawrence,09,Delegates To State Convention,,Naomi Merchant,REP,117
+Lawrence,09,Delegates To State Convention,,David L. Gross,REP,93
+Lawrence,09,Delegates To State Convention,,Ellen L. Gross,REP,73
+Lawrence,09,Delegates To State Convention,,Meta Halverson,REP,154
+Lawrence,10,Delegates To State Convention,,Naomi Merchant,REP,270
+Lawrence,10,Delegates To State Convention,,David L. Gross,REP,172
+Lawrence,10,Delegates To State Convention,,Ellen L. Gross,REP,148
+Lawrence,10,Delegates To State Convention,,Meta Halverson,REP,222
+Lawrence,Absentee Precinct,Precinct Committeeman,Precinct-01,Donald Lutz,REP,34
+Lawrence,01,Precinct Committeeman,Precinct-01,Donald Lutz,REP,111
+Lawrence,Absentee Precinct,Precinct Committeeman,Precinct-01,Jimmy J. Roberts,REP,9
+Lawrence,01,Precinct Committeeman,Precinct-01,Jimmy J. Roberts,REP,62
+Lawrence,Absentee Precinct,Precinct Committeeman,Precinct-02,Ayden Q. Wrisley,REP,4
+Lawrence,02,Precinct Committeeman,Precinct-02,Ayden Q. Wrisley,REP,8
+Lawrence,Absentee Precinct,Precinct Committeeman,Precinct-02,Nathan Hoogshagen,REP,37
+Lawrence,02,Precinct Committeeman,Precinct-02,Nathan Hoogshagen,REP,152
+Lawrence,Absentee Precinct,Precinct Committeeman,Precinct-02,Thomas R. Nelson,REP,31
+Lawrence,02,Precinct Committeeman,Precinct-02,Thomas R. Nelson,REP,63
+Lawrence,Absentee Precinct,Precinct Committeeman,Precinct-03,Richard Prezkuta,REP,31
+Lawrence,03,Precinct Committeeman,Precinct-03,Richard Prezkuta,REP,150
+Lawrence,Absentee Precinct,Precinct Committeeman,Precinct-03,Perry Washenberger,REP,33
+Lawrence,03,Precinct Committeeman,Precinct-03,Perry Washenberger,REP,124
+Lawrence,Absentee Precinct,Precinct Committeeman,Precinct-04,Lloyd A. Rich,REP,15
+Lawrence,04,Precinct Committeeman,Precinct-04,Lloyd A. Rich,REP,74
+Lawrence,Absentee Precinct,Precinct Committeeman,Precinct-04,Gary Coe,REP,16
+Lawrence,04,Precinct Committeeman,Precinct-04,Gary Coe,REP,62
+Lawrence,Absentee Precinct,Precinct Committeeman,07,Joseph Palmer,REP,31
+Lawrence,Absentee Precinct,Precinct Committeeman,07,Ronald J. Moeller,REP,44
+Lawrence,Absentee Precinct,Precinct Committeeman,08,Justin Tupper,REP,0
+Lawrence,Absentee Precinct,Precinct Committeeman,08,Dave Samuelson,REP,5
+Lawrence,Absentee Precinct,Precinct Committeeman,09,Dahl H. McLean,REP,27
+Lawrence,Absentee Precinct,Precinct Committeeman,09,Tristen Rhoden,REP,10
+Lawrence,Absentee Precinct,Precinct Committeeman,10,Timothy A. Braithwait,REP,110
+Lawrence,Absentee Precinct,Precinct Committeeman,10,Richard D Sleep,REP,94
+Lawrence,07,Precinct Committeeman,07,Joseph Palmer,REP,61
+Lawrence,07,Precinct Committeeman,07,Ronald J. Moeller,REP,90
+Lawrence,08,Precinct Committeeman,08,Justin Tupper,REP,31
+Lawrence,08,Precinct Committeeman,08,Dave Samuelson,REP,39
+Lawrence,09,Precinct Committeeman,09,Dahl H. McLean,REP,142
+Lawrence,09,Precinct Committeeman,09,Tristen Rhoden,REP,97
+Lawrence,10,Precinct Committeeman,10,Timothy A. Braithwait,REP,255
+Lawrence,10,Precinct Committeeman,10,Richard D Sleep,REP,264
+Lawrence,Absentee Precinct,Precinct Committeewoman,01,Cindy K. Roberts,REP,17
+Lawrence,Absentee Precinct,Precinct Committeewoman,01,Dawn M. Lutz,REP,28
+Lawrence,01,Precinct Committeewoman,01,Cindy K. Roberts,REP,97
+Lawrence,01,Precinct Committeewoman,01,Dawn M. Lutz,REP,82
+Lawrence,Absentee Precinct,Precinct Committeewoman,03,Paulette Washenberger,REP,45
+Lawrence,Absentee Precinct,Precinct Committeewoman,03,Delia Prezkuta,REP,18
+Lawrence,03,Precinct Committeewoman,03,Paulette Washenberger,REP,150
+Lawrence,03,Precinct Committeewoman,03,Delia Prezkuta,REP,125
+Lawrence,Absentee Precinct,Precinct Committeewoman,06,Ami M Keller,REP,3
+Lawrence,Absentee Precinct,Precinct Committeewoman,06,Susan Johnson,REP,6
+Lawrence,06,Precinct Committeewoman,06,Ami M Keller,REP,14
+Lawrence,06,Precinct Committeewoman,06,Susan Johnson,REP,20
+Lawrence,Absentee Precinct,Precinct Committeewoman,08,Valerie Samuelson,REP,6
+Lawrence,Absentee Precinct,Precinct Committeewoman,08,Mary J Fitzgerald,REP,0
+Lawrence,08,Precinct Committeewoman,08,Valerie Samuelson,REP,43
+Lawrence,08,Precinct Committeewoman,08,Mary J Fitzgerald,REP,22
+Lawrence,Absentee Precinct,Precinct Committeewoman,09,Kalen Lemmel,REP,9
+Lawrence,Absentee Precinct,Precinct Committeewoman,09,Anna P. Marrs,REP,27
+Lawrence,Absentee Precinct,Precinct Committeewoman,10,Laura Odenbach,REP,138
+Lawrence,Absentee Precinct,Precinct Committeewoman,10,Karen E. Sleep,REP,63
+Lawrence,09,Precinct Committeewoman,09,Kalen Lemmel,REP,75
+Lawrence,09,Precinct Committeewoman,09,Anna P. Marrs,REP,178
+Lawrence,10,Precinct Committeewoman,10,Laura Odenbach,REP,320
+Lawrence,10,Precinct Committeewoman,10,Karen E. Sleep,REP,211

--- a/2024/counties/20240604__sd__primary__lincoln__precinct.csv
+++ b/2024/counties/20240604__sd__primary__lincoln__precinct.csv
@@ -1,0 +1,332 @@
+county,precinct,office,district,candidate,party,votes
+Lincoln,02-21,President,,Marianne Williamson,DEM,0
+Lincoln,02-21,President,,Joseph R Biden Jr,DEM,6
+Lincoln,02-21,President,,Dean Phillips,DEM,4
+Lincoln,02-21,President,,Armando Perez-Serrato,DEM,1
+Lincoln,06,President,,Marianne Williamson,DEM,3
+Lincoln,06,President,,Joseph R Biden Jr,DEM,6
+Lincoln,06,President,,Dean Phillips,DEM,3
+Lincoln,06,President,,Armando Perez-Serrato,DEM,1
+Lincoln,08,President,,Marianne Williamson,DEM,0
+Lincoln,08,President,,Joseph R Biden Jr,DEM,7
+Lincoln,08,President,,Dean Phillips,DEM,4
+Lincoln,08,President,,Armando Perez-Serrato,DEM,0
+Lincoln,11-14,President,,Marianne Williamson,DEM,2
+Lincoln,11-14,President,,Joseph R Biden Jr,DEM,7
+Lincoln,11-14,President,,Dean Phillips,DEM,1
+Lincoln,11-14,President,,Armando Perez-Serrato,DEM,0
+Lincoln,12,President,,Marianne Williamson,DEM,3
+Lincoln,12,President,,Joseph R Biden Jr,DEM,4
+Lincoln,12,President,,Dean Phillips,DEM,3
+Lincoln,12,President,,Armando Perez-Serrato,DEM,1
+Lincoln,13-14,President,,Marianne Williamson,DEM,0
+Lincoln,13-14,President,,Joseph R Biden Jr,DEM,11
+Lincoln,13-14,President,,Dean Phillips,DEM,0
+Lincoln,13-14,President,,Armando Perez-Serrato,DEM,0
+Lincoln,15,President,,Marianne Williamson,DEM,3
+Lincoln,15,President,,Joseph R Biden Jr,DEM,18
+Lincoln,15,President,,Dean Phillips,DEM,1
+Lincoln,15,President,,Armando Perez-Serrato,DEM,1
+Lincoln,16,President,,Marianne Williamson,DEM,2
+Lincoln,16,President,,Joseph R Biden Jr,DEM,8
+Lincoln,16,President,,Dean Phillips,DEM,0
+Lincoln,16,President,,Armando Perez-Serrato,DEM,2
+Lincoln,20,President,,Marianne Williamson,DEM,6
+Lincoln,20,President,,Joseph R Biden Jr,DEM,39
+Lincoln,20,President,,Dean Phillips,DEM,5
+Lincoln,20,President,,Armando Perez-Serrato,DEM,0
+Lincoln,23-13,President,,Marianne Williamson,DEM,4
+Lincoln,23-13,President,,Joseph R Biden Jr,DEM,9
+Lincoln,23-13,President,,Dean Phillips,DEM,2
+Lincoln,23-13,President,,Armando Perez-Serrato,DEM,0
+Lincoln,24-01,President,,Marianne Williamson,DEM,5
+Lincoln,24-01,President,,Joseph R Biden Jr,DEM,17
+Lincoln,24-01,President,,Dean Phillips,DEM,3
+Lincoln,24-01,President,,Armando Perez-Serrato,DEM,0
+Lincoln,24-02,President,,Marianne Williamson,DEM,3
+Lincoln,24-02,President,,Joseph R Biden Jr,DEM,12
+Lincoln,24-02,President,,Dean Phillips,DEM,0
+Lincoln,24-02,President,,Armando Perez-Serrato,DEM,0
+Lincoln,24-03,President,,Marianne Williamson,DEM,3
+Lincoln,24-03,President,,Joseph R Biden Jr,DEM,10
+Lincoln,24-03,President,,Dean Phillips,DEM,0
+Lincoln,24-03,President,,Armando Perez-Serrato,DEM,2
+Lincoln,25,President,,Marianne Williamson,DEM,2
+Lincoln,25,President,,Joseph R Biden Jr,DEM,10
+Lincoln,25,President,,Dean Phillips,DEM,1
+Lincoln,25,President,,Armando Perez-Serrato,DEM,0
+Lincoln,26,President,,Marianne Williamson,DEM,5
+Lincoln,26,President,,Joseph R Biden Jr,DEM,8
+Lincoln,26,President,,Dean Phillips,DEM,2
+Lincoln,26,President,,Armando Perez-Serrato,DEM,0
+Lincoln,27,President,,Marianne Williamson,DEM,1
+Lincoln,27,President,,Joseph R Biden Jr,DEM,22
+Lincoln,27,President,,Dean Phillips,DEM,3
+Lincoln,27,President,,Armando Perez-Serrato,DEM,2
+Lincoln,29,President,,Marianne Williamson,DEM,6
+Lincoln,29,President,,Joseph R Biden Jr,DEM,18
+Lincoln,29,President,,Dean Phillips,DEM,6
+Lincoln,29,President,,Armando Perez-Serrato,DEM,1
+Lincoln,30,President,,Marianne Williamson,DEM,3
+Lincoln,30,President,,Joseph R Biden Jr,DEM,10
+Lincoln,30,President,,Dean Phillips,DEM,0
+Lincoln,30,President,,Armando Perez-Serrato,DEM,3
+Lincoln,Sioux Falls 1-11,President,,Marianne Williamson,DEM,1
+Lincoln,Sioux Falls 1-11,President,,Joseph R Biden Jr,DEM,45
+Lincoln,Sioux Falls 1-11,President,,Dean Phillips,DEM,3
+Lincoln,Sioux Falls 1-11,President,,Armando Perez-Serrato,DEM,0
+Lincoln,Sioux Falls 1-12,President,,Marianne Williamson,DEM,1
+Lincoln,Sioux Falls 1-12,President,,Joseph R Biden Jr,DEM,29
+Lincoln,Sioux Falls 1-12,President,,Dean Phillips,DEM,4
+Lincoln,Sioux Falls 1-12,President,,Armando Perez-Serrato,DEM,1
+Lincoln,Sioux Falls 1-13,President,,Marianne Williamson,DEM,2
+Lincoln,Sioux Falls 1-13,President,,Joseph R Biden Jr,DEM,9
+Lincoln,Sioux Falls 1-13,President,,Dean Phillips,DEM,0
+Lincoln,Sioux Falls 1-13,President,,Armando Perez-Serrato,DEM,0
+Lincoln,Sioux Falls 1-14,President,,Marianne Williamson,DEM,0
+Lincoln,Sioux Falls 1-14,President,,Joseph R Biden Jr,DEM,11
+Lincoln,Sioux Falls 1-14,President,,Dean Phillips,DEM,3
+Lincoln,Sioux Falls 1-14,President,,Armando Perez-Serrato,DEM,0
+Lincoln,Sioux Falls 1-15,President,,Marianne Williamson,DEM,2
+Lincoln,Sioux Falls 1-15,President,,Joseph R Biden Jr,DEM,18
+Lincoln,Sioux Falls 1-15,President,,Dean Phillips,DEM,3
+Lincoln,Sioux Falls 1-15,President,,Armando Perez-Serrato,DEM,0
+Lincoln,Sioux Falls 1-16,President,,Marianne Williamson,DEM,2
+Lincoln,Sioux Falls 1-16,President,,Joseph R Biden Jr,DEM,8
+Lincoln,Sioux Falls 1-16,President,,Dean Phillips,DEM,0
+Lincoln,Sioux Falls 1-16,President,,Armando Perez-Serrato,DEM,0
+Lincoln,Sioux Falls 1-18,President,,Marianne Williamson,DEM,4
+Lincoln,Sioux Falls 1-18,President,,Joseph R Biden Jr,DEM,29
+Lincoln,Sioux Falls 1-18,President,,Dean Phillips,DEM,2
+Lincoln,Sioux Falls 1-18,President,,Armando Perez-Serrato,DEM,0
+Lincoln,Sioux Falls 1-20,President,,Marianne Williamson,DEM,3
+Lincoln,Sioux Falls 1-20,President,,Joseph R Biden Jr,DEM,11
+Lincoln,Sioux Falls 1-20,President,,Dean Phillips,DEM,0
+Lincoln,Sioux Falls 1-20,President,,Armando Perez-Serrato,DEM,0
+Lincoln,Sioux Falls 2-10,President,,Marianne Williamson,DEM,1
+Lincoln,Sioux Falls 2-10,President,,Joseph R Biden Jr,DEM,28
+Lincoln,Sioux Falls 2-10,President,,Dean Phillips,DEM,1
+Lincoln,Sioux Falls 2-10,President,,Armando Perez-Serrato,DEM,0
+Lincoln,Sioux Falls 2-11,President,,Marianne Williamson,DEM,3
+Lincoln,Sioux Falls 2-11,President,,Joseph R Biden Jr,DEM,51
+Lincoln,Sioux Falls 2-11,President,,Dean Phillips,DEM,2
+Lincoln,Sioux Falls 2-11,President,,Armando Perez-Serrato,DEM,0
+Lincoln,Sioux Falls 2-12,President,,Marianne Williamson,DEM,5
+Lincoln,Sioux Falls 2-12,President,,Joseph R Biden Jr,DEM,25
+Lincoln,Sioux Falls 2-12,President,,Dean Phillips,DEM,2
+Lincoln,Sioux Falls 2-12,President,,Armando Perez-Serrato,DEM,3
+Lincoln,Sioux Falls 2-13,President,,Marianne Williamson,DEM,1
+Lincoln,Sioux Falls 2-13,President,,Joseph R Biden Jr,DEM,51
+Lincoln,Sioux Falls 2-13,President,,Dean Phillips,DEM,4
+Lincoln,Sioux Falls 2-13,President,,Armando Perez-Serrato,DEM,1
+Lincoln,Sioux Falls 2-15,President,,Marianne Williamson,DEM,2
+Lincoln,Sioux Falls 2-15,President,,Joseph R Biden Jr,DEM,14
+Lincoln,Sioux Falls 2-15,President,,Dean Phillips,DEM,9
+Lincoln,Sioux Falls 2-15,President,,Armando Perez-Serrato,DEM,1
+Lincoln,Sioux Falls 2-16,President,,Marianne Williamson,DEM,7
+Lincoln,Sioux Falls 2-16,President,,Joseph R Biden Jr,DEM,54
+Lincoln,Sioux Falls 2-16,President,,Dean Phillips,DEM,1
+Lincoln,Sioux Falls 2-16,President,,Armando Perez-Serrato,DEM,1
+Lincoln,02-21,State Senate,16,Kevin D. Jensen,REP,71
+Lincoln,02-21,State Senate,16,Eric Hohman,REP,36
+Lincoln,06,State Senate,16,Kevin D. Jensen,REP,116
+Lincoln,06,State Senate,16,Eric Hohman,REP,68
+Lincoln,08,State Senate,16,Kevin D. Jensen,REP,32
+Lincoln,08,State Senate,16,Eric Hohman,REP,24
+Lincoln,11-14,State Senate,16,Kevin D. Jensen,REP,41
+Lincoln,11-14,State Senate,16,Eric Hohman,REP,16
+Lincoln,12,State Senate,16,Kevin D. Jensen,REP,87
+Lincoln,12,State Senate,16,Eric Hohman,REP,20
+Lincoln,20,State Senate,16,Kevin D. Jensen,REP,158
+Lincoln,20,State Senate,16,Eric Hohman,REP,136
+Lincoln,23-13,State Senate,16,Kevin D. Jensen,REP,100
+Lincoln,23-13,State Senate,16,Eric Hohman,REP,33
+Lincoln,25,State Senate,16,Kevin D. Jensen,REP,80
+Lincoln,25,State Senate,16,Eric Hohman,REP,54
+Lincoln,26,State Senate,16,Kevin D. Jensen,REP,75
+Lincoln,26,State Senate,16,Eric Hohman,REP,51
+Lincoln,29,State Senate,16,Kevin D. Jensen,REP,0
+Lincoln,29,State Senate,16,Eric Hohman,REP,0
+Lincoln,30,State Senate,16,Kevin D. Jensen,REP,77
+Lincoln,30,State Senate,16,Eric Hohman,REP,74
+Lincoln,02-21,State House,16,Karla J Lems,REP,92
+Lincoln,02-21,State House,16,Richard Vasgaard,REP,41
+Lincoln,02-21,State House,16,Brian J Burge,REP,28
+Lincoln,06,State House,16,Karla J Lems,REP,151
+Lincoln,06,State House,16,Richard Vasgaard,REP,77
+Lincoln,06,State House,16,Brian J Burge,REP,40
+Lincoln,08,State House,16,Karla J Lems,REP,36
+Lincoln,08,State House,16,Richard Vasgaard,REP,36
+Lincoln,08,State House,16,Brian J Burge,REP,17
+Lincoln,11-14,State House,16,Karla J Lems,REP,53
+Lincoln,11-14,State House,16,Richard Vasgaard,REP,32
+Lincoln,11-14,State House,16,Brian J Burge,REP,11
+Lincoln,12,State House,16,Karla J Lems,REP,95
+Lincoln,12,State House,16,Richard Vasgaard,REP,31
+Lincoln,12,State House,16,Brian J Burge,REP,32
+Lincoln,13-14,State House,06,Wendi Hogan,REP,37
+Lincoln,13-14,State House,06,Herman Otten,REP,56
+Lincoln,13-14,State House,06,Aaron Aylward,REP,55
+Lincoln,15,State House,06,Wendi Hogan,REP,75
+Lincoln,15,State House,06,Herman Otten,REP,64
+Lincoln,15,State House,06,Aaron Aylward,REP,99
+Lincoln,16,State House,06,Wendi Hogan,REP,53
+Lincoln,16,State House,06,Herman Otten,REP,84
+Lincoln,16,State House,06,Aaron Aylward,REP,79
+Lincoln,16,State House,12,Amber Arlint,REP,0
+Lincoln,16,State House,12,Greg Jamison,REP,0
+Lincoln,16,State House,12,Manny Steele,REP,0
+Lincoln,20,State House,16,Karla J Lems,REP,250
+Lincoln,20,State House,16,Richard Vasgaard,REP,128
+Lincoln,20,State House,16,Brian J Burge,REP,54
+Lincoln,23-13,State House,16,Karla J Lems,REP,107
+Lincoln,23-13,State House,16,Richard Vasgaard,REP,58
+Lincoln,23-13,State House,16,Brian J Burge,REP,39
+Lincoln,24-01,State House,06,Wendi Hogan,REP,37
+Lincoln,24-01,State House,06,Herman Otten,REP,69
+Lincoln,24-01,State House,06,Aaron Aylward,REP,63
+Lincoln,24-02,State House,06,Wendi Hogan,REP,26
+Lincoln,24-02,State House,06,Herman Otten,REP,41
+Lincoln,24-02,State House,06,Aaron Aylward,REP,45
+Lincoln,24-03,State House,06,Wendi Hogan,REP,26
+Lincoln,24-03,State House,06,Herman Otten,REP,37
+Lincoln,24-03,State House,06,Aaron Aylward,REP,33
+Lincoln,25,State House,16,Karla J Lems,REP,105
+Lincoln,25,State House,16,Richard Vasgaard,REP,82
+Lincoln,25,State House,16,Brian J Burge,REP,37
+Lincoln,26,State House,16,Karla J Lems,REP,92
+Lincoln,26,State House,16,Richard Vasgaard,REP,83
+Lincoln,26,State House,16,Brian J Burge,REP,32
+Lincoln,27,State House,06,Wendi Hogan,REP,68
+Lincoln,27,State House,06,Herman Otten,REP,63
+Lincoln,27,State House,06,Aaron Aylward,REP,105
+Lincoln,29,State House,06,Wendi Hogan,REP,57
+Lincoln,29,State House,06,Herman Otten,REP,51
+Lincoln,29,State House,06,Aaron Aylward,REP,89
+Lincoln,29,State House,16,Karla J Lems,REP,0
+Lincoln,29,State House,16,Richard Vasgaard,REP,0
+Lincoln,29,State House,16,Brian J Burge,REP,0
+Lincoln,30,State House,16,Karla J Lems,REP,125
+Lincoln,30,State House,16,Richard Vasgaard,REP,64
+Lincoln,30,State House,16,Brian J Burge,REP,22
+Lincoln,Sioux Falls 1-11,State House,12,Amber Arlint,REP,250
+Lincoln,Sioux Falls 1-11,State House,12,Greg Jamison,REP,204
+Lincoln,Sioux Falls 1-11,State House,12,Manny Steele,REP,154
+Lincoln,Sioux Falls 1-12,State House,12,Amber Arlint,REP,66
+Lincoln,Sioux Falls 1-12,State House,12,Greg Jamison,REP,40
+Lincoln,Sioux Falls 1-12,State House,12,Manny Steele,REP,55
+Lincoln,Sioux Falls 1-13,State House,06,Wendi Hogan,REP,22
+Lincoln,Sioux Falls 1-13,State House,06,Herman Otten,REP,19
+Lincoln,Sioux Falls 1-13,State House,06,Aaron Aylward,REP,26
+Lincoln,Sioux Falls 1-14,State House,06,Wendi Hogan,REP,25
+Lincoln,Sioux Falls 1-14,State House,06,Herman Otten,REP,35
+Lincoln,Sioux Falls 1-14,State House,06,Aaron Aylward,REP,35
+Lincoln,Sioux Falls 1-15,State House,12,Amber Arlint,REP,53
+Lincoln,Sioux Falls 1-15,State House,12,Greg Jamison,REP,41
+Lincoln,Sioux Falls 1-15,State House,12,Manny Steele,REP,31
+Lincoln,Sioux Falls 1-16,State House,06,Wendi Hogan,REP,18
+Lincoln,Sioux Falls 1-16,State House,06,Herman Otten,REP,20
+Lincoln,Sioux Falls 1-16,State House,06,Aaron Aylward,REP,26
+Lincoln,Sioux Falls 1-18,State House,12,Amber Arlint,REP,113
+Lincoln,Sioux Falls 1-18,State House,12,Greg Jamison,REP,70
+Lincoln,Sioux Falls 1-18,State House,12,Manny Steele,REP,77
+Lincoln,Sioux Falls 1-20,State House,06,Wendi Hogan,REP,19
+Lincoln,Sioux Falls 1-20,State House,06,Herman Otten,REP,27
+Lincoln,Sioux Falls 1-20,State House,06,Aaron Aylward,REP,32
+Lincoln,Sioux Falls 2-10,State House,13,John Hughes,REP,177
+Lincoln,Sioux Falls 2-10,State House,13,Brad Jankord,REP,128
+Lincoln,Sioux Falls 2-10,State House,13,Penny BayBridge,REP,18
+Lincoln,Sioux Falls 2-10,State House,13,Tony Venhuizen,REP,175
+Lincoln,Sioux Falls 2-11,State House,06,Wendi Hogan,REP,0
+Lincoln,Sioux Falls 2-11,State House,06,Herman Otten,REP,0
+Lincoln,Sioux Falls 2-11,State House,06,Aaron Aylward,REP,0
+Lincoln,Sioux Falls 2-11,State House,13,John Hughes,REP,228
+Lincoln,Sioux Falls 2-11,State House,13,Brad Jankord,REP,202
+Lincoln,Sioux Falls 2-11,State House,13,Penny BayBridge,REP,35
+Lincoln,Sioux Falls 2-11,State House,13,Tony Venhuizen,REP,220
+Lincoln,Sioux Falls 2-12,State House,13,John Hughes,REP,79
+Lincoln,Sioux Falls 2-12,State House,13,Brad Jankord,REP,47
+Lincoln,Sioux Falls 2-12,State House,13,Penny BayBridge,REP,11
+Lincoln,Sioux Falls 2-12,State House,13,Tony Venhuizen,REP,76
+Lincoln,Sioux Falls 2-13,State House,13,John Hughes,REP,170
+Lincoln,Sioux Falls 2-13,State House,13,Brad Jankord,REP,119
+Lincoln,Sioux Falls 2-13,State House,13,Penny BayBridge,REP,28
+Lincoln,Sioux Falls 2-13,State House,13,Tony Venhuizen,REP,169
+Lincoln,Sioux Falls 2-15,State House,13,John Hughes,REP,117
+Lincoln,Sioux Falls 2-15,State House,13,Brad Jankord,REP,107
+Lincoln,Sioux Falls 2-15,State House,13,Penny BayBridge,REP,10
+Lincoln,Sioux Falls 2-15,State House,13,Tony Venhuizen,REP,130
+Lincoln,Sioux Falls 2-16,State House,06,Wendi Hogan,REP,0
+Lincoln,Sioux Falls 2-16,State House,06,Herman Otten,REP,0
+Lincoln,Sioux Falls 2-16,State House,06,Aaron Aylward,REP,0
+Lincoln,Sioux Falls 2-16,State House,13,John Hughes,REP,154
+Lincoln,Sioux Falls 2-16,State House,13,Brad Jankord,REP,101
+Lincoln,Sioux Falls 2-16,State House,13,Penny BayBridge,REP,26
+Lincoln,Sioux Falls 2-16,State House,13,Tony Venhuizen,REP,147
+Lincoln,02-21,County Commissioner,2,Betty Otten,REP,32
+Lincoln,02-21,County Commissioner,2,Duane A.M. Carlson,REP,67
+Lincoln,02-21,County Commissioner,4,Michael E Poppens,REP,0
+Lincoln,02-21,County Commissioner,4,Douglas Putnam,REP,0
+Lincoln,06,County Commissioner,2,Betty Otten,REP,81
+Lincoln,06,County Commissioner,2,Duane A.M. Carlson,REP,82
+Lincoln,08,County Commissioner,2,Betty Otten,REP,22
+Lincoln,08,County Commissioner,2,Duane A.M. Carlson,REP,32
+Lincoln,11-14,County Commissioner,2,Betty Otten,REP,31
+Lincoln,11-14,County Commissioner,2,Duane A.M. Carlson,REP,25
+Lincoln,12,County Commissioner,2,Betty Otten,REP,36
+Lincoln,12,County Commissioner,2,Duane A.M. Carlson,REP,63
+Lincoln,13-14,County Commissioner,2,Betty Otten,REP,60
+Lincoln,13-14,County Commissioner,2,Duane A.M. Carlson,REP,29
+Lincoln,16,County Commissioner,4,Michael E Poppens,REP,35
+Lincoln,16,County Commissioner,4,Douglas Putnam,REP,49
+Lincoln,20,County Commissioner,2,Betty Otten,REP,132
+Lincoln,20,County Commissioner,2,Duane A.M. Carlson,REP,120
+Lincoln,23-13,County Commissioner,2,Betty Otten,REP,66
+Lincoln,23-13,County Commissioner,2,Duane A.M. Carlson,REP,55
+Lincoln,24-01,County Commissioner,4,Michael E Poppens,REP,32
+Lincoln,24-01,County Commissioner,4,Douglas Putnam,REP,63
+Lincoln,24-02,County Commissioner,4,Michael E Poppens,REP,34
+Lincoln,24-02,County Commissioner,4,Douglas Putnam,REP,27
+Lincoln,24-03,County Commissioner,4,Michael E Poppens,REP,25
+Lincoln,24-03,County Commissioner,4,Douglas Putnam,REP,29
+Lincoln,25,County Commissioner,2,Betty Otten,REP,92
+Lincoln,25,County Commissioner,2,Duane A.M. Carlson,REP,41
+Lincoln,26,County Commissioner,2,Betty Otten,REP,44
+Lincoln,26,County Commissioner,2,Duane A.M. Carlson,REP,77
+Lincoln,30,County Commissioner,2,Betty Otten,REP,74
+Lincoln,30,County Commissioner,2,Duane A.M. Carlson,REP,45
+Lincoln,Sioux Falls 1-13,County Commissioner,4,Michael E Poppens,REP,18
+Lincoln,Sioux Falls 1-13,County Commissioner,4,Douglas Putnam,REP,13
+Lincoln,Sioux Falls 1-14,County Commissioner,4,Michael E Poppens,REP,26
+Lincoln,Sioux Falls 1-14,County Commissioner,4,Douglas Putnam,REP,18
+Lincoln,Sioux Falls 1-16,County Commissioner,4,Michael E Poppens,REP,16
+Lincoln,Sioux Falls 1-16,County Commissioner,4,Douglas Putnam,REP,14
+Lincoln,15,Precinct Committeeman,15,Seth Moser,REP,61
+Lincoln,15,Precinct Committeeman,15,Christopher Steven Enger,REP,47
+Lincoln,30,Precinct Committeeman,30,Samuel J. Nelson,REP,89
+Lincoln,30,Precinct Committeeman,30,Robert Wells,REP,29
+Lincoln,Sioux Falls 1-11,Precinct Committeeman,Sioux Falls 1-11,Manny Steele,REP,203
+Lincoln,Sioux Falls 1-11,Precinct Committeeman,Sioux Falls 1-11,Ryan Spellerberg,REP,133
+Lincoln,Sioux Falls 1-12,Precinct Committeeman,Sioux Falls 1-12,Dennis Harms,REP,28
+Lincoln,Sioux Falls 1-12,Precinct Committeeman,Sioux Falls 1-12,Arch Beal,REP,70
+Lincoln,Sioux Falls 1-18,Precinct Committeeman,Sioux Falls 1-18,Chad Bishop,REP,26
+Lincoln,Sioux Falls 1-18,Precinct Committeeman,Sioux Falls 1-18,Trenton Arlint,REP,68
+Lincoln,Sioux Falls 1-18,Precinct Committeeman,Sioux Falls 1-18,Dale Jelen,REP,27
+Lincoln,Sioux Falls 2-11,Precinct Committeeman,Sioux Falls 2-11,Tony Venhuizen,REP,234
+Lincoln,Sioux Falls 2-11,Precinct Committeeman,Sioux Falls 2-11,Wayne Miller,REP,121
+Lincoln,Sioux Falls 2-12,Precinct Committeeman,Sioux Falls 2-12,Chad David,REP,45
+Lincoln,Sioux Falls 2-12,Precinct Committeeman,Sioux Falls 2-12,Christopher Daugaard,REP,62
+Lincoln,Sioux Falls 2-13,Precinct Committeeman,Sioux Falls 2-13,Mike Mathis,REP,109
+Lincoln,Sioux Falls 2-13,Precinct Committeeman,Sioux Falls 2-13,Justin G. Smith,REP,69
+Lincoln,Sioux Falls 2-15,Precinct Committeeman,Sioux Falls 2-15,Brad Jankord,REP,129
+Lincoln,Sioux Falls 2-15,Precinct Committeeman,Sioux Falls 2-15,William G. Peterson,REP,64
+Lincoln,27,Precinct Committeewoman,27,Hannah Lems,REP,54
+Lincoln,27,Precinct Committeewoman,27,Wendi Hogan,REP,77
+Lincoln,Sioux Falls 1-11,Precinct Committeewoman Sioux Falls 1-11,,Hayley Halverson,REP,145
+Lincoln,Sioux Falls 1-11,Precinct Committeewoman Sioux Falls 1-11,,Barbara Steele,REP,163
+Lincoln,Sioux Falls 1-18,Precinct Committeewoman Sioux Falls 1-18,,Kimberly Bishop,REP,31
+Lincoln,Sioux Falls 1-18,Precinct Committeewoman Sioux Falls 1-18,,Amber Arlint,REP,112
+Lincoln,Sioux Falls 2-11,Precinct Committeewoman Sioux Falls 2-11,,Janet Miller,REP,150
+Lincoln,Sioux Falls 2-11,Precinct Committeewoman Sioux Falls 2-11,,Sara Venhuizen,REP,185
+Lincoln,Sioux Falls 2-12,Precinct Committeewoman Sioux Falls 2-12,,Christina David,REP,37
+Lincoln,Sioux Falls 2-12,Precinct Committeewoman Sioux Falls 2-12,,Emily Daugaard,REP,70

--- a/2024/counties/20240604__sd__primary__lyman__precinct.csv
+++ b/2024/counties/20240604__sd__primary__lyman__precinct.csv
@@ -1,0 +1,57 @@
+county,precinct,office,district,candidate,party,votes
+Lyman,Iona,U.S. Senate,,Marianne Williamson,DEM,6
+Lyman,Oacoma,U.S. Senate,,Marianne Williamson,DEM,1
+Lyman,Reliance,U.S. Senate,,Marianne Williamson,DEM,2
+Lyman,Lower Brule,U.S. Senate,,Marianne Williamson,DEM,1
+Lyman,Kennebec,U.S. Senate,,Marianne Williamson,DEM,0
+Lyman,Presho,U.S. Senate,,Marianne Williamson,DEM,0
+Lyman,Vivian,U.S. Senate,,Marianne Williamson,DEM,1
+Lyman,Iona,U.S. Senate,,Joseph R Biden Jr,DEM,1
+Lyman,Oacoma,U.S. Senate,,Joseph R Biden Jr,DEM,5
+Lyman,Reliance,U.S. Senate,,Joseph R Biden Jr,DEM,3
+Lyman,Lower Brule,U.S. Senate,,Joseph R Biden Jr,DEM,24
+Lyman,Kennebec,U.S. Senate,,Joseph R Biden Jr,DEM,2
+Lyman,Presho,U.S. Senate,,Joseph R Biden Jr,DEM,5
+Lyman,Vivian,U.S. Senate,,Joseph R Biden Jr,DEM,2
+Lyman,Iona,U.S. Senate,,Dean Phillips,DEM,3
+Lyman,Oacoma,U.S. Senate,,Dean Phillips,DEM,1
+Lyman,Reliance,U.S. Senate,,Dean Phillips,DEM,0
+Lyman,Lower Brule,U.S. Senate,,Dean Phillips,DEM,1
+Lyman,Kennebec,U.S. Senate,,Dean Phillips,DEM,1
+Lyman,Presho,U.S. Senate,,Dean Phillips,DEM,2
+Lyman,Vivian,U.S. Senate,,Dean Phillips,DEM,0
+Lyman,Iona,U.S. Senate,,Armando Perez-Serrato,DEM,1
+Lyman,Oacoma,U.S. Senate,,Armando Perez-Serrato,DEM,0
+Lyman,Reliance,U.S. Senate,,Armando Perez-Serrato,DEM,0
+Lyman,Lower Brule,U.S. Senate,,Armando Perez-Serrato,DEM,2
+Lyman,Kennebec,U.S. Senate,,Armando Perez-Serrato,DEM,0
+Lyman,Presho,U.S. Senate,,Armando Perez-Serrato,DEM,1
+Lyman,Vivian,U.S. Senate,,Armando Perez-Serrato,DEM,1
+Lyman,01,President,,Marianne Williamson,DEM,6
+Lyman,01,President,,Joseph R Biden Jr,DEM,1
+Lyman,01,President,,Dean Phillips,DEM,3
+Lyman,01,President,,Armando Perez-Serrato,DEM,1
+Lyman,04,President,,Marianne Williamson,DEM,1
+Lyman,04,President,,Joseph R Biden Jr,DEM,5
+Lyman,04,President,,Dean Phillips,DEM,1
+Lyman,04,President,,Armando Perez-Serrato,DEM,0
+Lyman,06,President,,Marianne Williamson,DEM,2
+Lyman,06,President,,Joseph R Biden Jr,DEM,3
+Lyman,06,President,,Dean Phillips,DEM,0
+Lyman,06,President,,Armando Perez-Serrato,DEM,0
+Lyman,07,President,,Marianne Williamson,DEM,1
+Lyman,07,President,,Joseph R Biden Jr,DEM,24
+Lyman,07,President,,Dean Phillips,DEM,1
+Lyman,07,President,,Armando Perez-Serrato,DEM,2
+Lyman,09,President,,Marianne Williamson,DEM,0
+Lyman,09,President,,Joseph R Biden Jr,DEM,2
+Lyman,09,President,,Dean Phillips,DEM,1
+Lyman,09,President,,Armando Perez-Serrato,DEM,0
+Lyman,12,President,,Marianne Williamson,DEM,0
+Lyman,12,President,,Joseph R Biden Jr,DEM,5
+Lyman,12,President,,Dean Phillips,DEM,2
+Lyman,12,President,,Armando Perez-Serrato,DEM,1
+Lyman,13,President,,Marianne Williamson,DEM,1
+Lyman,13,President,,Joseph R Biden Jr,DEM,2
+Lyman,13,President,,Dean Phillips,DEM,0
+Lyman,13,President,,Armando Perez-Serrato,DEM,1

--- a/2024/counties/20240604__sd__primary__marshall__precinct.csv
+++ b/2024/counties/20240604__sd__primary__marshall__precinct.csv
@@ -1,0 +1,43 @@
+county,precinct,office,district,candidate,party,votes
+Marshall,"A1 (Precinct-A2, Precinct-A3)",President,,Marianne Williamson,DEM,2
+Marshall,"A1 (Precinct-A2, Precinct-A3)",President,,Joseph R Biden Jr,DEM,25
+Marshall,"A1 (Precinct-A2, Precinct-A3)",President,,Dean Phillips,DEM,9
+Marshall,"A1 (Precinct-A2, Precinct-A3)",President,,Armando Perez-Serrato,DEM,0
+Marshall,A4,President,,Marianne Williamson,DEM,0
+Marshall,A4,President,,Joseph R Biden Jr,DEM,21
+Marshall,A4,President,,Dean Phillips,DEM,3
+Marshall,A4,President,,Armando Perez-Serrato,DEM,0
+Marshall,A5,President,,Marianne Williamson,DEM,0
+Marshall,A5,President,,Joseph R Biden Jr,DEM,14
+Marshall,A5,President,,Dean Phillips,DEM,3
+Marshall,A5,President,,Armando Perez-Serrato,DEM,1
+Marshall,A6,President,,Marianne Williamson,DEM,2
+Marshall,A6,President,,Joseph R Biden Jr,DEM,10
+Marshall,A6,President,,Dean Phillips,DEM,1
+Marshall,A6,President,,Armando Perez-Serrato,DEM,1
+Marshall,A7,President,,Marianne Williamson,DEM,2
+Marshall,A7,President,,Joseph R Biden Jr,DEM,6
+Marshall,A7,President,,Dean Phillips,DEM,1
+Marshall,A7,President,,Armando Perez-Serrato,DEM,0
+Marshall,A8 (Precinct-A9),President,,Marianne Williamson,DEM,8
+Marshall,A8 (Precinct-A9),President,,Joseph R Biden Jr,DEM,21
+Marshall,A8 (Precinct-A9),President,,Dean Phillips,DEM,2
+Marshall,A8 (Precinct-A9),President,,Armando Perez-Serrato,DEM,4
+Marshall,"A1 (Precinct-A2, Precinct-A3)",State House,01,Logan Manhart,REP,37
+Marshall,"A1 (Precinct-A2, Precinct-A3)",State House,01,Tamara St John,REP,45
+Marshall,"A1 (Precinct-A2, Precinct-A3)",State House,01,Christopher Reder,REP,37
+Marshall,A4,State House,01,Logan Manhart,REP,27
+Marshall,A4,State House,01,Tamara St John,REP,12
+Marshall,A4,State House,01,Christopher Reder,REP,20
+Marshall,A5,State House,01,Logan Manhart,REP,9
+Marshall,A5,State House,01,Tamara St John,REP,18
+Marshall,A5,State House,01,Christopher Reder,REP,6
+Marshall,A6,State House,01,Logan Manhart,REP,43
+Marshall,A6,State House,01,Tamara St John,REP,31
+Marshall,A6,State House,01,Christopher Reder,REP,38
+Marshall,A7,State House,01,Logan Manhart,REP,28
+Marshall,A7,State House,01,Tamara St John,REP,17
+Marshall,A7,State House,01,Christopher Reder,REP,30
+Marshall,A8 (Precinct-A9),State House,01,Logan Manhart,REP,27
+Marshall,A8 (Precinct-A9),State House,01,Tamara St John,REP,29
+Marshall,A8 (Precinct-A9),State House,01,Christopher Reder,REP,35

--- a/2024/counties/20240604__sd__primary__mccook__precinct.csv
+++ b/2024/counties/20240604__sd__primary__mccook__precinct.csv
@@ -1,0 +1,43 @@
+county,precinct,office,district,candidate,party,votes
+McCook,01,President,,Marianne Williamson,DEM,2
+McCook,01,President,,Joseph R Biden Jr,DEM,18
+McCook,01,President,,Dean Phillips,DEM,4
+McCook,01,President,,Armando Perez-Serrato,DEM,0
+McCook,02,President,,Marianne Williamson,DEM,1
+McCook,02,President,,Joseph R Biden Jr,DEM,9
+McCook,02,President,,Dean Phillips,DEM,2
+McCook,02,President,,Armando Perez-Serrato,DEM,0
+McCook,03,President,,Marianne Williamson,DEM,1
+McCook,03,President,,Joseph R Biden Jr,DEM,5
+McCook,03,President,,Dean Phillips,DEM,2
+McCook,03,President,,Armando Perez-Serrato,DEM,0
+McCook,04,President,,Marianne Williamson,DEM,1
+McCook,04,President,,Joseph R Biden Jr,DEM,6
+McCook,04,President,,Dean Phillips,DEM,3
+McCook,04,President,,Armando Perez-Serrato,DEM,3
+McCook,05,President,,Marianne Williamson,DEM,3
+McCook,05,President,,Joseph R Biden Jr,DEM,20
+McCook,05,President,,Dean Phillips,DEM,4
+McCook,05,President,,Armando Perez-Serrato,DEM,1
+McCook,06,President,,Marianne Williamson,DEM,1
+McCook,06,President,,Joseph R Biden Jr,DEM,7
+McCook,06,President,,Dean Phillips,DEM,1
+McCook,06,President,,Armando Perez-Serrato,DEM,0
+McCook,01,State House,19,Drew Peterson,REP,55
+McCook,01,State House,19,Steven Mettler,REP,23
+McCook,01,State House,19,Jessica Bahmuller,REP,54
+McCook,02,State House,19,Drew Peterson,REP,27
+McCook,02,State House,19,Steven Mettler,REP,12
+McCook,02,State House,19,Jessica Bahmuller,REP,32
+McCook,03,State House,19,Drew Peterson,REP,48
+McCook,03,State House,19,Steven Mettler,REP,61
+McCook,03,State House,19,Jessica Bahmuller,REP,84
+McCook,04,State House,19,Drew Peterson,REP,52
+McCook,04,State House,19,Steven Mettler,REP,62
+McCook,04,State House,19,Jessica Bahmuller,REP,114
+McCook,05,State House,19,Drew Peterson,REP,115
+McCook,05,State House,19,Steven Mettler,REP,57
+McCook,05,State House,19,Jessica Bahmuller,REP,117
+McCook,06,State House,19,Drew Peterson,REP,70
+McCook,06,State House,19,Steven Mettler,REP,37
+McCook,06,State House,19,Jessica Bahmuller,REP,77

--- a/2024/counties/20240604__sd__primary__mcpherson__precinct.csv
+++ b/2024/counties/20240604__sd__primary__mcpherson__precinct.csv
@@ -1,0 +1,43 @@
+county,precinct,office,district,candidate,party,votes
+McPherson,1,President,,Marianne Williamson,DEM,1
+McPherson,1,President,,Joseph R Biden Jr,DEM,6
+McPherson,1,President,,Dean Phillips,DEM,1
+McPherson,1,President,,Armando Perez-Serrato,DEM,1
+McPherson,2,President,,Marianne Williamson,DEM,1
+McPherson,2,President,,Joseph R Biden Jr,DEM,6
+McPherson,2,President,,Dean Phillips,DEM,3
+McPherson,2,President,,Armando Perez-Serrato,DEM,0
+McPherson,3,President,,Marianne Williamson,DEM,1
+McPherson,3,President,,Joseph R Biden Jr,DEM,8
+McPherson,3,President,,Dean Phillips,DEM,0
+McPherson,3,President,,Armando Perez-Serrato,DEM,1
+McPherson,4,President,,Marianne Williamson,DEM,2
+McPherson,4,President,,Joseph R Biden Jr,DEM,5
+McPherson,4,President,,Dean Phillips,DEM,1
+McPherson,4,President,,Armando Perez-Serrato,DEM,1
+McPherson,1,State Senate,23,Steven Ray Roseland,REP,5
+McPherson,1,State Senate,23,Mark Lapka,REP,184
+McPherson,2,State Senate,23,Steven Ray Roseland,REP,16
+McPherson,2,State Senate,23,Mark Lapka,REP,173
+McPherson,3,State Senate,23,Steven Ray Roseland,REP,27
+McPherson,3,State Senate,23,Mark Lapka,REP,97
+McPherson,4,State Senate,23,Steven Ray Roseland,REP,36
+McPherson,4,State Senate,23,Mark Lapka,REP,99
+McPherson,1,State House,23,Spencer Gosch,REP,172
+McPherson,1,State House,23,Scott Moore,REP,166
+McPherson,1,State House,23,James D. Wangsness,REP,16
+McPherson,2,State House,23,Spencer Gosch,REP,158
+McPherson,2,State House,23,Scott Moore,REP,158
+McPherson,2,State House,23,James D. Wangsness,REP,21
+McPherson,3,State House,23,Spencer Gosch,REP,88
+McPherson,3,State House,23,Scott Moore,REP,95
+McPherson,3,State House,23,James D. Wangsness,REP,40
+McPherson,4,State House,23,Spencer Gosch,REP,82
+McPherson,4,State House,23,Scott Moore,REP,119
+McPherson,4,State House,23,James D. Wangsness,REP,33
+McPherson,2,County Commissioner,2,Peggy Bieber,REP,27
+McPherson,2,County Commissioner,2,Michael Jacob Mardian,REP,96
+McPherson,2,County Commissioner,2,Bruce Mack,REP,56
+McPherson,4,County Commissioner,2,Peggy Bieber,REP,0
+McPherson,4,County Commissioner,2,Michael Jacob Mardian,REP,2
+McPherson,4,County Commissioner,2,Bruce Mack,REP,2

--- a/2024/counties/20240604__sd__primary__meade__precinct.csv
+++ b/2024/counties/20240604__sd__primary__meade__precinct.csv
@@ -1,0 +1,783 @@
+county,precinct,office,district,candidate,party,votes
+Meade,ALKALI #6A,President,,Marianne Williamson,DEM,1
+Meade,ALKALI #6A,President,,Joseph R Biden Jr,DEM,1
+Meade,ALKALI #6A,President,,Dean Phillips,DEM,1
+Meade,ALKALI #6A,President,,Armando Perez-Serrano,DEM,1
+Meade,BASE #23,President,,Marianne Williamson,DEM,2
+Meade,BASE #23,President,,Joseph R Biden Jr,DEM,9
+Meade,BASE #23,President,,Dean Phillips,DEM,1
+Meade,BASE #23,President,,Armando Perez-Serrano,DEM,1
+Meade,BEAR BUTTE #9,President,,Marianne Williamson,DEM,1
+Meade,BEAR BUTTE #9,President,,Joseph R Biden Jr,DEM,2
+Meade,BEAR BUTTE #9,President,,Dean Phillips,DEM,2
+Meade,BEAR BUTTE #9,President,,Armando Perez-Serrano,DEM,0
+Meade,BLACK HAWK #14,President,,Marianne Williamson,DEM,1
+Meade,BLACK HAWK #14,President,,Joseph R Biden Jr,DEM,4
+Meade,BLACK HAWK #14,President,,Dean Phillips,DEM,0
+Meade,BLACK HAWK #14,President,,Armando Perez-Serrano,DEM,1
+Meade,CENTRAL BLACK HAWK #19,President,,Marianne Williamson,DEM,8
+Meade,CENTRAL BLACK HAWK #19,President,,Joseph R Biden Jr,DEM,29
+Meade,CENTRAL BLACK HAWK #19,President,,Dean Phillips,DEM,6
+Meade,CENTRAL BLACK HAWK #19,President,,Armando Perez-Serrano,DEM,1
+Meade,CENTRAL STURGIS #3,President,,Marianne Williamson,DEM,0
+Meade,CENTRAL STURGIS #3,President,,Joseph R Biden Jr,DEM,15
+Meade,CENTRAL STURGIS #3,President,,Dean Phillips,DEM,1
+Meade,CENTRAL STURGIS #3,President,,Armando Perez-Serrano,DEM,2
+Meade,HALK BUTTE #27,President,,Marianne Williamson,DEM,0
+Meade,HALK BUTTE #27,President,,Joseph R Biden Jr,DEM,5
+Meade,HALK BUTTE #27,President,,Dean Phillips,DEM,2
+Meade,HALK BUTTE #27,President,,Armando Perez-Serrano,DEM,0
+Meade,EAST ELK VALE #21A,President,,Marianne Williamson,DEM,2
+Meade,EAST ELK VALE #21A,President,,Joseph R Biden Jr,DEM,1
+Meade,EAST ELK VALE #21A,President,,Dean Phillips,DEM,0
+Meade,EAST ELK VALE #21A,President,,Armando Perez-Serrano,DEM,0
+Meade,EAST PIEDMONT #12A,President,,Marianne Williamson,DEM,0
+Meade,EAST PIEDMONT #12A,President,,Joseph R Biden Jr,DEM,3
+Meade,EAST PIEDMONT #12A,President,,Dean Phillips,DEM,0
+Meade,EAST PIEDMONT #12A,President,,Armando Perez-Serrano,DEM,0
+Meade,EAST STURGIS #1,President,,Marianne Williamson,DEM,2
+Meade,EAST STURGIS #1,President,,Joseph R Biden Jr,DEM,11
+Meade,EAST STURGIS #1,President,,Dean Phillips,DEM,1
+Meade,EAST STURGIS #1,President,,Armando Perez-Serrano,DEM,0
+Meade,ELK VALE #21,President,,Marianne Williamson,DEM,0
+Meade,ELK VALE #21,President,,Joseph R Biden Jr,DEM,1
+Meade,ELK VALE #21,President,,Dean Phillips,DEM,1
+Meade,ELK VALE #21,President,,Armando Perez-Serrano,DEM,0
+Meade,ELM SPRINGS #18,President,,Marianne Williamson,DEM,1
+Meade,ELM SPRINGS #18,President,,Joseph R Biden Jr,DEM,2
+Meade,ELM SPRINGS #18,President,,Dean Phillips,DEM,0
+Meade,ELM SPRINGS #18,President,,Armando Perez-Serrano,DEM,0
+Meade,FAIRPOINT #29,President,,Marianne Williamson,DEM,1
+Meade,FAIRPOINT #29,President,,Joseph R Biden Jr,DEM,0
+Meade,FAIRPOINT #29,President,,Dean Phillips,DEM,0
+Meade,FAIRPOINT #29,President,,Armando Perez-Serrano,DEM,0
+Meade,FAITH #31,President,,Marianne Williamson,DEM,3
+Meade,FAITH #31,President,,Joseph R Biden Jr,DEM,4
+Meade,FAITH #31,President,,Dean Phillips,DEM,1
+Meade,FAITH #31,President,,Armando Perez-Serrano,DEM,0
+Meade,FORT MEADE #1A,President,,Marianne Williamson,DEM,0
+Meade,FORT MEADE #1A,President,,Joseph R Biden Jr,DEM,0
+Meade,FORT MEADE #1A,President,,Dean Phillips,DEM,0
+Meade,FORT MEADE #1A,President,,Armando Perez-Serrano,DEM,0
+Meade,HARMONY #8,President,,Marianne Williamson,DEM,2
+Meade,HARMONY #8,President,,Joseph R Biden Jr,DEM,15
+Meade,HARMONY #8,President,,Dean Phillips,DEM,0
+Meade,HARMONY #8,President,,Armando Perez-Serrano,DEM,0
+Meade,HEREFORD #20,President,,Marianne Williamson,DEM,2
+Meade,HEREFORD #20,President,,Joseph R Biden Jr,DEM,1
+Meade,HEREFORD #20,President,,Dean Phillips,DEM,1
+Meade,HEREFORD #20,President,,Armando Perez-Serrano,DEM,0
+Meade,MARCUS #41,President,,Marianne Williamson,DEM,0
+Meade,MARCUS #41,President,,Joseph R Biden Jr,DEM,0
+Meade,MARCUS #41,President,,Dean Phillips,DEM,0
+Meade,MARCUS #41,President,,Armando Perez-Serrano,DEM,0
+Meade,NORTHEAST PIEDMONT #12,President,,Marianne Williamson,DEM,1
+Meade,NORTHEAST PIEDMONT #12,President,,Joseph R Biden Jr,DEM,17
+Meade,NORTHEAST PIEDMONT #12,President,,Dean Phillips,DEM,2
+Meade,NORTHEAST PIEDMONT #12,President,,Armando Perez-Serrano,DEM,0
+Meade,NORTHEAST STURGIS #1-A,President,,Marianne Williamson,DEM,0
+Meade,NORTHEAST STURGIS #1-A,President,,Joseph R Biden Jr,DEM,5
+Meade,NORTHEAST STURGIS #1-A,President,,Dean Phillips,DEM,0
+Meade,NORTHEAST STURGIS #1-A,President,,Armando Perez-Serrano,DEM,0
+Meade,NORTHWEST STURGIS #5,President,,Marianne Williamson,DEM,6
+Meade,NORTHWEST STURGIS #5,President,,Joseph R Biden Jr,DEM,10
+Meade,NORTHWEST STURGIS #5,President,,Dean Phillips,DEM,0
+Meade,NORTHWEST STURGIS #5,President,,Armando Perez-Serrano,DEM,1
+Meade,PIEDMONT CENTRAL #11A,President,,Marianne Williamson,DEM,2
+Meade,PIEDMONT CENTRAL #11A,President,,Joseph R Biden Jr,DEM,6
+Meade,PIEDMONT CENTRAL #11A,President,,Dean Phillips,DEM,0
+Meade,PIEDMONT CENTRAL #11A,President,,Armando Perez-Serrano,DEM,1
+Meade,PIEDMONT WEST #11,President,,Marianne Williamson,DEM,3
+Meade,PIEDMONT WEST #11,President,,Joseph R Biden Jr,DEM,13
+Meade,PIEDMONT WEST #11,President,,Dean Phillips,DEM,3
+Meade,PIEDMONT WEST #11,President,,Armando Perez-Serrano,DEM,0
+Meade,PINE #33,President,,Marianne Williamson,DEM,0
+Meade,PINE #33,President,,Joseph R Biden Jr,DEM,0
+Meade,PINE #33,President,,Dean Phillips,DEM,0
+Meade,PINE #33,President,,Armando Perez-Serrano,DEM,0
+Meade,RED OWL #30,President,,Marianne Williamson,DEM,1
+Meade,RED OWL #30,President,,Joseph R Biden Jr,DEM,2
+Meade,RED OWL #30,President,,Dean Phillips,DEM,0
+Meade,RED OWL #30,President,,Armando Perez-Serrano,DEM,0
+Meade,RURAL BLACK HAWK #15,President,,Marianne Williamson,DEM,1
+Meade,RURAL BLACK HAWK #15,President,,Joseph R Biden Jr,DEM,9
+Meade,RURAL BLACK HAWK #15,President,,Dean Phillips,DEM,1
+Meade,RURAL BLACK HAWK #15,President,,Armando Perez-Serrano,DEM,1
+Meade,RURAL STURGIS #7,President,,Marianne Williamson,DEM,2
+Meade,RURAL STURGIS #7,President,,Joseph R Biden Jr,DEM,14
+Meade,RURAL STURGIS #7,President,,Dean Phillips,DEM,1
+Meade,RURAL STURGIS #7,President,,Armando Perez-Serrano,DEM,0
+Meade,SOUTH STURGIS #2A,President,,Marianne Williamson,DEM,1
+Meade,SOUTH STURGIS #2A,President,,Joseph R Biden Jr,DEM,26
+Meade,SOUTH STURGIS #2A,President,,Dean Phillips,DEM,3
+Meade,SOUTH STURGIS #2A,President,,Armando Perez-Serrano,DEM,5
+Meade,SOUTHEAST PIEDMONT #13,President,,Marianne Williamson,DEM,3
+Meade,SOUTHEAST PIEDMONT #13,President,,Joseph R Biden Jr,DEM,22
+Meade,SOUTHEAST PIEDMONT #13,President,,Dean Phillips,DEM,5
+Meade,SOUTHEAST PIEDMONT #13,President,,Armando Perez-Serrano,DEM,1
+Meade,SOUTHEAST STURGIS #2,President,,Marianne Williamson,DEM,2
+Meade,SOUTHEAST STURGIS #2,President,,Joseph R Biden Jr,DEM,16
+Meade,SOUTHEAST STURGIS #2,President,,Dean Phillips,DEM,4
+Meade,SOUTHEAST STURGIS #2,President,,Armando Perez-Serrano,DEM,1
+Meade,SOUTHWEST STURGIS #4A,President,,Marianne Williamson,DEM,0
+Meade,SOUTHWEST STURGIS #4A,President,,Joseph R Biden Jr,DEM,19
+Meade,SOUTHWEST STURGIS #4A,President,,Dean Phillips,DEM,0
+Meade,SOUTHWEST STURGIS #4A,President,,Armando Perez-Serrano,DEM,0
+Meade,STURGIS #5A,President,,Marianne Williamson,DEM,1
+Meade,STURGIS #5A,President,,Joseph R Biden Jr,DEM,18
+Meade,STURGIS #5A,President,,Dean Phillips,DEM,0
+Meade,STURGIS #5A,President,,Armando Perez-Serrano,DEM,2
+Meade,SULPHUR #35,President,,Marianne Williamson,DEM,0
+Meade,SULPHUR #35,President,,Joseph R Biden Jr,DEM,0
+Meade,SULPHUR #35,President,,Dean Phillips,DEM,0
+Meade,SULPHUR #35,President,,Armando Perez-Serrano,DEM,0
+Meade,SUMMERSET #10,President,,Marianne Williamson,DEM,14
+Meade,SUMMERSET #10,President,,Joseph R Biden Jr,DEM,28
+Meade,SUMMERSET #10,President,,Dean Phillips,DEM,7
+Meade,SUMMERSET #10,President,,Armando Perez-Serrano,DEM,2
+Meade,TILTFORD #6,President,,Marianne Williamson,DEM,3
+Meade,TILTFORD #6,President,,Joseph R Biden Jr,DEM,19
+Meade,TILTFORD #6,President,,Dean Phillips,DEM,1
+Meade,TILTFORD #6,President,,Armando Perez-Serrano,DEM,0
+Meade,UNION #40,President,,Marianne Williamson,DEM,1
+Meade,UNION #40,President,,Joseph R Biden Jr,DEM,2
+Meade,UNION #40,President,,Dean Phillips,DEM,0
+Meade,UNION #40,President,,Armando Perez-Serrano,DEM,0
+Meade,VIEWFIELD #17,President,,Marianne Williamson,DEM,0
+Meade,VIEWFIELD #17,President,,Joseph R Biden Jr,DEM,0
+Meade,VIEWFIELD #17,President,,Dean Phillips,DEM,2
+Meade,VIEWFIELD #17,President,,Armando Perez-Serrano,DEM,0
+Meade,WEST BLACK HAWK #16,President,,Marianne Williamson,DEM,4
+Meade,WEST BLACK HAWK #16,President,,Joseph R Biden Jr,DEM,15
+Meade,WEST BLACK HAWK #16,President,,Dean Phillips,DEM,4
+Meade,WEST BLACK HAWK #16,President,,Armando Perez-Serrano,DEM,0
+Meade,WEST ELK VALE #24,President,,Marianne Williamson,DEM,0
+Meade,WEST ELK VALE #24,President,,Joseph R Biden Jr,DEM,4
+Meade,WEST ELK VALE #24,President,,Dean Phillips,DEM,0
+Meade,WEST ELK VALE #24,President,,Armando Perez-Serrano,DEM,0
+Meade,WEST STURGIS #4,President,,Marianne Williamson,DEM,1
+Meade,WEST STURGIS #4,President,,Joseph R Biden Jr,DEM,5
+Meade,WEST STURGIS #4,President,,Dean Phillips,DEM,0
+Meade,WEST STURGIS #4,President,,Armando Perez-Serrano,DEM,1
+Meade,WHITE OWL #25,President,,Marianne Williamson,DEM,0
+Meade,WHITE OWL #25,President,,Joseph R Biden Jr,DEM,0
+Meade,WHITE OWL #25,President,,Dean Phillips,DEM,1
+Meade,WHITE OWL #25,President,,Armando Perez-Serrano,DEM,0
+Meade,ALKALI #6A,State Senate,29,Kirk Chaffee,REP,31
+Meade,ALKALI #6A,State Senate,29,John Carley,REP,31
+Meade,BASE #23,State Senate,29,Kirk Chaffee,REP,9
+Meade,BASE #23,State Senate,29,John Carley,REP,23
+Meade,BEAR BUTTE #9,State Senate,29,Kirk Chaffee,REP,31
+Meade,BEAR BUTTE #9,State Senate,29,John Carley,REP,30
+Meade,BLACK HAWK #14,State Senate,29,Kirk Chaffee,REP,20
+Meade,BLACK HAWK #14,State Senate,29,John Carley,REP,56
+Meade,CENTRAL BLACK HAWK #19,State Senate,33,David Johnson,REP,102
+Meade,CENTRAL BLACK HAWK #19,State Senate,33,Curt Voight,REP,113
+Meade,CENTRAL STURGIS #3,State Senate,29,Kirk Chaffee,REP,43
+Meade,CENTRAL STURGIS #3,State Senate,29,John Carley,REP,47
+Meade,CHALK BUTTE #27,State Senate,29,Kirk Chaffee,REP,36
+Meade,CHALK BUTTE #27,State Senate,29,John Carley,REP,26
+Meade,EAST ELK VALE #21A,State Senate,29,Kirk Chaffee,REP,23
+Meade,EAST ELK VALE #21A,State Senate,29,John Carley,REP,78
+Meade,EAST PIEDMONT #12A,State Senate,29,Kirk Chaffee,REP,25
+Meade,EAST PIEDMONT #12A,State Senate,29,John Carley,REP,72
+Meade,EAST STURGIS #1,State Senate,29,Kirk Chaffee,REP,56
+Meade,EAST STURGIS #1,State Senate,29,John Carley,REP,52
+Meade,ELK VALE #21,State Senate,29,Kirk Chaffee,REP,7
+Meade,ELK VALE #21,State Senate,29,John Carley,REP,15
+Meade,ELM SPRINGS #18,State Senate,29,Kirk Chaffee,REP,21
+Meade,ELM SPRINGS #18,State Senate,29,John Carley,REP,33
+Meade,FAIRPOINT #29,State Senate,29,Kirk Chaffee,REP,11
+Meade,FAIRPOINT #29,State Senate,29,John Carley,REP,5
+Meade,FAITH #31,State Senate,29,Kirk Chaffee,REP,32
+Meade,FAITH #31,State Senate,29,John Carley,REP,44
+Meade,FORT MEADE #1A,State Senate,29,Kirk Chaffee,REP,5
+Meade,FORT MEADE #1A,State Senate,29,John Carley,REP,4
+Meade,HARMONY #8,State Senate,29,Kirk Chaffee,REP,64
+Meade,HARMONY #8,State Senate,29,John Carley,REP,79
+Meade,HEREFORD #20,State Senate,29,Kirk Chaffee,REP,14
+Meade,HEREFORD #20,State Senate,29,John Carley,REP,11
+Meade,MARCUS #41,State Senate,29,Kirk Chaffee,REP,10
+Meade,MARCUS #41,State Senate,29,John Carley,REP,14
+Meade,NORTHEAST PIEDMONT #12,State Senate,29,Kirk Chaffee,REP,58
+Meade,NORTHEAST PIEDMONT #12,State Senate,29,John Carley,REP,151
+Meade,NORTHEAST STURGIS #1-A,State Senate,29,Kirk Chaffee,REP,9
+Meade,NORTHEAST STURGIS #1-A,State Senate,29,John Carley,REP,17
+Meade,NORTHWEST STURGIS #5,State Senate,29,Kirk Chaffee,REP,34
+Meade,NORTHWEST STURGIS #5,State Senate,29,John Carley,REP,69
+Meade,PIEDMONT CENTRAL #11A,State Senate,29,Kirk Chaffee,REP,61
+Meade,PIEDMONT CENTRAL #11A,State Senate,29,John Carley,REP,164
+Meade,PIEDMONT WEST #11,State Senate,29,Kirk Chaffee,REP,58
+Meade,PIEDMONT WEST #11,State Senate,29,John Carley,REP,119
+Meade,PINE #33,State Senate,29,Kirk Chaffee,REP,9
+Meade,PINE #33,State Senate,29,John Carley,REP,32
+Meade,RED OWL #30,State Senate,29,Kirk Chaffee,REP,30
+Meade,RED OWL #30,State Senate,29,John Carley,REP,23
+Meade,RURAL BLACK HAWK #15,State Senate,29,Kirk Chaffee,REP,28
+Meade,RURAL BLACK HAWK #15,State Senate,29,John Carley,REP,80
+Meade,RURAL STURGIS #7,State Senate,29,Kirk Chaffee,REP,102
+Meade,RURAL STURGIS #7,State Senate,29,John Carley,REP,62
+Meade,SOUTH STURGIS #2A,State Senate,29,Kirk Chaffee,REP,65
+Meade,SOUTH STURGIS #2A,State Senate,29,John Carley,REP,47
+Meade,SOUTHEAST PIEDMONT #13,State Senate,29,Kirk Chaffee,REP,59
+Meade,SOUTHEAST PIEDMONT #13,State Senate,29,John Carley,REP,144
+Meade,SOUTHEAST STURGIS #2,State Senate,29,Kirk Chaffee,REP,110
+Meade,SOUTHEAST STURGIS #2,State Senate,29,John Carley,REP,103
+Meade,SOUTHWEST STURGIS #4A,State Senate,29,Kirk Chaffee,REP,43
+Meade,SOUTHWEST STURGIS #4A,State Senate,29,John Carley,REP,43
+Meade,STURGIS #5A,State Senate,29,Kirk Chaffee,REP,48
+Meade,STURGIS #5A,State Senate,29,John Carley,REP,38
+Meade,SULPHUR #35,State Senate,29,Kirk Chaffee,REP,5
+Meade,SULPHUR #35,State Senate,29,John Carley,REP,20
+Meade,SUMMERSET #10,State Senate,33,David Johnson,REP,150
+Meade,SUMMERSET #10,State Senate,33,Curt Voight,REP,136
+Meade,TILFORD #6,State Senate,29,Kirk Chaffee,REP,116
+Meade,TILFORD #6,State Senate,29,John Carley,REP,155
+Meade,UNION #40,State Senate,29,Kirk Chaffee,REP,6
+Meade,UNION #40,State Senate,29,John Carley,REP,7
+Meade,VIEWFIELD #17,State Senate,29,Kirk Chaffee,REP,27
+Meade,VIEWFIELD #17,State Senate,29,John Carley,REP,31
+Meade,WEST BLACK HAWK #16,State Senate,33,David Johnson,REP,35
+Meade,WEST BLACK HAWK #16,State Senate,33,Curt Voight,REP,58
+Meade,WEST ELK VALE #24,State Senate,29,Kirk Chaffee,REP,9
+Meade,WEST ELK VALE #24,State Senate,29,John Carley,REP,30
+Meade,WEST STURGIS #4,State Senate,29,Kirk Chaffee,REP,27
+Meade,WEST STURGIS #4,State Senate,29,John Carley,REP,24
+Meade,WHITE OWL #25,State Senate,29,Kirk Chaffee,REP,20
+Meade,WHITE OWL #25,State Senate,29,John Carley,REP,6
+Meade,ALKALI #6A,State House,29,Gary L. Cammack,REP,30
+Meade,ALKALI #6A,State House,29,Terri Jorgenson,REP,31
+Meade,ALKALI #6A,State House,29,Kathy Rice,REP,35
+Meade,BASE #23,State House,29,Gary L. Cammack,REP,11
+Meade,BASE #23,State House,29,Terri Jorgenson,REP,14
+Meade,BASE #23,State House,29,Kathy Rice,REP,20
+Meade,BEAR BUTTE #9,State House,29,Gary L. Cammack,REP,34
+Meade,BEAR BUTTE #9,State House,29,Terri Jorgenson,REP,36
+Meade,BEAR BUTTE #9,State House,29,Kathy Rice,REP,27
+Meade,BLACK HAWK #14,State House,29,Gary L. Cammack,REP,23
+Meade,BLACK HAWK #14,State House,29,Terri Jorgenson,REP,49
+Meade,BLACK HAWK #14,State House,29,Kathy Rice,REP,48
+Meade,CENTRAL STURGIS #3,State House,29,Gary L. Cammack,REP,41
+Meade,CENTRAL STURGIS #3,State House,29,Terri Jorgenson,REP,48
+Meade,CENTRAL STURGIS #3,State House,29,Kathy Rice,REP,47
+Meade,CHALK BUTTE #27,State House,29,Gary L. Cammack,REP,37
+Meade,CHALK BUTTE #27,State House,29,Terri Jorgenson,REP,32
+Meade,CHALK BUTTE #27,State House,29,Kathy Rice,REP,20
+Meade,EAST ELK VALE #21A,State House,29,Gary L. Cammack,REP,39
+Meade,EAST ELK VALE #21A,State House,29,Terri Jorgenson,REP,49
+Meade,EAST ELK VALE #21A,State House,29,Kathy Rice,REP,59
+Meade,EAST PIEDMONT #12A,State House,29,Gary L. Cammack,REP,38
+Meade,EAST PIEDMONT #12A,State House,29,Terri Jorgenson,REP,43
+Meade,EAST PIEDMONT #12A,State House,29,Kathy Rice,REP,70
+Meade,EAST STURGIS #1,State House,29,Gary L. Cammack,REP,54
+Meade,EAST STURGIS #1,State House,29,Terri Jorgenson,REP,49
+Meade,EAST STURGIS #1,State House,29,Kathy Rice,REP,48
+Meade,ELK VALE #21,State House,29,Gary L. Cammack,REP,5
+Meade,ELK VALE #21,State House,29,Terri Jorgenson,REP,11
+Meade,ELK VALE #21,State House,29,Kathy Rice,REP,15
+Meade,ELM SPRINGS #18,State House,29,Gary L. Cammack,REP,18
+Meade,ELM SPRINGS #18,State House,29,Terri Jorgenson,REP,28
+Meade,ELM SPRINGS #18,State House,29,Kathy Rice,REP,32
+Meade,FAIRPOINT #29,State House,29,Gary L. Cammack,REP,11
+Meade,FAIRPOINT #29,State House,29,Terri Jorgenson,REP,10
+Meade,FAIRPOINT #29,State House,29,Kathy Rice,REP,5
+Meade,FAITH #31,State House,29,Gary L. Cammack,REP,31
+Meade,FAITH #31,State House,29,Terri Jorgenson,REP,47
+Meade,FAITH #31,State House,29,Kathy Rice,REP,40
+Meade,FORT MEADE #1A,State House,29,Gary L. Cammack,REP,8
+Meade,FORT MEADE #1A,State House,29,Terri Jorgenson,REP,3
+Meade,FORT MEADE #1A,State House,29,Kathy Rice,REP,2
+Meade,HARMONY #8,State House,29,Gary L. Cammack,REP,66
+Meade,HARMONY #8,State House,29,Terri Jorgenson,REP,67
+Meade,HARMONY #8,State House,29,Kathy Rice,REP,75
+Meade,HEREFORD #20,State House,29,Gary L. Cammack,REP,15
+Meade,HEREFORD #20,State House,29,Terri Jorgenson,REP,16
+Meade,HEREFORD #20,State House,29,Kathy Rice,REP,9
+Meade,MARCUS #41,State House,29,Gary L. Cammack,REP,7
+Meade,MARCUS #41,State House,29,Terri Jorgenson,REP,13
+Meade,MARCUS #41,State House,29,Kathy Rice,REP,19
+Meade,NORTHEAST PIEDMONT #12,State House,29,Gary L. Cammack,REP,62
+Meade,NORTHEAST PIEDMONT #12,State House,29,Terri Jorgenson,REP,94
+Meade,NORTHEAST PIEDMONT #12,State House,29,Kathy Rice,REP,167
+Meade,NORTHEAST STURGIS #1-A,State House,29,Gary L. Cammack,REP,7
+Meade,NORTHEAST STURGIS #1-A,State House,29,Terri Jorgenson,REP,18
+Meade,NORTHEAST STURGIS #1-A,State House,29,Kathy Rice,REP,15
+Meade,NORTHWEST STURGIS #5,State House,29,Gary L. Cammack,REP,43
+Meade,NORTHWEST STURGIS #5,State House,29,Terri Jorgenson,REP,57
+Meade,NORTHWEST STURGIS #5,State House,29,Kathy Rice,REP,61
+Meade,PIEDMONT CENTRAL #11A,State House,29,Gary L. Cammack,REP,79
+Meade,PIEDMONT CENTRAL #11A,State House,29,Terri Jorgenson,REP,87
+Meade,PIEDMONT CENTRAL #11A,State House,29,Kathy Rice,REP,164
+Meade,PIEDMONT WEST #11,State House,29,Gary L. Cammack,REP,73
+Meade,PIEDMONT WEST #11,State House,29,Terri Jorgenson,REP,85
+Meade,PIEDMONT WEST #11,State House,29,Kathy Rice,REP,122
+Meade,PINE #33,State House,29,Gary L. Cammack,REP,6
+Meade,PINE #33,State House,29,Terri Jorgenson,REP,22
+Meade,PINE #33,State House,29,Kathy Rice,REP,34
+Meade,RED OWL #30,State House,29,Gary L. Cammack,REP,28
+Meade,RED OWL #30,State House,29,Terri Jorgenson,REP,28
+Meade,RED OWL #30,State House,29,Kathy Rice,REP,20
+Meade,RURAL BLACK HAWK #15,State House,29,Gary L. Cammack,REP,37
+Meade,RURAL BLACK HAWK #15,State House,29,Terri Jorgenson,REP,56
+Meade,RURAL BLACK HAWK #15,State House,29,Kathy Rice,REP,75
+Meade,RURAL STURGIS #7,State House,29,Gary L. Cammack,REP,86
+Meade,RURAL STURGIS #7,State House,29,Terri Jorgenson,REP,95
+Meade,RURAL STURGIS #7,State House,29,Kathy Rice,REP,73
+Meade,SOUTH STURGIS #2A,State House,29,Gary L. Cammack,REP,69
+Meade,SOUTH STURGIS #2A,State House,29,Terri Jorgenson,REP,61
+Meade,SOUTH STURGIS #2A,State House,29,Kathy Rice,REP,53
+Meade,SOUTHEAST PIEDMONT #13,State House,29,Gary L. Cammack,REP,73
+Meade,SOUTHEAST PIEDMONT #13,State House,29,Terri Jorgenson,REP,88
+Meade,SOUTHEAST PIEDMONT #13,State House,29,Kathy Rice,REP,144
+Meade,SOUTHEAST STURGIS #2,State House,29,Gary L. Cammack,REP,117
+Meade,SOUTHEAST STURGIS #2,State House,29,Terri Jorgenson,REP,120
+Meade,SOUTHEAST STURGIS #2,State House,29,Kathy Rice,REP,88
+Meade,SOUTHWEST STURGIS #4A,State House,29,Gary L. Cammack,REP,37
+Meade,SOUTHWEST STURGIS #4A,State House,29,Terri Jorgenson,REP,46
+Meade,SOUTHWEST STURGIS #4A,State House,29,Kathy Rice,REP,51
+Meade,STURGIS #5A,State House,29,Gary L. Cammack,REP,49
+Meade,STURGIS #5A,State House,29,Terri Jorgenson,REP,56
+Meade,STURGIS #5A,State House,29,Kathy Rice,REP,38
+Meade,SULPHUR #35,State House,29,Gary L. Cammack,REP,6
+Meade,SULPHUR #35,State House,29,Terri Jorgenson,REP,12
+Meade,SULPHUR #35,State House,29,Kathy Rice,REP,20
+Meade,TILFORD #6,State House,29,Gary L. Cammack,REP,126
+Meade,TILFORD #6,State House,29,Terri Jorgenson,REP,151
+Meade,TILFORD #6,State House,29,Kathy Rice,REP,151
+Meade,UNION #40,State House,29,Gary L. Cammack,REP,7
+Meade,UNION #40,State House,29,Terri Jorgenson,REP,8
+Meade,UNION #40,State House,29,Kathy Rice,REP,4
+Meade,VIEWFIELD #17,State House,29,Gary L. Cammack,REP,29
+Meade,VIEWFIELD #17,State House,29,Terri Jorgenson,REP,38
+Meade,VIEWFIELD #17,State House,29,Kathy Rice,REP,32
+Meade,WEST ELK VALE #24,State House,29,Gary L. Cammack,REP,10
+Meade,WEST ELK VALE #24,State House,29,Terri Jorgenson,REP,23
+Meade,WEST ELK VALE #24,State House,29,Kathy Rice,REP,26
+Meade,WEST STURGIS #4,State House,29,Gary L. Cammack,REP,26
+Meade,WEST STURGIS #4,State House,29,Terri Jorgenson,REP,35
+Meade,WEST STURGIS #4,State House,29,Kathy Rice,REP,21
+Meade,WHITE OWL #25,State House,29,Gary L. Cammack,REP,16
+Meade,WHITE OWL #25,State House,29,Terri Jorgenson,REP,8
+Meade,WHITE OWL #25,State House,29,Kathy Rice,REP,8
+Meade,ALKALI #6A,County Treasurer,,Robin Shrake,REP,37
+Meade,ALKALI #6A,County Treasurer,,Robin Harrison Korth,REP,20
+Meade,BASE #23,County Treasurer,,Robin Shrake,REP,18
+Meade,BASE #23,County Treasurer,,Robin Harrison Korth,REP,10
+Meade,BEAR BUTTE #9,County Treasurer,,Robin Shrake,REP,26
+Meade,BEAR BUTTE #9,County Treasurer,,Robin Harrison Korth,REP,36
+Meade,BLACK HAWK #14,County Treasurer,,Robin Shrake,REP,36
+Meade,BLACK HAWK #14,County Treasurer,,Robin Harrison Korth,REP,33
+Meade,CENTRAL BLACK HAWK #19,County Treasurer,,Robin Shrake,REP,111
+Meade,CENTRAL BLACK HAWK #19,County Treasurer,,Robin Harrison Korth,REP,85
+Meade,CENTRAL STURGIS #3,County Treasurer,,Robin Shrake,REP,32
+Meade,CENTRAL STURGIS #3,County Treasurer,,Robin Harrison Korth,REP,58
+Meade,CHALK BUTTE #27,County Treasurer,,Robin Shrake,REP,31
+Meade,CHALK BUTTE #27,County Treasurer,,Robin Harrison Korth,REP,28
+Meade,EAST ELK VALE #21A,County Treasurer,,Robin Shrake,REP,46
+Meade,EAST ELK VALE #21A,County Treasurer,,Robin Harrison Korth,REP,40
+Meade,EAST PIEDMONT #12A,County Treasurer,,Robin Shrake,REP,50
+Meade,EAST PIEDMONT #12A,County Treasurer,,Robin Harrison Korth,REP,38
+Meade,EAST STURGIS #1,County Treasurer,,Robin Shrake,REP,61
+Meade,EAST STURGIS #1,County Treasurer,,Robin Harrison Korth,REP,42
+Meade,ELK VALE #21,County Treasurer,,Robin Shrake,REP,7
+Meade,ELK VALE #21,County Treasurer,,Robin Harrison Korth,REP,11
+Meade,ELM SPRINGS #18,County Treasurer,,Robin Shrake,REP,27
+Meade,ELM SPRINGS #18,County Treasurer,,Robin Harrison Korth,REP,23
+Meade,FAIRPOINT #29,County Treasurer,,Robin Shrake,REP,11
+Meade,FAIRPOINT #29,County Treasurer,,Robin Harrison Korth,REP,7
+Meade,FAITH #31,County Treasurer,,Robin Shrake,REP,53
+Meade,FAITH #31,County Treasurer,,Robin Harrison Korth,REP,14
+Meade,FORT MEADE #1A,County Treasurer,,Robin Shrake,REP,4
+Meade,FORT MEADE #1A,County Treasurer,,Robin Harrison Korth,REP,4
+Meade,HARMONY #8,County Treasurer,,Robin Shrake,REP,69
+Meade,HARMONY #8,County Treasurer,,Robin Harrison Korth,REP,69
+Meade,HEREFORD #20,County Treasurer,,Robin Shrake,REP,17
+Meade,HEREFORD #20,County Treasurer,,Robin Harrison Korth,REP,5
+Meade,MARCUS #41,County Treasurer,,Robin Shrake,REP,21
+Meade,MARCUS #41,County Treasurer,,Robin Harrison Korth,REP,4
+Meade,NORTHEAST PIEDMONT #12,County Treasurer,,Robin Shrake,REP,102
+Meade,NORTHEAST PIEDMONT #12,County Treasurer,,Robin Harrison Korth,REP,95
+Meade,NORTHEAST STURGIS #1-A,County Treasurer,,Robin Shrake,REP,10
+Meade,NORTHEAST STURGIS #1-A,County Treasurer,,Robin Harrison Korth,REP,16
+Meade,NORTHWEST STURGIS #5,County Treasurer,,Robin Shrake,REP,42
+Meade,NORTHWEST STURGIS #5,County Treasurer,,Robin Harrison Korth,REP,56
+Meade,PIEDMONT CENTRAL #11A,County Treasurer,,Robin Shrake,REP,89
+Meade,PIEDMONT CENTRAL #11A,County Treasurer,,Robin Harrison Korth,REP,109
+Meade,PIEDMONT WEST #11,County Treasurer,,Robin Shrake,REP,92
+Meade,PIEDMONT WEST #11,County Treasurer,,Robin Harrison Korth,REP,66
+Meade,PINE #33,County Treasurer,,Robin Shrake,REP,27
+Meade,PINE #33,County Treasurer,,Robin Harrison Korth,REP,14
+Meade,RED OWL #30,County Treasurer,,Robin Shrake,REP,9
+Meade,RED OWL #30,County Treasurer,,Robin Harrison Korth,REP,41
+Meade,RURAL BLACK HAWK #15,County Treasurer,,Robin Shrake,REP,41
+Meade,RURAL BLACK HAWK #15,County Treasurer,,Robin Harrison Korth,REP,44
+Meade,RURAL STURGIS #7,County Treasurer,,Robin Shrake,REP,68
+Meade,RURAL STURGIS #7,County Treasurer,,Robin Harrison Korth,REP,101
+Meade,SOUTH STURGIS #2A,County Treasurer,,Robin Shrake,REP,42
+Meade,SOUTH STURGIS #2A,County Treasurer,,Robin Harrison Korth,REP,60
+Meade,SOUTHEAST PIEDMONT #13,County Treasurer,,Robin Shrake,REP,86
+Meade,SOUTHEAST PIEDMONT #13,County Treasurer,,Robin Harrison Korth,REP,104
+Meade,SOUTHEAST STURGIS #2,County Treasurer,,Robin Shrake,REP,119
+Meade,SOUTHEAST STURGIS #2,County Treasurer,,Robin Harrison Korth,REP,96
+Meade,SOUTHWEST STURGIS #4A,County Treasurer,,Robin Shrake,REP,42
+Meade,SOUTHWEST STURGIS #4A,County Treasurer,,Robin Harrison Korth,REP,42
+Meade,STURGIS #5A,County Treasurer,,Robin Shrake,REP,42
+Meade,STURGIS #5A,County Treasurer,,Robin Harrison Korth,REP,39
+Meade,SULPHUR #35,County Treasurer,,Robin Shrake,REP,4
+Meade,SULPHUR #35,County Treasurer,,Robin Harrison Korth,REP,17
+Meade,SUMMERSET #10,County Treasurer,,Robin Shrake,REP,141
+Meade,SUMMERSET #10,County Treasurer,,Robin Harrison Korth,REP,120
+Meade,TILFORD #6,County Treasurer,,Robin Shrake,REP,113
+Meade,TILFORD #6,County Treasurer,,Robin Harrison Korth,REP,149
+Meade,UNION #40,County Treasurer,,Robin Shrake,REP,8
+Meade,UNION #40,County Treasurer,,Robin Harrison Korth,REP,4
+Meade,VIEWFIELD #17,County Treasurer,,Robin Shrake,REP,17
+Meade,VIEWFIELD #17,County Treasurer,,Robin Harrison Korth,REP,37
+Meade,WEST BLACK HAWK #16,County Treasurer,,Robin Shrake,REP,47
+Meade,WEST BLACK HAWK #16,County Treasurer,,Robin Harrison Korth,REP,35
+Meade,WEST ELK VALE #24,County Treasurer,,Robin Shrake,REP,23
+Meade,WEST ELK VALE #24,County Treasurer,,Robin Harrison Korth,REP,9
+Meade,WEST STURGIS #4,County Treasurer,,Robin Shrake,REP,19
+Meade,WEST STURGIS #4,County Treasurer,,Robin Harrison Korth,REP,33
+Meade,WHITE OWL #25,County Treasurer,,Robin Shrake,REP,22
+Meade,WHITE OWL #25,County Treasurer,,Robin Harrison Korth,REP,4
+Meade,BLACK HAWK #14,County Commissioner,Meade-2,Joshua Ross,REP,0
+Meade,BLACK HAWK #14,County Commissioner,Meade-2,Doreen Allison Creed,REP,0
+Meade,BLACK HAWK #14,County Commissioner,Meade-4,Earl Severn,REP,50
+Meade,BLACK HAWK #14,County Commissioner,Meade-4,Melanie Torno,REP,27
+Meade,CENTRAL BLACK HAWK #19,County Commissioner,Meade-2,Joshua Ross,REP,0
+Meade,CENTRAL BLACK HAWK #19,County Commissioner,Meade-2,Doreen Allison Creed,REP,0
+Meade,CENTRAL BLACK HAWK #19,County Commissioner,Meade-4,Earl Severn,REP,153
+Meade,CENTRAL BLACK HAWK #19,County Commissioner,Meade-4,Melanie Torno,REP,51
+Meade,CENTRAL STURGIS #3,County Commissioner,Meade-2,Joshua Ross,REP,42
+Meade,CENTRAL STURGIS #3,County Commissioner,Meade-2,Doreen Allison Creed,REP,47
+Meade,CENTRAL STURGIS #3,County Commissioner,Meade-4,Earl Severn,REP,0
+Meade,CENTRAL STURGIS #3,County Commissioner,Meade-4,Melanie Torno,REP,0
+Meade,EAST STURGIS #1,County Commissioner,Meade-2,Joshua Ross,REP,35
+Meade,EAST STURGIS #1,County Commissioner,Meade-2,Doreen Allison Creed,REP,68
+Meade,EAST STURGIS #1,County Commissioner,Meade-4,Earl Severn,REP,0
+Meade,EAST STURGIS #1,County Commissioner,Meade-4,Melanie Torno,REP,0
+Meade,FORT MEADE #1A,County Commissioner,Meade-2,Joshua Ross,REP,4
+Meade,FORT MEADE #1A,County Commissioner,Meade-2,Doreen Allison Creed,REP,3
+Meade,FORT MEADE #1A,County Commissioner,Meade-4,Earl Severn,REP,0
+Meade,FORT MEADE #1A,County Commissioner,Meade-4,Melanie Torno,REP,0
+Meade,NORTHEAST STURGIS #1-A,County Commissioner,Meade-2,Joshua Ross,REP,9
+Meade,NORTHEAST STURGIS #1-A,County Commissioner,Meade-2,Doreen Allison Creed,REP,15
+Meade,NORTHEAST STURGIS #1-A,County Commissioner,Meade-4,Earl Severn,REP,0
+Meade,NORTHEAST STURGIS #1-A,County Commissioner,Meade-4,Melanie Torno,REP,0
+Meade,PIEDMONT WEST #11,County Commissioner,Meade-2,Joshua Ross,REP,0
+Meade,PIEDMONT WEST #11,County Commissioner,Meade-2,Doreen Allison Creed,REP,0
+Meade,PIEDMONT WEST #11,County Commissioner,Meade-4,Earl Severn,REP,105
+Meade,PIEDMONT WEST #11,County Commissioner,Meade-4,Melanie Torno,REP,63
+Meade,RURAL STURGIS #7,County Commissioner,Meade-2,Joshua Ross,REP,65
+Meade,RURAL STURGIS #7,County Commissioner,Meade-2,Doreen Allison Creed,REP,96
+Meade,RURAL STURGIS #7,County Commissioner,Meade-4,Earl Severn,REP,0
+Meade,RURAL STURGIS #7,County Commissioner,Meade-4,Melanie Torno,REP,0
+Meade,SOUTH STURGIS #2A,County Commissioner,Meade-2,Joshua Ross,REP,51
+Meade,SOUTH STURGIS #2A,County Commissioner,Meade-2,Doreen Allison Creed,REP,58
+Meade,SOUTH STURGIS #2A,County Commissioner,Meade-4,Earl Severn,REP,0
+Meade,SOUTH STURGIS #2A,County Commissioner,Meade-4,Melanie Torno,REP,0
+Meade,SOUTHEAST STURGIS #2,County Commissioner,Meade-2,Joshua Ross,REP,87
+Meade,SOUTHEAST STURGIS #2,County Commissioner,Meade-2,Doreen Allison Creed,REP,122
+Meade,SOUTHEAST STURGIS #2,County Commissioner,Meade-4,Earl Severn,REP,0
+Meade,SOUTHEAST STURGIS #2,County Commissioner,Meade-4,Melanie Torno,REP,0
+Meade,SOUTHWEST STURGIS #4A,County Commissioner,Meade-2,Joshua Ross,REP,41
+Meade,SOUTHWEST STURGIS #4A,County Commissioner,Meade-2,Doreen Allison Creed,REP,42
+Meade,SOUTHWEST STURGIS #4A,County Commissioner,Meade-4,Earl Severn,REP,0
+Meade,SOUTHWEST STURGIS #4A,County Commissioner,Meade-4,Melanie Torno,REP,0
+Meade,STURGIS #5A,County Commissioner,Meade-2,Joshua Ross,REP,33
+Meade,STURGIS #5A,County Commissioner,Meade-2,Doreen Allison Creed,REP,50
+Meade,STURGIS #5A,County Commissioner,Meade-4,Earl Severn,REP,0
+Meade,STURGIS #5A,County Commissioner,Meade-4,Melanie Torno,REP,0
+Meade,SUMMERSET #10,County Commissioner,Meade-2,Joshua Ross,REP,0
+Meade,SUMMERSET #10,County Commissioner,Meade-2,Doreen Allison Creed,REP,0
+Meade,SUMMERSET #10,County Commissioner,Meade-4,Earl Severn,REP,208
+Meade,SUMMERSET #10,County Commissioner,Meade-4,Melanie Torno,REP,80
+Meade,WEST BLACK HAWK #16,County Commissioner,Meade-2,Joshua Ross,REP,0
+Meade,WEST BLACK HAWK #16,County Commissioner,Meade-2,Doreen Allison Creed,REP,0
+Meade,WEST BLACK HAWK #16,County Commissioner,Meade-4,Earl Severn,REP,60
+Meade,WEST BLACK HAWK #16,County Commissioner,Meade-4,Melanie Torno,REP,27
+Meade,WEST STURGIS #4,County Commissioner,Meade-2,Joshua Ross,REP,21
+Meade,WEST STURGIS #4,County Commissioner,Meade-2,Doreen Allison Creed,REP,30
+Meade,WEST STURGIS #4,County Commissioner,Meade-4,Earl Severn,REP,0
+Meade,WEST STURGIS #4,County Commissioner,Meade-4,Melanie Torno,REP,0
+Meade,ELK VALE #21,Precinct Committeeman,ELK VALE #21,Timothy Henning Amdahl,REP,15
+Meade,ELK VALE #21,Precinct Committeeman,ELK VALE #21,Cody Rhoden,REP,7
+Meade,PIEDMONT WEST #11,Precinct Committeeman,PIEDMONT WEST #11,Robert V. Westman,REP,69
+Meade,PIEDMONT WEST #11,Precinct Committeeman,PIEDMONT WEST #11,Edwin C Egbert,REP,47
+Meade,SOUTHEAST PIEDMONT #13,Precinct Committeeman,SOUTHEAST PIEDMONT #13,Roger Wagoner,REP,77
+Meade,SOUTHEAST PIEDMONT #13,Precinct Committeeman,SOUTHEAST PIEDMONT #13,Scott Kendall,REP,85
+Meade,VIEWFIELD #17,Precinct Committeeman,VIEWFIELD #17,Jason Simmons,REP,36
+Meade,VIEWFIELD #17,Precinct Committeeman,VIEWFIELD #17,Jake Julson,REP,25
+Meade,EAST ELK VALE #21A,Precinct Committeewoman,EAST ELK VALE #21A,Terri Jorgenson,REP,61
+Meade,EAST ELK VALE #21A,Precinct Committeewoman,EAST ELK VALE #21A,Carmen Hays,REP,34
+Meade,SOUTHEAST PIEDMONT #13,Precinct Committeewoman,SOUTHEAST PIEDMONT #13,Lynn Kendall,REP,71
+Meade,SOUTHEAST PIEDMONT #13,Precinct Committeewoman,SOUTHEAST PIEDMONT #13,Julie Korth,REP,100
+Meade,VIEWFIELD #17,Precinct Committeewoman,VIEWFIELD #17,Chastity Julson,REP,27
+Meade,VIEWFIELD #17,Precinct Committeewoman,VIEWFIELD #17,Teri L. Farland,REP,34
+Meade,ALKALI #6A,School Board Member Meade School-1,46,Aaron Oedegaard,,37
+Meade,ALKALI #6A,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,10
+Meade,ALKALI #6A,School Board Member Meade School-1,46,Kolten K Odle,,15
+Meade,ALKALI #6A,School Board Member Meade School-1,46,Charles M Wheeler,,18
+Meade,ALKALI #6A,School Board Member Meade School-1,46,Terry Koontz,,26
+Meade,ALKALI #6A,School Board Member Meade School-1,46,Scottie Bruch,,46
+Meade,ALKALI #6A,School Board Member Meade School-1,46,Amber Lopez,,11
+Meade,BASE #23,School Board Member Meade School-1,46,Aaron Oedegaard,,1
+Meade,BASE #23,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,0
+Meade,BASE #23,School Board Member Meade School-1,46,Kolten K Odle,,1
+Meade,BASE #23,School Board Member Meade School-1,46,Charles M Wheeler,,0
+Meade,BASE #23,School Board Member Meade School-1,46,Terry Koontz,,0
+Meade,BASE #23,School Board Member Meade School-1,46,Scottie Bruch,,0
+Meade,BASE #23,School Board Member Meade School-1,46,Amber Lopez,,1
+Meade,BEAR BUTTE #9,School Board Member Meade School-1,46,Aaron Oedegaard,,18
+Meade,BEAR BUTTE #9,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,9
+Meade,BEAR BUTTE #9,School Board Member Meade School-1,46,Kolten K Odle,,23
+Meade,BEAR BUTTE #9,School Board Member Meade School-1,46,Charles M Wheeler,,19
+Meade,BEAR BUTTE #9,School Board Member Meade School-1,46,Terry Koontz,,24
+Meade,BEAR BUTTE #9,School Board Member Meade School-1,46,Scottie Bruch,,49
+Meade,BEAR BUTTE #9,School Board Member Meade School-1,46,Amber Lopez,,15
+Meade,CENTRAL STURGIS #3,School Board Member Meade School-1,46,Aaron Oedegaard,,53
+Meade,CENTRAL STURGIS #3,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,11
+Meade,CENTRAL STURGIS #3,School Board Member Meade School-1,46,Kolten K Odle,,28
+Meade,CENTRAL STURGIS #3,School Board Member Meade School-1,46,Charles M Wheeler,,31
+Meade,CENTRAL STURGIS #3,School Board Member Meade School-1,46,Terry Koontz,,54
+Meade,CENTRAL STURGIS #3,School Board Member Meade School-1,46,Scottie Bruch,,53
+Meade,CENTRAL STURGIS #3,School Board Member Meade School-1,46,Amber Lopez,,34
+Meade,CHALK BUTTE #27,School Board Member Meade School-1,46,Aaron Oedegaard,,38
+Meade,CHALK BUTTE #27,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,7
+Meade,CHALK BUTTE #27,School Board Member Meade School-1,46,Kolten K Odle,,15
+Meade,CHALK BUTTE #27,School Board Member Meade School-1,46,Charles M Wheeler,,24
+Meade,CHALK BUTTE #27,School Board Member Meade School-1,46,Terry Koontz,,11
+Meade,CHALK BUTTE #27,School Board Member Meade School-1,46,Scottie Bruch,,60
+Meade,CHALK BUTTE #27,School Board Member Meade School-1,46,Amber Lopez,,13
+Meade,ELK VALE #22 1A,School Board Member Meade School-1,46,Aaron Oedegaard,,6
+Meade,ELK VALE #22 1A,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,1
+Meade,ELK VALE #22 1A,School Board Member Meade School-1,46,Kolten K Odle,,2
+Meade,ELK VALE #22 1A,School Board Member Meade School-1,46,Charles M Wheeler,,1
+Meade,ELK VALE #22 1A,School Board Member Meade School-1,46,Terry Koontz,,3
+Meade,ELK VALE #22 1A,School Board Member Meade School-1,46,Scottie Bruch,,0
+Meade,ELK VALE #22 1A,School Board Member Meade School-1,46,Amber Lopez,,1
+Meade,EAST PIEDMONT #12A,School Board Member Meade School-1,46,Aaron Oedegaard,,51
+Meade,EAST PIEDMONT #12A,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,31
+Meade,EAST PIEDMONT #12A,School Board Member Meade School-1,46,Kolten K Odle,,30
+Meade,EAST PIEDMONT #12A,School Board Member Meade School-1,46,Charles M Wheeler,,19
+Meade,EAST PIEDMONT #12A,School Board Member Meade School-1,46,Terry Koontz,,35
+Meade,EAST PIEDMONT #12A,School Board Member Meade School-1,46,Scottie Bruch,,29
+Meade,EAST PIEDMONT #12A,School Board Member Meade School-1,46,Amber Lopez,,37
+Meade,EAST STURGIS #1,School Board Member Meade School-1,46,Aaron Oedegaard,,64
+Meade,EAST STURGIS #1,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,23
+Meade,EAST STURGIS #1,School Board Member Meade School-1,46,Kolten K Odle,,11
+Meade,EAST STURGIS #1,School Board Member Meade School-1,46,Charles M Wheeler,,40
+Meade,EAST STURGIS #1,School Board Member Meade School-1,46,Terry Koontz,,51
+Meade,EAST STURGIS #1,School Board Member Meade School-1,46,Scottie Bruch,,72
+Meade,EAST STURGIS #1,School Board Member Meade School-1,46,Amber Lopez,,26
+Meade,ELK VALE #21,School Board Member Meade School-1,46,Aaron Oedegaard,,2
+Meade,ELK VALE #21,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,4
+Meade,ELK VALE #21,School Board Member Meade School-1,46,Kolten K Odle,,5
+Meade,ELK VALE #21,School Board Member Meade School-1,46,Charles M Wheeler,,1
+Meade,ELK VALE #21,School Board Member Meade School-1,46,Terry Koontz,,2
+Meade,ELK VALE #21,School Board Member Meade School-1,46,Scottie Bruch,,4
+Meade,ELK VALE #21,School Board Member Meade School-1,46,Amber Lopez,,2
+Meade,ELM SPRINGS #18,School Board Member Meade School-1,46,Aaron Oedegaard,,5
+Meade,ELM SPRINGS #18,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,33
+Meade,ELM SPRINGS #18,School Board Member Meade School-1,46,Kolten K Odle,,37
+Meade,ELM SPRINGS #18,School Board Member Meade School-1,46,Charles M Wheeler,,2
+Meade,ELM SPRINGS #18,School Board Member Meade School-1,46,Terry Koontz,,4
+Meade,ELM SPRINGS #18,School Board Member Meade School-1,46,Scottie Bruch,,51
+Meade,ELM SPRINGS #18,School Board Member Meade School-1,46,Amber Lopez,,5
+Meade,FAIRPOINT #29,School Board Member Meade School-1,46,Aaron Oedegaard,,6
+Meade,FAIRPOINT #29,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,0
+Meade,FAIRPOINT #29,School Board Member Meade School-1,46,Kolten K Odle,,5
+Meade,FAIRPOINT #29,School Board Member Meade School-1,46,Charles M Wheeler,,5
+Meade,FAIRPOINT #29,School Board Member Meade School-1,46,Terry Koontz,,8
+Meade,FAIRPOINT #29,School Board Member Meade School-1,46,Scottie Bruch,,16
+Meade,FAIRPOINT #29,School Board Member Meade School-1,46,Amber Lopez,,5
+Meade,FAITH #31,School Board Member Meade School-1,46,Aaron Oedegaard,,1
+Meade,FAITH #31,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,0
+Meade,FAITH #31,School Board Member Meade School-1,46,Kolten K Odle,,0
+Meade,FAITH #31,School Board Member Meade School-1,46,Charles M Wheeler,,0
+Meade,FAITH #31,School Board Member Meade School-1,46,Terry Koontz,,1
+Meade,FAITH #31,School Board Member Meade School-1,46,Scottie Bruch,,1
+Meade,FAITH #31,School Board Member Meade School-1,46,Amber Lopez,,1
+Meade,FORT MEADE #1A,School Board Member Meade School-1,46,Aaron Oedegaard,,3
+Meade,FORT MEADE #1A,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,3
+Meade,FORT MEADE #1A,School Board Member Meade School-1,46,Kolten K Odle,,1
+Meade,FORT MEADE #1A,School Board Member Meade School-1,46,Charles M Wheeler,,3
+Meade,FORT MEADE #1A,School Board Member Meade School-1,46,Terry Koontz,,2
+Meade,FORT MEADE #1A,School Board Member Meade School-1,46,Scottie Bruch,,5
+Meade,FORT MEADE #1A,School Board Member Meade School-1,46,Amber Lopez,,3
+Meade,HARMONY #8,School Board Member Meade School-1,46,Aaron Oedegaard,,71
+Meade,HARMONY #8,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,23
+Meade,HARMONY #8,School Board Member Meade School-1,46,Kolten K Odle,,37
+Meade,HARMONY #8,School Board Member Meade School-1,46,Charles M Wheeler,,54
+Meade,HARMONY #8,School Board Member Meade School-1,46,Terry Koontz,,69
+Meade,HARMONY #8,School Board Member Meade School-1,46,Scottie Bruch,,99
+Meade,HARMONY #8,School Board Member Meade School-1,46,Amber Lopez,,32
+Meade,HEREFORD #20,School Board Member Meade School-1,46,Aaron Oedegaard,,11
+Meade,HEREFORD #20,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,3
+Meade,HEREFORD #20,School Board Member Meade School-1,46,Kolten K Odle,,5
+Meade,HEREFORD #20,School Board Member Meade School-1,46,Charles M Wheeler,,7
+Meade,HEREFORD #20,School Board Member Meade School-1,46,Terry Koontz,,9
+Meade,HEREFORD #20,School Board Member Meade School-1,46,Scottie Bruch,,18
+Meade,HEREFORD #20,School Board Member Meade School-1,46,Amber Lopez,,4
+Meade,MARCUS #41,School Board Member Meade School-1,46,Aaron Oedegaard,,3
+Meade,MARCUS #41,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,1
+Meade,MARCUS #41,School Board Member Meade School-1,46,Kolten K Odle,,5
+Meade,MARCUS #41,School Board Member Meade School-1,46,Charles M Wheeler,,2
+Meade,MARCUS #41,School Board Member Meade School-1,46,Terry Koontz,,3
+Meade,MARCUS #41,School Board Member Meade School-1,46,Scottie Bruch,,10
+Meade,MARCUS #41,School Board Member Meade School-1,46,Amber Lopez,,2
+Meade,NORTHEAST PIEDMONT #12,School Board Member Meade School-1,46,Aaron Oedegaard,,121
+Meade,NORTHEAST PIEDMONT #12,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,58
+Meade,NORTHEAST PIEDMONT #12,School Board Member Meade School-1,46,Kolten K Odle,,54
+Meade,NORTHEAST PIEDMONT #12,School Board Member Meade School-1,46,Charles M Wheeler,,57
+Meade,NORTHEAST PIEDMONT #12,School Board Member Meade School-1,46,Terry Koontz,,58
+Meade,NORTHEAST PIEDMONT #12,School Board Member Meade School-1,46,Scottie Bruch,,86
+Meade,NORTHEAST PIEDMONT #12,School Board Member Meade School-1,46,Amber Lopez,,60
+Meade,NORTHEAST STURGIS #1-,School Board Member Meade School-1,46,Aaron Oedegaard,,13
+Meade,NORTHEAST STURGIS #1-,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,4
+Meade,NORTHEAST STURGIS #1-,School Board Member Meade School-1,46,Kolten K Odle,,9
+Meade,NORTHEAST STURGIS #1-,School Board Member Meade School-1,46,Charles M Wheeler,,12
+Meade,NORTHEAST STURGIS #1-,School Board Member Meade School-1,46,Terry Koontz,,12
+Meade,NORTHEAST STURGIS #1-,School Board Member Meade School-1,46,Scottie Bruch,,21
+Meade,NORTHEAST STURGIS #1-,School Board Member Meade School-1,46,Amber Lopez,,14
+Meade,NORTHWEST STURGIS #5,School Board Member Meade School-1,46,Aaron Oedegaard,,38
+Meade,NORTHWEST STURGIS #5,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,11
+Meade,NORTHWEST STURGIS #5,School Board Member Meade School-1,46,Kolten K Odle,,36
+Meade,NORTHWEST STURGIS #5,School Board Member Meade School-1,46,Charles M Wheeler,,49
+Meade,NORTHWEST STURGIS #5,School Board Member Meade School-1,46,Terry Koontz,,48
+Meade,NORTHWEST STURGIS #5,School Board Member Meade School-1,46,Scottie Bruch,,78
+Meade,NORTHWEST STURGIS #5,School Board Member Meade School-1,46,Amber Lopez,,34
+Meade,PIEDMONT CENTRAL #11A,School Board Member Meade School-1,46,Aaron Oedegaard,,149
+Meade,PIEDMONT CENTRAL #11A,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,46
+Meade,PIEDMONT CENTRAL #11A,School Board Member Meade School-1,46,Kolten K Odle,,58
+Meade,PIEDMONT CENTRAL #11A,School Board Member Meade School-1,46,Charles M Wheeler,,73
+Meade,PIEDMONT CENTRAL #11A,School Board Member Meade School-1,46,Terry Koontz,,78
+Meade,PIEDMONT CENTRAL #11A,School Board Member Meade School-1,46,Scottie Bruch,,77
+Meade,PIEDMONT CENTRAL #11A,School Board Member Meade School-1,46,Amber Lopez,,41
+Meade,PIEDMONT WEST #11,School Board Member Meade School-1,46,Aaron Oedegaard,,97
+Meade,PIEDMONT WEST #11,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,34
+Meade,PIEDMONT WEST #11,School Board Member Meade School-1,46,Kolten K Odle,,41
+Meade,PIEDMONT WEST #11,School Board Member Meade School-1,46,Charles M Wheeler,,63
+Meade,PIEDMONT WEST #11,School Board Member Meade School-1,46,Terry Koontz,,64
+Meade,PIEDMONT WEST #11,School Board Member Meade School-1,46,Scottie Bruch,,64
+Meade,PIEDMONT WEST #11,School Board Member Meade School-1,46,Amber Lopez,,58
+Meade,PINE #33,School Board Member Meade School-1,46,Aaron Oedegaard,,10
+Meade,PINE #33,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,9
+Meade,PINE #33,School Board Member Meade School-1,46,Kolten K Odle,,12
+Meade,PINE #33,School Board Member Meade School-1,46,Charles M Wheeler,,2
+Meade,PINE #33,School Board Member Meade School-1,46,Terry Koontz,,5
+Meade,PINE #33,School Board Member Meade School-1,46,Scottie Bruch,,22
+Meade,PINE #33,School Board Member Meade School-1,46,Amber Lopez,,4
+Meade,RED OWL #30,School Board Member Meade School-1,46,Aaron Oedegaard,,23
+Meade,RED OWL #30,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,7
+Meade,RED OWL #30,School Board Member Meade School-1,46,Kolten K Odle,,24
+Meade,RED OWL #30,School Board Member Meade School-1,46,Charles M Wheeler,,12
+Meade,RED OWL #30,School Board Member Meade School-1,46,Terry Koontz,,9
+Meade,RED OWL #30,School Board Member Meade School-1,46,Scottie Bruch,,37
+Meade,RED OWL #30,School Board Member Meade School-1,46,Amber Lopez,,9
+Meade,RURAL BLACK HAWK #15,School Board Member Meade School-1,46,Aaron Oedegaard,,34
+Meade,RURAL BLACK HAWK #15,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,26
+Meade,RURAL BLACK HAWK #15,School Board Member Meade School-1,46,Kolten K Odle,,25
+Meade,RURAL BLACK HAWK #15,School Board Member Meade School-1,46,Charles M Wheeler,,17
+Meade,RURAL BLACK HAWK #15,School Board Member Meade School-1,46,Terry Koontz,,32
+Meade,RURAL BLACK HAWK #15,School Board Member Meade School-1,46,Scottie Bruch,,16
+Meade,RURAL BLACK HAWK #15,School Board Member Meade School-1,46,Amber Lopez,,25
+Meade,RURAL STURGIS #7,School Board Member Meade School-1,46,Aaron Oedegaard,,89
+Meade,RURAL STURGIS #7,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,21
+Meade,RURAL STURGIS #7,School Board Member Meade School-1,46,Kolten K Odle,,34
+Meade,RURAL STURGIS #7,School Board Member Meade School-1,46,Charles M Wheeler,,57
+Meade,RURAL STURGIS #7,School Board Member Meade School-1,46,Terry Koontz,,82
+Meade,RURAL STURGIS #7,School Board Member Meade School-1,46,Scottie Bruch,,136
+Meade,RURAL STURGIS #7,School Board Member Meade School-1,46,Amber Lopez,,43
+Meade,SOUTH STURGIS #2A,School Board Member Meade School-1,46,Aaron Oedegaard,,66
+Meade,SOUTH STURGIS #2A,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,22
+Meade,SOUTH STURGIS #2A,School Board Member Meade School-1,46,Kolten K Odle,,36
+Meade,SOUTH STURGIS #2A,School Board Member Meade School-1,46,Charles M Wheeler,,48
+Meade,SOUTH STURGIS #2A,School Board Member Meade School-1,46,Terry Koontz,,62
+Meade,SOUTH STURGIS #2A,School Board Member Meade School-1,46,Scottie Bruch,,96
+Meade,SOUTH STURGIS #2A,School Board Member Meade School-1,46,Amber Lopez,,46
+Meade,SOUTHEAST PIEDMONT #13,School Board Member Meade School-1,46,Aaron Oedegaard,,117
+Meade,SOUTHEAST PIEDMONT #13,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,45
+Meade,SOUTHEAST PIEDMONT #13,School Board Member Meade School-1,46,Kolten K Odle,,57
+Meade,SOUTHEAST PIEDMONT #13,School Board Member Meade School-1,46,Charles M Wheeler,,70
+Meade,SOUTHEAST PIEDMONT #13,School Board Member Meade School-1,46,Terry Koontz,,73
+Meade,SOUTHEAST PIEDMONT #13,School Board Member Meade School-1,46,Scottie Bruch,,86
+Meade,SOUTHEAST PIEDMONT #13,School Board Member Meade School-1,46,Amber Lopez,,79
+Meade,SOUTHEAST STURGIS #2,School Board Member Meade School-1,46,Aaron Oedegaard,,118
+Meade,SOUTHEAST STURGIS #2,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,18
+Meade,SOUTHEAST STURGIS #2,School Board Member Meade School-1,46,Kolten K Odle,,41
+Meade,SOUTHEAST STURGIS #2,School Board Member Meade School-1,46,Charles M Wheeler,,95
+Meade,SOUTHEAST STURGIS #2,School Board Member Meade School-1,46,Terry Koontz,,95
+Meade,SOUTHEAST STURGIS #2,School Board Member Meade School-1,46,Scottie Bruch,,163
+Meade,SOUTHEAST STURGIS #2,School Board Member Meade School-1,46,Amber Lopez,,72
+Meade,SOUTHWEST STURGIS #4A,School Board Member Meade School-1,46,Aaron Oedegaard,,46
+Meade,SOUTHWEST STURGIS #4A,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,14
+Meade,SOUTHWEST STURGIS #4A,School Board Member Meade School-1,46,Kolten K Odle,,27
+Meade,SOUTHWEST STURGIS #4A,School Board Member Meade School-1,46,Charles M Wheeler,,28
+Meade,SOUTHWEST STURGIS #4A,School Board Member Meade School-1,46,Terry Koontz,,56
+Meade,SOUTHWEST STURGIS #4A,School Board Member Meade School-1,46,Scottie Bruch,,59
+Meade,SOUTHWEST STURGIS #4A,School Board Member Meade School-1,46,Amber Lopez,,40
+Meade,STURGIS #5A,School Board Member Meade School-1,46,Aaron Oedegaard,,55
+Meade,STURGIS #5A,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,9
+Meade,STURGIS #5A,School Board Member Meade School-1,46,Kolten K Odle,,15
+Meade,STURGIS #5A,School Board Member Meade School-1,46,Charles M Wheeler,,54
+Meade,STURGIS #5A,School Board Member Meade School-1,46,Terry Koontz,,43
+Meade,STURGIS #5A,School Board Member Meade School-1,46,Scottie Bruch,,81
+Meade,STURGIS #5A,School Board Member Meade School-1,46,Amber Lopez,,33
+Meade,SULPHUR #35,School Board Member Meade School-1,46,Aaron Oedegaard,,7
+Meade,SULPHUR #35,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,2
+Meade,SULPHUR #35,School Board Member Meade School-1,46,Kolten K Odle,,1
+Meade,SULPHUR #35,School Board Member Meade School-1,46,Charles M Wheeler,,2
+Meade,SULPHUR #35,School Board Member Meade School-1,46,Terry Koontz,,1
+Meade,SULPHUR #35,School Board Member Meade School-1,46,Scottie Bruch,,9
+Meade,SULPHUR #35,School Board Member Meade School-1,46,Amber Lopez,,3
+Meade,TILFORD #6,School Board Member Meade School-1,46,Aaron Oedegaard,,128
+Meade,TILFORD #6,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,42
+Meade,TILFORD #6,School Board Member Meade School-1,46,Kolten K Odle,,62
+Meade,TILFORD #6,School Board Member Meade School-1,46,Charles M Wheeler,,89
+Meade,TILFORD #6,School Board Member Meade School-1,46,Terry Koontz,,125
+Meade,TILFORD #6,School Board Member Meade School-1,46,Scottie Bruch,,175
+Meade,TILFORD #6,School Board Member Meade School-1,46,Amber Lopez,,72
+Meade,UNION #40,School Board Member Meade School-1,46,Aaron Oedegaard,,1
+Meade,UNION #40,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,1
+Meade,UNION #40,School Board Member Meade School-1,46,Kolten K Odle,,1
+Meade,UNION #40,School Board Member Meade School-1,46,Charles M Wheeler,,1
+Meade,UNION #40,School Board Member Meade School-1,46,Terry Koontz,,1
+Meade,UNION #40,School Board Member Meade School-1,46,Scottie Bruch,,3
+Meade,UNION #40,School Board Member Meade School-1,46,Amber Lopez,,1
+Meade,VIEWFIELD #17,School Board Member Meade School-1,46,Aaron Oedegaard,,20
+Meade,VIEWFIELD #17,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,6
+Meade,VIEWFIELD #17,School Board Member Meade School-1,46,Kolten K Odle,,9
+Meade,VIEWFIELD #17,School Board Member Meade School-1,46,Charles M Wheeler,,3
+Meade,VIEWFIELD #17,School Board Member Meade School-1,46,Terry Koontz,,12
+Meade,VIEWFIELD #17,School Board Member Meade School-1,46,Scottie Bruch,,26
+Meade,VIEWFIELD #17,School Board Member Meade School-1,46,Amber Lopez,,5
+Meade,WEST BLACK HAWK #16,School Board Member Meade School-1,46,Aaron Oedegaard,,3
+Meade,WEST BLACK HAWK #16,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,1
+Meade,WEST BLACK HAWK #16,School Board Member Meade School-1,46,Kolten K Odle,,0
+Meade,WEST BLACK HAWK #16,School Board Member Meade School-1,46,Charles M Wheeler,,1
+Meade,WEST BLACK HAWK #16,School Board Member Meade School-1,46,Terry Koontz,,2
+Meade,WEST BLACK HAWK #16,School Board Member Meade School-1,46,Scottie Bruch,,1
+Meade,WEST BLACK HAWK #16,School Board Member Meade School-1,46,Amber Lopez,,1
+Meade,WEST ELK VALE #24,School Board Member Meade School-1,46,Aaron Oedegaard,,5
+Meade,WEST ELK VALE #24,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,0
+Meade,WEST ELK VALE #24,School Board Member Meade School-1,46,Kolten K Odle,,1
+Meade,WEST ELK VALE #24,School Board Member Meade School-1,46,Charles M Wheeler,,0
+Meade,WEST ELK VALE #24,School Board Member Meade School-1,46,Terry Koontz,,1
+Meade,WEST ELK VALE #24,School Board Member Meade School-1,46,Scottie Bruch,,0
+Meade,WEST ELK VALE #24,School Board Member Meade School-1,46,Amber Lopez,,2
+Meade,WEST STURGIS #4,School Board Member Meade School-1,46,Aaron Oedegaard,,32
+Meade,WEST STURGIS #4,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,11
+Meade,WEST STURGIS #4,School Board Member Meade School-1,46,Kolten K Odle,,11
+Meade,WEST STURGIS #4,School Board Member Meade School-1,46,Charles M Wheeler,,21
+Meade,WEST STURGIS #4,School Board Member Meade School-1,46,Terry Koontz,,22
+Meade,WEST STURGIS #4,School Board Member Meade School-1,46,Scottie Bruch,,39
+Meade,WEST STURGIS #4,School Board Member Meade School-1,46,Amber Lopez,,14
+Meade,WHITE OWL #25,School Board Member Meade School-1,46,Aaron Oedegaard,,4
+Meade,WHITE OWL #25,School Board Member Meade School-1,46,Thomas Christopher Schmeller,,3
+Meade,WHITE OWL #25,School Board Member Meade School-1,46,Kolten K Odle,,2
+Meade,WHITE OWL #25,School Board Member Meade School-1,46,Charles M Wheeler,,5
+Meade,WHITE OWL #25,School Board Member Meade School-1,46,Terry Koontz,,13
+Meade,WHITE OWL #25,School Board Member Meade School-1,46,Scottie Bruch,,19
+Meade,WHITE OWL #25,School Board Member Meade School-1,46,Amber Lopez,,2

--- a/2024/counties/20240604__sd__primary__mellette__precinct.csv
+++ b/2024/counties/20240604__sd__primary__mellette__precinct.csv
@@ -1,0 +1,21 @@
+county,precinct,office,district,candidate,party,votes
+Mellette,2,President,,Marianne Williamson,DEM,4
+Mellette,2,President,,Joseph R Biden Jr,DEM,9
+Mellette,2,President,,Dean Phillips,DEM,3
+Mellette,2,President,,Armando Perez-Serrato,DEM,1
+Mellette,3,President,,Marianne Williamson,DEM,0
+Mellette,3,President,,Joseph R Biden Jr,DEM,5
+Mellette,3,President,,Dean Phillips,DEM,2
+Mellette,3,President,,Armando Perez-Serrato,DEM,0
+Mellette,5,President,,Marianne Williamson,DEM,2
+Mellette,5,President,,Joseph R Biden Jr,DEM,12
+Mellette,5,President,,Dean Phillips,DEM,2
+Mellette,5,President,,Armando Perez-Serrato,DEM,0
+Mellette,6,President,,Marianne Williamson,DEM,1
+Mellette,6,President,,Joseph R Biden Jr,DEM,15
+Mellette,6,President,,Dean Phillips,DEM,1
+Mellette,6,President,,Armando Perez-Serrato,DEM,1
+Mellette,2,County Commissioner,Mellette-3,Dan Valburg,REP,23
+Mellette,2,County Commissioner,Mellette-3,Vernon Brown,REP,11
+Mellette,3,County Commissioner,Mellette-3,Dan Valburg,REP,23
+Mellette,3,County Commissioner,Mellette-3,Vernon Brown,REP,37

--- a/2024/counties/20240604__sd__primary__miner__precinct.csv
+++ b/2024/counties/20240604__sd__primary__miner__precinct.csv
@@ -1,0 +1,68 @@
+county,precinct,office,district,candidate,party,votes
+Miner,1,President,,Marianne Williamson,DEM,0
+Miner,1,President,,Joseph R Biden Jr,DEM,10
+Miner,1,President,,Dean Phillips,DEM,2
+Miner,1,President,,Armando Perez-Serrato,DEM,3
+Miner,2,President,,Marianne Williamson,DEM,2
+Miner,2,President,,Joseph R Biden Jr,DEM,9
+Miner,2,President,,Dean Phillips,DEM,1
+Miner,2,President,,Armando Perez-Serrato,DEM,3
+Miner,3,President,,Marianne Williamson,DEM,3
+Miner,3,President,,Joseph R Biden Jr,DEM,6
+Miner,3,President,,Dean Phillips,DEM,2
+Miner,3,President,,Armando Perez-Serrato,DEM,0
+Miner,4,President,,Marianne Williamson,DEM,0
+Miner,4,President,,Joseph R Biden Jr,DEM,5
+Miner,4,President,,Dean Phillips,DEM,2
+Miner,4,President,,Armando Perez-Serrato,DEM,0
+Miner,5,President,,Marianne Williamson,DEM,1
+Miner,5,President,,Joseph R Biden Jr,DEM,4
+Miner,5,President,,Dean Phillips,DEM,2
+Miner,5,President,,Armando Perez-Serrato,DEM,1
+Miner,6,President,,Marianne Williamson,DEM,0
+Miner,6,President,,Joseph R Biden Jr,DEM,7
+Miner,6,President,,Dean Phillips,DEM,1
+Miner,6,President,,Armando Perez-Serrato,DEM,0
+Miner,7,President,,Marianne Williamson,DEM,2
+Miner,7,President,,Joseph R Biden Jr,DEM,7
+Miner,7,President,,Dean Phillips,DEM,6
+Miner,7,President,,Armando Perez-Serrato,DEM,0
+Miner,8,President,,Marianne Williamson,DEM,1
+Miner,8,President,,Joseph R Biden Jr,DEM,5
+Miner,8,President,,Dean Phillips,DEM,0
+Miner,8,President,,Armando Perez-Serrato,DEM,0
+Miner,1,State Senate,08,Casey Crabtree,REP,22
+Miner,1,State Senate,08,Rick Weible,REP,6
+Miner,2,State Senate,08,Casey Crabtree,REP,18
+Miner,2,State Senate,08,Rick Weible,REP,10
+Miner,3,State Senate,08,Casey Crabtree,REP,24
+Miner,3,State Senate,08,Rick Weible,REP,2
+Miner,4,State Senate,08,Casey Crabtree,REP,17
+Miner,4,State Senate,08,Rick Weible,REP,3
+Miner,6,State Senate,08,Casey Crabtree,REP,46
+Miner,6,State Senate,08,Rick Weible,REP,23
+Miner,7,State Senate,08,Casey Crabtree,REP,19
+Miner,7,State Senate,08,Rick Weible,REP,15
+Miner,8,State Senate,08,Casey Crabtree,REP,22
+Miner,8,State Senate,08,Rick Weible,REP,12
+Miner,1,State House,08,Matt Wagner,REP,12
+Miner,1,State House,08,Tim Walburg,REP,12
+Miner,1,State House,08,Tim Reisch,REP,23
+Miner,2,State House,08,Matt Wagner,REP,13
+Miner,2,State House,08,Tim Walburg,REP,14
+Miner,2,State House,08,Tim Reisch,REP,21
+Miner,3,State House,08,Matt Wagner,REP,6
+Miner,3,State House,08,Tim Walburg,REP,10
+Miner,3,State House,08,Tim Reisch,REP,24
+Miner,4,State House,08,Matt Wagner,REP,8
+Miner,4,State House,08,Tim Walburg,REP,6
+Miner,4,State House,08,Tim Reisch,REP,18
+Miner,6,State House,08,Matt Wagner,REP,37
+Miner,6,State House,08,Tim Walburg,REP,23
+Miner,6,State House,08,Tim Reisch,REP,47
+Miner,7,State House,08,Matt Wagner,REP,22
+Miner,7,State House,08,Tim Walburg,REP,6
+Miner,7,State House,08,Tim Reisch,REP,19
+Miner,8,State House,08,Matt Wagner,REP,18
+Miner,8,State House,08,Tim Walburg,REP,16
+Miner,8,State House,08,Tim Reisch,REP,26

--- a/2024/counties/20240604__sd__primary__moody__precinct.csv
+++ b/2024/counties/20240604__sd__primary__moody__precinct.csv
@@ -1,0 +1,39 @@
+county,precinct,office,district,candidate,party,votes
+Moody,1,President,,Marianne Williamson,DEM,0
+Moody,1,President,,Joseph R Biden Jr,DEM,21
+Moody,1,President,,Dean Phillips,DEM,0
+Moody,1,President,,Armando Perez-Serrato,DEM,0
+Moody,2,President,,Marianne Williamson,DEM,0
+Moody,2,President,,Joseph R Biden Jr,DEM,14
+Moody,2,President,,Dean Phillips,DEM,2
+Moody,2,President,,Armando Perez-Serrato,DEM,0
+Moody,3,President,,Marianne Williamson,DEM,7
+Moody,3,President,,Joseph R Biden Jr,DEM,14
+Moody,3,President,,Dean Phillips,DEM,8
+Moody,3,President,,Armando Perez-Serrato,DEM,3
+Moody,34,President,,Marianne Williamson,DEM,0
+Moody,34,President,,Joseph R Biden Jr,DEM,6
+Moody,34,President,,Dean Phillips,DEM,3
+Moody,34,President,,Armando Perez-Serrato,DEM,0
+Moody,4,President,,Marianne Williamson,DEM,4
+Moody,4,President,,Joseph R Biden Jr,DEM,7
+Moody,4,President,,Dean Phillips,DEM,2
+Moody,4,President,,Armando Perez-Serrato,DEM,0
+Moody,5,President,,Marianne Williamson,DEM,4
+Moody,5,President,,Joseph R Biden Jr,DEM,14
+Moody,5,President,,Dean Phillips,DEM,0
+Moody,5,President,,Armando Perez-Serrato,DEM,0
+Moody,1,State Senate,25,Jordan Youngberg,REP,19
+Moody,1,State Senate,25,Tom Pischke,REP,19
+Moody,2,State Senate,25,Jordan Youngberg,REP,26
+Moody,2,State Senate,25,Tom Pischke,REP,25
+Moody,3,State Senate,25,Jordan Youngberg,REP,36
+Moody,3,State Senate,25,Tom Pischke,REP,80
+Moody,34,State Senate,25,Jordan Youngberg,REP,18
+Moody,34,State Senate,25,Tom Pischke,REP,35
+Moody,4,State Senate,25,Jordan Youngberg,REP,31
+Moody,4,State Senate,25,Tom Pischke,REP,60
+Moody,5,State Senate,25,Jordan Youngberg,REP,54
+Moody,5,State Senate,25,Tom Pischke,REP,65
+Moody,3,Trustee Trent Town,,Kathy Baty,,26
+Moody,3,Trustee Trent Town,,Jami Alberts,,19

--- a/2024/counties/20240604__sd__primary__oglala_lakota__precinct.csv
+++ b/2024/counties/20240604__sd__primary__oglala_lakota__precinct.csv
@@ -1,0 +1,65 @@
+county,precinct,office,district,candidate,party,votes
+Oglala Lakota,Bill Conquering Bear Gymnasium/Oglala Lakota County Schools,President,,Marianne Williamson,DEM,0
+Oglala Lakota,Bill Conquering Bear Gymnasium/Oglala Lakota County Schools,President,,Joseph R Biden Jr,DEM,14
+Oglala Lakota,Bill Conquering Bear Gymnasium/Oglala Lakota County Schools,President,,Dean Phillips,DEM,0
+Oglala Lakota,Bill Conquering Bear Gymnasium/Oglala Lakota County Schools,President,,Armando Perez-Serrato,DEM,3
+Oglala Lakota,Brother Renee Hall,President,,Marianne Williamson,DEM,6
+Oglala Lakota,Brother Renee Hall,President,,Joseph R Biden Jr,DEM,40
+Oglala Lakota,Brother Renee Hall,President,,Dean Phillips,DEM,2
+Oglala Lakota,Brother Renee Hall,President,,Armando Perez-Serrato,DEM,10
+Oglala Lakota,"Christ The King Parish, Bill Pauly Hall",President,,Marianne Williamson,DEM,3
+Oglala Lakota,"Christ The King Parish, Bill Pauly Hall",President,,Joseph R Biden Jr,DEM,22
+Oglala Lakota,"Christ The King Parish, Bill Pauly Hall",President,,Dean Phillips,DEM,0
+Oglala Lakota,"Christ The King Parish, Bill Pauly Hall",President,,Armando Perez-Serrato,DEM,4
+Oglala Lakota,Little Wound School,President,,Marianne Williamson,DEM,3
+Oglala Lakota,Little Wound School,President,,Joseph R Biden Jr,DEM,28
+Oglala Lakota,Little Wound School,President,,Dean Phillips,DEM,0
+Oglala Lakota,Little Wound School,President,,Armando Perez-Serrato,DEM,5
+Oglala Lakota,Red Shirt School,President,,Marianne Williamson,DEM,2
+Oglala Lakota,Red Shirt School,President,,Joseph R Biden Jr,DEM,7
+Oglala Lakota,Red Shirt School,President,,Dean Phillips,DEM,0
+Oglala Lakota,Red Shirt School,President,,Armando Perez-Serrato,DEM,1
+Oglala Lakota,Sacred Heart Church Hall,President,,Marianne Williamson,DEM,21
+Oglala Lakota,Sacred Heart Church Hall,President,,Joseph R Biden Jr,DEM,115
+Oglala Lakota,Sacred Heart Church Hall,President,,Dean Phillips,DEM,4
+Oglala Lakota,Sacred Heart Church Hall,President,,Armando Perez-Serrato,DEM,14
+Oglala Lakota,Wakan Tiospaye #12 Community Building,President,,Marianne Williamson,DEM,1
+Oglala Lakota,Wakan Tiospaye #12 Community Building,President,,Joseph R Biden Jr,DEM,4
+Oglala Lakota,Wakan Tiospaye #12 Community Building,President,,Dean Phillips,DEM,0
+Oglala Lakota,Wakan Tiospaye #12 Community Building,President,,Armando Perez-Serrato,DEM,1
+Oglala Lakota,Wound Knee District School Gym,President,,Marianne Williamson,DEM,5
+Oglala Lakota,Wound Knee District School Gym,President,,Joseph R Biden Jr,DEM,14
+Oglala Lakota,Wound Knee District School Gym,President,,Dean Phillips,DEM,0
+Oglala Lakota,Wound Knee District School Gym,President,,Armando Perez-Serrato,DEM,5
+Oglala Lakota,Bill Conquering Bear Gymnasium/Oglala Lakota County Schools,State Senate,27,Gerald M Cournoyer Jr,DEM,5
+Oglala Lakota,Bill Conquering Bear Gymnasium/Oglala Lakota County Schools,State Senate,27,Red Dawn Foster,DEM,12
+Oglala Lakota,Bill Conquering Bear Gymnasium/Oglala Lakota County Schools,State Senate,27,Anthony G. Kathol,REP,13
+Oglala Lakota,Bill Conquering Bear Gymnasium/Oglala Lakota County Schools,State Senate,27,Bruce Whalen,REP,1
+Oglala Lakota,Brother Renee Hall,State Senate,27,Gerald M Cournoyer Jr,DEM,12
+Oglala Lakota,Brother Renee Hall,State Senate,27,Red Dawn Foster,DEM,47
+Oglala Lakota,Brother Renee Hall,State Senate,27,Anthony G. Kathol,REP,3
+Oglala Lakota,Brother Renee Hall,State Senate,27,Bruce Whalen,REP,1
+Oglala Lakota,"Christ The King Parish, Bill Pauly Hall",State Senate,27,Gerald M Cournoyer Jr,DEM,9
+Oglala Lakota,"Christ The King Parish, Bill Pauly Hall",State Senate,27,Red Dawn Foster,DEM,24
+Oglala Lakota,"Christ The King Parish, Bill Pauly Hall",State Senate,27,Anthony G. Kathol,REP,1
+Oglala Lakota,"Christ The King Parish, Bill Pauly Hall",State Senate,27,Bruce Whalen,REP,3
+Oglala Lakota,Little Wound School,State Senate,27,Gerald M Cournoyer Jr,DEM,17
+Oglala Lakota,Little Wound School,State Senate,27,Red Dawn Foster,DEM,21
+Oglala Lakota,Little Wound School,State Senate,27,Anthony G. Kathol,REP,2
+Oglala Lakota,Little Wound School,State Senate,27,Bruce Whalen,REP,2
+Oglala Lakota,Red Shirt School,State Senate,27,Gerald M Cournoyer Jr,DEM,3
+Oglala Lakota,Red Shirt School,State Senate,27,Red Dawn Foster,DEM,8
+Oglala Lakota,Red Shirt School,State Senate,27,Anthony G. Kathol,REP,0
+Oglala Lakota,Red Shirt School,State Senate,27,Bruce Whalen,REP,5
+Oglala Lakota,Sacred Heart Church Hall,State Senate,27,Gerald M Cournoyer Jr,DEM,29
+Oglala Lakota,Sacred Heart Church Hall,State Senate,27,Red Dawn Foster,DEM,137
+Oglala Lakota,Sacred Heart Church Hall,State Senate,27,Anthony G. Kathol,REP,2
+Oglala Lakota,Sacred Heart Church Hall,State Senate,27,Bruce Whalen,REP,11
+Oglala Lakota,Wakan Tiospaye #12 Community Building,State Senate,27,Gerald M Cournoyer Jr,DEM,2
+Oglala Lakota,Wakan Tiospaye #12 Community Building,State Senate,27,Red Dawn Foster,DEM,4
+Oglala Lakota,Wakan Tiospaye #12 Community Building,State Senate,27,Anthony G. Kathol,REP,0
+Oglala Lakota,Wakan Tiospaye #12 Community Building,State Senate,27,Bruce Whalen,REP,0
+Oglala Lakota,Wound Knee District School Gym,State Senate,27,Gerald M Cournoyer Jr,DEM,6
+Oglala Lakota,Wound Knee District School Gym,State Senate,27,Red Dawn Foster,DEM,19
+Oglala Lakota,Wound Knee District School Gym,State Senate,27,Anthony G. Kathol,REP,0
+Oglala Lakota,Wound Knee District School Gym,State Senate,27,Bruce Whalen,REP,0

--- a/2024/counties/20240604__sd__primary__perkins__precinct.csv
+++ b/2024/counties/20240604__sd__primary__perkins__precinct.csv
@@ -1,0 +1,101 @@
+county,precinct,office,district,candidate,party,votes
+Perkins,01,President,,Marianne Williamson,DEM,3
+Perkins,01,President,,Joseph R Biden Jr,DEM,2
+Perkins,01,President,,Dean Phillips,DEM,0
+Perkins,01,President,,Armando Perez-Serrato,DEM,0
+Perkins,02,President,,Marianne Williamson,DEM,0
+Perkins,02,President,,Joseph R Biden Jr,DEM,1
+Perkins,02,President,,Dean Phillips,DEM,0
+Perkins,02,President,,Armando Perez-Serrato,DEM,0
+Perkins,03,President,,Marianne Williamson,DEM,0
+Perkins,03,President,,Joseph R Biden Jr,DEM,1
+Perkins,03,President,,Dean Phillips,DEM,1
+Perkins,03,President,,Armando Perez-Serrato,DEM,1
+Perkins,04,President,,Marianne Williamson,DEM,0
+Perkins,04,President,,Joseph R Biden Jr,DEM,4
+Perkins,04,President,,Dean Phillips,DEM,1
+Perkins,04,President,,Armando Perez-Serrato,DEM,0
+Perkins,05,President,,Marianne Williamson,DEM,0
+Perkins,05,President,,Joseph R Biden Jr,DEM,1
+Perkins,05,President,,Dean Phillips,DEM,2
+Perkins,05,President,,Armando Perez-Serrato,DEM,0
+Perkins,06,President,,Marianne Williamson,DEM,2
+Perkins,06,President,,Joseph R Biden Jr,DEM,0
+Perkins,06,President,,Dean Phillips,DEM,0
+Perkins,06,President,,Armando Perez-Serrato,DEM,3
+Perkins,07,President,,Marianne Williamson,DEM,2
+Perkins,07,President,,Joseph R Biden Jr,DEM,1
+Perkins,07,President,,Dean Phillips,DEM,1
+Perkins,07,President,,Armando Perez-Serrato,DEM,0
+Perkins,08,President,,Marianne Williamson,DEM,0
+Perkins,08,President,,Joseph R Biden Jr,DEM,1
+Perkins,08,President,,Dean Phillips,DEM,1
+Perkins,08,President,,Armando Perez-Serrato,DEM,0
+Perkins,09,President,,Marianne Williamson,DEM,0
+Perkins,09,President,,Joseph R Biden Jr,DEM,3
+Perkins,09,President,,Dean Phillips,DEM,0
+Perkins,09,President,,Armando Perez-Serrato,DEM,0
+Perkins,12,President,,Marianne Williamson,DEM,1
+Perkins,12,President,,Joseph R Biden Jr,DEM,2
+Perkins,12,President,,Dean Phillips,DEM,0
+Perkins,12,President,,Armando Perez-Serrato,DEM,1
+Perkins,01,State Senate,28,Susan M. Peterson,REP,26
+Perkins,01,State Senate,28,Sam Marty,REP,20
+Perkins,02,State Senate,28,Susan M. Peterson,REP,4
+Perkins,02,State Senate,28,Sam Marty,REP,26
+Perkins,03,State Senate,28,Susan M. Peterson,REP,34
+Perkins,03,State Senate,28,Sam Marty,REP,23
+Perkins,04,State Senate,28,Susan M. Peterson,REP,1
+Perkins,04,State Senate,28,Sam Marty,REP,19
+Perkins,05,State Senate,28,Susan M. Peterson,REP,13
+Perkins,05,State Senate,28,Sam Marty,REP,24
+Perkins,06,State Senate,28,Susan M. Peterson,REP,10
+Perkins,06,State Senate,28,Sam Marty,REP,31
+Perkins,07,State Senate,28,Susan M. Peterson,REP,12
+Perkins,07,State Senate,28,Sam Marty,REP,60
+Perkins,08,State Senate,28,Susan M. Peterson,REP,4
+Perkins,08,State Senate,28,Sam Marty,REP,8
+Perkins,09,State Senate,28,Susan M. Peterson,REP,5
+Perkins,09,State Senate,28,Sam Marty,REP,33
+Perkins,12,State Senate,28,Susan M. Peterson,REP,24
+Perkins,12,State Senate,28,Sam Marty,REP,91
+Perkins,01,State House,28A,Ryan Maher,REP,0
+Perkins,01,State House,28A,Jana Hunt,REP,0
+Perkins,01,State House,28B,Travis Ismay,REP,28
+Perkins,01,State House,28B,Travis W. Martin,REP,19
+Perkins,02,State House,28A,Ryan Maher,REP,0
+Perkins,02,State House,28A,Jana Hunt,REP,0
+Perkins,02,State House,28B,Travis Ismay,REP,19
+Perkins,02,State House,28B,Travis W. Martin,REP,7
+Perkins,03,State House,28A,Ryan Maher,REP,0
+Perkins,03,State House,28A,Jana Hunt,REP,0
+Perkins,03,State House,28B,Travis Ismay,REP,28
+Perkins,03,State House,28B,Travis W. Martin,REP,28
+Perkins,04,State House,28A,Ryan Maher,REP,0
+Perkins,04,State House,28A,Jana Hunt,REP,0
+Perkins,04,State House,28B,Travis Ismay,REP,17
+Perkins,04,State House,28B,Travis W. Martin,REP,3
+Perkins,05,State House,28A,Ryan Maher,REP,0
+Perkins,05,State House,28A,Jana Hunt,REP,0
+Perkins,05,State House,28B,Travis Ismay,REP,24
+Perkins,05,State House,28B,Travis W. Martin,REP,13
+Perkins,06,State House,28A,Ryan Maher,REP,13
+Perkins,06,State House,28A,Jana Hunt,REP,28
+Perkins,06,State House,28B,Travis Ismay,REP,0
+Perkins,06,State House,28B,Travis W. Martin,REP,0
+Perkins,07,State House,28A,Ryan Maher,REP,20
+Perkins,07,State House,28A,Jana Hunt,REP,52
+Perkins,07,State House,28B,Travis Ismay,REP,0
+Perkins,07,State House,28B,Travis W. Martin,REP,0
+Perkins,08,State House,28A,Ryan Maher,REP,8
+Perkins,08,State House,28A,Jana Hunt,REP,5
+Perkins,08,State House,28B,Travis Ismay,REP,0
+Perkins,08,State House,28B,Travis W. Martin,REP,0
+Perkins,09,State House,28A,Ryan Maher,REP,10
+Perkins,09,State House,28A,Jana Hunt,REP,29
+Perkins,09,State House,28B,Travis Ismay,REP,0
+Perkins,09,State House,28B,Travis W. Martin,REP,0
+Perkins,12,State House,28A,Ryan Maher,REP,38
+Perkins,12,State House,28A,Jana Hunt,REP,77
+Perkins,12,State House,28B,Travis Ismay,REP,0
+Perkins,12,State House,28B,Travis W. Martin,REP,0

--- a/2024/counties/20240604__sd__primary__potter__precinct.csv
+++ b/2024/counties/20240604__sd__primary__potter__precinct.csv
@@ -1,0 +1,34 @@
+county,precinct,office,district,candidate,party,votes
+Potter,Absentee Precinct,President,,Marianne Williamson,DEM,0
+Potter,Absentee Precinct,President,,Joseph R Biden Jr,DEM,3
+Potter,Absentee Precinct,President,,Dean Phillips,DEM,1
+Potter,Absentee Precinct,President,,Armando Perez-Serrato,DEM,0
+Potter,CC Bar (Gettysburg Legion Annex),President,,Marianne Williamson,DEM,2
+Potter,CC Bar (Gettysburg Legion Annex),President,,Joseph R Biden Jr,DEM,15
+Potter,CC Bar (Gettysburg Legion Annex),President,,Dean Phillips,DEM,2
+Potter,CC Bar (Gettysburg Legion Annex),President,,Armando Perez-Serrato,DEM,0
+Potter,Hoven Legion Hall,President,,Marianne Williamson,DEM,1
+Potter,Hoven Legion Hall,President,,Joseph R Biden Jr,DEM,3
+Potter,Hoven Legion Hall,President,,Dean Phillips,DEM,3
+Potter,Hoven Legion Hall,President,,Armando Perez-Serrato,DEM,2
+Potter,Absentee Precinct,State Senate,23,Steven Ray Roseland,REP,29
+Potter,Absentee Precinct,State Senate,23,Mark Lapka,REP,20
+Potter,CC Bar (Gettysburg Legion Annex),State Senate,23,Steven Ray Roseland,REP,275
+Potter,CC Bar (Gettysburg Legion Annex),State Senate,23,Mark Lapka,REP,76
+Potter,Hoven Legion Hall,State Senate,23,Steven Ray Roseland,REP,68
+Potter,Hoven Legion Hall,State Senate,23,Mark Lapka,REP,47
+Potter,Absentee Precinct,State House,23,Spencer Gosch,REP,35
+Potter,Absentee Precinct,State House,23,Scott Moore,REP,21
+Potter,Absentee Precinct,State House,23,James D. Wangsness,REP,24
+Potter,CC Bar (Gettysburg Legion Annex),State House,23,Spencer Gosch,REP,159
+Potter,CC Bar (Gettysburg Legion Annex),State House,23,Scott Moore,REP,212
+Potter,CC Bar (Gettysburg Legion Annex),State House,23,James D. Wangsness,REP,199
+Potter,Hoven Legion Hall,State House,23,Spencer Gosch,REP,53
+Potter,Hoven Legion Hall,State House,23,Scott Moore,REP,80
+Potter,Hoven Legion Hall,State House,23,James D. Wangsness,REP,48
+Potter,Absentee Precinct,County Commissioner,4,Tonya A Tanner,REP,8
+Potter,Absentee Precinct,County Commissioner,4,John C Wager,REP,17
+Potter,CC Bar (Gettysburg Legion Annex),County Commissioner,4,Tonya A Tanner,REP,66
+Potter,CC Bar (Gettysburg Legion Annex),County Commissioner,4,John C Wager,REP,49
+Potter,Hoven Legion Hall,County Commissioner,4,Tonya A Tanner,REP,0
+Potter,Hoven Legion Hall,County Commissioner,4,John C Wager,REP,0

--- a/2024/counties/20240604__sd__primary__roberts__precinct.csv
+++ b/2024/counties/20240604__sd__primary__roberts__precinct.csv
@@ -1,0 +1,144 @@
+county,precinct,office,district,candidate,party,votes
+Roberts,01,President,,Marianne Williamson,DEM,1
+Roberts,01,President,,Joseph R Biden Jr,DEM,15
+Roberts,01,President,,Dean Phillips,DEM,3
+Roberts,01,President,,Armando Perez-Serrato,DEM,2
+Roberts,02,President,,Marianne Williamson,DEM,3
+Roberts,02,President,,Joseph R Biden Jr,DEM,23
+Roberts,02,President,,Dean Phillips,DEM,5
+Roberts,02,President,,Armando Perez-Serrato,DEM,0
+Roberts,03,President,,Marianne Williamson,DEM,0
+Roberts,03,President,,Joseph R Biden Jr,DEM,16
+Roberts,03,President,,Dean Phillips,DEM,1
+Roberts,03,President,,Armando Perez-Serrato,DEM,2
+Roberts,04,President,,Marianne Williamson,DEM,1
+Roberts,04,President,,Joseph R Biden Jr,DEM,4
+Roberts,04,President,,Dean Phillips,DEM,0
+Roberts,04,President,,Armando Perez-Serrato,DEM,0
+Roberts,05,President,,Marianne Williamson,DEM,1
+Roberts,05,President,,Joseph R Biden Jr,DEM,16
+Roberts,05,President,,Dean Phillips,DEM,8
+Roberts,05,President,,Armando Perez-Serrato,DEM,0
+Roberts,06,President,,Marianne Williamson,DEM,1
+Roberts,06,President,,Joseph R Biden Jr,DEM,7
+Roberts,06,President,,Dean Phillips,DEM,0
+Roberts,06,President,,Armando Perez-Serrato,DEM,0
+Roberts,07,President,,Marianne Williamson,DEM,1
+Roberts,07,President,,Joseph R Biden Jr,DEM,12
+Roberts,07,President,,Dean Phillips,DEM,4
+Roberts,07,President,,Armando Perez-Serrato,DEM,1
+Roberts,08,President,,Marianne Williamson,DEM,2
+Roberts,08,President,,Joseph R Biden Jr,DEM,6
+Roberts,08,President,,Dean Phillips,DEM,2
+Roberts,08,President,,Armando Perez-Serrato,DEM,0
+Roberts,09,President,,Marianne Williamson,DEM,5
+Roberts,09,President,,Joseph R Biden Jr,DEM,25
+Roberts,09,President,,Dean Phillips,DEM,7
+Roberts,09,President,,Armando Perez-Serrato,DEM,3
+Roberts,10,President,,Marianne Williamson,DEM,0
+Roberts,10,President,,Joseph R Biden Jr,DEM,12
+Roberts,10,President,,Dean Phillips,DEM,1
+Roberts,10,President,,Armando Perez-Serrato,DEM,1
+Roberts,11,President,,Marianne Williamson,DEM,3
+Roberts,11,President,,Joseph R Biden Jr,DEM,26
+Roberts,11,President,,Dean Phillips,DEM,4
+Roberts,11,President,,Armando Perez-Serrato,DEM,4
+Roberts,12,President,,Marianne Williamson,DEM,1
+Roberts,12,President,,Joseph R Biden Jr,DEM,9
+Roberts,12,President,,Dean Phillips,DEM,1
+Roberts,12,President,,Armando Perez-Serrato,DEM,0
+Roberts,13,President,,Marianne Williamson,DEM,0
+Roberts,13,President,,Joseph R Biden Jr,DEM,8
+Roberts,13,President,,Dean Phillips,DEM,2
+Roberts,13,President,,Armando Perez-Serrato,DEM,1
+Roberts,14,President,,Marianne Williamson,DEM,0
+Roberts,14,President,,Joseph R Biden Jr,DEM,5
+Roberts,14,President,,Dean Phillips,DEM,0
+Roberts,14,President,,Armando Perez-Serrato,DEM,1
+Roberts,02,State Senate,04,Fred Deutsch,REP,63
+Roberts,02,State Senate,04,Stephanie Sauder,REP,65
+Roberts,05,State Senate,04,Fred Deutsch,REP,6
+Roberts,05,State Senate,04,Stephanie Sauder,REP,2
+Roberts,09,State Senate,04,Fred Deutsch,REP,59
+Roberts,09,State Senate,04,Stephanie Sauder,REP,56
+Roberts,01,State House,01,Logan Manhart,REP,24
+Roberts,01,State House,01,Tamara St John,REP,12
+Roberts,01,State House,01,Christopher Reder,REP,22
+Roberts,02,State House,04,Dylan C. Jordan,REP,73
+Roberts,02,State House,04,Vanessa Namken,REP,45
+Roberts,02,State House,04,Barbara Guenette,REP,37
+Roberts,02,State House,04,Kent Roe,REP,66
+Roberts,03,State House,01,Logan Manhart,REP,19
+Roberts,03,State House,01,Tamara St John,REP,12
+Roberts,03,State House,01,Christopher Reder,REP,16
+Roberts,04,State House,01,Logan Manhart,REP,6
+Roberts,04,State House,01,Tamara St John,REP,4
+Roberts,04,State House,01,Christopher Reder,REP,4
+Roberts,05,State House,01,Logan Manhart,REP,25
+Roberts,05,State House,01,Tamara St John,REP,11
+Roberts,05,State House,01,Christopher Reder,REP,26
+Roberts,05,State House,04,Dylan C. Jordan,REP,3
+Roberts,05,State House,04,Vanessa Namken,REP,1
+Roberts,05,State House,04,Barbara Guenette,REP,4
+Roberts,05,State House,04,Kent Roe,REP,7
+Roberts,06,State House,01,Logan Manhart,REP,19
+Roberts,06,State House,01,Tamara St John,REP,24
+Roberts,06,State House,01,Christopher Reder,REP,14
+Roberts,07,State House,01,Logan Manhart,REP,27
+Roberts,07,State House,01,Tamara St John,REP,23
+Roberts,07,State House,01,Christopher Reder,REP,26
+Roberts,08,State House,01,Logan Manhart,REP,6
+Roberts,08,State House,01,Tamara St John,REP,8
+Roberts,08,State House,01,Christopher Reder,REP,5
+Roberts,09,State House,01,Logan Manhart,REP,0
+Roberts,09,State House,01,Tamara St John,REP,0
+Roberts,09,State House,01,Christopher Reder,REP,0
+Roberts,09,State House,04,Dylan C. Jordan,REP,60
+Roberts,09,State House,04,Vanessa Namken,REP,32
+Roberts,09,State House,04,Barbara Guenette,REP,29
+Roberts,09,State House,04,Kent Roe,REP,56
+Roberts,10,State House,01,Logan Manhart,REP,14
+Roberts,10,State House,01,Tamara St John,REP,14
+Roberts,10,State House,01,Christopher Reder,REP,14
+Roberts,11,State House,01,Logan Manhart,REP,58
+Roberts,11,State House,01,Tamara St John,REP,36
+Roberts,11,State House,01,Christopher Reder,REP,48
+Roberts,12,State House,01,Logan Manhart,REP,6
+Roberts,12,State House,01,Tamara St John,REP,9
+Roberts,12,State House,01,Christopher Reder,REP,6
+Roberts,13,State House,01,Logan Manhart,REP,18
+Roberts,13,State House,01,Tamara St John,REP,21
+Roberts,13,State House,01,Christopher Reder,REP,12
+Roberts,14,State House,01,Logan Manhart,REP,8
+Roberts,14,State House,01,Tamara St John,REP,11
+Roberts,14,State House,01,Christopher Reder,REP,8
+Roberts,01,Referendum: A Resolution Establishing A Road And Bridge Levy,,Yes,,22
+Roberts,01,Referendum: A Resolution Establishing A Road And Bridge Levy,,No,,42
+Roberts,02,Referendum: A Resolution Establishing A Road And Bridge Levy,,Yes,,46
+Roberts,02,Referendum: A Resolution Establishing A Road And Bridge Levy,,No,,146
+Roberts,03,Referendum: A Resolution Establishing A Road And Bridge Levy,,Yes,,22
+Roberts,03,Referendum: A Resolution Establishing A Road And Bridge Levy,,No,,37
+Roberts,04,Referendum: A Resolution Establishing A Road And Bridge Levy,,Yes,,5
+Roberts,04,Referendum: A Resolution Establishing A Road And Bridge Levy,,No,,13
+Roberts,05,Referendum: A Resolution Establishing A Road And Bridge Levy,,Yes,,29
+Roberts,05,Referendum: A Resolution Establishing A Road And Bridge Levy,,No,,59
+Roberts,06,Referendum: A Resolution Establishing A Road And Bridge Levy,,Yes,,27
+Roberts,06,Referendum: A Resolution Establishing A Road And Bridge Levy,,No,,29
+Roberts,07,Referendum: A Resolution Establishing A Road And Bridge Levy,,Yes,,31
+Roberts,07,Referendum: A Resolution Establishing A Road And Bridge Levy,,No,,44
+Roberts,08,Referendum: A Resolution Establishing A Road And Bridge Levy,,Yes,,12
+Roberts,08,Referendum: A Resolution Establishing A Road And Bridge Levy,,No,,17
+Roberts,09,Referendum: A Resolution Establishing A Road And Bridge Levy,,Yes,,53
+Roberts,09,Referendum: A Resolution Establishing A Road And Bridge Levy,,No,,126
+Roberts,10,Referendum: A Resolution Establishing A Road And Bridge Levy,,Yes,,18
+Roberts,10,Referendum: A Resolution Establishing A Road And Bridge Levy,,No,,22
+Roberts,11,Referendum: A Resolution Establishing A Road And Bridge Levy,,Yes,,62
+Roberts,11,Referendum: A Resolution Establishing A Road And Bridge Levy,,No,,75
+Roberts,12,Referendum: A Resolution Establishing A Road And Bridge Levy,,Yes,,21
+Roberts,12,Referendum: A Resolution Establishing A Road And Bridge Levy,,No,,9
+Roberts,13,Referendum: A Resolution Establishing A Road And Bridge Levy,,Yes,,26
+Roberts,13,Referendum: A Resolution Establishing A Road And Bridge Levy,,No,,21
+Roberts,14,Referendum: A Resolution Establishing A Road And Bridge Levy,,Yes,,23
+Roberts,14,Referendum: A Resolution Establishing A Road And Bridge Levy,,No,,4
+Roberts,02,Official School,25-1,Yes,,55
+Roberts,02,Official School,25-1,No,,14

--- a/2024/counties/20240604__sd__primary__sanborn__precinct.csv
+++ b/2024/counties/20240604__sd__primary__sanborn__precinct.csv
@@ -1,0 +1,17 @@
+county,precinct,office,district,candidate,party,votes
+Sanborn,1,President,,Marianne Williamson,DEM,0
+Sanborn,1,President,,Joseph R Biden Jr,DEM,4
+Sanborn,1,President,,Dean Phillips,DEM,1
+Sanborn,1,President,,Armando Perez-Serrato,DEM,0
+Sanborn,2,President,,Marianne Williamson,DEM,0
+Sanborn,2,President,,Joseph R Biden Jr,DEM,2
+Sanborn,2,President,,Dean Phillips,DEM,1
+Sanborn,2,President,,Armando Perez-Serrato,DEM,0
+Sanborn,4,President,,Marianne Williamson,DEM,1
+Sanborn,4,President,,Joseph R Biden Jr,DEM,7
+Sanborn,4,President,,Dean Phillips,DEM,0
+Sanborn,4,President,,Armando Perez-Serrato,DEM,0
+Sanborn,5,President,,Marianne Williamson,DEM,2
+Sanborn,5,President,,Joseph R Biden Jr,DEM,11
+Sanborn,5,President,,Dean Phillips,DEM,1
+Sanborn,5,President,,Armando Perez-Serrato,DEM,1

--- a/2024/counties/20240604__sd__primary__spink__precinct.csv
+++ b/2024/counties/20240604__sd__primary__spink__precinct.csv
@@ -1,0 +1,64 @@
+county,precinct,office,district,candidate,party,votes
+Spink,01,President,,Marianne Williamson,DEM,5
+Spink,01,President,,Joseph R Biden Jr,DEM,6
+Spink,01,President,,Dean Phillips,DEM,2
+Spink,01,President,,Armando Perez-Serrato,DEM,0
+Spink,03,President,,Marianne Williamson,DEM,2
+Spink,03,President,,Joseph R Biden Jr,DEM,5
+Spink,03,President,,Dean Phillips,DEM,1
+Spink,03,President,,Armando Perez-Serrato,DEM,0
+Spink,04,President,,Marianne Williamson,DEM,2
+Spink,04,President,,Joseph R Biden Jr,DEM,8
+Spink,04,President,,Dean Phillips,DEM,1
+Spink,04,President,,Armando Perez-Serrato,DEM,0
+Spink,05,President,,Marianne Williamson,DEM,0
+Spink,05,President,,Joseph R Biden Jr,DEM,8
+Spink,05,President,,Dean Phillips,DEM,2
+Spink,05,President,,Armando Perez-Serrato,DEM,0
+Spink,06,President,,Marianne Williamson,DEM,0
+Spink,06,President,,Joseph R Biden Jr,DEM,2
+Spink,06,President,,Dean Phillips,DEM,2
+Spink,06,President,,Armando Perez-Serrato,DEM,0
+Spink,07,President,,Marianne Williamson,DEM,3
+Spink,07,President,,Joseph R Biden Jr,DEM,12
+Spink,07,President,,Dean Phillips,DEM,2
+Spink,07,President,,Armando Perez-Serrato,DEM,1
+Spink,08,President,,Marianne Williamson,DEM,1
+Spink,08,President,,Joseph R Biden Jr,DEM,4
+Spink,08,President,,Dean Phillips,DEM,2
+Spink,08,President,,Armando Perez-Serrato,DEM,0
+Spink,09,President,,Marianne Williamson,DEM,2
+Spink,09,President,,Joseph R Biden Jr,DEM,13
+Spink,09,President,,Dean Phillips,DEM,3
+Spink,09,President,,Armando Perez-Serrato,DEM,0
+Spink,10,President,,Marianne Williamson,DEM,2
+Spink,10,President,,Joseph R Biden Jr,DEM,17
+Spink,10,President,,Dean Phillips,DEM,0
+Spink,10,President,,Armando Perez-Serrato,DEM,0
+Spink,01,State House,22,Kevin Van Diepen,REP,13
+Spink,01,State House,22,Terry Nebelsick,REP,19
+Spink,01,State House,22,Lana Greenfield,REP,91
+Spink,03,State House,22,Kevin Van Diepen,REP,37
+Spink,03,State House,22,Terry Nebelsick,REP,33
+Spink,03,State House,22,Lana Greenfield,REP,69
+Spink,04,State House,22,Kevin Van Diepen,REP,15
+Spink,04,State House,22,Terry Nebelsick,REP,22
+Spink,04,State House,22,Lana Greenfield,REP,44
+Spink,05,State House,22,Kevin Van Diepen,REP,7
+Spink,05,State House,22,Terry Nebelsick,REP,6
+Spink,05,State House,22,Lana Greenfield,REP,44
+Spink,06,State House,22,Kevin Van Diepen,REP,2
+Spink,06,State House,22,Terry Nebelsick,REP,5
+Spink,06,State House,22,Lana Greenfield,REP,10
+Spink,07,State House,22,Kevin Van Diepen,REP,32
+Spink,07,State House,22,Terry Nebelsick,REP,34
+Spink,07,State House,22,Lana Greenfield,REP,91
+Spink,08,State House,22,Kevin Van Diepen,REP,6
+Spink,08,State House,22,Terry Nebelsick,REP,10
+Spink,08,State House,22,Lana Greenfield,REP,16
+Spink,09,State House,22,Kevin Van Diepen,REP,28
+Spink,09,State House,22,Terry Nebelsick,REP,29
+Spink,09,State House,22,Lana Greenfield,REP,43
+Spink,10,State House,22,Kevin Van Diepen,REP,24
+Spink,10,State House,22,Terry Nebelsick,REP,39
+Spink,10,State House,22,Lana Greenfield,REP,57

--- a/2024/counties/20240604__sd__primary__stanley__precinct.csv
+++ b/2024/counties/20240604__sd__primary__stanley__precinct.csv
@@ -1,0 +1,15 @@
+county,precinct,office,district,candidate,party,votes
+Stanley,01,President,,Marianne Williamson,DEM,3
+Stanley,01,President,,Joseph R Biden Jr,DEM,45
+Stanley,01,President,,Dean Phillips,DEM,5
+Stanley,01,President,,Armando Perez-Serrato,DEM,0
+Stanley,02,President,,Marianne Williamson,DEM,0
+Stanley,02,President,,Joseph R Biden Jr,DEM,1
+Stanley,02,President,,Dean Phillips,DEM,2
+Stanley,02,President,,Armando Perez-Serrato,DEM,0
+Stanley,03,President,,Marianne Williamson,DEM,1
+Stanley,03,President,,Joseph R Biden Jr,DEM,2
+Stanley,03,President,,Dean Phillips,DEM,0
+Stanley,03,President,,Armando Perez-Serrato,DEM,0
+Stanley,01,Precinct Committeewoman,01,Kathryn Sieverding,REP,58
+Stanley,01,Precinct Committeewoman,01,Kristin Gabriel,REP,199

--- a/2024/counties/20240604__sd__primary__sully__precinct.csv
+++ b/2024/counties/20240604__sd__primary__sully__precinct.csv
@@ -1,0 +1,25 @@
+county,precinct,office,district,candidate,party,votes
+Sully,Absentee Precinct,President,,Marianne Williamson,DEM,0
+Sully,Absentee Precinct,President,,Joseph R Biden Jr,DEM,8
+Sully,Absentee Precinct,President,,Dean Phillips,DEM,0
+Sully,Absentee Precinct,President,,Armando Perez-Serrato,DEM,1
+Sully,Agar Fire Hall,President,,Marianne Williamson,DEM,3
+Sully,Agar Fire Hall,President,,Joseph R Biden Jr,DEM,2
+Sully,Agar Fire Hall,President,,Dean Phillips,DEM,2
+Sully,Agar Fire Hall,President,,Armando Perez-Serrato,DEM,0
+Sully,Bill Floyd Shop,President,,Marianne Williamson,DEM,3
+Sully,Bill Floyd Shop,President,,Joseph R Biden Jr,DEM,8
+Sully,Bill Floyd Shop,President,,Dean Phillips,DEM,0
+Sully,Bill Floyd Shop,President,,Armando Perez-Serrato,DEM,1
+Sully,Phoenix Center,President,,Marianne Williamson,DEM,2
+Sully,Phoenix Center,President,,Joseph R Biden Jr,DEM,26
+Sully,Phoenix Center,President,,Dean Phillips,DEM,4
+Sully,Phoenix Center,President,,Armando Perez-Serrato,DEM,1
+Sully,Absentee Precinct,Referendum: Resolution 2024-8 Attention Taxpayers: Notice Of Property Tax,,Yes,,16
+Sully,Absentee Precinct,Referendum: Resolution 2024-8 Attention Taxpayers: Notice Of Property Tax,,No,,15
+Sully,Agar Fire Hall,Referendum: Resolution 2024-8 Attention Taxpayers: Notice Of Property Tax,,Yes,,19
+Sully,Agar Fire Hall,Referendum: Resolution 2024-8 Attention Taxpayers: Notice Of Property Tax,,No,,22
+Sully,Bill Floyd Shop,Referendum: Resolution 2024-8 Attention Taxpayers: Notice Of Property Tax,,Yes,,24
+Sully,Bill Floyd Shop,Referendum: Resolution 2024-8 Attention Taxpayers: Notice Of Property Tax,,No,,75
+Sully,Phoenix Center,Referendum: Resolution 2024-8 Attention Taxpayers: Notice Of Property Tax,,Yes,,199
+Sully,Phoenix Center,Referendum: Resolution 2024-8 Attention Taxpayers: Notice Of Property Tax,,No,,83

--- a/2024/counties/20240604__sd__primary__todd__precinct.csv
+++ b/2024/counties/20240604__sd__primary__todd__precinct.csv
@@ -1,0 +1,71 @@
+county,precinct,office,district,candidate,party,votes
+Todd,Bordeaux,President,,Marianne Williamson,DEM,3
+Todd,Bordeaux,President,,Joseph R Biden Jr,DEM,11
+Todd,Bordeaux,President,,Dean Phillips,DEM,0
+Todd,Bordeaux,President,,Armando Perez-Serrato,DEM,2
+Todd,Fairgrounds-10,President,,Marianne Williamson,DEM,2
+Todd,Fairgrounds-10,President,,Joseph R Biden Jr,DEM,6
+Todd,Fairgrounds-10,President,,Dean Phillips,DEM,0
+Todd,Fairgrounds-10,President,,Armando Perez-Serrato,DEM,0
+Todd,Jeanette,President,,Marianne Williamson,DEM,1
+Todd,Jeanette,President,,Joseph R Biden Jr,DEM,4
+Todd,Jeanette,President,,Dean Phillips,DEM,1
+Todd,Jeanette,President,,Armando Perez-Serrato,DEM,0
+Todd,Lakeview,President,,Marianne Williamson,DEM,0
+Todd,Lakeview,President,,Joseph R Biden Jr,DEM,5
+Todd,Lakeview,President,,Dean Phillips,DEM,1
+Todd,Lakeview,President,,Armando Perez-Serrato,DEM,1
+Todd,Mission-N. Antelope,President,,Marianne Williamson,DEM,9
+Todd,Mission-N. Antelope,President,,Joseph R Biden Jr,DEM,64
+Todd,Mission-N. Antelope,President,,Dean Phillips,DEM,2
+Todd,Mission-N. Antelope,President,,Armando Perez-Serrato,DEM,4
+Todd,OKreek,President,,Marianne Williamson,DEM,0
+Todd,OKreek,President,,Joseph R Biden Jr,DEM,12
+Todd,OKreek,President,,Dean Phillips,DEM,0
+Todd,OKreek,President,,Armando Perez-Serrato,DEM,2
+Todd,Parmelee,President,,Marianne Williamson,DEM,7
+Todd,Parmelee,President,,Joseph R Biden Jr,DEM,26
+Todd,Parmelee,President,,Dean Phillips,DEM,1
+Todd,Parmelee,President,,Armando Perez-Serrato,DEM,1
+Todd,Rosebud,President,,Marianne Williamson,DEM,10
+Todd,Rosebud,President,,Joseph R Biden Jr,DEM,52
+Todd,Rosebud,President,,Dean Phillips,DEM,2
+Todd,Rosebud,President,,Armando Perez-Serrato,DEM,3
+Todd,S. Antelope,President,,Marianne Williamson,DEM,4
+Todd,S. Antelope,President,,Joseph R Biden Jr,DEM,31
+Todd,S. Antelope,President,,Dean Phillips,DEM,1
+Todd,S. Antelope,President,,Armando Perez-Serrato,DEM,3
+Todd,Saint Francis,President,,Marianne Williamson,DEM,2
+Todd,Saint Francis,President,,Joseph R Biden Jr,DEM,23
+Todd,Saint Francis,President,,Dean Phillips,DEM,2
+Todd,Saint Francis,President,,Armando Perez-Serrato,DEM,4
+Todd,Bordeaux,School Board Member Todd County,66-1,Linda Bordeaux,NPA,11
+Todd,Bordeaux,School Board Member Todd County,66-1,Michelle Allen,NPA,5
+Todd,Bordeaux,School Board Member Todd County,66-1,Amanda Riley,NPA,9
+Todd,Fairgrounds-10,School Board Member Todd County,66-1,Linda Bordeaux,NPA,8
+Todd,Fairgrounds-10,School Board Member Todd County,66-1,Michelle Allen,NPA,5
+Todd,Fairgrounds-10,School Board Member Todd County,66-1,Amanda Riley,NPA,8
+Todd,Jeanette,School Board Member Todd County,66-1,Linda Bordeaux,NPA,1
+Todd,Jeanette,School Board Member Todd County,66-1,Michelle Allen,NPA,12
+Todd,Jeanette,School Board Member Todd County,66-1,Amanda Riley,NPA,13
+Todd,Lakeview,School Board Member Todd County,66-1,Linda Bordeaux,NPA,9
+Todd,Lakeview,School Board Member Todd County,66-1,Michelle Allen,NPA,19
+Todd,Lakeview,School Board Member Todd County,66-1,Amanda Riley,NPA,12
+Todd,Mission-N. Antelope,School Board Member Todd County,66-1,Linda Bordeaux,NPA,39
+Todd,Mission-N. Antelope,School Board Member Todd County,66-1,Michelle Allen,NPA,57
+Todd,Mission-N. Antelope,School Board Member Todd County,66-1,Amanda Riley,NPA,69
+Todd,OKreek,School Board Member Todd County,66-1,Linda Bordeaux,NPA,11
+Todd,OKreek,School Board Member Todd County,66-1,Michelle Allen,NPA,14
+Todd,OKreek,School Board Member Todd County,66-1,Amanda Riley,NPA,10
+Todd,Parmelee,School Board Member Todd County,66-1,Linda Bordeaux,NPA,26
+Todd,Parmelee,School Board Member Todd County,66-1,Michelle Allen,NPA,21
+Todd,Parmelee,School Board Member Todd County,66-1,Amanda Riley,NPA,28
+Todd,Rosebud,School Board Member Todd County,66-1,Linda Bordeaux,NPA,37
+Todd,Rosebud,School Board Member Todd County,66-1,Michelle Allen,NPA,42
+Todd,Rosebud,School Board Member Todd County,66-1,Amanda Riley,NPA,34
+Todd,S. Antelope,School Board Member Todd County,66-1,Linda Bordeaux,NPA,21
+Todd,S. Antelope,School Board Member Todd County,66-1,Michelle Allen,NPA,26
+Todd,S. Antelope,School Board Member Todd County,66-1,Amanda Riley,NPA,26
+Todd,Saint Francis,School Board Member Todd County,66-1,Linda Bordeaux,NPA,30
+Todd,Saint Francis,School Board Member Todd County,66-1,Michelle Allen,NPA,21
+Todd,Saint Francis,School Board Member Todd County,66-1,Amanda Riley,NPA,10

--- a/2024/counties/20240604__sd__primary__tripp__precinct.csv
+++ b/2024/counties/20240604__sd__primary__tripp__precinct.csv
@@ -1,0 +1,152 @@
+county,precinct,office,district,candidate,party,votes
+Tripp,Clearfield Consolidated,President,,Marianne Williamson,DEM,0
+Tripp,Clearfield Consolidated,President,,Joseph R Biden Jr,DEM,3
+Tripp,Clearfield Consolidated,President,,Dean Phillips,DEM,1
+Tripp,Clearfield Consolidated,President,,Armando Perez-Serrato,DEM,1
+Tripp,Colome Consolidated,President,,Marianne Williamson,DEM,4
+Tripp,Colome Consolidated,President,,Joseph R Biden Jr,DEM,13
+Tripp,Colome Consolidated,President,,Dean Phillips,DEM,2
+Tripp,Colome Consolidated,President,,Armando Perez-Serrato,DEM,0
+Tripp,Hamill Consolidated,President,,Marianne Williamson,DEM,0
+Tripp,Hamill Consolidated,President,,Joseph R Biden Jr,DEM,2
+Tripp,Hamill Consolidated,President,,Dean Phillips,DEM,2
+Tripp,Hamill Consolidated,President,,Armando Perez-Serrato,DEM,0
+Tripp,Ideal Consolidated,President,,Marianne Williamson,DEM,0
+Tripp,Ideal Consolidated,President,,Joseph R Biden Jr,DEM,0
+Tripp,Ideal Consolidated,President,,Dean Phillips,DEM,0
+Tripp,Ideal Consolidated,President,,Armando Perez-Serrato,DEM,0
+Tripp,Lake Consolidated,President,,Marianne Williamson,DEM,0
+Tripp,Lake Consolidated,President,,Joseph R Biden Jr,DEM,5
+Tripp,Lake Consolidated,President,,Dean Phillips,DEM,0
+Tripp,Lake Consolidated,President,,Armando Perez-Serrato,DEM,0
+Tripp,Lamro Consolidated,President,,Marianne Williamson,DEM,3
+Tripp,Lamro Consolidated,President,,Joseph R Biden Jr,DEM,11
+Tripp,Lamro Consolidated,President,,Dean Phillips,DEM,2
+Tripp,Lamro Consolidated,President,,Armando Perez-Serrato,DEM,0
+Tripp,Sully Consolidated,President,,Marianne Williamson,DEM,1
+Tripp,Sully Consolidated,President,,Joseph R Biden Jr,DEM,8
+Tripp,Sully Consolidated,President,,Dean Phillips,DEM,1
+Tripp,Sully Consolidated,President,,Armando Perez-Serrato,DEM,0
+Tripp,WINNER Consolidated SE 1ST,President,,Marianne Williamson,DEM,1
+Tripp,WINNER Consolidated SE 1ST,President,,Joseph R Biden Jr,DEM,3
+Tripp,WINNER Consolidated SE 1ST,President,,Dean Phillips,DEM,0
+Tripp,WINNER Consolidated SE 1ST,President,,Armando Perez-Serrato,DEM,1
+Tripp,WINNER Consolidated-E 2ND,President,,Marianne Williamson,DEM,1
+Tripp,WINNER Consolidated-E 2ND,President,,Joseph R Biden Jr,DEM,5
+Tripp,WINNER Consolidated-E 2ND,President,,Dean Phillips,DEM,0
+Tripp,WINNER Consolidated-E 2ND,President,,Armando Perez-Serrato,DEM,0
+Tripp,WINNER Consolidated-E 3RD,President,,Marianne Williamson,DEM,1
+Tripp,WINNER Consolidated-E 3RD,President,,Joseph R Biden Jr,DEM,6
+Tripp,WINNER Consolidated-E 3RD,President,,Dean Phillips,DEM,0
+Tripp,WINNER Consolidated-E 3RD,President,,Armando Perez-Serrato,DEM,2
+Tripp,WINNER Consolidated-W 2ND,President,,Marianne Williamson,DEM,2
+Tripp,WINNER Consolidated-W 2ND,President,,Joseph R Biden Jr,DEM,15
+Tripp,WINNER Consolidated-W 2ND,President,,Dean Phillips,DEM,0
+Tripp,WINNER Consolidated-W 2ND,President,,Armando Perez-Serrato,DEM,1
+Tripp,WINNER Consolidated-W 3RD,President,,Marianne Williamson,DEM,1
+Tripp,WINNER Consolidated-W 3RD,President,,Joseph R Biden Jr,DEM,8
+Tripp,WINNER Consolidated-W 3RD,President,,Dean Phillips,DEM,2
+Tripp,WINNER Consolidated-W 3RD,President,,Armando Perez-Serrato,DEM,1
+Tripp,Witten Consolidated,President,,Marianne Williamson,DEM,3
+Tripp,Witten Consolidated,President,,Joseph R Biden Jr,DEM,1
+Tripp,Witten Consolidated,President,,Dean Phillips,DEM,3
+Tripp,Witten Consolidated,President,,Armando Perez-Serrato,DEM,0
+Tripp,Clearfield Consolidated,State Senate,21,Erin Tobin,REP,40
+Tripp,Clearfield Consolidated,State Senate,21,Mykala Voita,REP,52
+Tripp,Colome Consolidated,State Senate,21,Erin Tobin,REP,82
+Tripp,Colome Consolidated,State Senate,21,Mykala Voita,REP,72
+Tripp,Hamill Consolidated,State Senate,21,Erin Tobin,REP,17
+Tripp,Hamill Consolidated,State Senate,21,Mykala Voita,REP,27
+Tripp,Ideal Consolidated,State Senate,21,Erin Tobin,REP,31
+Tripp,Ideal Consolidated,State Senate,21,Mykala Voita,REP,10
+Tripp,Lake Consolidated,State Senate,21,Erin Tobin,REP,22
+Tripp,Lake Consolidated,State Senate,21,Mykala Voita,REP,46
+Tripp,Lamro Consolidated,State Senate,21,Erin Tobin,REP,96
+Tripp,Lamro Consolidated,State Senate,21,Mykala Voita,REP,70
+Tripp,Sully Consolidated,State Senate,21,Erin Tobin,REP,20
+Tripp,Sully Consolidated,State Senate,21,Mykala Voita,REP,16
+Tripp,WINNER Consolidated SE 1ST,State Senate,21,Erin Tobin,REP,48
+Tripp,WINNER Consolidated SE 1ST,State Senate,21,Mykala Voita,REP,9
+Tripp,WINNER Consolidated-E 2ND,State Senate,21,Erin Tobin,REP,68
+Tripp,WINNER Consolidated-E 2ND,State Senate,21,Mykala Voita,REP,30
+Tripp,WINNER Consolidated-E 3RD,State Senate,21,Erin Tobin,REP,81
+Tripp,WINNER Consolidated-E 3RD,State Senate,21,Mykala Voita,REP,42
+Tripp,WINNER Consolidated-W 2ND,State Senate,21,Erin Tobin,REP,97
+Tripp,WINNER Consolidated-W 2ND,State Senate,21,Mykala Voita,REP,38
+Tripp,WINNER Consolidated-W 3RD,State Senate,21,Erin Tobin,REP,38
+Tripp,WINNER Consolidated-W 3RD,State Senate,21,Mykala Voita,REP,20
+Tripp,Witten Consolidated,State Senate,21,Erin Tobin,REP,22
+Tripp,Witten Consolidated,State Senate,21,Mykala Voita,REP,25
+Tripp,Clearfield Consolidated,State House,21,Lee Qualm,REP,48
+Tripp,Clearfield Consolidated,State House,21,Marty Overweg,REP,49
+Tripp,Clearfield Consolidated,State House,21,Jim Halverson,REP,51
+Tripp,Colome Consolidated,State House,21,Lee Qualm,REP,63
+Tripp,Colome Consolidated,State House,21,Marty Overweg,REP,65
+Tripp,Colome Consolidated,State House,21,Jim Halverson,REP,105
+Tripp,Hamill Consolidated,State House,21,Lee Qualm,REP,21
+Tripp,Hamill Consolidated,State House,21,Marty Overweg,REP,21
+Tripp,Hamill Consolidated,State House,21,Jim Halverson,REP,29
+Tripp,Ideal Consolidated,State House,21,Lee Qualm,REP,12
+Tripp,Ideal Consolidated,State House,21,Marty Overweg,REP,19
+Tripp,Ideal Consolidated,State House,21,Jim Halverson,REP,31
+Tripp,Lake Consolidated,State House,21,Lee Qualm,REP,31
+Tripp,Lake Consolidated,State House,21,Marty Overweg,REP,38
+Tripp,Lake Consolidated,State House,21,Jim Halverson,REP,36
+Tripp,Lamro Consolidated,State House,21,Lee Qualm,REP,50
+Tripp,Lamro Consolidated,State House,21,Marty Overweg,REP,74
+Tripp,Lamro Consolidated,State House,21,Jim Halverson,REP,134
+Tripp,Sully Consolidated,State House,21,Lee Qualm,REP,14
+Tripp,Sully Consolidated,State House,21,Marty Overweg,REP,21
+Tripp,Sully Consolidated,State House,21,Jim Halverson,REP,28
+Tripp,WINNER Consolidated SE 1ST,State House,21,Lee Qualm,REP,14
+Tripp,WINNER Consolidated SE 1ST,State House,21,Marty Overweg,REP,26
+Tripp,WINNER Consolidated SE 1ST,State House,21,Jim Halverson,REP,48
+Tripp,WINNER Consolidated-E 2ND,State House,21,Lee Qualm,REP,28
+Tripp,WINNER Consolidated-E 2ND,State House,21,Marty Overweg,REP,35
+Tripp,WINNER Consolidated-E 2ND,State House,21,Jim Halverson,REP,88
+Tripp,WINNER Consolidated-E 3RD,State House,21,Lee Qualm,REP,41
+Tripp,WINNER Consolidated-E 3RD,State House,21,Marty Overweg,REP,50
+Tripp,WINNER Consolidated-E 3RD,State House,21,Jim Halverson,REP,99
+Tripp,WINNER Consolidated-W 2ND,State House,21,Lee Qualm,REP,46
+Tripp,WINNER Consolidated-W 2ND,State House,21,Marty Overweg,REP,49
+Tripp,WINNER Consolidated-W 2ND,State House,21,Jim Halverson,REP,111
+Tripp,WINNER Consolidated-W 3RD,State House,21,Lee Qualm,REP,12
+Tripp,WINNER Consolidated-W 3RD,State House,21,Marty Overweg,REP,17
+Tripp,WINNER Consolidated-W 3RD,State House,21,Jim Halverson,REP,48
+Tripp,Witten Consolidated,State House,21,Lee Qualm,REP,27
+Tripp,Witten Consolidated,State House,21,Marty Overweg,REP,18
+Tripp,Witten Consolidated,State House,21,Jim Halverson,REP,30
+Tripp,Clearfield Consolidated,County Commissioner,4,Jeremy D. Clay,REP,46
+Tripp,Clearfield Consolidated,County Commissioner,4,Joyce Kartak,REP,43
+Tripp,Lamro Consolidated,County Commissioner,4,Jeremy D. Clay,REP,5
+Tripp,Lamro Consolidated,County Commissioner,4,Joyce Kartak,REP,11
+Tripp,WINNER Consolidated-W 2ND,County Commissioner,4,Jeremy D. Clay,REP,46
+Tripp,WINNER Consolidated-W 2ND,County Commissioner,4,Joyce Kartak,REP,85
+Tripp,Lake Consolidated,Precinct Committeewoman,,Margie Wiley,REP,44
+Tripp,Lake Consolidated,Precinct Committeewoman,,Brenda Hofeldt,REP,22
+Tripp,Clearfield Consolidated,Initiated Measure : An Initiated Measure Defining The Use Of Automatic Tabulators Within Tripp County,,Yes,,40
+Tripp,Clearfield Consolidated,Initiated Measure : An Initiated Measure Defining The Use Of Automatic Tabulators Within Tripp County,,No,,57
+Tripp,Colome Consolidated,Initiated Measure : An Initiated Measure Defining The Use Of Automatic Tabulators Within Tripp County,,Yes,,108
+Tripp,Colome Consolidated,Initiated Measure : An Initiated Measure Defining The Use Of Automatic Tabulators Within Tripp County,,No,,75
+Tripp,Hamill Consolidated,Initiated Measure : An Initiated Measure Defining The Use Of Automatic Tabulators Within Tripp County,,Yes,,20
+Tripp,Hamill Consolidated,Initiated Measure : An Initiated Measure Defining The Use Of Automatic Tabulators Within Tripp County,,No,,31
+Tripp,Ideal Consolidated,Initiated Measure : An Initiated Measure Defining The Use Of Automatic Tabulators Within Tripp County,,Yes,,16
+Tripp,Ideal Consolidated,Initiated Measure : An Initiated Measure Defining The Use Of Automatic Tabulators Within Tripp County,,No,,26
+Tripp,Lake Consolidated,Initiated Measure : An Initiated Measure Defining The Use Of Automatic Tabulators Within Tripp County,,Yes,,47
+Tripp,Lake Consolidated,Initiated Measure : An Initiated Measure Defining The Use Of Automatic Tabulators Within Tripp County,,No,,28
+Tripp,Lamro Consolidated,Initiated Measure : An Initiated Measure Defining The Use Of Automatic Tabulators Within Tripp County,,Yes,,75
+Tripp,Lamro Consolidated,Initiated Measure : An Initiated Measure Defining The Use Of Automatic Tabulators Within Tripp County,,No,,112
+Tripp,Sully Consolidated,Initiated Measure : An Initiated Measure Defining The Use Of Automatic Tabulators Within Tripp County,,Yes,,19
+Tripp,Sully Consolidated,Initiated Measure : An Initiated Measure Defining The Use Of Automatic Tabulators Within Tripp County,,No,,30
+Tripp,WINNER Consolidated SE 1ST,Initiated Measure : An Initiated Measure Defining The Use Of Automatic Tabulators Within Tripp County,,Yes,,21
+Tripp,WINNER Consolidated SE 1ST,Initiated Measure : An Initiated Measure Defining The Use Of Automatic Tabulators Within Tripp County,,No,,45
+Tripp,WINNER Consolidated-E 2ND,Initiated Measure : An Initiated Measure Defining The Use Of Automatic Tabulators Within Tripp County,,Yes,,43
+Tripp,WINNER Consolidated-E 2ND,Initiated Measure : An Initiated Measure Defining The Use Of Automatic Tabulators Within Tripp County,,No,,67
+Tripp,WINNER Consolidated-E 3RD,Initiated Measure : An Initiated Measure Defining The Use Of Automatic Tabulators Within Tripp County,,Yes,,58
+Tripp,WINNER Consolidated-E 3RD,Initiated Measure : An Initiated Measure Defining The Use Of Automatic Tabulators Within Tripp County,,No,,78
+Tripp,WINNER Consolidated-W 2ND,Initiated Measure : An Initiated Measure Defining The Use Of Automatic Tabulators Within Tripp County,,Yes,,53
+Tripp,WINNER Consolidated-W 2ND,Initiated Measure : An Initiated Measure Defining The Use Of Automatic Tabulators Within Tripp County,,No,,101
+Tripp,WINNER Consolidated-W 3RD,Initiated Measure : An Initiated Measure Defining The Use Of Automatic Tabulators Within Tripp County,,Yes,,25
+Tripp,WINNER Consolidated-W 3RD,Initiated Measure : An Initiated Measure Defining The Use Of Automatic Tabulators Within Tripp County,,No,,50
+Tripp,Witten Consolidated,Initiated Measure : An Initiated Measure Defining The Use Of Automatic Tabulators Within Tripp County,,Yes,,28
+Tripp,Witten Consolidated,Initiated Measure : An Initiated Measure Defining The Use Of Automatic Tabulators Within Tripp County,,No,,34

--- a/2024/counties/20240604__sd__primary__turner__precinct.csv
+++ b/2024/counties/20240604__sd__primary__turner__precinct.csv
@@ -1,0 +1,94 @@
+county,precinct,office,district,candidate,party,votes
+Turner,01,President,,Marianne Williamson,DEM,16
+Turner,01,President,,Joseph R Biden Jr,DEM,42
+Turner,01,President,,Dean Phillips,DEM,21
+Turner,01,President,,Armando Perez-Serrato,DEM,5
+Turner,02,President,,Marianne Williamson,DEM,10
+Turner,02,President,,Joseph R Biden Jr,DEM,20
+Turner,02,President,,Dean Phillips,DEM,6
+Turner,02,President,,Armando Perez-Serrato,DEM,4
+Turner,03,President,,Marianne Williamson,DEM,3
+Turner,03,President,,Joseph R Biden Jr,DEM,8
+Turner,03,President,,Dean Phillips,DEM,0
+Turner,03,President,,Armando Perez-Serrato,DEM,1
+Turner,04,President,,Marianne Williamson,DEM,4
+Turner,04,President,,Joseph R Biden Jr,DEM,7
+Turner,04,President,,Dean Phillips,DEM,2
+Turner,04,President,,Armando Perez-Serrato,DEM,1
+Turner,05,President,,Marianne Williamson,DEM,1
+Turner,05,President,,Joseph R Biden Jr,DEM,5
+Turner,05,President,,Dean Phillips,DEM,4
+Turner,05,President,,Armando Perez-Serrato,DEM,0
+Turner,06,President,,Marianne Williamson,DEM,3
+Turner,06,President,,Joseph R Biden Jr,DEM,21
+Turner,06,President,,Dean Phillips,DEM,4
+Turner,06,President,,Armando Perez-Serrato,DEM,3
+Turner,07,President,,Marianne Williamson,DEM,3
+Turner,07,President,,Joseph R Biden Jr,DEM,3
+Turner,07,President,,Dean Phillips,DEM,1
+Turner,07,President,,Armando Perez-Serrato,DEM,1
+Turner,08,President,,Marianne Williamson,DEM,2
+Turner,08,President,,Joseph R Biden Jr,DEM,15
+Turner,08,President,,Dean Phillips,DEM,2
+Turner,08,President,,Armando Perez-Serrato,DEM,1
+Turner,01,State Senate,16,Kevin D. Jensen,REP,196
+Turner,01,State Senate,16,Eric Hohman,REP,95
+Turner,02,State Senate,16,Kevin D. Jensen,REP,159
+Turner,02,State Senate,16,Eric Hohman,REP,70
+Turner,03,State Senate,16,Kevin D. Jensen,REP,81
+Turner,03,State Senate,16,Eric Hohman,REP,23
+Turner,05,State Senate,16,Kevin D. Jensen,REP,66
+Turner,05,State Senate,16,Eric Hohman,REP,28
+Turner,06,State Senate,16,Kevin D. Jensen,REP,144
+Turner,06,State Senate,16,Eric Hohman,REP,43
+Turner,07,State Senate,16,Kevin D. Jensen,REP,22
+Turner,07,State Senate,16,Eric Hohman,REP,4
+Turner,08,State Senate,16,Kevin D. Jensen,REP,74
+Turner,08,State Senate,16,Eric Hohman,REP,49
+Turner,01,State House,16,Karla J Lems,REP,208
+Turner,01,State House,16,Richard Vasgaard,REP,145
+Turner,01,State House,16,Brian J Burge,REP,131
+Turner,02,State House,16,Karla J Lems,REP,159
+Turner,02,State House,16,Richard Vasgaard,REP,148
+Turner,02,State House,16,Brian J Burge,REP,60
+Turner,03,State House,16,Karla J Lems,REP,83
+Turner,03,State House,16,Richard Vasgaard,REP,61
+Turner,03,State House,16,Brian J Burge,REP,21
+Turner,04,State House,19,Drew Peterson,REP,26
+Turner,04,State House,19,Steven Mettler,REP,34
+Turner,04,State House,19,Jessica Bahmuller,REP,35
+Turner,05,State House,16,Karla J Lems,REP,65
+Turner,05,State House,16,Richard Vasgaard,REP,70
+Turner,05,State House,16,Brian J Burge,REP,20
+Turner,06,State House,16,Karla J Lems,REP,121
+Turner,06,State House,16,Richard Vasgaard,REP,139
+Turner,06,State House,16,Brian J Burge,REP,31
+Turner,07,State House,16,Karla J Lems,REP,20
+Turner,07,State House,16,Richard Vasgaard,REP,21
+Turner,07,State House,16,Brian J Burge,REP,5
+Turner,08,State House,16,Karla J Lems,REP,63
+Turner,08,State House,16,Richard Vasgaard,REP,109
+Turner,08,State House,16,Brian J Burge,REP,22
+Turner,02,County Commissioner,2,James A Jones,REP,100
+Turner,02,County Commissioner,2,Joyce Willoughby,REP,25
+Turner,02,County Commissioner,2,Sheila Hagemann,REP,112
+Turner,04,County Commissioner,4,"Ross ""Mick"" Miller",REP,16
+Turner,04,County Commissioner,4,Greg Benson,REP,25
+Turner,04,County Commissioner,4,Daniel Roth,REP,14
+Turner,06,County Commissioner,4,"Ross ""Mick"" Miller",REP,76
+Turner,06,County Commissioner,4,Greg Benson,REP,76
+Turner,06,County Commissioner,4,Daniel Roth,REP,36
+Turner,02,Precinct Committeeman,02,David Hurtado,REP,47
+Turner,02,Precinct Committeeman,02,Joseph Plucker,REP,176
+Turner,03,Precinct Committeeman,03,Blake Olson,REP,59
+Turner,03,Precinct Committeeman,03,Allen Weis,REP,28
+Turner,05,Precinct Committeeman,05,Kerry R Norton,REP,38
+Turner,05,Precinct Committeeman,05,Troi Andernacht,REP,47
+Turner,08,Precinct Committeeman,08,Charles N Oster,REP,44
+Turner,08,Precinct Committeeman,08,Richard Vasgaard,REP,81
+Turner,02,Precinct Committeewoman,02,Monique Hurtado,REP,59
+Turner,02,Precinct Committeewoman,02,Kay Plucker,REP,165
+Turner,03,Precinct Committeewoman,03,Tamera Weis,REP,37
+Turner,03,Precinct Committeewoman,03,Janae Olson,REP,50
+Turner,06,Precinct Committeewoman,06,Shelley Fox,REP,79
+Turner,06,Precinct Committeewoman,06,Lisa M Johnson,REP,83

--- a/2024/counties/20240604__sd__primary__union__precinct.csv
+++ b/2024/counties/20240604__sd__primary__union__precinct.csv
@@ -1,0 +1,145 @@
+county,precinct,office,district,candidate,party,votes
+Union,01,President,,Marianne Williamson,DEM,0
+Union,01,President,,Joseph R Biden Jr,DEM,12
+Union,01,President,,Dean Phillips,DEM,2
+Union,01,President,,Armando Perez-Serrato,DEM,0
+Union,02,President,,Marianne Williamson,DEM,6
+Union,02,President,,Joseph R Biden Jr,DEM,24
+Union,02,President,,Dean Phillips,DEM,2
+Union,02,President,,Armando Perez-Serrato,DEM,1
+Union,03,President,,Marianne Williamson,DEM,8
+Union,03,President,,Joseph R Biden Jr,DEM,41
+Union,03,President,,Dean Phillips,DEM,5
+Union,03,President,,Armando Perez-Serrato,DEM,2
+Union,04,President,,Marianne Williamson,DEM,3
+Union,04,President,,Joseph R Biden Jr,DEM,13
+Union,04,President,,Dean Phillips,DEM,3
+Union,04,President,,Armando Perez-Serrato,DEM,0
+Union,05,President,,Marianne Williamson,DEM,1
+Union,05,President,,Joseph R Biden Jr,DEM,30
+Union,05,President,,Dean Phillips,DEM,3
+Union,05,President,,Armando Perez-Serrato,DEM,2
+Union,06,President,,Marianne Williamson,DEM,3
+Union,06,President,,Joseph R Biden Jr,DEM,16
+Union,06,President,,Dean Phillips,DEM,4
+Union,06,President,,Armando Perez-Serrato,DEM,0
+Union,07,President,,Marianne Williamson,DEM,3
+Union,07,President,,Joseph R Biden Jr,DEM,6
+Union,07,President,,Dean Phillips,DEM,3
+Union,07,President,,Armando Perez-Serrato,DEM,0
+Union,08,President,,Marianne Williamson,DEM,5
+Union,08,President,,Joseph R Biden Jr,DEM,20
+Union,08,President,,Dean Phillips,DEM,3
+Union,08,President,,Armando Perez-Serrato,DEM,2
+Union,09,President,,Marianne Williamson,DEM,2
+Union,09,President,,Joseph R Biden Jr,DEM,17
+Union,09,President,,Dean Phillips,DEM,6
+Union,09,President,,Armando Perez-Serrato,DEM,1
+Union,10,President,,Marianne Williamson,DEM,8
+Union,10,President,,Joseph R Biden Jr,DEM,13
+Union,10,President,,Dean Phillips,DEM,4
+Union,10,President,,Armando Perez-Serrato,DEM,0
+Union,11,President,,Marianne Williamson,DEM,0
+Union,11,President,,Joseph R Biden Jr,DEM,9
+Union,11,President,,Dean Phillips,DEM,0
+Union,11,President,,Armando Perez-Serrato,DEM,3
+Union,12,President,,Marianne Williamson,DEM,2
+Union,12,President,,Joseph R Biden Jr,DEM,12
+Union,12,President,,Dean Phillips,DEM,2
+Union,12,President,,Armando Perez-Serrato,DEM,0
+Union,01,State Senate,16,Kevin D. Jensen,REP,29
+Union,01,State Senate,16,Eric Hohman,REP,25
+Union,02,State Senate,16,Kevin D. Jensen,REP,53
+Union,02,State Senate,16,Eric Hohman,REP,22
+Union,03,State Senate,17,Sydney Davis,REP,209
+Union,03,State Senate,17,Jeffrey Church,REP,107
+Union,04,State Senate,16,Kevin D. Jensen,REP,60
+Union,04,State Senate,16,Eric Hohman,REP,40
+Union,05,State Senate,16,Kevin D. Jensen,REP,90
+Union,05,State Senate,16,Eric Hohman,REP,51
+Union,06,State Senate,17,Sydney Davis,REP,118
+Union,06,State Senate,17,Jeffrey Church,REP,47
+Union,07,State Senate,16,Kevin D. Jensen,REP,44
+Union,07,State Senate,16,Eric Hohman,REP,17
+Union,07,State Senate,17,Sydney Davis,REP,22
+Union,07,State Senate,17,Jeffrey Church,REP,13
+Union,08,State Senate,17,Sydney Davis,REP,59
+Union,08,State Senate,17,Jeffrey Church,REP,42
+Union,09,State Senate,17,Sydney Davis,REP,108
+Union,09,State Senate,17,Jeffrey Church,REP,20
+Union,10,State Senate,17,Sydney Davis,REP,70
+Union,10,State Senate,17,Jeffrey Church,REP,34
+Union,11,State Senate,17,Sydney Davis,REP,112
+Union,11,State Senate,17,Jeffrey Church,REP,57
+Union,12,State Senate,17,Sydney Davis,REP,132
+Union,12,State Senate,17,Jeffrey Church,REP,79
+Union,01,State House,16,Karla J Lems,REP,42
+Union,01,State House,16,Richard Vasgaard,REP,29
+Union,01,State House,16,Brian J Burge,REP,10
+Union,02,State House,16,Karla J Lems,REP,56
+Union,02,State House,16,Richard Vasgaard,REP,39
+Union,02,State House,16,Brian J Burge,REP,11
+Union,03,State House,17,William (Bill) Shorma,REP,225
+Union,03,State House,17,Chris Kassin,REP,259
+Union,03,State House,17,Robin J. Schiro,REP,24
+Union,04,State House,16,Karla J Lems,REP,73
+Union,04,State House,16,Richard Vasgaard,REP,57
+Union,04,State House,16,Brian J Burge,REP,33
+Union,05,State House,16,Karla J Lems,REP,102
+Union,05,State House,16,Richard Vasgaard,REP,89
+Union,05,State House,16,Brian J Burge,REP,40
+Union,06,State House,17,William (Bill) Shorma,REP,120
+Union,06,State House,17,Chris Kassin,REP,121
+Union,06,State House,17,Robin J. Schiro,REP,22
+Union,07,State House,16,Karla J Lems,REP,35
+Union,07,State House,16,Richard Vasgaard,REP,31
+Union,07,State House,16,Brian J Burge,REP,24
+Union,07,State House,17,William (Bill) Shorma,REP,16
+Union,07,State House,17,Chris Kassin,REP,28
+Union,07,State House,17,Robin J. Schiro,REP,8
+Union,08,State House,17,William (Bill) Shorma,REP,58
+Union,08,State House,17,Chris Kassin,REP,73
+Union,08,State House,17,Robin J. Schiro,REP,13
+Union,09,State House,17,William (Bill) Shorma,REP,85
+Union,09,State House,17,Chris Kassin,REP,108
+Union,09,State House,17,Robin J. Schiro,REP,12
+Union,10,State House,17,William (Bill) Shorma,REP,63
+Union,10,State House,17,Chris Kassin,REP,85
+Union,10,State House,17,Robin J. Schiro,REP,10
+Union,11,State House,17,William (Bill) Shorma,REP,132
+Union,11,State House,17,Chris Kassin,REP,143
+Union,11,State House,17,Robin J. Schiro,REP,25
+Union,12,State House,17,William (Bill) Shorma,REP,176
+Union,12,State House,17,Chris Kassin,REP,147
+Union,12,State House,17,Robin J. Schiro,REP,33
+Union,01,Sheriff,,Richard Roy William Headid,REP,8
+Union,01,Sheriff,,James Dean Prouty,REP,53
+Union,02,Sheriff,,Richard Roy William Headid,REP,11
+Union,02,Sheriff,,James Dean Prouty,REP,63
+Union,03,Sheriff,,Richard Roy William Headid,REP,24
+Union,03,Sheriff,,James Dean Prouty,REP,314
+Union,04,Sheriff,,Richard Roy William Headid,REP,15
+Union,04,Sheriff,,James Dean Prouty,REP,82
+Union,05,Sheriff,,Richard Roy William Headid,REP,17
+Union,05,Sheriff,,James Dean Prouty,REP,118
+Union,06,Sheriff,,Richard Roy William Headid,REP,44
+Union,06,Sheriff,,James Dean Prouty,REP,129
+Union,07,Sheriff,,Richard Roy William Headid,REP,2
+Union,07,Sheriff,,James Dean Prouty,REP,107
+Union,08,Sheriff,,Richard Roy William Headid,REP,8
+Union,08,Sheriff,,James Dean Prouty,REP,104
+Union,09,Sheriff,,Richard Roy William Headid,REP,72
+Union,09,Sheriff,,James Dean Prouty,REP,66
+Union,10,Sheriff,,Richard Roy William Headid,REP,56
+Union,10,Sheriff,,James Dean Prouty,REP,54
+Union,11,Sheriff,,Richard Roy William Headid,REP,50
+Union,11,Sheriff,,James Dean Prouty,REP,124
+Union,12,Sheriff,,Richard Roy William Headid,REP,55
+Union,12,Sheriff,,James Dean Prouty,REP,153
+Union,03,Precinct Committeewoman,03,Robin Joyce Schiro,REP,82
+Union,03,Precinct Committeewoman,03,Alesha Marie Voeltz,REP,196
+Union,06,Precinct Committeewoman,06,Rachelle Teresa Gerkin,REP,59
+Union,06,Precinct Committeewoman,06,Constance Jean Larson,REP,53
+Union,07,School Board Member,Vermillion School District 13-1,Michael Phelan,,7
+Union,07,School Board Member,Vermillion School District 13-1,Corey L Thomason,,6
+Union,07,School Board Member,Vermillion School District 13-1,Rachel E Olson,,3

--- a/2024/counties/20240604__sd__primary__walworth__precinct.csv
+++ b/2024/counties/20240604__sd__primary__walworth__precinct.csv
@@ -1,0 +1,91 @@
+county,precinct,office,district,candidate,party,votes
+Walworth,01,President,,Marianne Williamson,DEM,0
+Walworth,01,President,,Joseph R Biden Jr,DEM,2
+Walworth,01,President,,Dean Phillips,DEM,2
+Walworth,01,President,,Armando Perez-Serrato,DEM,0
+Walworth,02,President,,Marianne Williamson,DEM,1
+Walworth,02,President,,Joseph R Biden Jr,DEM,0
+Walworth,02,President,,Dean Phillips,DEM,0
+Walworth,02,President,,Armando Perez-Serrato,DEM,0
+Walworth,03,President,,Marianne Williamson,DEM,1
+Walworth,03,President,,Joseph R Biden Jr,DEM,2
+Walworth,03,President,,Dean Phillips,DEM,3
+Walworth,03,President,,Armando Perez-Serrato,DEM,0
+Walworth,04,President,,Marianne Williamson,DEM,0
+Walworth,04,President,,Joseph R Biden Jr,DEM,6
+Walworth,04,President,,Dean Phillips,DEM,0
+Walworth,04,President,,Armando Perez-Serrato,DEM,0
+Walworth,05,President,,Marianne Williamson,DEM,3
+Walworth,05,President,,Joseph R Biden Jr,DEM,6
+Walworth,05,President,,Dean Phillips,DEM,1
+Walworth,05,President,,Armando Perez-Serrato,DEM,0
+Walworth,06,President,,Marianne Williamson,DEM,2
+Walworth,06,President,,Joseph R Biden Jr,DEM,4
+Walworth,06,President,,Dean Phillips,DEM,1
+Walworth,06,President,,Armando Perez-Serrato,DEM,1
+Walworth,07,President,,Marianne Williamson,DEM,0
+Walworth,07,President,,Joseph R Biden Jr,DEM,5
+Walworth,07,President,,Dean Phillips,DEM,0
+Walworth,07,President,,Armando Perez-Serrato,DEM,1
+Walworth,08,President,,Marianne Williamson,DEM,2
+Walworth,08,President,,Joseph R Biden Jr,DEM,0
+Walworth,08,President,,Dean Phillips,DEM,0
+Walworth,08,President,,Armando Perez-Serrato,DEM,0
+Walworth,09,President,,Marianne Williamson,DEM,1
+Walworth,09,President,,Joseph R Biden Jr,DEM,0
+Walworth,09,President,,Dean Phillips,DEM,0
+Walworth,09,President,,Armando Perez-Serrato,DEM,0
+Walworth,10,President,,Marianne Williamson,DEM,0
+Walworth,10,President,,Joseph R Biden Jr,DEM,2
+Walworth,10,President,,Dean Phillips,DEM,1
+Walworth,10,President,,Armando Perez-Serrato,DEM,0
+Walworth,01,State Senate,23,Steven Ray Roseland,REP,25
+Walworth,01,State Senate,23,Mark Lapka,REP,38
+Walworth,02,State Senate,23,Steven Ray Roseland,REP,32
+Walworth,02,State Senate,23,Mark Lapka,REP,39
+Walworth,03,State Senate,23,Steven Ray Roseland,REP,82
+Walworth,03,State Senate,23,Mark Lapka,REP,105
+Walworth,04,State Senate,23,Steven Ray Roseland,REP,15
+Walworth,04,State Senate,23,Mark Lapka,REP,41
+Walworth,05,State Senate,23,Steven Ray Roseland,REP,27
+Walworth,05,State Senate,23,Mark Lapka,REP,48
+Walworth,06,State Senate,23,Steven Ray Roseland,REP,44
+Walworth,06,State Senate,23,Mark Lapka,REP,66
+Walworth,07,State Senate,23,Steven Ray Roseland,REP,39
+Walworth,07,State Senate,23,Mark Lapka,REP,91
+Walworth,08,State Senate,23,Steven Ray Roseland,REP,12
+Walworth,08,State Senate,23,Mark Lapka,REP,16
+Walworth,09,State Senate,23,Steven Ray Roseland,REP,1
+Walworth,09,State Senate,23,Mark Lapka,REP,29
+Walworth,10,State Senate,23,Steven Ray Roseland,REP,25
+Walworth,10,State Senate,23,Mark Lapka,REP,40
+Walworth,01,State House,23,Spencer Gosch,REP,44
+Walworth,01,State House,23,Scott Moore,REP,44
+Walworth,01,State House,23,James D. Wangsness,REP,23
+Walworth,02,State House,23,Spencer Gosch,REP,49
+Walworth,02,State House,23,Scott Moore,REP,42
+Walworth,02,State House,23,James D. Wangsness,REP,34
+Walworth,03,State House,23,Spencer Gosch,REP,149
+Walworth,03,State House,23,Scott Moore,REP,113
+Walworth,03,State House,23,James D. Wangsness,REP,61
+Walworth,04,State House,23,Spencer Gosch,REP,49
+Walworth,04,State House,23,Scott Moore,REP,26
+Walworth,04,State House,23,James D. Wangsness,REP,15
+Walworth,05,State House,23,Spencer Gosch,REP,58
+Walworth,05,State House,23,Scott Moore,REP,47
+Walworth,05,State House,23,James D. Wangsness,REP,24
+Walworth,06,State House,23,Spencer Gosch,REP,85
+Walworth,06,State House,23,Scott Moore,REP,58
+Walworth,06,State House,23,James D. Wangsness,REP,41
+Walworth,07,State House,23,Spencer Gosch,REP,115
+Walworth,07,State House,23,Scott Moore,REP,78
+Walworth,07,State House,23,James D. Wangsness,REP,26
+Walworth,08,State House,23,Spencer Gosch,REP,24
+Walworth,08,State House,23,Scott Moore,REP,16
+Walworth,08,State House,23,James D. Wangsness,REP,8
+Walworth,09,State House,23,Spencer Gosch,REP,29
+Walworth,09,State House,23,Scott Moore,REP,10
+Walworth,09,State House,23,James D. Wangsness,REP,2
+Walworth,10,State House,23,Spencer Gosch,REP,50
+Walworth,10,State House,23,Scott Moore,REP,44
+Walworth,10,State House,23,James D. Wangsness,REP,20

--- a/2024/counties/20240604__sd__primary__yankton__precinct.csv
+++ b/2024/counties/20240604__sd__primary__yankton__precinct.csv
@@ -1,0 +1,288 @@
+county,precinct,office,district,candidate,party,votes
+Yankton,Absentee Precinct,President,,Marianne Williamson,DEM,9
+Yankton,Absentee Precinct,President,,Joseph R Biden Jr,DEM,88
+Yankton,Absentee Precinct,President,,Dean Phillips,DEM,4
+Yankton,Absentee Precinct,President,,Armando Perez-Serrato,DEM,4
+Yankton,Gayville Community Center,President,,Marianne Williamson,DEM,5
+Yankton,Gayville Community Center,President,,Joseph R Biden Jr,DEM,10
+Yankton,Gayville Community Center,President,,Dean Phillips,DEM,1
+Yankton,Gayville Community Center,President,,Armando Perez-Serrato,DEM,1
+Yankton,Lesterville Fire Hall,President,,Marianne Williamson,DEM,1
+Yankton,Lesterville Fire Hall,President,,Joseph R Biden Jr,DEM,0
+Yankton,Lesterville Fire Hall,President,,Dean Phillips,DEM,1
+Yankton,Lesterville Fire Hall,President,,Armando Perez-Serrato,DEM,0
+Yankton,Lewis and Clark Recreation Area,President,,Marianne Williamson,DEM,2
+Yankton,Lewis and Clark Recreation Area,President,,Joseph R Biden Jr,DEM,25
+Yankton,Lewis and Clark Recreation Area,President,,Dean Phillips,DEM,1
+Yankton,Lewis and Clark Recreation Area,President,,Armando Perez-Serrato,DEM,3
+Yankton,Mayfield Store,President,,Marianne Williamson,DEM,1
+Yankton,Mayfield Store,President,,Joseph R Biden Jr,DEM,3
+Yankton,Mayfield Store,President,,Dean Phillips,DEM,2
+Yankton,Mayfield Store,President,,Armando Perez-Serrato,DEM,1
+Yankton,Yankton City Hall,President,,Marianne Williamson,DEM,8
+Yankton,Yankton City Hall,President,,Joseph R Biden Jr,DEM,88
+Yankton,Yankton City Hall,President,,Dean Phillips,DEM,7
+Yankton,Yankton City Hall,President,,Armando Perez-Serrato,DEM,8
+Yankton,Yankton Fire Station #2,President,,Marianne Williamson,DEM,15
+Yankton,Yankton Fire Station #2,President,,Joseph R Biden Jr,DEM,80
+Yankton,Yankton Fire Station #2,President,,Dean Phillips,DEM,15
+Yankton,Yankton Fire Station #2,President,,Armando Perez-Serrato,DEM,6
+Yankton,Absentee Precinct,State Senate,18,Lauren Nelson,REP,246
+Yankton,Absentee Precinct,State Senate,18,Jean M. Hunhoff,REP,345
+Yankton,Gayville Community Center,State Senate,18,Lauren Nelson,REP,52
+Yankton,Gayville Community Center,State Senate,18,Jean M. Hunhoff,REP,15
+Yankton,Lesterville Fire Hall,State Senate,18,Lauren Nelson,REP,79
+Yankton,Lesterville Fire Hall,State Senate,18,Jean M. Hunhoff,REP,37
+Yankton,Lewis and Clark Recreation Area,State Senate,18,Lauren Nelson,REP,91
+Yankton,Lewis and Clark Recreation Area,State Senate,18,Jean M. Hunhoff,REP,69
+Yankton,Mayfield Store,State Senate,18,Lauren Nelson,REP,61
+Yankton,Mayfield Store,State Senate,18,Jean M. Hunhoff,REP,23
+Yankton,Yankton City Hall,State Senate,18,Lauren Nelson,REP,286
+Yankton,Yankton City Hall,State Senate,18,Jean M. Hunhoff,REP,255
+Yankton,Yankton Fire Station #2,State Senate,18,Lauren Nelson,REP,385
+Yankton,Yankton Fire Station #2,State Senate,18,Jean M. Hunhoff,REP,379
+Yankton,Absentee Precinct,State House,18,Mike Stevens,REP,365
+Yankton,Absentee Precinct,State House,18,Julie Auch,REP,308
+Yankton,Absentee Precinct,State House,18,John R Marquardt,REP,334
+Yankton,Gayville Community Center,State House,18,Mike Stevens,REP,27
+Yankton,Gayville Community Center,State House,18,Julie Auch,REP,52
+Yankton,Gayville Community Center,State House,18,John R Marquardt,REP,26
+Yankton,Lesterville Fire Hall,State House,18,Mike Stevens,REP,37
+Yankton,Lesterville Fire Hall,State House,18,Julie Auch,REP,101
+Yankton,Lesterville Fire Hall,State House,18,John R Marquardt,REP,35
+Yankton,Lewis and Clark Recreation Area,State House,18,Mike Stevens,REP,76
+Yankton,Lewis and Clark Recreation Area,State House,18,Julie Auch,REP,106
+Yankton,Lewis and Clark Recreation Area,State House,18,John R Marquardt,REP,78
+Yankton,Mayfield Store,State House,18,Mike Stevens,REP,27
+Yankton,Mayfield Store,State House,18,Julie Auch,REP,73
+Yankton,Mayfield Store,State House,18,John R Marquardt,REP,26
+Yankton,Yankton City Hall,State House,18,Mike Stevens,REP,292
+Yankton,Yankton City Hall,State House,18,Julie Auch,REP,352
+Yankton,Yankton City Hall,State House,18,John R Marquardt,REP,244
+Yankton,Yankton Fire Station #2,State House,18,Mike Stevens,REP,425
+Yankton,Yankton Fire Station #2,State House,18,Julie Auch,REP,474
+Yankton,Yankton Fire Station #2,State House,18,John R Marquardt,REP,366
+Yankton,Absentee Precinct,Precinct Committeeman,01,Dan M Korus,REP,8
+Yankton,Absentee Precinct,Precinct Committeeman,01,Roger Meyer,REP,12
+Yankton,Absentee Precinct,Precinct Committeeman,02,John Mattacola,REP,9
+Yankton,Absentee Precinct,Precinct Committeeman,02,Wayne R Diede,REP,17
+Yankton,Absentee Precinct,Precinct Committeeman,03,Thomas D Stotz,REP,38
+Yankton,Absentee Precinct,Precinct Committeeman,03,Christopher J Patton,REP,11
+Yankton,Absentee Precinct,Precinct Committeeman,04,Nick Moser,REP,47
+Yankton,Absentee Precinct,Precinct Committeeman,04,Mark Konrad,REP,22
+Yankton,Gayville Community Center,Precinct Committeeman,01,Dan M Korus,REP,0
+Yankton,Gayville Community Center,Precinct Committeeman,01,Roger Meyer,REP,0
+Yankton,Gayville Community Center,Precinct Committeeman,02,John Mattacola,REP,0
+Yankton,Gayville Community Center,Precinct Committeeman,02,Wayne R Diede,REP,0
+Yankton,Gayville Community Center,Precinct Committeeman,03,Thomas D Stotz,REP,0
+Yankton,Gayville Community Center,Precinct Committeeman,03,Christopher J Patton,REP,0
+Yankton,Gayville Community Center,Precinct Committeeman,04,Nick Moser,REP,0
+Yankton,Gayville Community Center,Precinct Committeeman,04,Mark Konrad,REP,0
+Yankton,Lesterville Fire Hall,Precinct Committeeman,01,Dan M Korus,REP,0
+Yankton,Lesterville Fire Hall,Precinct Committeeman,01,Roger Meyer,REP,3
+Yankton,Lesterville Fire Hall,Precinct Committeeman,02,John Mattacola,REP,0
+Yankton,Lesterville Fire Hall,Precinct Committeeman,02,Wayne R Diede,REP,0
+Yankton,Lesterville Fire Hall,Precinct Committeeman,03,Thomas D Stotz,REP,0
+Yankton,Lesterville Fire Hall,Precinct Committeeman,03,Christopher J Patton,REP,0
+Yankton,Lesterville Fire Hall,Precinct Committeeman,04,Nick Moser,REP,0
+Yankton,Lesterville Fire Hall,Precinct Committeeman,04,Mark Konrad,REP,0
+Yankton,Lewis and Clark Recreation Area,Precinct Committeeman,01,Dan M Korus,REP,0
+Yankton,Lewis and Clark Recreation Area,Precinct Committeeman,01,Roger Meyer,REP,0
+Yankton,Lewis and Clark Recreation Area,Precinct Committeeman,02,John Mattacola,REP,0
+Yankton,Lewis and Clark Recreation Area,Precinct Committeeman,02,Wayne R Diede,REP,1
+Yankton,Lewis and Clark Recreation Area,Precinct Committeeman,03,Thomas D Stotz,REP,0
+Yankton,Lewis and Clark Recreation Area,Precinct Committeeman,03,Christopher J Patton,REP,0
+Yankton,Lewis and Clark Recreation Area,Precinct Committeeman,04,Nick Moser,REP,0
+Yankton,Lewis and Clark Recreation Area,Precinct Committeeman,04,Mark Konrad,REP,0
+Yankton,Mayfield Store,Precinct Committeeman,01,Dan M Korus,REP,0
+Yankton,Mayfield Store,Precinct Committeeman,01,Roger Meyer,REP,0
+Yankton,Mayfield Store,Precinct Committeeman,02,John Mattacola,REP,0
+Yankton,Mayfield Store,Precinct Committeeman,02,Wayne R Diede,REP,0
+Yankton,Mayfield Store,Precinct Committeeman,03,Thomas D Stotz,REP,2
+Yankton,Mayfield Store,Precinct Committeeman,03,Christopher J Patton,REP,0
+Yankton,Mayfield Store,Precinct Committeeman,04,Nick Moser,REP,0
+Yankton,Mayfield Store,Precinct Committeeman,04,Mark Konrad,REP,0
+Yankton,Yankton City Hall,Precinct Committeeman,01,Dan M Korus,REP,23
+Yankton,Yankton City Hall,Precinct Committeeman,01,Roger Meyer,REP,29
+Yankton,Yankton City Hall,Precinct Committeeman,02,John Mattacola,REP,18
+Yankton,Yankton City Hall,Precinct Committeeman,02,Wayne R Diede,REP,29
+Yankton,Yankton City Hall,Precinct Committeeman,03,Thomas D Stotz,REP,28
+Yankton,Yankton City Hall,Precinct Committeeman,03,Christopher J Patton,REP,11
+Yankton,Yankton City Hall,Precinct Committeeman,04,Nick Moser,REP,65
+Yankton,Yankton City Hall,Precinct Committeeman,04,Mark Konrad,REP,30
+Yankton,Yankton Fire Station #2,Precinct Committeeman,01,Dan M Korus,REP,2
+Yankton,Yankton Fire Station #2,Precinct Committeeman,01,Roger Meyer,REP,7
+Yankton,Yankton Fire Station #2,Precinct Committeeman,02,John Mattacola,REP,18
+Yankton,Yankton Fire Station #2,Precinct Committeeman,02,Wayne R Diede,REP,33
+Yankton,Yankton Fire Station #2,Precinct Committeeman,03,Thomas D Stotz,REP,75
+Yankton,Yankton Fire Station #2,Precinct Committeeman,03,Christopher J Patton,REP,29
+Yankton,Yankton Fire Station #2,Precinct Committeeman,04,Nick Moser,REP,46
+Yankton,Yankton Fire Station #2,Precinct Committeeman,04,Mark Konrad,REP,20
+Yankton,Absentee Precinct,Precinct Committeeman,05,Lance Anderson,REP,65
+Yankton,Absentee Precinct,Precinct Committeeman,05,Doug Marquardt,REP,74
+Yankton,Absentee Precinct,Precinct Committeeman,14,John H Gunderson,REP,8
+Yankton,Absentee Precinct,Precinct Committeeman,14,Jake McManus,REP,13
+Yankton,Absentee Precinct,Precinct Committeeman,26,Steven Rokahr,REP,42
+Yankton,Absentee Precinct,Precinct Committeeman,26,Duane (Butch) G Becker,REP,81
+Yankton,Absentee Precinct,Precinct Committeeman,28,Dan Tacke,REP,8
+Yankton,Absentee Precinct,Precinct Committeeman,28,Jared Adamson,REP,4
+Yankton,Gayville Community Center,Precinct Committeeman,05,Lance Anderson,REP,0
+Yankton,Gayville Community Center,Precinct Committeeman,05,Doug Marquardt,REP,0
+Yankton,Gayville Community Center,Precinct Committeeman,14,John H Gunderson,REP,0
+Yankton,Gayville Community Center,Precinct Committeeman,14,Jake McManus,REP,1
+Yankton,Gayville Community Center,Precinct Committeeman,26,Steven Rokahr,REP,0
+Yankton,Gayville Community Center,Precinct Committeeman,26,Duane (Butch) G Becker,REP,2
+Yankton,Gayville Community Center,Precinct Committeeman,28,Dan Tacke,REP,1
+Yankton,Gayville Community Center,Precinct Committeeman,28,Jared Adamson,REP,0
+Yankton,Lesterville Fire Hall,Precinct Committeeman,05,Lance Anderson,REP,0
+Yankton,Lesterville Fire Hall,Precinct Committeeman,05,Doug Marquardt,REP,0
+Yankton,Lesterville Fire Hall,Precinct Committeeman,14,John H Gunderson,REP,0
+Yankton,Lesterville Fire Hall,Precinct Committeeman,14,Jake McManus,REP,0
+Yankton,Lesterville Fire Hall,Precinct Committeeman,26,Steven Rokahr,REP,1
+Yankton,Lesterville Fire Hall,Precinct Committeeman,26,Duane (Butch) G Becker,REP,1
+Yankton,Lesterville Fire Hall,Precinct Committeeman,28,Dan Tacke,REP,0
+Yankton,Lesterville Fire Hall,Precinct Committeeman,28,Jared Adamson,REP,0
+Yankton,Lewis and Clark Recreation Area,Precinct Committeeman,05,Lance Anderson,REP,7
+Yankton,Lewis and Clark Recreation Area,Precinct Committeeman,05,Doug Marquardt,REP,1
+Yankton,Lewis and Clark Recreation Area,Precinct Committeeman,14,John H Gunderson,REP,0
+Yankton,Lewis and Clark Recreation Area,Precinct Committeeman,14,Jake McManus,REP,1
+Yankton,Lewis and Clark Recreation Area,Precinct Committeeman,26,Steven Rokahr,REP,51
+Yankton,Lewis and Clark Recreation Area,Precinct Committeeman,26,Duane (Butch) G Becker,REP,59
+Yankton,Lewis and Clark Recreation Area,Precinct Committeeman,28,Dan Tacke,REP,0
+Yankton,Lewis and Clark Recreation Area,Precinct Committeeman,28,Jared Adamson,REP,0
+Yankton,Mayfield Store,Precinct Committeeman,05,Lance Anderson,REP,0
+Yankton,Mayfield Store,Precinct Committeeman,05,Doug Marquardt,REP,0
+Yankton,Mayfield Store,Precinct Committeeman,14,John H Gunderson,REP,30
+Yankton,Mayfield Store,Precinct Committeeman,14,Jake McManus,REP,32
+Yankton,Mayfield Store,Precinct Committeeman,26,Steven Rokahr,REP,0
+Yankton,Mayfield Store,Precinct Committeeman,26,Duane (Butch) G Becker,REP,0
+Yankton,Mayfield Store,Precinct Committeeman,28,Dan Tacke,REP,0
+Yankton,Mayfield Store,Precinct Committeeman,28,Jared Adamson,REP,0
+Yankton,Yankton City Hall,Precinct Committeeman,05,Lance Anderson,REP,48
+Yankton,Yankton City Hall,Precinct Committeeman,05,Doug Marquardt,REP,27
+Yankton,Yankton City Hall,Precinct Committeeman,14,John H Gunderson,REP,1
+Yankton,Yankton City Hall,Precinct Committeeman,14,Jake McManus,REP,1
+Yankton,Yankton City Hall,Precinct Committeeman,26,Steven Rokahr,REP,28
+Yankton,Yankton City Hall,Precinct Committeeman,26,Duane (Butch) G Becker,REP,21
+Yankton,Yankton City Hall,Precinct Committeeman,28,Dan Tacke,REP,19
+Yankton,Yankton City Hall,Precinct Committeeman,28,Jared Adamson,REP,6
+Yankton,Yankton Fire Station #2,Precinct Committeeman,05,Lance Anderson,REP,176
+Yankton,Yankton Fire Station #2,Precinct Committeeman,05,Doug Marquardt,REP,118
+Yankton,Yankton Fire Station #2,Precinct Committeeman,14,John H Gunderson,REP,5
+Yankton,Yankton Fire Station #2,Precinct Committeeman,14,Jake McManus,REP,3
+Yankton,Yankton Fire Station #2,Precinct Committeeman,26,Steven Rokahr,REP,26
+Yankton,Yankton Fire Station #2,Precinct Committeeman,26,Duane (Butch) G Becker,REP,26
+Yankton,Yankton Fire Station #2,Precinct Committeeman,28,Dan Tacke,REP,9
+Yankton,Yankton Fire Station #2,Precinct Committeeman,28,Jared Adamson,REP,10
+Yankton,Absentee Precinct,Precinct Committeewoman,01,(Van) Veandeen Pace,REP,8
+Yankton,Absentee Precinct,Precinct Committeewoman,01,Diane Korus,REP,12
+Yankton,Absentee Precinct,Precinct Committeewoman,02,Kimberlee Kappel,REP,13
+Yankton,Absentee Precinct,Precinct Committeewoman,02,Malena Diede,REP,14
+Yankton,Absentee Precinct,Precinct Committeewoman,03,Stacey Nickels,REP,17
+Yankton,Absentee Precinct,Precinct Committeewoman,03,Julie A Stotz,REP,32
+Yankton,Absentee Precinct,Precinct Committeewoman,04,Patricia Konrad,REP,22
+Yankton,Absentee Precinct,Precinct Committeewoman,04,Barbara M Law,REP,43
+Yankton,Gayville Community Center,Precinct Committeewoman,01,(Van) Veandeen Pace,REP,0
+Yankton,Gayville Community Center,Precinct Committeewoman,01,Diane Korus,REP,0
+Yankton,Gayville Community Center,Precinct Committeewoman,02,Kimberlee Kappel,REP,0
+Yankton,Gayville Community Center,Precinct Committeewoman,02,Malena Diede,REP,0
+Yankton,Gayville Community Center,Precinct Committeewoman,03,Stacey Nickels,REP,0
+Yankton,Gayville Community Center,Precinct Committeewoman,03,Julie A Stotz,REP,0
+Yankton,Gayville Community Center,Precinct Committeewoman,04,Patricia Konrad,REP,0
+Yankton,Gayville Community Center,Precinct Committeewoman,04,Barbara M Law,REP,0
+Yankton,Lesterville Fire Hall,Precinct Committeewoman,01,(Van) Veandeen Pace,REP,2
+Yankton,Lesterville Fire Hall,Precinct Committeewoman,01,Diane Korus,REP,1
+Yankton,Lesterville Fire Hall,Precinct Committeewoman,02,Kimberlee Kappel,REP,0
+Yankton,Lesterville Fire Hall,Precinct Committeewoman,02,Malena Diede,REP,0
+Yankton,Lesterville Fire Hall,Precinct Committeewoman,03,Stacey Nickels,REP,0
+Yankton,Lesterville Fire Hall,Precinct Committeewoman,03,Julie A Stotz,REP,0
+Yankton,Lesterville Fire Hall,Precinct Committeewoman,04,Patricia Konrad,REP,0
+Yankton,Lesterville Fire Hall,Precinct Committeewoman,04,Barbara M Law,REP,0
+Yankton,Lewis and Clark Recreation Area,Precinct Committeewoman,01,(Van) Veandeen Pace,REP,0
+Yankton,Lewis and Clark Recreation Area,Precinct Committeewoman,01,Diane Korus,REP,0
+Yankton,Lewis and Clark Recreation Area,Precinct Committeewoman,02,Kimberlee Kappel,REP,0
+Yankton,Lewis and Clark Recreation Area,Precinct Committeewoman,02,Malena Diede,REP,1
+Yankton,Lewis and Clark Recreation Area,Precinct Committeewoman,03,Stacey Nickels,REP,0
+Yankton,Lewis and Clark Recreation Area,Precinct Committeewoman,03,Julie A Stotz,REP,0
+Yankton,Lewis and Clark Recreation Area,Precinct Committeewoman,04,Patricia Konrad,REP,0
+Yankton,Lewis and Clark Recreation Area,Precinct Committeewoman,04,Barbara M Law,REP,0
+Yankton,Mayfield Store,Precinct Committeewoman,01,(Van) Veandeen Pace,REP,0
+Yankton,Mayfield Store,Precinct Committeewoman,01,Diane Korus,REP,0
+Yankton,Mayfield Store,Precinct Committeewoman,02,Kimberlee Kappel,REP,0
+Yankton,Mayfield Store,Precinct Committeewoman,02,Malena Diede,REP,0
+Yankton,Mayfield Store,Precinct Committeewoman,03,Stacey Nickels,REP,0
+Yankton,Mayfield Store,Precinct Committeewoman,03,Julie A Stotz,REP,2
+Yankton,Mayfield Store,Precinct Committeewoman,04,Patricia Konrad,REP,0
+Yankton,Mayfield Store,Precinct Committeewoman,04,Barbara M Law,REP,0
+Yankton,Yankton City Hall,Precinct Committeewoman,01,(Van) Veandeen Pace,REP,19
+Yankton,Yankton City Hall,Precinct Committeewoman,01,Diane Korus,REP,31
+Yankton,Yankton City Hall,Precinct Committeewoman,02,Kimberlee Kappel,REP,32
+Yankton,Yankton City Hall,Precinct Committeewoman,02,Malena Diede,REP,19
+Yankton,Yankton City Hall,Precinct Committeewoman,03,Stacey Nickels,REP,27
+Yankton,Yankton City Hall,Precinct Committeewoman,03,Julie A Stotz,REP,24
+Yankton,Yankton City Hall,Precinct Committeewoman,04,Patricia Konrad,REP,36
+Yankton,Yankton City Hall,Precinct Committeewoman,04,Barbara M Law,REP,53
+Yankton,Yankton Fire Station #2,Precinct Committeewoman,01,(Van) Veandeen Pace,REP,7
+Yankton,Yankton Fire Station #2,Precinct Committeewoman,01,Diane Korus,REP,2
+Yankton,Yankton Fire Station #2,Precinct Committeewoman,02,Kimberlee Kappel,REP,25
+Yankton,Yankton Fire Station #2,Precinct Committeewoman,02,Malena Diede,REP,26
+Yankton,Yankton Fire Station #2,Precinct Committeewoman,03,Stacey Nickels,REP,49
+Yankton,Yankton Fire Station #2,Precinct Committeewoman,03,Julie A Stotz,REP,64
+Yankton,Yankton Fire Station #2,Precinct Committeewoman,04,Patricia Konrad,REP,22
+Yankton,Yankton Fire Station #2,Precinct Committeewoman,04,Barbara M Law,REP,42
+Yankton,Absentee Precinct,Precinct Committeewoman,05,Jean M Hunhoff,REP,92
+Yankton,Absentee Precinct,Precinct Committeewoman,05,Lisa Anderson,REP,57
+Yankton,Absentee Precinct,Precinct Committeewoman,14,Amanda Hauger,REP,9
+Yankton,Absentee Precinct,Precinct Committeewoman,14,Cassondra K Richelieu,REP,12
+Yankton,Absentee Precinct,Precinct Committeewoman,23,Jacqueline I Sempek,REP,3
+Yankton,Absentee Precinct,Precinct Committeewoman,23,Lauren Nelson,REP,11
+Yankton,Absentee Precinct,Precinct Committeewoman,26,Jennifer Morkve,REP,28
+Yankton,Absentee Precinct,Precinct Committeewoman,26,Linda Stevens,REP,110
+Yankton,Gayville Community Center,Precinct Committeewoman,05,Jean M Hunhoff,REP,0
+Yankton,Gayville Community Center,Precinct Committeewoman,05,Lisa Anderson,REP,0
+Yankton,Gayville Community Center,Precinct Committeewoman,14,Amanda Hauger,REP,0
+Yankton,Gayville Community Center,Precinct Committeewoman,14,Cassondra K Richelieu,REP,1
+Yankton,Gayville Community Center,Precinct Committeewoman,23,Jacqueline I Sempek,REP,0
+Yankton,Gayville Community Center,Precinct Committeewoman,23,Lauren Nelson,REP,1
+Yankton,Gayville Community Center,Precinct Committeewoman,26,Jennifer Morkve,REP,0
+Yankton,Gayville Community Center,Precinct Committeewoman,26,Linda Stevens,REP,2
+Yankton,Lesterville Fire Hall,Precinct Committeewoman,05,Jean M Hunhoff,REP,0
+Yankton,Lesterville Fire Hall,Precinct Committeewoman,05,Lisa Anderson,REP,0
+Yankton,Lesterville Fire Hall,Precinct Committeewoman,14,Amanda Hauger,REP,0
+Yankton,Lesterville Fire Hall,Precinct Committeewoman,14,Cassondra K Richelieu,REP,0
+Yankton,Lesterville Fire Hall,Precinct Committeewoman,23,Jacqueline I Sempek,REP,0
+Yankton,Lesterville Fire Hall,Precinct Committeewoman,23,Lauren Nelson,REP,0
+Yankton,Lesterville Fire Hall,Precinct Committeewoman,26,Jennifer Morkve,REP,1
+Yankton,Lesterville Fire Hall,Precinct Committeewoman,26,Linda Stevens,REP,1
+Yankton,Lewis and Clark Recreation Area,Precinct Committeewoman,05,Jean M Hunhoff,REP,2
+Yankton,Lewis and Clark Recreation Area,Precinct Committeewoman,05,Lisa Anderson,REP,7
+Yankton,Lewis and Clark Recreation Area,Precinct Committeewoman,14,Amanda Hauger,REP,0
+Yankton,Lewis and Clark Recreation Area,Precinct Committeewoman,14,Cassondra K Richelieu,REP,1
+Yankton,Lewis and Clark Recreation Area,Precinct Committeewoman,23,Jacqueline I Sempek,REP,0
+Yankton,Lewis and Clark Recreation Area,Precinct Committeewoman,23,Lauren Nelson,REP,0
+Yankton,Lewis and Clark Recreation Area,Precinct Committeewoman,26,Jennifer Morkve,REP,37
+Yankton,Lewis and Clark Recreation Area,Precinct Committeewoman,26,Linda Stevens,REP,77
+Yankton,Mayfield Store,Precinct Committeewoman,05,Jean M Hunhoff,REP,0
+Yankton,Mayfield Store,Precinct Committeewoman,05,Lisa Anderson,REP,0
+Yankton,Mayfield Store,Precinct Committeewoman,14,Amanda Hauger,REP,12
+Yankton,Mayfield Store,Precinct Committeewoman,14,Cassondra K Richelieu,REP,47
+Yankton,Mayfield Store,Precinct Committeewoman,23,Jacqueline I Sempek,REP,0
+Yankton,Mayfield Store,Precinct Committeewoman,23,Lauren Nelson,REP,6
+Yankton,Mayfield Store,Precinct Committeewoman,26,Jennifer Morkve,REP,0
+Yankton,Mayfield Store,Precinct Committeewoman,26,Linda Stevens,REP,0
+Yankton,Yankton City Hall,Precinct Committeewoman,05,Jean M Hunhoff,REP,38
+Yankton,Yankton City Hall,Precinct Committeewoman,05,Lisa Anderson,REP,39
+Yankton,Yankton City Hall,Precinct Committeewoman,14,Amanda Hauger,REP,1
+Yankton,Yankton City Hall,Precinct Committeewoman,14,Cassondra K Richelieu,REP,0
+Yankton,Yankton City Hall,Precinct Committeewoman,23,Jacqueline I Sempek,REP,2
+Yankton,Yankton City Hall,Precinct Committeewoman,23,Lauren Nelson,REP,8
+Yankton,Yankton City Hall,Precinct Committeewoman,26,Jennifer Morkve,REP,21
+Yankton,Yankton City Hall,Precinct Committeewoman,26,Linda Stevens,REP,27
+Yankton,Yankton Fire Station #2,Precinct Committeewoman,05,Jean M Hunhoff,REP,163
+Yankton,Yankton Fire Station #2,Precinct Committeewoman,05,Lisa Anderson,REP,154
+Yankton,Yankton Fire Station #2,Precinct Committeewoman,14,Amanda Hauger,REP,8
+Yankton,Yankton Fire Station #2,Precinct Committeewoman,14,Cassondra K Richelieu,REP,1
+Yankton,Yankton Fire Station #2,Precinct Committeewoman,23,Jacqueline I Sempek,REP,6
+Yankton,Yankton Fire Station #2,Precinct Committeewoman,23,Lauren Nelson,REP,4
+Yankton,Yankton Fire Station #2,Precinct Committeewoman,26,Jennifer Morkve,REP,18
+Yankton,Yankton Fire Station #2,Precinct Committeewoman,26,Linda Stevens,REP,32

--- a/2024/counties/20240604__sd__primary__ziebach__precinct.csv
+++ b/2024/counties/20240604__sd__primary__ziebach__precinct.csv
@@ -1,0 +1,49 @@
+county,precinct,office,district,candidate,party,votes
+Ziebach,1 Bridger,President,,Marianne Williamson,DEM,0
+Ziebach,1 Bridger,President,,Joseph R Biden Jr,DEM,2
+Ziebach,1 Bridger,President,,Dean Phillips,DEM,0
+Ziebach,1 Bridger,President,,Armando Perez-Serrato,DEM,1
+Ziebach,2 Cherry Creek,President,,Marianne Williamson,DEM,3
+Ziebach,2 Cherry Creek,President,,Joseph R Biden Jr,DEM,7
+Ziebach,2 Cherry Creek,President,,Dean Phillips,DEM,0
+Ziebach,2 Cherry Creek,President,,Armando Perez-Serrato,DEM,0
+Ziebach,3 Davis,President,,Marianne Williamson,DEM,2
+Ziebach,3 Davis,President,,Joseph R Biden Jr,DEM,5
+Ziebach,3 Davis,President,,Dean Phillips,DEM,0
+Ziebach,3 Davis,President,,Armando Perez-Serrato,DEM,1
+Ziebach,4 Glad Valley,President,,Marianne Williamson,DEM,2
+Ziebach,4 Glad Valley,President,,Joseph R Biden Jr,DEM,4
+Ziebach,4 Glad Valley,President,,Dean Phillips,DEM,0
+Ziebach,4 Glad Valley,President,,Armando Perez-Serrato,DEM,0
+Ziebach,"5 North Dupree (Precinct-6 Redelm, Precinct-8 South Dupree)",President,,Marianne Williamson,DEM,6
+Ziebach,"5 North Dupree (Precinct-6 Redelm, Precinct-8 South Dupree)",President,,Joseph R Biden Jr,DEM,23
+Ziebach,"5 North Dupree (Precinct-6 Redelm, Precinct-8 South Dupree)",President,,Dean Phillips,DEM,2
+Ziebach,"5 North Dupree (Precinct-6 Redelm, Precinct-8 South Dupree)",President,,Armando Perez-Serrato,DEM,0
+Ziebach,7 Red Scaffold,President,,Marianne Williamson,DEM,0
+Ziebach,7 Red Scaffold,President,,Joseph R Biden Jr,DEM,0
+Ziebach,7 Red Scaffold,President,,Dean Phillips,DEM,0
+Ziebach,7 Red Scaffold,President,,Armando Perez-Serrato,DEM,1
+Ziebach,1 Bridger,State Senate,28,Susan M. Peterson,REP,4
+Ziebach,1 Bridger,State Senate,28,Sam Marty,REP,2
+Ziebach,2 Cherry Creek,State Senate,28,Susan M. Peterson,REP,0
+Ziebach,2 Cherry Creek,State Senate,28,Sam Marty,REP,2
+Ziebach,3 Davis,State Senate,28,Susan M. Peterson,REP,10
+Ziebach,3 Davis,State Senate,28,Sam Marty,REP,6
+Ziebach,4 Glad Valley,State Senate,28,Susan M. Peterson,REP,8
+Ziebach,4 Glad Valley,State Senate,28,Sam Marty,REP,14
+Ziebach,"5 North Dupree (Precinct-6 Redelm, Precinct-8 South Dupree)",State Senate,28,Susan M. Peterson,REP,31
+Ziebach,"5 North Dupree (Precinct-6 Redelm, Precinct-8 South Dupree)",State Senate,28,Sam Marty,REP,35
+Ziebach,7 Red Scaffold,State Senate,28,Susan M. Peterson,REP,0
+Ziebach,7 Red Scaffold,State Senate,28,Sam Marty,REP,4
+Ziebach,1 Bridger,State House,28A,Ryan Maher,REP,1
+Ziebach,1 Bridger,State House,28A,Jana Hunt,REP,5
+Ziebach,2 Cherry Creek,State House,28A,Ryan Maher,REP,0
+Ziebach,2 Cherry Creek,State House,28A,Jana Hunt,REP,2
+Ziebach,3 Davis,State House,28A,Ryan Maher,REP,3
+Ziebach,3 Davis,State House,28A,Jana Hunt,REP,15
+Ziebach,4 Glad Valley,State House,28A,Ryan Maher,REP,15
+Ziebach,4 Glad Valley,State House,28A,Jana Hunt,REP,9
+Ziebach,"5 North Dupree (Precinct-6 Redelm, Precinct-8 South Dupree)",State House,28A,Ryan Maher,REP,23
+Ziebach,"5 North Dupree (Precinct-6 Redelm, Precinct-8 South Dupree)",State House,28A,Jana Hunt,REP,49
+Ziebach,7 Red Scaffold,State House,28A,Ryan Maher,REP,0
+Ziebach,7 Red Scaffold,State House,28A,Jana Hunt,REP,4


### PR DESCRIPTION
This pull request introduces new precinct-level results for the South Dakota 2024 primary for several counties and corrects county name capitalization in existing results. The main changes are the addition of detailed precinct results for Aurora, Beadle, Bennett, Bon Homme counties, and corrections to the capitalization of "McCook" and "McPherson" in multiple offices and districts. Still missing are results from Codington, Minnehaha and Pennington counties.

**New precinct-level results added:**

* Added `20240604__sd__primary__aurora__precinct.csv` with Democratic and Republican results for President, State Senate, State House, and School Board Member for Aurora County.
* Added `20240604__sd__primary__beadle__precinct.csv` with Democratic and Republican results for President, State House, and County Commissioner for Beadle County.
* Added `20240604__sd__primary__bennett__precinct.csv` with Democratic and Republican results for President, State Senate, and County Commissioner At Large for Bennett County.
* Added `20240604__sd__primary__bon_homme__precinct.csv` with Democratic and Republican results for President, State House, and States Attorney for Bon Homme County.

**Data corrections:**

* Standardized capitalization for "McCook" and "McPherson" counties in `20240604__sd__primary__county.csv` across all relevant races and parties. [[1]](diffhunk://#diff-129b5017563d76272fa4da7f16850cdc2ec02b5f9e6c3bae24be69073d5e3fbbL174-R181) [[2]](diffhunk://#diff-129b5017563d76272fa4da7f16850cdc2ec02b5f9e6c3bae24be69073d5e3fbbL324-R325) [[3]](diffhunk://#diff-129b5017563d76272fa4da7f16850cdc2ec02b5f9e6c3bae24be69073d5e3fbbL499-R501) [[4]](diffhunk://#diff-129b5017563d76272fa4da7f16850cdc2ec02b5f9e6c3bae24be69073d5e3fbbL544-R546)