### PR TITLE
2022 general precinct results

### DIFF
--- a/2022/20221108__sd__general__county.csv
+++ b/2022/20221108__sd__general__county.csv
@@ -1,0 +1,2639 @@
+county,office,district,party,candidate,votes
+Aurora,U.S. Senate,,DEM,Brian L. Bengs,170
+Aurora,U.S. Senate,,LIB,Tamara J Lesnar,66
+Aurora,U.S. Senate,,REP,John R. Thune,978
+Beadle,U.S. Senate,,DEM,Brian L. Bengs,1214
+Beadle,U.S. Senate,,LIB,Tamara J Lesnar,182
+Beadle,U.S. Senate,,REP,John R. Thune,4441
+Bennett,U.S. Senate,,DEM,Brian L. Bengs,295
+Bennett,U.S. Senate,,LIB,Tamara J Lesnar,41
+Bennett,U.S. Senate,,REP,John R. Thune,684
+Bon Homme,U.S. Senate,,DEM,Brian L. Bengs,453
+Bon Homme,U.S. Senate,,LIB,Tamara J Lesnar,91
+Bon Homme,U.S. Senate,,REP,John R. Thune,2010
+Brookings,U.S. Senate,,DEM,Brian L. Bengs,3816
+Brookings,U.S. Senate,,LIB,Tamara J Lesnar,545
+Brookings,U.S. Senate,,REP,John R. Thune,7990
+Brown,U.S. Senate,,DEM,Brian L. Bengs,3893
+Brown,U.S. Senate,,LIB,Tamara J Lesnar,451
+Brown,U.S. Senate,,REP,John R. Thune,9577
+Brule,U.S. Senate,,DEM,Brian L. Bengs,428
+Brule,U.S. Senate,,LIB,Tamara J Lesnar,97
+Brule,U.S. Senate,,REP,John R. Thune,1573
+Buffalo,U.S. Senate,,DEM,Brian L. Bengs,202
+Buffalo,U.S. Senate,,LIB,Tamara J Lesnar,15
+Buffalo,U.S. Senate,,REP,John R. Thune,173
+Butte,U.S. Senate,,DEM,Brian L. Bengs,597
+Butte,U.S. Senate,,LIB,Tamara J Lesnar,292
+Butte,U.S. Senate,,REP,John R. Thune,3269
+Campbell,U.S. Senate,,DEM,Brian L. Bengs,66
+Campbell,U.S. Senate,,LIB,Tamara J Lesnar,26
+Campbell,U.S. Senate,,REP,John R. Thune,571
+Charles Mix,U.S. Senate,,DEM,Brian L. Bengs,666
+Charles Mix,U.S. Senate,,LIB,Tamara J Lesnar,100
+Charles Mix,U.S. Senate,,REP,John R. Thune,2323
+Clark,U.S. Senate,,DEM,Brian L. Bengs,230
+Clark,U.S. Senate,,LIB,Tamara J Lesnar,56
+Clark,U.S. Senate,,REP,John R. Thune,1307
+Clay,U.S. Senate,,DEM,Brian L. Bengs,2042
+Clay,U.S. Senate,,LIB,Tamara J Lesnar,149
+Clay,U.S. Senate,,REP,John R. Thune,2522
+Codington,U.S. Senate,,DEM,Brian L. Bengs,2265
+Codington,U.S. Senate,,LIB,Tamara J Lesnar,460
+Codington,U.S. Senate,,REP,John R. Thune,8279
+Corson,U.S. Senate,,DEM,Brian L. Bengs,334
+Corson,U.S. Senate,,LIB,Tamara J Lesnar,57
+Corson,U.S. Senate,,REP,John R. Thune,534
+Custer,U.S. Senate,,DEM,Brian L. Bengs,1017
+Custer,U.S. Senate,,LIB,Tamara J Lesnar,267
+Custer,U.S. Senate,,REP,John R. Thune,3756
+Davison,U.S. Senate,,DEM,Brian L. Bengs,1524
+Davison,U.S. Senate,,LIB,Tamara J Lesnar,266
+Davison,U.S. Senate,,REP,John R. Thune,5420
+Day,U.S. Senate,,DEM,Brian L. Bengs,602
+Day,U.S. Senate,,LIB,Tamara J Lesnar,116
+Day,U.S. Senate,,REP,John R. Thune,1796
+Deuel,U.S. Senate,,DEM,Brian L. Bengs,346
+Deuel,U.S. Senate,,LIB,Tamara J Lesnar,92
+Deuel,U.S. Senate,,REP,John R. Thune,1548
+Dewey,U.S. Senate,,DEM,Brian L. Bengs,720
+Dewey,U.S. Senate,,LIB,Tamara J Lesnar,70
+Dewey,U.S. Senate,,REP,John R. Thune,770
+Douglas,U.S. Senate,,DEM,Brian L. Bengs,117
+Douglas,U.S. Senate,,LIB,Tamara J Lesnar,42
+Douglas,U.S. Senate,,REP,John R. Thune,1308
+Edmunds,U.S. Senate,,DEM,Brian L. Bengs,253
+Edmunds,U.S. Senate,,LIB,Tamara J Lesnar,49
+Edmunds,U.S. Senate,,REP,John R. Thune,1385
+Fall River,U.S. Senate,,DEM,Brian L. Bengs,665
+Fall River,U.S. Senate,,LIB,Tamara J Lesnar,222
+Fall River,U.S. Senate,,REP,John R. Thune,2754
+Faulk,U.S. Senate,,DEM,Brian L. Bengs,120
+Faulk,U.S. Senate,,LIB,Tamara J Lesnar,47
+Faulk,U.S. Senate,,REP,John R. Thune,780
+Grant,U.S. Senate,,DEM,Brian L. Bengs,601
+Grant,U.S. Senate,,LIB,Tamara J Lesnar,105
+Grant,U.S. Senate,,REP,John R. Thune,2492
+Gregory,U.S. Senate,,DEM,Brian L. Bengs,279
+Gregory,U.S. Senate,,LIB,Tamara J Lesnar,82
+Gregory,U.S. Senate,,REP,John R. Thune,1663
+Haakon,U.S. Senate,,DEM,Brian L. Bengs,56
+Haakon,U.S. Senate,,LIB,Tamara J Lesnar,50
+Haakon,U.S. Senate,,REP,John R. Thune,864
+Hamlin,U.S. Senate,,DEM,Brian L. Bengs,366
+Hamlin,U.S. Senate,,LIB,Tamara J Lesnar,123
+Hamlin,U.S. Senate,,REP,John R. Thune,2214
+Hand,U.S. Senate,,DEM,Brian L. Bengs,198
+Hand,U.S. Senate,,LIB,Tamara J Lesnar,70
+Hand,U.S. Senate,,REP,John R. Thune,1242
+Hanson,U.S. Senate,,DEM,Brian L. Bengs,254
+Hanson,U.S. Senate,,LIB,Tamara J Lesnar,52
+Hanson,U.S. Senate,,REP,John R. Thune,1323
+Harding,U.S. Senate,,DEM,Brian L. Bengs,22
+Harding,U.S. Senate,,LIB,Tamara J Lesnar,41
+Harding,U.S. Senate,,REP,John R. Thune,605
+Hughes,U.S. Senate,,DEM,Brian L. Bengs,1683
+Hughes,U.S. Senate,,LIB,Tamara J Lesnar,301
+Hughes,U.S. Senate,,REP,John R. Thune,5467
+Hutchinson,U.S. Senate,,DEM,Brian L. Bengs,417
+Hutchinson,U.S. Senate,,LIB,Tamara J Lesnar,106
+Hutchinson,U.S. Senate,,REP,John R. Thune,2619
+Hyde,U.S. Senate,,DEM,Brian L. Bengs,78
+Hyde,U.S. Senate,,LIB,Tamara J Lesnar,18
+Hyde,U.S. Senate,,REP,John R. Thune,484
+Jackson,U.S. Senate,,DEM,Brian L. Bengs,215
+Jackson,U.S. Senate,,LIB,Tamara J Lesnar,67
+Jackson,U.S. Senate,,REP,John R. Thune,617
+Jerauld,U.S. Senate,,DEM,Brian L. Bengs,154
+Jerauld,U.S. Senate,,LIB,Tamara J Lesnar,34
+Jerauld,U.S. Senate,,REP,John R. Thune,676
+Jones,U.S. Senate,,DEM,Brian L. Bengs,46
+Jones,U.S. Senate,,LIB,Tamara J Lesnar,36
+Jones,U.S. Senate,,REP,John R. Thune,383
+Kingsbury,U.S. Senate,,DEM,Brian L. Bengs,441
+Kingsbury,U.S. Senate,,LIB,Tamara J Lesnar,89
+Kingsbury,U.S. Senate,,REP,John R. Thune,2000
+Lake,U.S. Senate,,DEM,Brian L. Bengs,1139
+Lake,U.S. Senate,,LIB,Tamara J Lesnar,164
+Lake,U.S. Senate,,REP,John R. Thune,3615
+Lawrence,U.S. Senate,,DEM,Brian L. Bengs,3061
+Lawrence,U.S. Senate,,LIB,Tamara J Lesnar,646
+Lawrence,U.S. Senate,,REP,John R. Thune,8439
+Lincoln,U.S. Senate,,DEM,Brian L. Bengs,7365
+Lincoln,U.S. Senate,,LIB,Tamara J Lesnar,912
+Lincoln,U.S. Senate,,REP,John R. Thune,19703
+Lyman,U.S. Senate,,DEM,Brian L. Bengs,290
+Lyman,U.S. Senate,,LIB,Tamara J Lesnar,65
+Lyman,U.S. Senate,,REP,John R. Thune,944
+Marshall,U.S. Senate,,DEM,Brian L. Bengs,545
+Marshall,U.S. Senate,,LIB,Tamara J Lesnar,62
+Marshall,U.S. Senate,,REP,John R. Thune,1272
+McCook,U.S. Senate,,DEM,Brian L. Bengs,408
+McCook,U.S. Senate,,LIB,Tamara J Lesnar,92
+McCook,U.S. Senate,,REP,John R. Thune,2033
+McPherson,U.S. Senate,,DEM,Brian L. Bengs,108
+McPherson,U.S. Senate,,LIB,Tamara J Lesnar,40
+McPherson,U.S. Senate,,REP,John R. Thune,954
+Meade,U.S. Senate,,DEM,Brian L. Bengs,2134
+Meade,U.S. Senate,,LIB,Tamara J Lesnar,702
+Meade,U.S. Senate,,REP,John R. Thune,8934
+Mellette,U.S. Senate,,DEM,Brian L. Bengs,165
+Mellette,U.S. Senate,,LIB,Tamara J Lesnar,44
+Mellette,U.S. Senate,,REP,John R. Thune,415
+Miner,U.S. Senate,,DEM,Brian L. Bengs,161
+Miner,U.S. Senate,,LIB,Tamara J Lesnar,30
+Miner,U.S. Senate,,REP,John R. Thune,813
+Minnehaha,U.S. Senate,,DEM,Brian L. Bengs,24772
+Minnehaha,U.S. Senate,,LIB,Tamara J Lesnar,2821
+Minnehaha,U.S. Senate,,REP,John R. Thune,46551
+Moody,U.S. Senate,,DEM,Brian L. Bengs,694
+Moody,U.S. Senate,,LIB,Tamara J Lesnar,109
+Moody,U.S. Senate,,REP,John R. Thune,1839
+Oglala Lakota,U.S. Senate,,DEM,Brian L. Bengs,1889
+Oglala Lakota,U.S. Senate,,LIB,Tamara J Lesnar,129
+Oglala Lakota,U.S. Senate,,REP,John R. Thune,422
+Pennington,U.S. Senate,,DEM,Brian L. Bengs,12441
+Pennington,U.S. Senate,,LIB,Tamara J Lesnar,2314
+Pennington,U.S. Senate,,REP,John R. Thune,30398
+Perkins,U.S. Senate,,DEM,Brian L. Bengs,133
+Perkins,U.S. Senate,,LIB,Tamara J Lesnar,95
+Perkins,U.S. Senate,,REP,John R. Thune,1141
+Potter,U.S. Senate,,DEM,Brian L. Bengs,123
+Potter,U.S. Senate,,LIB,Tamara J Lesnar,33
+Potter,U.S. Senate,,REP,John R. Thune,937
+Roberts,U.S. Senate,,DEM,Brian L. Bengs,1000
+Roberts,U.S. Senate,,LIB,Tamara J Lesnar,147
+Roberts,U.S. Senate,,REP,John R. Thune,2384
+Sanborn,U.S. Senate,,DEM,Brian L. Bengs,154
+Sanborn,U.S. Senate,,LIB,Tamara J Lesnar,27
+Sanborn,U.S. Senate,,REP,John R. Thune,821
+Spink,U.S. Senate,,DEM,Brian L. Bengs,546
+Spink,U.S. Senate,,LIB,Tamara J Lesnar,91
+Spink,U.S. Senate,,REP,John R. Thune,2027
+Stanley,U.S. Senate,,DEM,Brian L. Bengs,245
+Stanley,U.S. Senate,,LIB,Tamara J Lesnar,64
+Stanley,U.S. Senate,,REP,John R. Thune,1138
+Sully,U.S. Senate,,DEM,Brian L. Bengs,114
+Sully,U.S. Senate,,LIB,Tamara J Lesnar,47
+Sully,U.S. Senate,,REP,John R. Thune,622
+Todd,U.S. Senate,,DEM,Brian L. Bengs,1308
+Todd,U.S. Senate,,LIB,Tamara J Lesnar,101
+Todd,U.S. Senate,,REP,John R. Thune,502
+Tripp,U.S. Senate,,DEM,Brian L. Bengs,263
+Tripp,U.S. Senate,,LIB,Tamara J Lesnar,113
+Tripp,U.S. Senate,,REP,John R. Thune,1861
+Turner,U.S. Senate,,DEM,Brian L. Bengs,602
+Turner,U.S. Senate,,LIB,Tamara J Lesnar,168
+Turner,U.S. Senate,,REP,John R. Thune,3078
+Union,U.S. Senate,,DEM,Brian L. Bengs,1497
+Union,U.S. Senate,,LIB,Tamara J Lesnar,229
+Union,U.S. Senate,,REP,John R. Thune,4991
+Walworth,U.S. Senate,,DEM,Brian L. Bengs,301
+Walworth,U.S. Senate,,LIB,Tamara J Lesnar,92
+Walworth,U.S. Senate,,REP,John R. Thune,1645
+Yankton,U.S. Senate,,DEM,Brian L. Bengs,2462
+Yankton,U.S. Senate,,LIB,Tamara J Lesnar,340
+Yankton,U.S. Senate,,REP,John R. Thune,6051
+Ziebach,U.S. Senate,,DEM,Brian L. Bengs,242
+Ziebach,U.S. Senate,,LIB,Tamara J Lesnar,47
+Ziebach,U.S. Senate,,REP,John R. Thune,389
+Aurora,U.S. House,1,LIB,Collin Duprel,179
+Aurora,U.S. House,1,REP,Dusty Johnson,989
+Beadle,U.S. House,1,LIB,Collin Duprel,870
+Beadle,U.S. House,1,REP,Dusty Johnson,4712
+Bennett,U.S. House,1,LIB,Collin Duprel,258
+Bennett,U.S. House,1,REP,Dusty Johnson,699
+Bon Homme,U.S. House,1,LIB,Collin Duprel,388
+Bon Homme,U.S. House,1,REP,Dusty Johnson,2057
+Brookings,U.S. House,1,LIB,Collin Duprel,2757
+Brookings,U.S. House,1,REP,Dusty Johnson,8783
+Brown,U.S. House,1,LIB,Collin Duprel,2684
+Brown,U.S. House,1,REP,Dusty Johnson,10425
+Brule,U.S. House,1,LIB,Collin Duprel,367
+Brule,U.S. House,1,REP,Dusty Johnson,1652
+Buffalo,U.S. House,1,LIB,Collin Duprel,139
+Buffalo,U.S. House,1,REP,Dusty Johnson,211
+Butte,U.S. House,1,LIB,Collin Duprel,1022
+Butte,U.S. House,1,REP,Dusty Johnson,3021
+Campbell,U.S. House,1,LIB,Collin Duprel,64
+Campbell,U.S. House,1,REP,Dusty Johnson,583
+Charles Mix,U.S. House,1,LIB,Collin Duprel,572
+Charles Mix,U.S. House,1,REP,Dusty Johnson,2391
+Clark,U.S. House,1,LIB,Collin Duprel,213
+Clark,U.S. House,1,REP,Dusty Johnson,1320
+Clay,U.S. House,1,LIB,Collin Duprel,1163
+Clay,U.S. House,1,REP,Dusty Johnson,2971
+Codington,U.S. House,1,LIB,Collin Duprel,1790
+Codington,U.S. House,1,REP,Dusty Johnson,8729
+Corson,U.S. House,1,LIB,Collin Duprel,269
+Corson,U.S. House,1,REP,Dusty Johnson,550
+Custer,U.S. House,1,LIB,Collin Duprel,1023
+Custer,U.S. House,1,REP,Dusty Johnson,3753
+Davison,U.S. House,1,LIB,Collin Duprel,1143
+Davison,U.S. House,1,REP,Dusty Johnson,5769
+Day,U.S. House,1,LIB,Collin Duprel,480
+Day,U.S. House,1,REP,Dusty Johnson,1898
+Deuel,U.S. House,1,LIB,Collin Duprel,279
+Deuel,U.S. House,1,REP,Dusty Johnson,1643
+Dewey,U.S. House,1,LIB,Collin Duprel,519
+Dewey,U.S. House,1,REP,Dusty Johnson,870
+Douglas,U.S. House,1,LIB,Collin Duprel,146
+Douglas,U.S. House,1,REP,Dusty Johnson,1279
+Edmunds,U.S. House,1,LIB,Collin Duprel,200
+Edmunds,U.S. House,1,REP,Dusty Johnson,1440
+Fall River,U.S. House,1,LIB,Collin Duprel,759
+Fall River,U.S. House,1,REP,Dusty Johnson,2700
+Faulk,U.S. House,1,LIB,Collin Duprel,140
+Faulk,U.S. House,1,REP,Dusty Johnson,779
+Grant,U.S. House,1,LIB,Collin Duprel,468
+Grant,U.S. House,1,REP,Dusty Johnson,2587
+Gregory,U.S. House,1,LIB,Collin Duprel,280
+Gregory,U.S. House,1,REP,Dusty Johnson,1690
+Haakon,U.S. House,1,LIB,Collin Duprel,165
+Haakon,U.S. House,1,REP,Dusty Johnson,791
+Hamlin,U.S. House,1,LIB,Collin Duprel,366
+Hamlin,U.S. House,1,REP,Dusty Johnson,2255
+Hand,U.S. House,1,LIB,Collin Duprel,197
+Hand,U.S. House,1,REP,Dusty Johnson,1259
+Hanson,U.S. House,1,LIB,Collin Duprel,233
+Hanson,U.S. House,1,REP,Dusty Johnson,1336
+Harding,U.S. House,1,LIB,Collin Duprel,143
+Harding,U.S. House,1,REP,Dusty Johnson,518
+Hughes,U.S. House,1,LIB,Collin Duprel,1410
+Hughes,U.S. House,1,REP,Dusty Johnson,5706
+Hutchinson,U.S. House,1,LIB,Collin Duprel,358
+Hutchinson,U.S. House,1,REP,Dusty Johnson,2690
+Hyde,U.S. House,1,LIB,Collin Duprel,81
+Hyde,U.S. House,1,REP,Dusty Johnson,479
+Jackson,U.S. House,1,LIB,Collin Duprel,247
+Jackson,U.S. House,1,REP,Dusty Johnson,598
+Jerauld,U.S. House,1,LIB,Collin Duprel,105
+Jerauld,U.S. House,1,REP,Dusty Johnson,720
+Jones,U.S. House,1,LIB,Collin Duprel,72
+Jones,U.S. House,1,REP,Dusty Johnson,391
+Kingsbury,U.S. House,1,LIB,Collin Duprel,390
+Kingsbury,U.S. House,1,REP,Dusty Johnson,2055
+Lake,U.S. House,1,LIB,Collin Duprel,845
+Lake,U.S. House,1,REP,Dusty Johnson,3810
+Lawrence,U.S. House,1,LIB,Collin Duprel,2999
+Lawrence,U.S. House,1,REP,Dusty Johnson,8479
+Lincoln,U.S. House,1,LIB,Collin Duprel,5360
+Lincoln,U.S. House,1,REP,Dusty Johnson,21002
+Lyman,U.S. House,1,LIB,Collin Duprel,267
+Lyman,U.S. House,1,REP,Dusty Johnson,982
+Marshall,U.S. House,1,LIB,Collin Duprel,391
+Marshall,U.S. House,1,REP,Dusty Johnson,1378
+McCook,U.S. House,1,LIB,Collin Duprel,389
+McCook,U.S. House,1,REP,Dusty Johnson,2054
+McPherson,U.S. House,1,LIB,Collin Duprel,123
+McPherson,U.S. House,1,REP,Dusty Johnson,953
+Meade,U.S. House,1,LIB,Collin Duprel,3294
+Meade,U.S. House,1,REP,Dusty Johnson,8152
+Mellette,U.S. House,1,LIB,Collin Duprel,159
+Mellette,U.S. House,1,REP,Dusty Johnson,429
+Miner,U.S. House,1,LIB,Collin Duprel,133
+Miner,U.S. House,1,REP,Dusty Johnson,828
+Minnehaha,U.S. House,1,LIB,Collin Duprel,17765
+Minnehaha,U.S. House,1,REP,Dusty Johnson,50693
+Moody,U.S. House,1,LIB,Collin Duprel,574
+Moody,U.S. House,1,REP,Dusty Johnson,1976
+Oglala Lakota,U.S. House,1,LIB,Collin Duprel,1336
+Oglala Lakota,U.S. House,1,REP,Dusty Johnson,647
+Pennington,U.S. House,1,LIB,Collin Duprel,11080
+Pennington,U.S. House,1,REP,Dusty Johnson,31305
+Perkins,U.S. House,1,LIB,Collin Duprel,282
+Perkins,U.S. House,1,REP,Dusty Johnson,1060
+Potter,U.S. House,1,LIB,Collin Duprel,136
+Potter,U.S. House,1,REP,Dusty Johnson,944
+Roberts,U.S. House,1,LIB,Collin Duprel,738
+Roberts,U.S. House,1,REP,Dusty Johnson,2590
+Sanborn,U.S. House,1,LIB,Collin Duprel,124
+Sanborn,U.S. House,1,REP,Dusty Johnson,845
+Spink,U.S. House,1,LIB,Collin Duprel,410
+Spink,U.S. House,1,REP,Dusty Johnson,2166
+Stanley,U.S. House,1,LIB,Collin Duprel,272
+Stanley,U.S. House,1,REP,Dusty Johnson,1129
+Sully,U.S. House,1,LIB,Collin Duprel,129
+Sully,U.S. House,1,REP,Dusty Johnson,625
+Todd,U.S. House,1,LIB,Collin Duprel,947
+Todd,U.S. House,1,REP,Dusty Johnson,677
+Tripp,U.S. House,1,LIB,Collin Duprel,325
+Tripp,U.S. House,1,REP,Dusty Johnson,1865
+Turner,U.S. House,1,LIB,Collin Duprel,561
+Turner,U.S. House,1,REP,Dusty Johnson,3174
+Union,U.S. House,1,LIB,Collin Duprel,1139
+Union,U.S. House,1,REP,Dusty Johnson,5180
+Walworth,U.S. House,1,LIB,Collin Duprel,271
+Walworth,U.S. House,1,REP,Dusty Johnson,1691
+Yankton,U.S. House,1,LIB,Collin Duprel,1804
+Yankton,U.S. House,1,REP,Dusty Johnson,6499
+Ziebach,U.S. House,1,LIB,Collin Duprel,228
+Ziebach,U.S. House,1,REP,Dusty Johnson,389
+Aurora,Governor,,DEM,Jamie Smith and Jennifer Keintz,284
+Aurora,Governor,,LIB,Tracey Quint and Ashley Strand,36
+Aurora,Governor,,REP,Kristi Noem and Larry Rhoden,894
+Beadle,Governor,,DEM,Jamie Smith and Jennifer Keintz,1716
+Beadle,Governor,,LIB,Tracey Quint and Ashley Strand,219
+Beadle,Governor,,REP,Kristi Noem and Larry Rhoden,3901
+Bennett,Governor,,DEM,Jamie Smith and Jennifer Keintz,368
+Bennett,Governor,,LIB,Tracey Quint and Ashley Strand,38
+Bennett,Governor,,REP,Kristi Noem and Larry Rhoden,619
+Bon Homme,Governor,,DEM,Jamie Smith and Jennifer Keintz,650
+Bon Homme,Governor,,LIB,Tracey Quint and Ashley Strand,54
+Bon Homme,Governor,,REP,Kristi Noem and Larry Rhoden,1858
+Brookings,Governor,,DEM,Jamie Smith and Jennifer Keintz,5096
+Brookings,Governor,,LIB,Tracey Quint and Ashley Strand,357
+Brookings,Governor,,REP,Kristi Noem and Larry Rhoden,6974
+Brown,Governor,,DEM,Jamie Smith and Jennifer Keintz,5167
+Brown,Governor,,LIB,Tracey Quint and Ashley Strand,341
+Brown,Governor,,REP,Kristi Noem and Larry Rhoden,8456
+Brule,Governor,,DEM,Jamie Smith and Jennifer Keintz,589
+Brule,Governor,,LIB,Tracey Quint and Ashley Strand,57
+Brule,Governor,,REP,Kristi Noem and Larry Rhoden,1463
+Buffalo,Governor,,DEM,Jamie Smith and Jennifer Keintz,234
+Buffalo,Governor,,LIB,Tracey Quint and Ashley Strand,19
+Buffalo,Governor,,REP,Kristi Noem and Larry Rhoden,144
+Butte,Governor,,DEM,Jamie Smith and Jennifer Keintz,823
+Butte,Governor,,LIB,Tracey Quint and Ashley Strand,152
+Butte,Governor,,REP,Kristi Noem and Larry Rhoden,3211
+Campbell,Governor,,DEM,Jamie Smith and Jennifer Keintz,93
+Campbell,Governor,,LIB,Tracey Quint and Ashley Strand,13
+Campbell,Governor,,REP,Kristi Noem and Larry Rhoden,561
+Charles Mix,Governor,,DEM,Jamie Smith and Jennifer Keintz,849
+Charles Mix,Governor,,LIB,Tracey Quint and Ashley Strand,55
+Charles Mix,Governor,,REP,Kristi Noem and Larry Rhoden,2187
+Clark,Governor,,DEM,Jamie Smith and Jennifer Keintz,341
+Clark,Governor,,LIB,Tracey Quint and Ashley Strand,36
+Clark,Governor,,REP,Kristi Noem and Larry Rhoden,1223
+Clay,Governor,,DEM,Jamie Smith and Jennifer Keintz,2581
+Clay,Governor,,LIB,Tracey Quint and Ashley Strand,110
+Clay,Governor,,REP,Kristi Noem and Larry Rhoden,2054
+Codington,Governor,,DEM,Jamie Smith and Jennifer Keintz,3253
+Codington,Governor,,LIB,Tracey Quint and Ashley Strand,307
+Codington,Governor,,REP,Kristi Noem and Larry Rhoden,7520
+Corson,Governor,,DEM,Jamie Smith and Jennifer Keintz,379
+Corson,Governor,,LIB,Tracey Quint and Ashley Strand,27
+Corson,Governor,,REP,Kristi Noem and Larry Rhoden,522
+Custer,Governor,,DEM,Jamie Smith and Jennifer Keintz,1293
+Custer,Governor,,LIB,Tracey Quint and Ashley Strand,151
+Custer,Governor,,REP,Kristi Noem and Larry Rhoden,3633
+Davison,Governor,,DEM,Jamie Smith and Jennifer Keintz,2179
+Davison,Governor,,LIB,Tracey Quint and Ashley Strand,173
+Davison,Governor,,REP,Kristi Noem and Larry Rhoden,4887
+Day,Governor,,DEM,Jamie Smith and Jennifer Keintz,876
+Day,Governor,,LIB,Tracey Quint and Ashley Strand,46
+Day,Governor,,REP,Kristi Noem and Larry Rhoden,1599
+Deuel,Governor,,DEM,Jamie Smith and Jennifer Keintz,458
+Deuel,Governor,,LIB,Tracey Quint and Ashley Strand,54
+Deuel,Governor,,REP,Kristi Noem and Larry Rhoden,1479
+Dewey,Governor,,DEM,Jamie Smith and Jennifer Keintz,862
+Dewey,Governor,,LIB,Tracey Quint and Ashley Strand,50
+Dewey,Governor,,REP,Kristi Noem and Larry Rhoden,662
+Douglas,Governor,,DEM,Jamie Smith and Jennifer Keintz,188
+Douglas,Governor,,LIB,Tracey Quint and Ashley Strand,24
+Douglas,Governor,,REP,Kristi Noem and Larry Rhoden,1272
+Edmunds,Governor,,DEM,Jamie Smith and Jennifer Keintz,346
+Edmunds,Governor,,LIB,Tracey Quint and Ashley Strand,34
+Edmunds,Governor,,REP,Kristi Noem and Larry Rhoden,1321
+Fall River,Governor,,DEM,Jamie Smith and Jennifer Keintz,859
+Fall River,Governor,,LIB,Tracey Quint and Ashley Strand,130
+Fall River,Governor,,REP,Kristi Noem and Larry Rhoden,2679
+Faulk,Governor,,DEM,Jamie Smith and Jennifer Keintz,167
+Faulk,Governor,,LIB,Tracey Quint and Ashley Strand,17
+Faulk,Governor,,REP,Kristi Noem and Larry Rhoden,771
+Grant,Governor,,DEM,Jamie Smith and Jennifer Keintz,830
+Grant,Governor,,LIB,Tracey Quint and Ashley Strand,57
+Grant,Governor,,REP,Kristi Noem and Larry Rhoden,2328
+Gregory,Governor,,DEM,Jamie Smith and Jennifer Keintz,393
+Gregory,Governor,,LIB,Tracey Quint and Ashley Strand,43
+Gregory,Governor,,REP,Kristi Noem and Larry Rhoden,1618
+Haakon,Governor,,DEM,Jamie Smith and Jennifer Keintz,82
+Haakon,Governor,,LIB,Tracey Quint and Ashley Strand,13
+Haakon,Governor,,REP,Kristi Noem and Larry Rhoden,892
+Hamlin,Governor,,DEM,Jamie Smith and Jennifer Keintz,548
+Hamlin,Governor,,LIB,Tracey Quint and Ashley Strand,64
+Hamlin,Governor,,REP,Kristi Noem and Larry Rhoden,2118
+Hand,Governor,,DEM,Jamie Smith and Jennifer Keintz,290
+Hand,Governor,,LIB,Tracey Quint and Ashley Strand,35
+Hand,Governor,,REP,Kristi Noem and Larry Rhoden,1177
+Hanson,Governor,,DEM,Jamie Smith and Jennifer Keintz,336
+Hanson,Governor,,LIB,Tracey Quint and Ashley Strand,29
+Hanson,Governor,,REP,Kristi Noem and Larry Rhoden,1267
+Harding,Governor,,DEM,Jamie Smith and Jennifer Keintz,33
+Harding,Governor,,LIB,Tracey Quint and Ashley Strand,12
+Harding,Governor,,REP,Kristi Noem and Larry Rhoden,632
+Hughes,Governor,,DEM,Jamie Smith and Jennifer Keintz,2652
+Hughes,Governor,,LIB,Tracey Quint and Ashley Strand,224
+Hughes,Governor,,REP,Kristi Noem and Larry Rhoden,4571
+Hutchinson,Governor,,DEM,Jamie Smith and Jennifer Keintz,604
+Hutchinson,Governor,,LIB,Tracey Quint and Ashley Strand,63
+Hutchinson,Governor,,REP,Kristi Noem and Larry Rhoden,2507
+Hyde,Governor,,DEM,Jamie Smith and Jennifer Keintz,106
+Hyde,Governor,,LIB,Tracey Quint and Ashley Strand,9
+Hyde,Governor,,REP,Kristi Noem and Larry Rhoden,460
+Jackson,Governor,,DEM,Jamie Smith and Jennifer Keintz,280
+Jackson,Governor,,LIB,Tracey Quint and Ashley Strand,16
+Jackson,Governor,,REP,Kristi Noem and Larry Rhoden,623
+Jerauld,Governor,,DEM,Jamie Smith and Jennifer Keintz,238
+Jerauld,Governor,,LIB,Tracey Quint and Ashley Strand,24
+Jerauld,Governor,,REP,Kristi Noem and Larry Rhoden,604
+Jones,Governor,,DEM,Jamie Smith and Jennifer Keintz,64
+Jones,Governor,,LIB,Tracey Quint and Ashley Strand,13
+Jones,Governor,,REP,Kristi Noem and Larry Rhoden,395
+Kingsbury,Governor,,DEM,Jamie Smith and Jennifer Keintz,692
+Kingsbury,Governor,,LIB,Tracey Quint and Ashley Strand,67
+Kingsbury,Governor,,REP,Kristi Noem and Larry Rhoden,1792
+Lake,Governor,,DEM,Jamie Smith and Jennifer Keintz,1720
+Lake,Governor,,LIB,Tracey Quint and Ashley Strand,115
+Lake,Governor,,REP,Kristi Noem and Larry Rhoden,3131
+Lawrence,Governor,,DEM,Jamie Smith and Jennifer Keintz,4041
+Lawrence,Governor,,LIB,Tracey Quint and Ashley Strand,456
+Lawrence,Governor,,REP,Kristi Noem and Larry Rhoden,7749
+Lincoln,Governor,,DEM,Jamie Smith and Jennifer Keintz,10727
+Lincoln,Governor,,LIB,Tracey Quint and Ashley Strand,606
+Lincoln,Governor,,REP,Kristi Noem and Larry Rhoden,16828
+Lyman,Governor,,DEM,Jamie Smith and Jennifer Keintz,405
+Lyman,Governor,,LIB,Tracey Quint and Ashley Strand,34
+Lyman,Governor,,REP,Kristi Noem and Larry Rhoden,879
+Marshall,Governor,,DEM,Jamie Smith and Jennifer Keintz,737
+Marshall,Governor,,LIB,Tracey Quint and Ashley Strand,30
+Marshall,Governor,,REP,Kristi Noem and Larry Rhoden,1123
+McCook,Governor,,DEM,Jamie Smith and Jennifer Keintz,625
+McCook,Governor,,LIB,Tracey Quint and Ashley Strand,71
+McCook,Governor,,REP,Kristi Noem and Larry Rhoden,1851
+McPherson,Governor,,DEM,Jamie Smith and Jennifer Keintz,167
+McPherson,Governor,,LIB,Tracey Quint and Ashley Strand,22
+McPherson,Governor,,REP,Kristi Noem and Larry Rhoden,911
+Meade,Governor,,DEM,Jamie Smith and Jennifer Keintz,2887
+Meade,Governor,,LIB,Tracey Quint and Ashley Strand,501
+Meade,Governor,,REP,Kristi Noem and Larry Rhoden,8482
+Mellette,Governor,,DEM,Jamie Smith and Jennifer Keintz,214
+Mellette,Governor,,LIB,Tracey Quint and Ashley Strand,30
+Mellette,Governor,,REP,Kristi Noem and Larry Rhoden,386
+Miner,Governor,,DEM,Jamie Smith and Jennifer Keintz,248
+Miner,Governor,,LIB,Tracey Quint and Ashley Strand,27
+Miner,Governor,,REP,Kristi Noem and Larry Rhoden,732
+Minnehaha,Governor,,DEM,Jamie Smith and Jennifer Keintz,33376
+Minnehaha,Governor,,LIB,Tracey Quint and Ashley Strand,2072
+Minnehaha,Governor,,REP,Kristi Noem and Larry Rhoden,39234
+Moody,Governor,,DEM,Jamie Smith and Jennifer Keintz,910
+Moody,Governor,,LIB,Tracey Quint and Ashley Strand,71
+Moody,Governor,,REP,Kristi Noem and Larry Rhoden,1668
+Oglala Lakota,Governor,,DEM,Jamie Smith and Jennifer Keintz,2172
+Oglala Lakota,Governor,,LIB,Tracey Quint and Ashley Strand,87
+Oglala Lakota,Governor,,REP,Kristi Noem and Larry Rhoden,221
+Pennington,Governor,,DEM,Jamie Smith and Jennifer Keintz,16215
+Pennington,Governor,,LIB,Tracey Quint and Ashley Strand,1587
+Pennington,Governor,,REP,Kristi Noem and Larry Rhoden,27586
+Perkins,Governor,,DEM,Jamie Smith and Jennifer Keintz,177
+Perkins,Governor,,LIB,Tracey Quint and Ashley Strand,53
+Perkins,Governor,,REP,Kristi Noem and Larry Rhoden,1142
+Potter,Governor,,DEM,Jamie Smith and Jennifer Keintz,187
+Potter,Governor,,LIB,Tracey Quint and Ashley Strand,20
+Potter,Governor,,REP,Kristi Noem and Larry Rhoden,892
+Roberts,Governor,,DEM,Jamie Smith and Jennifer Keintz,1315
+Roberts,Governor,,LIB,Tracey Quint and Ashley Strand,86
+Roberts,Governor,,REP,Kristi Noem and Larry Rhoden,2164
+Sanborn,Governor,,DEM,Jamie Smith and Jennifer Keintz,226
+Sanborn,Governor,,LIB,Tracey Quint and Ashley Strand,21
+Sanborn,Governor,,REP,Kristi Noem and Larry Rhoden,757
+Spink,Governor,,DEM,Jamie Smith and Jennifer Keintz,765
+Spink,Governor,,LIB,Tracey Quint and Ashley Strand,73
+Spink,Governor,,REP,Kristi Noem and Larry Rhoden,1832
+Stanley,Governor,,DEM,Jamie Smith and Jennifer Keintz,407
+Stanley,Governor,,LIB,Tracey Quint and Ashley Strand,41
+Stanley,Governor,,REP,Kristi Noem and Larry Rhoden,999
+Sully,Governor,,DEM,Jamie Smith and Jennifer Keintz,169
+Sully,Governor,,LIB,Tracey Quint and Ashley Strand,22
+Sully,Governor,,REP,Kristi Noem and Larry Rhoden,597
+Todd,Governor,,DEM,Jamie Smith and Jennifer Keintz,1444
+Todd,Governor,,LIB,Tracey Quint and Ashley Strand,80
+Todd,Governor,,REP,Kristi Noem and Larry Rhoden,402
+Tripp,Governor,,DEM,Jamie Smith and Jennifer Keintz,364
+Tripp,Governor,,LIB,Tracey Quint and Ashley Strand,31
+Tripp,Governor,,REP,Kristi Noem and Larry Rhoden,1873
+Turner,Governor,,DEM,Jamie Smith and Jennifer Keintz,919
+Turner,Governor,,LIB,Tracey Quint and Ashley Strand,112
+Turner,Governor,,REP,Kristi Noem and Larry Rhoden,2834
+Union,Governor,,DEM,Jamie Smith and Jennifer Keintz,1848
+Union,Governor,,LIB,Tracey Quint and Ashley Strand,169
+Union,Governor,,REP,Kristi Noem and Larry Rhoden,4723
+Walworth,Governor,,DEM,Jamie Smith and Jennifer Keintz,430
+Walworth,Governor,,LIB,Tracey Quint and Ashley Strand,50
+Walworth,Governor,,REP,Kristi Noem and Larry Rhoden,1573
+Yankton,Governor,,DEM,Jamie Smith and Jennifer Keintz,3350
+Yankton,Governor,,LIB,Tracey Quint and Ashley Strand,313
+Yankton,Governor,,REP,Kristi Noem and Larry Rhoden,5247
+Ziebach,Governor,,DEM,Jamie Smith and Jennifer Keintz,304
+Ziebach,Governor,,LIB,Tracey Quint and Ashley Strand,34
+Ziebach,Governor,,REP,Kristi Noem and Larry Rhoden,345
+Aurora,Secretary of State,,DEM,Thomas A Cool,351
+Aurora,Secretary of State,,REP,Monae Johnson,785
+Beadle,Secretary of State,,DEM,Thomas A Cool,1792
+Beadle,Secretary of State,,REP,Monae Johnson,3807
+Bennett,Secretary of State,,DEM,Thomas A Cool,368
+Bennett,Secretary of State,,REP,Monae Johnson,593
+Bon Homme,Secretary of State,,DEM,Thomas A Cool,714
+Bon Homme,Secretary of State,,REP,Monae Johnson,1717
+Brookings,Secretary of State,,DEM,Thomas A Cool,4861
+Brookings,Secretary of State,,REP,Monae Johnson,6874
+Brown,Secretary of State,,DEM,Thomas A Cool,5184
+Brown,Secretary of State,,REP,Monae Johnson,8007
+Brule,Secretary of State,,DEM,Thomas A Cool,653
+Brule,Secretary of State,,REP,Monae Johnson,1330
+Buffalo,Secretary of State,,DEM,Thomas A Cool,244
+Buffalo,Secretary of State,,REP,Monae Johnson,134
+Butte,Secretary of State,,DEM,Thomas A Cool,824
+Butte,Secretary of State,,REP,Monae Johnson,3225
+Campbell,Secretary of State,,DEM,Thomas A Cool,95
+Campbell,Secretary of State,,REP,Monae Johnson,542
+Charles Mix,Secretary of State,,DEM,Thomas A Cool,1063
+Charles Mix,Secretary of State,,REP,Monae Johnson,1919
+Clark,Secretary of State,,DEM,Thomas A Cool,381
+Clark,Secretary of State,,REP,Monae Johnson,1091
+Clay,Secretary of State,,DEM,Thomas A Cool,2417
+Clay,Secretary of State,,REP,Monae Johnson,2029
+Codington,Secretary of State,,DEM,Thomas A Cool,3157
+Codington,Secretary of State,,REP,Monae Johnson,7162
+Corson,Secretary of State,,DEM,Thomas A Cool,385
+Corson,Secretary of State,,REP,Monae Johnson,513
+Custer,Secretary of State,,DEM,Thomas A Cool,1243
+Custer,Secretary of State,,REP,Monae Johnson,3660
+Davison,Secretary of State,,DEM,Thomas A Cool,2230
+Davison,Secretary of State,,REP,Monae Johnson,4680
+Day,Secretary of State,,DEM,Thomas A Cool,919
+Day,Secretary of State,,REP,Monae Johnson,1456
+Deuel,Secretary of State,,DEM,Thomas A Cool,540
+Deuel,Secretary of State,,REP,Monae Johnson,1359
+Dewey,Secretary of State,,DEM,Thomas A Cool,884
+Dewey,Secretary of State,,REP,Monae Johnson,628
+Douglas,Secretary of State,,DEM,Thomas A Cool,207
+Douglas,Secretary of State,,REP,Monae Johnson,1189
+Edmunds,Secretary of State,,DEM,Thomas A Cool,379
+Edmunds,Secretary of State,,REP,Monae Johnson,1215
+Fall River,Secretary of State,,DEM,Thomas A Cool,898
+Fall River,Secretary of State,,REP,Monae Johnson,2646
+Faulk,Secretary of State,,DEM,Thomas A Cool,193
+Faulk,Secretary of State,,REP,Monae Johnson,712
+Grant,Secretary of State,,DEM,Thomas A Cool,853
+Grant,Secretary of State,,REP,Monae Johnson,2177
+Gregory,Secretary of State,,DEM,Thomas A Cool,462
+Gregory,Secretary of State,,REP,Monae Johnson,1497
+Haakon,Secretary of State,,DEM,Thomas A Cool,94
+Haakon,Secretary of State,,REP,Monae Johnson,856
+Hamlin,Secretary of State,,DEM,Thomas A Cool,551
+Hamlin,Secretary of State,,REP,Monae Johnson,2021
+Hand,Secretary of State,,DEM,Thomas A Cool,308
+Hand,Secretary of State,,REP,Monae Johnson,1134
+Hanson,Secretary of State,,DEM,Thomas A Cool,370
+Hanson,Secretary of State,,REP,Monae Johnson,1172
+Harding,Secretary of State,,DEM,Thomas A Cool,46
+Harding,Secretary of State,,REP,Monae Johnson,605
+Hughes,Secretary of State,,DEM,Thomas A Cool,2563
+Hughes,Secretary of State,,REP,Monae Johnson,4563
+Hutchinson,Secretary of State,,DEM,Thomas A Cool,659
+Hutchinson,Secretary of State,,REP,Monae Johnson,2342
+Hyde,Secretary of State,,DEM,Thomas A Cool,137
+Hyde,Secretary of State,,REP,Monae Johnson,412
+Jackson,Secretary of State,,DEM,Thomas A Cool,279
+Jackson,Secretary of State,,REP,Monae Johnson,618
+Jerauld,Secretary of State,,DEM,Thomas A Cool,265
+Jerauld,Secretary of State,,REP,Monae Johnson,539
+Jones,Secretary of State,,DEM,Thomas A Cool,66
+Jones,Secretary of State,,REP,Monae Johnson,391
+Kingsbury,Secretary of State,,DEM,Thomas A Cool,720
+Kingsbury,Secretary of State,,REP,Monae Johnson,1673
+Lake,Secretary of State,,DEM,Thomas A Cool,1679
+Lake,Secretary of State,,REP,Monae Johnson,3007
+Lawrence,Secretary of State,,DEM,Thomas A Cool,3831
+Lawrence,Secretary of State,,REP,Monae Johnson,7812
+Lincoln,Secretary of State,,DEM,Thomas A Cool,9916
+Lincoln,Secretary of State,,REP,Monae Johnson,16642
+Lyman,Secretary of State,,DEM,Thomas A Cool,404
+Lyman,Secretary of State,,REP,Monae Johnson,831
+Marshall,Secretary of State,,DEM,Thomas A Cool,751
+Marshall,Secretary of State,,REP,Monae Johnson,1036
+McCook,Secretary of State,,DEM,Thomas A Cool,669
+McCook,Secretary of State,,REP,Monae Johnson,1735
+McPherson,Secretary of State,,DEM,Thomas A Cool,171
+McPherson,Secretary of State,,REP,Monae Johnson,895
+Meade,Secretary of State,,DEM,Thomas A Cool,2732
+Meade,Secretary of State,,REP,Monae Johnson,8607
+Mellette,Secretary of State,,DEM,Thomas A Cool,231
+Mellette,Secretary of State,,REP,Monae Johnson,374
+Miner,Secretary of State,,DEM,Thomas A Cool,296
+Miner,Secretary of State,,REP,Monae Johnson,629
+Minnehaha,Secretary of State,,DEM,Thomas A Cool,31534
+Minnehaha,Secretary of State,,REP,Monae Johnson,38912
+Moody,Secretary of State,,DEM,Thomas A Cool,980
+Moody,Secretary of State,,REP,Monae Johnson,1553
+Oglala Lakota,Secretary of State,,DEM,Thomas A Cool,2112
+Oglala Lakota,Secretary of State,,REP,Monae Johnson,291
+Pennington,Secretary of State,,DEM,Thomas A Cool,15242
+Pennington,Secretary of State,,REP,Monae Johnson,28228
+Perkins,Secretary of State,,DEM,Thomas A Cool,196
+Perkins,Secretary of State,,REP,Monae Johnson,1110
+Potter,Secretary of State,,DEM,Thomas A Cool,201
+Potter,Secretary of State,,REP,Monae Johnson,851
+Roberts,Secretary of State,,DEM,Thomas A Cool,1411
+Roberts,Secretary of State,,REP,Monae Johnson,1970
+Sanborn,Secretary of State,,DEM,Thomas A Cool,255
+Sanborn,Secretary of State,,REP,Monae Johnson,692
+Spink,Secretary of State,,DEM,Thomas A Cool,824
+Spink,Secretary of State,,REP,Monae Johnson,1723
+Stanley,Secretary of State,,DEM,Thomas A Cool,395
+Stanley,Secretary of State,,REP,Monae Johnson,993
+Sully,Secretary of State,,DEM,Thomas A Cool,169
+Sully,Secretary of State,,REP,Monae Johnson,584
+Todd,Secretary of State,,DEM,Thomas A Cool,1448
+Todd,Secretary of State,,REP,Monae Johnson,435
+Tripp,Secretary of State,,DEM,Thomas A Cool,417
+Tripp,Secretary of State,,REP,Monae Johnson,1800
+Turner,Secretary of State,,DEM,Thomas A Cool,966
+Turner,Secretary of State,,REP,Monae Johnson,2731
+Union,Secretary of State,,DEM,Thomas A Cool,1851
+Union,Secretary of State,,REP,Monae Johnson,4653
+Walworth,Secretary of State,,DEM,Thomas A Cool,436
+Walworth,Secretary of State,,REP,Monae Johnson,1520
+Yankton,Secretary of State,,DEM,Thomas A Cool,3182
+Yankton,Secretary of State,,REP,Monae Johnson,5142
+Ziebach,Secretary of State,,DEM,Thomas A Cool,321
+Ziebach,Secretary of State,,REP,Monae Johnson,319
+Aurora,Attorney General,,REP,Marty J. Jackley,875
+Beadle,Attorney General,,REP,Marty J. Jackley,4710
+Bennett,Attorney General,,REP,Marty J. Jackley,689
+Bon Homme,Attorney General,,REP,Marty J. Jackley,1963
+Brookings,Attorney General,,REP,Marty J. Jackley,8904
+Brown,Attorney General,,REP,Marty J. Jackley,10228
+Brule,Attorney General,,REP,Marty J. Jackley,1606
+Buffalo,Attorney General,,REP,Marty J. Jackley,209
+Butte,Attorney General,,REP,Marty J. Jackley,3424
+Campbell,Attorney General,,REP,Marty J. Jackley,576
+Charles Mix,Attorney General,,REP,Marty J. Jackley,2239
+Clark,Attorney General,,REP,Marty J. Jackley,1273
+Clay,Attorney General,,REP,Marty J. Jackley,2843
+Codington,Attorney General,,REP,Marty J. Jackley,8609
+Corson,Attorney General,,REP,Marty J. Jackley,570
+Custer,Attorney General,,REP,Marty J. Jackley,3920
+Davison,Attorney General,,REP,Marty J. Jackley,5686
+Day,Attorney General,,REP,Marty J. Jackley,1907
+Deuel,Attorney General,,REP,Marty J. Jackley,1646
+Dewey,Attorney General,,REP,Marty J. Jackley,893
+Douglas,Attorney General,,REP,Marty J. Jackley,1200
+Edmunds,Attorney General,,REP,Marty J. Jackley,1398
+Fall River,Attorney General,,REP,Marty J. Jackley,2864
+Faulk,Attorney General,,REP,Marty J. Jackley,797
+Grant,Attorney General,,REP,Marty J. Jackley,2529
+Gregory,Attorney General,,REP,Marty J. Jackley,1635
+Haakon,Attorney General,,REP,Marty J. Jackley,870
+Hamlin,Attorney General,,REP,Marty J. Jackley,2246
+Hand,Attorney General,,REP,Marty J. Jackley,1266
+Hanson,Attorney General,,REP,Marty J. Jackley,1300
+Harding,Attorney General,,REP,Marty J. Jackley,609
+Hughes,Attorney General,,REP,Marty J. Jackley,6015
+Hutchinson,Attorney General,,REP,Marty J. Jackley,2634
+Hyde,Attorney General,,REP,Marty J. Jackley,500
+Jackson,Attorney General,,REP,Marty J. Jackley,688
+Jerauld,Attorney General,,REP,Marty J. Jackley,697
+Jones,Attorney General,,REP,Marty J. Jackley,405
+Kingsbury,Attorney General,,REP,Marty J. Jackley,2054
+Lake,Attorney General,,REP,Marty J. Jackley,3888
+Lawrence,Attorney General,,REP,Marty J. Jackley,9058
+Lincoln,Attorney General,,REP,Marty J. Jackley,20847
+Lyman,Attorney General,,REP,Marty J. Jackley,984
+Marshall,Attorney General,,REP,Marty J. Jackley,1351
+McCook,Attorney General,,REP,Marty J. Jackley,2036
+McPherson,Attorney General,,REP,Marty J. Jackley,968
+Meade,Attorney General,,REP,Marty J. Jackley,9633
+Mellette,Attorney General,,REP,Marty J. Jackley,458
+Miner,Attorney General,,REP,Marty J. Jackley,803
+Minnehaha,Attorney General,,REP,Marty J. Jackley,50574
+Moody,Attorney General,,REP,Marty J. Jackley,1908
+Oglala Lakota,Attorney General,,REP,Marty J. Jackley,663
+Pennington,Attorney General,,REP,Marty J. Jackley,32984
+Perkins,Attorney General,,REP,Marty J. Jackley,1119
+Potter,Attorney General,,REP,Marty J. Jackley,934
+Roberts,Attorney General,,REP,Marty J. Jackley,2556
+Sanborn,Attorney General,,REP,Marty J. Jackley,810
+Spink,Attorney General,,REP,Marty J. Jackley,2151
+Stanley,Attorney General,,REP,Marty J. Jackley,1198
+Sully,Attorney General,,REP,Marty J. Jackley,667
+Todd,Attorney General,,REP,Marty J. Jackley,796
+Tripp,Attorney General,,REP,Marty J. Jackley,1876
+Turner,Attorney General,,REP,Marty J. Jackley,3121
+Union,Attorney General,,REP,Marty J. Jackley,5121
+Walworth,Attorney General,,REP,Marty J. Jackley,1691
+Yankton,Attorney General,,REP,Marty J. Jackley,6347
+Ziebach,Attorney General,,REP,Marty J. Jackley,400
+Aurora,State Auditor,,DEM,Stephanie Marty,282
+Aurora,State Auditor,,LIB,Rene Meyer,76
+Aurora,State Auditor,,REP,Richard Sattgast,771
+Beadle,State Auditor,,DEM,Stephanie Marty,1464
+Beadle,State Auditor,,LIB,Rene Meyer,224
+Beadle,State Auditor,,REP,Richard Sattgast,3938
+Bennett,State Auditor,,DEM,Stephanie Marty,367
+Bennett,State Auditor,,LIB,Rene Meyer,48
+Bennett,State Auditor,,REP,Richard Sattgast,547
+Bon Homme,State Auditor,,DEM,Stephanie Marty,606
+Bon Homme,State Auditor,,LIB,Rene Meyer,101
+Bon Homme,State Auditor,,REP,Richard Sattgast,1684
+Brookings,State Auditor,,DEM,Stephanie Marty,4246
+Brookings,State Auditor,,LIB,Rene Meyer,709
+Brookings,State Auditor,,REP,Richard Sattgast,6602
+Brown,State Auditor,,DEM,Stephanie Marty,4637
+Brown,State Auditor,,LIB,Rene Meyer,671
+Brown,State Auditor,,REP,Richard Sattgast,7838
+Brule,State Auditor,,DEM,Stephanie Marty,527
+Brule,State Auditor,,LIB,Rene Meyer,106
+Brule,State Auditor,,REP,Richard Sattgast,1339
+Buffalo,State Auditor,,DEM,Stephanie Marty,231
+Buffalo,State Auditor,,LIB,Rene Meyer,21
+Buffalo,State Auditor,,REP,Richard Sattgast,130
+Butte,State Auditor,,DEM,Stephanie Marty,739
+Butte,State Auditor,,LIB,Rene Meyer,276
+Butte,State Auditor,,REP,Richard Sattgast,3016
+Campbell,State Auditor,,DEM,Stephanie Marty,84
+Campbell,State Auditor,,LIB,Rene Meyer,25
+Campbell,State Auditor,,REP,Richard Sattgast,529
+Charles Mix,State Auditor,,DEM,Stephanie Marty,856
+Charles Mix,State Auditor,,LIB,Rene Meyer,112
+Charles Mix,State Auditor,,REP,Richard Sattgast,1963
+Clark,State Auditor,,DEM,Stephanie Marty,333
+Clark,State Auditor,,LIB,Rene Meyer,65
+Clark,State Auditor,,REP,Richard Sattgast,1082
+Clay,State Auditor,,DEM,Stephanie Marty,2230
+Clay,State Auditor,,LIB,Rene Meyer,185
+Clay,State Auditor,,REP,Richard Sattgast,2017
+Codington,State Auditor,,DEM,Stephanie Marty,2836
+Codington,State Auditor,,LIB,Rene Meyer,540
+Codington,State Auditor,,REP,Richard Sattgast,6857
+Corson,State Auditor,,DEM,Stephanie Marty,377
+Corson,State Auditor,,LIB,Rene Meyer,55
+Corson,State Auditor,,REP,Richard Sattgast,461
+Custer,State Auditor,,DEM,Stephanie Marty,1159
+Custer,State Auditor,,LIB,Rene Meyer,298
+Custer,State Auditor,,REP,Richard Sattgast,3435
+Davison,State Auditor,,DEM,Stephanie Marty,1874
+Davison,State Auditor,,LIB,Rene Meyer,318
+Davison,State Auditor,,REP,Richard Sattgast,4663
+Day,State Auditor,,DEM,Stephanie Marty,826
+Day,State Auditor,,LIB,Rene Meyer,125
+Day,State Auditor,,REP,Richard Sattgast,1423
+Deuel,State Auditor,,DEM,Stephanie Marty,463
+Deuel,State Auditor,,LIB,Rene Meyer,99
+Deuel,State Auditor,,REP,Richard Sattgast,1325
+Dewey,State Auditor,,DEM,Stephanie Marty,841
+Dewey,State Auditor,,LIB,Rene Meyer,90
+Dewey,State Auditor,,REP,Richard Sattgast,570
+Douglas,State Auditor,,DEM,Stephanie Marty,165
+Douglas,State Auditor,,LIB,Rene Meyer,25
+Douglas,State Auditor,,REP,Richard Sattgast,1185
+Edmunds,State Auditor,,DEM,Stephanie Marty,327
+Edmunds,State Auditor,,LIB,Rene Meyer,51
+Edmunds,State Auditor,,REP,Richard Sattgast,1205
+Fall River,State Auditor,,DEM,Stephanie Marty,800
+Fall River,State Auditor,,LIB,Rene Meyer,242
+Fall River,State Auditor,,REP,Richard Sattgast,2499
+Faulk,State Auditor,,DEM,Stephanie Marty,153
+Faulk,State Auditor,,LIB,Rene Meyer,31
+Faulk,State Auditor,,REP,Richard Sattgast,723
+Grant,State Auditor,,DEM,Stephanie Marty,767
+Grant,State Auditor,,LIB,Rene Meyer,147
+Grant,State Auditor,,REP,Richard Sattgast,2084
+Gregory,State Auditor,,DEM,Stephanie Marty,377
+Gregory,State Auditor,,LIB,Rene Meyer,80
+Gregory,State Auditor,,REP,Richard Sattgast,1475
+Haakon,State Auditor,,DEM,Stephanie Marty,78
+Haakon,State Auditor,,LIB,Rene Meyer,35
+Haakon,State Auditor,,REP,Richard Sattgast,826
+Hamlin,State Auditor,,DEM,Stephanie Marty,472
+Hamlin,State Auditor,,LIB,Rene Meyer,105
+Hamlin,State Auditor,,REP,Richard Sattgast,1975
+Hand,State Auditor,,DEM,Stephanie Marty,259
+Hand,State Auditor,,LIB,Rene Meyer,60
+Hand,State Auditor,,REP,Richard Sattgast,1124
+Hanson,State Auditor,,DEM,Stephanie Marty,310
+Hanson,State Auditor,,LIB,Rene Meyer,65
+Hanson,State Auditor,,REP,Richard Sattgast,1169
+Harding,State Auditor,,DEM,Stephanie Marty,57
+Harding,State Auditor,,LIB,Rene Meyer,37
+Harding,State Auditor,,REP,Richard Sattgast,562
+Hughes,State Auditor,,DEM,Stephanie Marty,1788
+Hughes,State Auditor,,LIB,Rene Meyer,360
+Hughes,State Auditor,,REP,Richard Sattgast,5118
+Hutchinson,State Auditor,,DEM,Stephanie Marty,548
+Hutchinson,State Auditor,,LIB,Rene Meyer,119
+Hutchinson,State Auditor,,REP,Richard Sattgast,2283
+Hyde,State Auditor,,DEM,Stephanie Marty,105
+Hyde,State Auditor,,LIB,Rene Meyer,22
+Hyde,State Auditor,,REP,Richard Sattgast,429
+Jackson,State Auditor,,DEM,Stephanie Marty,263
+Jackson,State Auditor,,LIB,Rene Meyer,48
+Jackson,State Auditor,,REP,Richard Sattgast,577
+Jerauld,State Auditor,,DEM,Stephanie Marty,208
+Jerauld,State Auditor,,LIB,Rene Meyer,24
+Jerauld,State Auditor,,REP,Richard Sattgast,579
+Jones,State Auditor,,DEM,Stephanie Marty,50
+Jones,State Auditor,,LIB,Rene Meyer,22
+Jones,State Auditor,,REP,Richard Sattgast,385
+Kingsbury,State Auditor,,DEM,Stephanie Marty,583
+Kingsbury,State Auditor,,LIB,Rene Meyer,97
+Kingsbury,State Auditor,,REP,Richard Sattgast,1696
+Lake,State Auditor,,DEM,Stephanie Marty,1432
+Lake,State Auditor,,LIB,Rene Meyer,195
+Lake,State Auditor,,REP,Richard Sattgast,3001
+Lawrence,State Auditor,,DEM,Stephanie Marty,3362
+Lawrence,State Auditor,,LIB,Rene Meyer,780
+Lawrence,State Auditor,,REP,Richard Sattgast,7544
+Lincoln,State Auditor,,DEM,Stephanie Marty,8461
+Lincoln,State Auditor,,LIB,Rene Meyer,1144
+Lincoln,State Auditor,,REP,Richard Sattgast,16689
+Lyman,State Auditor,,DEM,Stephanie Marty,346
+Lyman,State Auditor,,LIB,Rene Meyer,62
+Lyman,State Auditor,,REP,Richard Sattgast,815
+Marshall,State Auditor,,DEM,Stephanie Marty,662
+Marshall,State Auditor,,LIB,Rene Meyer,77
+Marshall,State Auditor,,REP,Richard Sattgast,1018
+McCook,State Auditor,,DEM,Stephanie Marty,565
+McCook,State Auditor,,LIB,Rene Meyer,116
+McCook,State Auditor,,REP,Richard Sattgast,1707
+McPherson,State Auditor,,DEM,Stephanie Marty,144
+McPherson,State Auditor,,LIB,Rene Meyer,38
+McPherson,State Auditor,,REP,Richard Sattgast,869
+Meade,State Auditor,,DEM,Stephanie Marty,2386
+Meade,State Auditor,,LIB,Rene Meyer,902
+Meade,State Auditor,,REP,Richard Sattgast,7954
+Mellette,State Auditor,,DEM,Stephanie Marty,207
+Mellette,State Auditor,,LIB,Rene Meyer,38
+Mellette,State Auditor,,REP,Richard Sattgast,353
+Miner,State Auditor,,DEM,Stephanie Marty,231
+Miner,State Auditor,,LIB,Rene Meyer,37
+Miner,State Auditor,,REP,Richard Sattgast,651
+Minnehaha,State Auditor,,DEM,Stephanie Marty,27615
+Minnehaha,State Auditor,,LIB,Rene Meyer,3714
+Minnehaha,State Auditor,,REP,Richard Sattgast,38329
+Moody,State Auditor,,DEM,Stephanie Marty,882
+Moody,State Auditor,,LIB,Rene Meyer,135
+Moody,State Auditor,,REP,Richard Sattgast,1489
+Oglala Lakota,State Auditor,,DEM,Stephanie Marty,2061
+Oglala Lakota,State Auditor,,LIB,Rene Meyer,132
+Oglala Lakota,State Auditor,,REP,Richard Sattgast,199
+Pennington,State Auditor,,DEM,Stephanie Marty,13745
+Pennington,State Auditor,,LIB,Rene Meyer,2995
+Pennington,State Auditor,,REP,Richard Sattgast,26360
+Perkins,State Auditor,,DEM,Stephanie Marty,197
+Perkins,State Auditor,,LIB,Rene Meyer,81
+Perkins,State Auditor,,REP,Richard Sattgast,1019
+Potter,State Auditor,,DEM,Stephanie Marty,153
+Potter,State Auditor,,LIB,Rene Meyer,39
+Potter,State Auditor,,REP,Richard Sattgast,853
+Roberts,State Auditor,,DEM,Stephanie Marty,1331
+Roberts,State Auditor,,LIB,Rene Meyer,151
+Roberts,State Auditor,,REP,Richard Sattgast,1873
+Sanborn,State Auditor,,DEM,Stephanie Marty,201
+Sanborn,State Auditor,,LIB,Rene Meyer,43
+Sanborn,State Auditor,,REP,Richard Sattgast,700
+Spink,State Auditor,,DEM,Stephanie Marty,691
+Spink,State Auditor,,LIB,Rene Meyer,116
+Spink,State Auditor,,REP,Richard Sattgast,1743
+Stanley,State Auditor,,DEM,Stephanie Marty,294
+Stanley,State Auditor,,LIB,Rene Meyer,93
+Stanley,State Auditor,,REP,Richard Sattgast,1020
+Sully,State Auditor,,DEM,Stephanie Marty,134
+Sully,State Auditor,,LIB,Rene Meyer,33
+Sully,State Auditor,,REP,Richard Sattgast,598
+Todd,State Auditor,,DEM,Stephanie Marty,1380
+Todd,State Auditor,,LIB,Rene Meyer,131
+Todd,State Auditor,,REP,Richard Sattgast,364
+Tripp,State Auditor,,DEM,Stephanie Marty,364
+Tripp,State Auditor,,LIB,Rene Meyer,108
+Tripp,State Auditor,,REP,Richard Sattgast,1612
+Turner,State Auditor,,DEM,Stephanie Marty,799
+Turner,State Auditor,,LIB,Rene Meyer,212
+Turner,State Auditor,,REP,Richard Sattgast,2647
+Union,State Auditor,,DEM,Stephanie Marty,1729
+Union,State Auditor,,LIB,Rene Meyer,312
+Union,State Auditor,,REP,Richard Sattgast,4457
+Walworth,State Auditor,,DEM,Stephanie Marty,401
+Walworth,State Auditor,,LIB,Rene Meyer,76
+Walworth,State Auditor,,REP,Richard Sattgast,1474
+Yankton,State Auditor,,DEM,Stephanie Marty,2812
+Yankton,State Auditor,,LIB,Rene Meyer,465
+Yankton,State Auditor,,REP,Richard Sattgast,4921
+Ziebach,State Auditor,,DEM,Stephanie Marty,290
+Ziebach,State Auditor,,LIB,Rene Meyer,62
+Ziebach,State Auditor,,REP,Richard Sattgast,290
+Aurora,State Treasurer,,DEM,John Cunningham,302
+Aurora,State Treasurer,,REP,Josh Haeder,811
+Beadle,State Treasurer,,DEM,John Cunningham,1106
+Beadle,State Treasurer,,REP,Josh Haeder,4656
+Bennett,State Treasurer,,DEM,John Cunningham,374
+Bennett,State Treasurer,,REP,Josh Haeder,582
+Bon Homme,State Treasurer,,DEM,John Cunningham,622
+Bon Homme,State Treasurer,,REP,Josh Haeder,1745
+Brookings,State Treasurer,,DEM,John Cunningham,4356
+Brookings,State Treasurer,,REP,Josh Haeder,7096
+Brown,State Treasurer,,DEM,John Cunningham,4657
+Brown,State Treasurer,,REP,Josh Haeder,8482
+Brule,State Treasurer,,DEM,John Cunningham,568
+Brule,State Treasurer,,REP,Josh Haeder,1375
+Buffalo,State Treasurer,,DEM,John Cunningham,236
+Buffalo,State Treasurer,,REP,Josh Haeder,139
+Butte,State Treasurer,,DEM,John Cunningham,769
+Butte,State Treasurer,,REP,Josh Haeder,3217
+Campbell,State Treasurer,,DEM,John Cunningham,83
+Campbell,State Treasurer,,REP,Josh Haeder,553
+Charles Mix,State Treasurer,,DEM,John Cunningham,886
+Charles Mix,State Treasurer,,REP,Josh Haeder,2014
+Clark,State Treasurer,,DEM,John Cunningham,333
+Clark,State Treasurer,,REP,Josh Haeder,1128
+Clay,State Treasurer,,DEM,John Cunningham,2282
+Clay,State Treasurer,,REP,Josh Haeder,2116
+Codington,State Treasurer,,DEM,John Cunningham,2972
+Codington,State Treasurer,,REP,Josh Haeder,7203
+Corson,State Treasurer,,DEM,John Cunningham,387
+Corson,State Treasurer,,REP,Josh Haeder,499
+Custer,State Treasurer,,DEM,John Cunningham,1172
+Custer,State Treasurer,,REP,Josh Haeder,3680
+Davison,State Treasurer,,DEM,John Cunningham,2015
+Davison,State Treasurer,,REP,Josh Haeder,4761
+Day,State Treasurer,,DEM,John Cunningham,843
+Day,State Treasurer,,REP,Josh Haeder,1502
+Deuel,State Treasurer,,DEM,John Cunningham,470
+Deuel,State Treasurer,,REP,Josh Haeder,1412
+Dewey,State Treasurer,,DEM,John Cunningham,882
+Dewey,State Treasurer,,REP,Josh Haeder,611
+Douglas,State Treasurer,,DEM,John Cunningham,163
+Douglas,State Treasurer,,REP,Josh Haeder,1210
+Edmunds,State Treasurer,,DEM,John Cunningham,346
+Edmunds,State Treasurer,,REP,Josh Haeder,1230
+Fall River,State Treasurer,,DEM,John Cunningham,827
+Fall River,State Treasurer,,REP,Josh Haeder,2685
+Faulk,State Treasurer,,DEM,John Cunningham,167
+Faulk,State Treasurer,,REP,Josh Haeder,730
+Grant,State Treasurer,,DEM,John Cunningham,776
+Grant,State Treasurer,,REP,Josh Haeder,2201
+Gregory,State Treasurer,,DEM,John Cunningham,391
+Gregory,State Treasurer,,REP,Josh Haeder,1533
+Haakon,State Treasurer,,DEM,John Cunningham,84
+Haakon,State Treasurer,,REP,Josh Haeder,846
+Hamlin,State Treasurer,,DEM,John Cunningham,491
+Hamlin,State Treasurer,,REP,Josh Haeder,2034
+Hand,State Treasurer,,DEM,John Cunningham,226
+Hand,State Treasurer,,REP,Josh Haeder,1219
+Hanson,State Treasurer,,DEM,John Cunningham,307
+Hanson,State Treasurer,,REP,Josh Haeder,1216
+Harding,State Treasurer,,DEM,John Cunningham,39
+Harding,State Treasurer,,REP,Josh Haeder,612
+Hughes,State Treasurer,,DEM,John Cunningham,1892
+Hughes,State Treasurer,,REP,Josh Haeder,5304
+Hutchinson,State Treasurer,,DEM,John Cunningham,569
+Hutchinson,State Treasurer,,REP,Josh Haeder,2385
+Hyde,State Treasurer,,DEM,John Cunningham,109
+Hyde,State Treasurer,,REP,Josh Haeder,442
+Jackson,State Treasurer,,DEM,John Cunningham,280
+Jackson,State Treasurer,,REP,Josh Haeder,609
+Jerauld,State Treasurer,,DEM,John Cunningham,177
+Jerauld,State Treasurer,,REP,Josh Haeder,640
+Jones,State Treasurer,,DEM,John Cunningham,53
+Jones,State Treasurer,,REP,Josh Haeder,397
+Kingsbury,State Treasurer,,DEM,John Cunningham,579
+Kingsbury,State Treasurer,,REP,Josh Haeder,1780
+Lake,State Treasurer,,DEM,John Cunningham,1461
+Lake,State Treasurer,,REP,Josh Haeder,3092
+Lawrence,State Treasurer,,DEM,John Cunningham,3572
+Lawrence,State Treasurer,,REP,Josh Haeder,7982
+Lincoln,State Treasurer,,DEM,John Cunningham,8584
+Lincoln,State Treasurer,,REP,Josh Haeder,17433
+Lyman,State Treasurer,,DEM,John Cunningham,371
+Lyman,State Treasurer,,REP,Josh Haeder,836
+Marshall,State Treasurer,,DEM,John Cunningham,687
+Marshall,State Treasurer,,REP,Josh Haeder,1056
+McCook,State Treasurer,,DEM,John Cunningham,605
+McCook,State Treasurer,,REP,Josh Haeder,1752
+McPherson,State Treasurer,,DEM,John Cunningham,148
+McPherson,State Treasurer,,REP,Josh Haeder,906
+Meade,State Treasurer,,DEM,John Cunningham,2586
+Meade,State Treasurer,,REP,Josh Haeder,8576
+Mellette,State Treasurer,,DEM,John Cunningham,213
+Mellette,State Treasurer,,REP,Josh Haeder,383
+Miner,State Treasurer,,DEM,John Cunningham,242
+Miner,State Treasurer,,REP,Josh Haeder,651
+Minnehaha,State Treasurer,,DEM,John Cunningham,28313
+Minnehaha,State Treasurer,,REP,Josh Haeder,40546
+Moody,State Treasurer,,DEM,John Cunningham,903
+Moody,State Treasurer,,REP,Josh Haeder,1575
+Oglala Lakota,State Treasurer,,DEM,John Cunningham,2132
+Oglala Lakota,State Treasurer,,REP,Josh Haeder,243
+Pennington,State Treasurer,,DEM,John Cunningham,14138
+Pennington,State Treasurer,,REP,Josh Haeder,28661
+Perkins,State Treasurer,,DEM,John Cunningham,173
+Perkins,State Treasurer,,REP,Josh Haeder,1098
+Potter,State Treasurer,,DEM,John Cunningham,165
+Potter,State Treasurer,,REP,Josh Haeder,871
+Roberts,State Treasurer,,DEM,John Cunningham,1371
+Roberts,State Treasurer,,REP,Josh Haeder,1956
+Sanborn,State Treasurer,,DEM,John Cunningham,193
+Sanborn,State Treasurer,,REP,Josh Haeder,762
+Spink,State Treasurer,,DEM,John Cunningham,704
+Spink,State Treasurer,,REP,Josh Haeder,1837
+Stanley,State Treasurer,,DEM,John Cunningham,314
+Stanley,State Treasurer,,REP,Josh Haeder,1082
+Sully,State Treasurer,,DEM,John Cunningham,142
+Sully,State Treasurer,,REP,Josh Haeder,616
+Todd,State Treasurer,,DEM,John Cunningham,1447
+Todd,State Treasurer,,REP,Josh Haeder,429
+Tripp,State Treasurer,,DEM,John Cunningham,398
+Tripp,State Treasurer,,REP,Josh Haeder,1760
+Turner,State Treasurer,,DEM,John Cunningham,861
+Turner,State Treasurer,,REP,Josh Haeder,2782
+Union,State Treasurer,,DEM,John Cunningham,1768
+Union,State Treasurer,,REP,Josh Haeder,4701
+Walworth,State Treasurer,,DEM,John Cunningham,377
+Walworth,State Treasurer,,REP,Josh Haeder,1570
+Yankton,State Treasurer,,DEM,John Cunningham,2946
+Yankton,State Treasurer,,REP,Josh Haeder,5205
+Ziebach,State Treasurer,,DEM,John Cunningham,311
+Ziebach,State Treasurer,,REP,Josh Haeder,318
+Aurora,Commissioner of School and Public Lands,,DEM,Timothy Azure,282
+Aurora,Commissioner of School and Public Lands,,REP,Brock Greenfield,815
+Beadle,Commissioner of School and Public Lands,,DEM,Timothy Azure,1593
+Beadle,Commissioner of School and Public Lands,,REP,Brock Greenfield,3966
+Bennett,Commissioner of School and Public Lands,,DEM,Timothy Azure,370
+Bennett,Commissioner of School and Public Lands,,REP,Brock Greenfield,572
+Bon Homme,Commissioner of School and Public Lands,,DEM,Timothy Azure,598
+Bon Homme,Commissioner of School and Public Lands,,REP,Brock Greenfield,1753
+Brookings,Commissioner of School and Public Lands,,DEM,Timothy Azure,4329
+Brookings,Commissioner of School and Public Lands,,REP,Brock Greenfield,6965
+Brown,Commissioner of School and Public Lands,,DEM,Timothy Azure,4703
+Brown,Commissioner of School and Public Lands,,REP,Brock Greenfield,8351
+Brule,Commissioner of School and Public Lands,,DEM,Timothy Azure,551
+Brule,Commissioner of School and Public Lands,,REP,Brock Greenfield,1368
+Buffalo,Commissioner of School and Public Lands,,DEM,Timothy Azure,241
+Buffalo,Commissioner of School and Public Lands,,REP,Brock Greenfield,133
+Butte,Commissioner of School and Public Lands,,DEM,Timothy Azure,751
+Butte,Commissioner of School and Public Lands,,REP,Brock Greenfield,3216
+Campbell,Commissioner of School and Public Lands,,DEM,Timothy Azure,81
+Campbell,Commissioner of School and Public Lands,,REP,Brock Greenfield,549
+Charles Mix,Commissioner of School and Public Lands,,DEM,Timothy Azure,858
+Charles Mix,Commissioner of School and Public Lands,,REP,Brock Greenfield,1993
+Clark,Commissioner of School and Public Lands,,DEM,Timothy Azure,400
+Clark,Commissioner of School and Public Lands,,REP,Brock Greenfield,1123
+Clay,Commissioner of School and Public Lands,,DEM,Timothy Azure,2239
+Clay,Commissioner of School and Public Lands,,REP,Brock Greenfield,2085
+Codington,Commissioner of School and Public Lands,,DEM,Timothy Azure,2740
+Codington,Commissioner of School and Public Lands,,REP,Brock Greenfield,7516
+Corson,Commissioner of School and Public Lands,,DEM,Timothy Azure,396
+Corson,Commissioner of School and Public Lands,,REP,Brock Greenfield,500
+Custer,Commissioner of School and Public Lands,,DEM,Timothy Azure,1181
+Custer,Commissioner of School and Public Lands,,REP,Brock Greenfield,3634
+Davison,Commissioner of School and Public Lands,,DEM,Timothy Azure,1863
+Davison,Commissioner of School and Public Lands,,REP,Brock Greenfield,4776
+Day,Commissioner of School and Public Lands,,DEM,Timothy Azure,806
+Day,Commissioner of School and Public Lands,,REP,Brock Greenfield,1523
+Deuel,Commissioner of School and Public Lands,,DEM,Timothy Azure,426
+Deuel,Commissioner of School and Public Lands,,REP,Brock Greenfield,1467
+Dewey,Commissioner of School and Public Lands,,DEM,Timothy Azure,872
+Dewey,Commissioner of School and Public Lands,,REP,Brock Greenfield,614
+Douglas,Commissioner of School and Public Lands,,DEM,Timothy Azure,148
+Douglas,Commissioner of School and Public Lands,,REP,Brock Greenfield,1204
+Edmunds,Commissioner of School and Public Lands,,DEM,Timothy Azure,303
+Edmunds,Commissioner of School and Public Lands,,REP,Brock Greenfield,1257
+Fall River,Commissioner of School and Public Lands,,DEM,Timothy Azure,811
+Fall River,Commissioner of School and Public Lands,,REP,Brock Greenfield,2656
+Faulk,Commissioner of School and Public Lands,,DEM,Timothy Azure,148
+Faulk,Commissioner of School and Public Lands,,REP,Brock Greenfield,746
+Grant,Commissioner of School and Public Lands,,DEM,Timothy Azure,729
+Grant,Commissioner of School and Public Lands,,REP,Brock Greenfield,2213
+Gregory,Commissioner of School and Public Lands,,DEM,Timothy Azure,360
+Gregory,Commissioner of School and Public Lands,,REP,Brock Greenfield,1546
+Haakon,Commissioner of School and Public Lands,,DEM,Timothy Azure,83
+Haakon,Commissioner of School and Public Lands,,REP,Brock Greenfield,850
+Hamlin,Commissioner of School and Public Lands,,DEM,Timothy Azure,524
+Hamlin,Commissioner of School and Public Lands,,REP,Brock Greenfield,2076
+Hand,Commissioner of School and Public Lands,,DEM,Timothy Azure,266
+Hand,Commissioner of School and Public Lands,,REP,Brock Greenfield,1124
+Hanson,Commissioner of School and Public Lands,,DEM,Timothy Azure,300
+Hanson,Commissioner of School and Public Lands,,REP,Brock Greenfield,1188
+Harding,Commissioner of School and Public Lands,,DEM,Timothy Azure,33
+Harding,Commissioner of School and Public Lands,,REP,Brock Greenfield,616
+Hughes,Commissioner of School and Public Lands,,DEM,Timothy Azure,2123
+Hughes,Commissioner of School and Public Lands,,REP,Brock Greenfield,4864
+Hutchinson,Commissioner of School and Public Lands,,DEM,Timothy Azure,530
+Hutchinson,Commissioner of School and Public Lands,,REP,Brock Greenfield,2389
+Hyde,Commissioner of School and Public Lands,,DEM,Timothy Azure,111
+Hyde,Commissioner of School and Public Lands,,REP,Brock Greenfield,428
+Jackson,Commissioner of School and Public Lands,,DEM,Timothy Azure,269
+Jackson,Commissioner of School and Public Lands,,REP,Brock Greenfield,621
+Jerauld,Commissioner of School and Public Lands,,DEM,Timothy Azure,273
+Jerauld,Commissioner of School and Public Lands,,REP,Brock Greenfield,544
+Jones,Commissioner of School and Public Lands,,DEM,Timothy Azure,54
+Jones,Commissioner of School and Public Lands,,REP,Brock Greenfield,391
+Kingsbury,Commissioner of School and Public Lands,,DEM,Timothy Azure,616
+Kingsbury,Commissioner of School and Public Lands,,REP,Brock Greenfield,1777
+Lake,Commissioner of School and Public Lands,,DEM,Timothy Azure,1435
+Lake,Commissioner of School and Public Lands,,REP,Brock Greenfield,3071
+Lawrence,Commissioner of School and Public Lands,,DEM,Timothy Azure,3576
+Lawrence,Commissioner of School and Public Lands,,REP,Brock Greenfield,7832
+Lincoln,Commissioner of School and Public Lands,,DEM,Timothy Azure,8581
+Lincoln,Commissioner of School and Public Lands,,REP,Brock Greenfield,17072
+Lyman,Commissioner of School and Public Lands,,DEM,Timothy Azure,351
+Lyman,Commissioner of School and Public Lands,,REP,Brock Greenfield,851
+Marshall,Commissioner of School and Public Lands,,DEM,Timothy Azure,668
+Marshall,Commissioner of School and Public Lands,,REP,Brock Greenfield,1068
+McCook,Commissioner of School and Public Lands,,DEM,Timothy Azure,558
+McCook,Commissioner of School and Public Lands,,REP,Brock Greenfield,1750
+McPherson,Commissioner of School and Public Lands,,DEM,Timothy Azure,141
+McPherson,Commissioner of School and Public Lands,,REP,Brock Greenfield,917
+Meade,Commissioner of School and Public Lands,,DEM,Timothy Azure,2563
+Meade,Commissioner of School and Public Lands,,REP,Brock Greenfield,8495
+Mellette,Commissioner of School and Public Lands,,DEM,Timothy Azure,212
+Mellette,Commissioner of School and Public Lands,,REP,Brock Greenfield,375
+Miner,Commissioner of School and Public Lands,,DEM,Timothy Azure,230
+Miner,Commissioner of School and Public Lands,,REP,Brock Greenfield,663
+Minnehaha,Commissioner of School and Public Lands,,DEM,Timothy Azure,28040
+Minnehaha,Commissioner of School and Public Lands,,REP,Brock Greenfield,39607
+Moody,Commissioner of School and Public Lands,,DEM,Timothy Azure,877
+Moody,Commissioner of School and Public Lands,,REP,Brock Greenfield,1577
+Oglala Lakota,Commissioner of School and Public Lands,,DEM,Timothy Azure,2109
+Oglala Lakota,Commissioner of School and Public Lands,,REP,Brock Greenfield,240
+Pennington,Commissioner of School and Public Lands,,DEM,Timothy Azure,14347
+Pennington,Commissioner of School and Public Lands,,REP,Brock Greenfield,27995
+Perkins,Commissioner of School and Public Lands,,DEM,Timothy Azure,171
+Perkins,Commissioner of School and Public Lands,,REP,Brock Greenfield,1105
+Potter,Commissioner of School and Public Lands,,DEM,Timothy Azure,149
+Potter,Commissioner of School and Public Lands,,REP,Brock Greenfield,881
+Roberts,Commissioner of School and Public Lands,,DEM,Timothy Azure,1362
+Roberts,Commissioner of School and Public Lands,,REP,Brock Greenfield,1933
+Sanborn,Commissioner of School and Public Lands,,DEM,Timothy Azure,197
+Sanborn,Commissioner of School and Public Lands,,REP,Brock Greenfield,718
+Spink,Commissioner of School and Public Lands,,DEM,Timothy Azure,665
+Spink,Commissioner of School and Public Lands,,REP,Brock Greenfield,1891
+Stanley,Commissioner of School and Public Lands,,DEM,Timothy Azure,329
+Stanley,Commissioner of School and Public Lands,,REP,Brock Greenfield,1033
+Sully,Commissioner of School and Public Lands,,DEM,Timothy Azure,141
+Sully,Commissioner of School and Public Lands,,REP,Brock Greenfield,598
+Todd,Commissioner of School and Public Lands,,DEM,Timothy Azure,1439
+Todd,Commissioner of School and Public Lands,,REP,Brock Greenfield,420
+Tripp,Commissioner of School and Public Lands,,DEM,Timothy Azure,350
+Tripp,Commissioner of School and Public Lands,,REP,Brock Greenfield,1788
+Turner,Commissioner of School and Public Lands,,DEM,Timothy Azure,806
+Turner,Commissioner of School and Public Lands,,REP,Brock Greenfield,2771
+Union,Commissioner of School and Public Lands,,DEM,Timothy Azure,1737
+Union,Commissioner of School and Public Lands,,REP,Brock Greenfield,4669
+Walworth,Commissioner of School and Public Lands,,DEM,Timothy Azure,383
+Walworth,Commissioner of School and Public Lands,,REP,Brock Greenfield,1540
+Yankton,Commissioner of School and Public Lands,,DEM,Timothy Azure,2818
+Yankton,Commissioner of School and Public Lands,,REP,Brock Greenfield,5169
+Ziebach,Commissioner of School and Public Lands,,DEM,Timothy Azure,322
+Ziebach,Commissioner of School and Public Lands,,REP,Brock Greenfield,304
+Aurora,Public Utilities Commissioner,,DEM,Jeffrey Barth,194
+Aurora,Public Utilities Commissioner,,REP,Chris Nelson,973
+Beadle,Public Utilities Commissioner,,DEM,Jeffrey Barth,1461
+Beadle,Public Utilities Commissioner,,REP,Chris Nelson,4163
+Bennett,Public Utilities Commissioner,,DEM,Jeffrey Barth,348
+Bennett,Public Utilities Commissioner,,REP,Chris Nelson,610
+Bon Homme,Public Utilities Commissioner,,DEM,Jeffrey Barth,574
+Bon Homme,Public Utilities Commissioner,,REP,Chris Nelson,1855
+Brookings,Public Utilities Commissioner,,DEM,Jeffrey Barth,4013
+Brookings,Public Utilities Commissioner,,REP,Chris Nelson,7605
+Brown,Public Utilities Commissioner,,DEM,Jeffrey Barth,4280
+Brown,Public Utilities Commissioner,,REP,Chris Nelson,8946
+Brule,Public Utilities Commissioner,,DEM,Jeffrey Barth,491
+Brule,Public Utilities Commissioner,,REP,Chris Nelson,1501
+Buffalo,Public Utilities Commissioner,,DEM,Jeffrey Barth,222
+Buffalo,Public Utilities Commissioner,,REP,Chris Nelson,153
+Butte,Public Utilities Commissioner,,DEM,Jeffrey Barth,726
+Butte,Public Utilities Commissioner,,REP,Chris Nelson,3298
+Campbell,Public Utilities Commissioner,,DEM,Jeffrey Barth,72
+Campbell,Public Utilities Commissioner,,REP,Chris Nelson,571
+Charles Mix,Public Utilities Commissioner,,DEM,Jeffrey Barth,783
+Charles Mix,Public Utilities Commissioner,,REP,Chris Nelson,2205
+Clark,Public Utilities Commissioner,,DEM,Jeffrey Barth,297
+Clark,Public Utilities Commissioner,,REP,Chris Nelson,1210
+Clay,Public Utilities Commissioner,,DEM,Jeffrey Barth,2117
+Clay,Public Utilities Commissioner,,REP,Chris Nelson,2333
+Codington,Public Utilities Commissioner,,DEM,Jeffrey Barth,2583
+Codington,Public Utilities Commissioner,,REP,Chris Nelson,7729
+Corson,Public Utilities Commissioner,,DEM,Jeffrey Barth,374
+Corson,Public Utilities Commissioner,,REP,Chris Nelson,514
+Custer,Public Utilities Commissioner,,DEM,Jeffrey Barth,1124
+Custer,Public Utilities Commissioner,,REP,Chris Nelson,3733
+Davison,Public Utilities Commissioner,,DEM,Jeffrey Barth,1731
+Davison,Public Utilities Commissioner,,REP,Chris Nelson,5159
+Day,Public Utilities Commissioner,,DEM,Jeffrey Barth,739
+Day,Public Utilities Commissioner,,REP,Chris Nelson,1638
+Deuel,Public Utilities Commissioner,,DEM,Jeffrey Barth,421
+Deuel,Public Utilities Commissioner,,REP,Chris Nelson,1491
+Dewey,Public Utilities Commissioner,,DEM,Jeffrey Barth,824
+Dewey,Public Utilities Commissioner,,REP,Chris Nelson,677
+Douglas,Public Utilities Commissioner,,DEM,Jeffrey Barth,123
+Douglas,Public Utilities Commissioner,,REP,Chris Nelson,1280
+Edmunds,Public Utilities Commissioner,,DEM,Jeffrey Barth,290
+Edmunds,Public Utilities Commissioner,,REP,Chris Nelson,1316
+Fall River,Public Utilities Commissioner,,DEM,Jeffrey Barth,789
+Fall River,Public Utilities Commissioner,,REP,Chris Nelson,2719
+Faulk,Public Utilities Commissioner,,DEM,Jeffrey Barth,131
+Faulk,Public Utilities Commissioner,,REP,Chris Nelson,780
+Grant,Public Utilities Commissioner,,DEM,Jeffrey Barth,678
+Grant,Public Utilities Commissioner,,REP,Chris Nelson,2350
+Gregory,Public Utilities Commissioner,,DEM,Jeffrey Barth,345
+Gregory,Public Utilities Commissioner,,REP,Chris Nelson,1607
+Haakon,Public Utilities Commissioner,,DEM,Jeffrey Barth,81
+Haakon,Public Utilities Commissioner,,REP,Chris Nelson,867
+Hamlin,Public Utilities Commissioner,,DEM,Jeffrey Barth,446
+Hamlin,Public Utilities Commissioner,,REP,Chris Nelson,2141
+Hand,Public Utilities Commissioner,,DEM,Jeffrey Barth,282
+Hand,Public Utilities Commissioner,,REP,Chris Nelson,1159
+Hanson,Public Utilities Commissioner,,DEM,Jeffrey Barth,282
+Hanson,Public Utilities Commissioner,,REP,Chris Nelson,1269
+Harding,Public Utilities Commissioner,,DEM,Jeffrey Barth,34
+Harding,Public Utilities Commissioner,,REP,Chris Nelson,611
+Hughes,Public Utilities Commissioner,,DEM,Jeffrey Barth,1746
+Hughes,Public Utilities Commissioner,,REP,Chris Nelson,5508
+Hutchinson,Public Utilities Commissioner,,DEM,Jeffrey Barth,490
+Hutchinson,Public Utilities Commissioner,,REP,Chris Nelson,2531
+Hyde,Public Utilities Commissioner,,DEM,Jeffrey Barth,119
+Hyde,Public Utilities Commissioner,,REP,Chris Nelson,436
+Jackson,Public Utilities Commissioner,,DEM,Jeffrey Barth,259
+Jackson,Public Utilities Commissioner,,REP,Chris Nelson,638
+Jerauld,Public Utilities Commissioner,,DEM,Jeffrey Barth,182
+Jerauld,Public Utilities Commissioner,,REP,Chris Nelson,651
+Jones,Public Utilities Commissioner,,DEM,Jeffrey Barth,56
+Jones,Public Utilities Commissioner,,REP,Chris Nelson,402
+Kingsbury,Public Utilities Commissioner,,DEM,Jeffrey Barth,554
+Kingsbury,Public Utilities Commissioner,,REP,Chris Nelson,1848
+Lake,Public Utilities Commissioner,,DEM,Jeffrey Barth,1325
+Lake,Public Utilities Commissioner,,REP,Chris Nelson,3369
+Lawrence,Public Utilities Commissioner,,DEM,Jeffrey Barth,3454
+Lawrence,Public Utilities Commissioner,,REP,Chris Nelson,8121
+Lincoln,Public Utilities Commissioner,,DEM,Jeffrey Barth,8462
+Lincoln,Public Utilities Commissioner,,REP,Chris Nelson,17898
+Lyman,Public Utilities Commissioner,,DEM,Jeffrey Barth,324
+Lyman,Public Utilities Commissioner,,REP,Chris Nelson,912
+Marshall,Public Utilities Commissioner,,DEM,Jeffrey Barth,595
+Marshall,Public Utilities Commissioner,,REP,Chris Nelson,1168
+McCook,Public Utilities Commissioner,,DEM,Jeffrey Barth,523
+McCook,Public Utilities Commissioner,,REP,Chris Nelson,1898
+McPherson,Public Utilities Commissioner,,DEM,Jeffrey Barth,186
+McPherson,Public Utilities Commissioner,,REP,Chris Nelson,882
+Meade,Public Utilities Commissioner,,DEM,Jeffrey Barth,2456
+Meade,Public Utilities Commissioner,,REP,Chris Nelson,8751
+Mellette,Public Utilities Commissioner,,DEM,Jeffrey Barth,203
+Mellette,Public Utilities Commissioner,,REP,Chris Nelson,400
+Miner,Public Utilities Commissioner,,DEM,Jeffrey Barth,203
+Miner,Public Utilities Commissioner,,REP,Chris Nelson,738
+Minnehaha,Public Utilities Commissioner,,DEM,Jeffrey Barth,28572
+Minnehaha,Public Utilities Commissioner,,REP,Chris Nelson,41364
+Moody,Public Utilities Commissioner,,DEM,Jeffrey Barth,886
+Moody,Public Utilities Commissioner,,REP,Chris Nelson,1643
+Oglala Lakota,Public Utilities Commissioner,,DEM,Jeffrey Barth,2035
+Oglala Lakota,Public Utilities Commissioner,,REP,Chris Nelson,279
+Pennington,Public Utilities Commissioner,,DEM,Jeffrey Barth,13742
+Pennington,Public Utilities Commissioner,,REP,Chris Nelson,28934
+Perkins,Public Utilities Commissioner,,DEM,Jeffrey Barth,160
+Perkins,Public Utilities Commissioner,,REP,Chris Nelson,1132
+Potter,Public Utilities Commissioner,,DEM,Jeffrey Barth,144
+Potter,Public Utilities Commissioner,,REP,Chris Nelson,914
+Roberts,Public Utilities Commissioner,,DEM,Jeffrey Barth,1224
+Roberts,Public Utilities Commissioner,,REP,Chris Nelson,2122
+Sanborn,Public Utilities Commissioner,,DEM,Jeffrey Barth,193
+Sanborn,Public Utilities Commissioner,,REP,Chris Nelson,759
+Spink,Public Utilities Commissioner,,DEM,Jeffrey Barth,680
+Spink,Public Utilities Commissioner,,REP,Chris Nelson,1893
+Stanley,Public Utilities Commissioner,,DEM,Jeffrey Barth,288
+Stanley,Public Utilities Commissioner,,REP,Chris Nelson,1114
+Sully,Public Utilities Commissioner,,DEM,Jeffrey Barth,154
+Sully,Public Utilities Commissioner,,REP,Chris Nelson,619
+Todd,Public Utilities Commissioner,,DEM,Jeffrey Barth,1379
+Todd,Public Utilities Commissioner,,REP,Chris Nelson,476
+Tripp,Public Utilities Commissioner,,DEM,Jeffrey Barth,331
+Tripp,Public Utilities Commissioner,,REP,Chris Nelson,1857
+Turner,Public Utilities Commissioner,,DEM,Jeffrey Barth,756
+Turner,Public Utilities Commissioner,,REP,Chris Nelson,2958
+Union,Public Utilities Commissioner,,DEM,Jeffrey Barth,1620
+Union,Public Utilities Commissioner,,REP,Chris Nelson,4831
+Walworth,Public Utilities Commissioner,,DEM,Jeffrey Barth,344
+Walworth,Public Utilities Commissioner,,REP,Chris Nelson,1623
+Yankton,Public Utilities Commissioner,,DEM,Jeffrey Barth,2592
+Yankton,Public Utilities Commissioner,,REP,Chris Nelson,5687
+Ziebach,Public Utilities Commissioner,,DEM,Jeffrey Barth,292
+Ziebach,Public Utilities Commissioner,,REP,Chris Nelson,348
+Brown,State Senate,01,REP,Michael H. Rohl,2374
+Brown,State Senate,01,IND,Susan Wismer,1249
+Day,State Senate,01,REP,Michael H. Rohl,1429
+Day,State Senate,01,IND,Susan Wismer,971
+Marshall,State Senate,01,REP,Michael H. Rohl,1037
+Marshall,State Senate,01,IND,Susan Wismer,813
+Roberts,State Senate,01,REP,Michael H. Rohl,1258
+Roberts,State Senate,01,IND,Susan Wismer,1223
+Minnehaha,State Senate,02,REP,Steve Kolbeck,7810
+Brown,State Senate,03,REP,Al Novstrup,5698
+Clark,State Senate,04,REP,John Wiik,1042
+Codington,State Senate,04,REP,John Wiik,1159
+Deuel,State Senate,04,REP,John Wiik,1572
+Grant,State Senate,04,REP,John Wiik,2412
+Hamlin,State Senate,04,REP,John Wiik,2061
+Roberts,State Senate,04,REP,John Wiik,671
+Codington,State Senate,05,REP,Lee Schoenbeck,6743
+Lincoln,State Senate,06,REP,Herman Otten,6513
+Brookings,State Senate,07,REP,Tim Reed,6263
+Brookings,State Senate,08,REP,Casey Crabtree,2506
+Kingsbury,State Senate,08,REP,Casey Crabtree,1956
+Lake,State Senate,08,REP,Casey Crabtree,3766
+Miner,State Senate,08,REP,Casey Crabtree,698
+Minnehaha,State Senate,09,REP,Brent Hoffman,6024
+Minnehaha,State Senate,10,DEM,Liz Larson,4488
+Minnehaha,State Senate,10,REP,Maggie Sutton,3429
+Minnehaha,State Senate,11,DEM,Sheryl L. Johnson,4286
+Minnehaha,State Senate,11,REP,Jim Stalzer,5289
+Lincoln,State Senate,12,DEM,Jessica Meyers,1693
+Lincoln,State Senate,12,REP,Arch Beal,2686
+Minnehaha,State Senate,12,DEM,Jessica Meyers,2544
+Minnehaha,State Senate,12,REP,Arch Beal,2264
+Lincoln,State Senate,13,REP,Jack Kolbeck,5710
+Lincoln,State Senate,13,IND,Lora Hubbel,2162
+Minnehaha,State Senate,13,REP,Jack Kolbeck,1635
+Minnehaha,State Senate,13,IND,Lora Hubbel,954
+Minnehaha,State Senate,14,DEM,Matthew Tysdal,5001
+Minnehaha,State Senate,14,REP,Larry P. Zikmund,5854
+Minnehaha,State Senate,15,DEM,Reynold F. Nesiba,3697
+Minnehaha,State Senate,15,REP,Brenda Lawrence,3310
+Lincoln,State Senate,16,DEM,Donn Larson,1270
+Lincoln,State Senate,16,REP,Jim Bolin,3289
+Lincoln,State Senate,16,IND,Brian J. Burge,317
+Turner,State Senate,16,DEM,Donn Larson,783
+Turner,State Senate,16,REP,Jim Bolin,2230
+Turner,State Senate,16,IND,Brian J. Burge,417
+Union,State Senate,16,DEM,Donn Larson,557
+Union,State Senate,16,REP,Jim Bolin,1251
+Union,State Senate,16,IND,Brian J. Burge,113
+Clay,State Senate,17,REP,Sydney Davis,2498
+Union,State Senate,17,REP,Sydney Davis,3499
+Clay,State Senate,18,DEM,Fredrick Bender,84
+Clay,State Senate,18,REP,Jean M. Hunhoff,213
+Yankton,State Senate,18,DEM,Fredrick Bender,3007
+Yankton,State Senate,18,REP,Jean M. Hunhoff,5535
+Bon Homme,State Senate,19,DEM,Russell Graeff,512
+Bon Homme,State Senate,19,REP,Kyle Schoenfish,1936
+Hanson,State Senate,19,DEM,Russell Graeff,286
+Hanson,State Senate,19,REP,Kyle Schoenfish,1246
+Hutchinson,State Senate,19,DEM,Russell Graeff,428
+Hutchinson,State Senate,19,REP,Kyle Schoenfish,2631
+McCook,State Senate,19,DEM,Russell Graeff,510
+McCook,State Senate,19,REP,Kyle Schoenfish,1870
+Turner,State Senate,19,DEM,Russell Graeff,56
+Turner,State Senate,19,REP,Kyle Schoenfish,223
+Davison,State Senate,20,REP,Joshua Klumb,5512
+Jerauld,State Senate,20,REP,Joshua Klumb,644
+Miner,State Senate,20,REP,Joshua Klumb,48
+Sanborn,State Senate,20,REP,Joshua Klumb,764
+Aurora,State Senate,21,DEM,Dan Andersson,218
+Aurora,State Senate,21,REP,Erin Tobin,924
+Charles Mix,State Senate,21,DEM,Dan Andersson,790
+Charles Mix,State Senate,21,REP,Erin Tobin,2205
+Douglas,State Senate,21,DEM,Dan Andersson,148
+Douglas,State Senate,21,REP,Erin Tobin,1239
+Gregory,State Senate,21,DEM,Dan Andersson,289
+Gregory,State Senate,21,REP,Erin Tobin,1726
+Tripp,State Senate,21,DEM,Dan Andersson,326
+Tripp,State Senate,21,REP,Erin Tobin,1882
+Beadle,State Senate,22,REP,David Wheeler,4584
+Clark,State Senate,22,REP,David Wheeler,104
+Spink,State Senate,22,REP,David Wheeler,1893
+Brown,State Senate,23,REP,Bryan J. Breitling,679
+Campbell,State Senate,23,REP,Bryan J. Breitling,549
+Edmunds,State Senate,23,REP,Bryan J. Breitling,1395
+Faulk,State Senate,23,REP,Bryan J. Breitling,730
+Hand,State Senate,23,REP,Bryan J. Breitling,1166
+McPherson,State Senate,23,REP,Bryan J. Breitling,942
+Potter,State Senate,23,REP,Bryan J. Breitling,888
+Walworth,State Senate,23,REP,Bryan J. Breitling,1605
+Haakon,State Senate,24,REP,Jim Mehlhaff,835
+Hughes,State Senate,24,REP,Jim Mehlhaff,5240
+Hyde,State Senate,24,REP,Jim Mehlhaff,448
+Stanley,State Senate,24,REP,Jim Mehlhaff,1097
+Sully,State Senate,24,REP,Jim Mehlhaff,626
+Minnehaha,State Senate,25,REP,Tom Pischke,6148
+Moody,State Senate,25,REP,Tom Pischke,1720
+Brule,State Senate,26,DEM,Shawn Bordeaux,733
+Brule,State Senate,26,REP,Joel Koskan,1077
+Buffalo,State Senate,26,DEM,Shawn Bordeaux,263
+Buffalo,State Senate,26,REP,Joel Koskan,106
+Hughes,State Senate,26,DEM,Shawn Bordeaux,22
+Hughes,State Senate,26,REP,Joel Koskan,5
+Hyde,State Senate,26,DEM,Shawn Bordeaux,11
+Hyde,State Senate,26,REP,Joel Koskan,3
+Jones,State Senate,26,DEM,Shawn Bordeaux,119
+Jones,State Senate,26,REP,Joel Koskan,250
+Lyman,State Senate,26,DEM,Shawn Bordeaux,553
+Lyman,State Senate,26,REP,Joel Koskan,520
+Mellette,State Senate,26,DEM,Shawn Bordeaux,297
+Mellette,State Senate,26,REP,Joel Koskan,195
+Todd,State Senate,26,DEM,Shawn Bordeaux,1485
+Todd,State Senate,26,REP,Joel Koskan,339
+Bennett,State Senate,27,DEM,Red Dawn Foster,387
+Bennett,State Senate,27,REP,David Jones,634
+Jackson,State Senate,27,DEM,Red Dawn Foster,286
+Jackson,State Senate,27,REP,David Jones,618
+Oglala Lakota,State Senate,27,DEM,Red Dawn Foster,2261
+Oglala Lakota,State Senate,27,REP,David Jones,208
+Pennington,State Senate,27,DEM,Red Dawn Foster,245
+Pennington,State Senate,27,REP,David Jones,1540
+Butte,State Senate,28,REP,Ryan M. Maher,3322
+Corson,State Senate,28,REP,Ryan M. Maher,591
+Dewey,State Senate,28,REP,Ryan M. Maher,935
+Harding,State Senate,28,REP,Ryan M. Maher,624
+Perkins,State Senate,28,REP,Ryan M. Maher,1178
+Ziebach,State Senate,28,REP,Ryan M. Maher,444
+Meade,State Senate,29,REP,Dean Wink,7272
+Custer,State Senate,30,REP,Julie Frye-Mueller,3600
+Fall River,State Senate,30,REP,Julie Frye-Mueller,2729
+Pennington,State Senate,30,REP,Julie Frye-Mueller,3269
+Lawrence,State Senate,31,REP,Randy Deibert,8536
+Pennington,State Senate,32,DEM,Nicole A. Heenan,3323
+Pennington,State Senate,32,REP,Helene Duhamel,4257
+Meade,State Senate,33,LIB,Darren Freidel,463
+Meade,State Senate,33,REP,David Johnson,1408
+Pennington,State Senate,33,LIB,Darren Freidel,2074
+Pennington,State Senate,33,REP,David Johnson,6477
+Pennington,State Senate,34,REP,Michael Diedrich,7505
+Pennington,State Senate,35,REP,Jessica Castleberry,6784
+Brown,State House,01,DEM,Steven D. McCleerey,1162
+Brown,State House,01,DEM,Kay F. Nikolas,1120
+Brown,State House,01,REP,Joe Donnell,2105
+Brown,State House,01,REP,Tamara St John,2096
+Day,State House,01,DEM,Steven D. McCleerey,907
+Day,State House,01,DEM,Kay F. Nikolas,676
+Day,State House,01,REP,Joe Donnell,1100
+Day,State House,01,REP,Tamara St John,1348
+Marshall,State House,01,DEM,Steven D. McCleerey,782
+Marshall,State House,01,DEM,Kay F. Nikolas,554
+Marshall,State House,01,REP,Joe Donnell,812
+Marshall,State House,01,REP,Tamara St John,978
+Roberts,State House,01,DEM,Steven D. McCleerey,1123
+Roberts,State House,01,DEM,Kay F. Nikolas,841
+Roberts,State House,01,REP,Joe Donnell,1121
+Roberts,State House,01,REP,Tamara St John,1304
+Minnehaha,State House,02,DEM,Gary Leighton,3323
+Minnehaha,State House,02,REP,John Sjaarda,5693
+Minnehaha,State House,02,REP,David Kull,6121
+Brown,State House,03,REP,Brandei Schaefbauer,4625
+Brown,State House,03,REP,Carl E. Perry,5050
+Clark,State House,04,REP,Stephanie Sauder,813
+Clark,State House,04,REP,Fred Deutsch,796
+Codington,State House,04,REP,Stephanie Sauder,749
+Codington,State House,04,REP,Fred Deutsch,947
+Deuel,State House,04,REP,Stephanie Sauder,1026
+Deuel,State House,04,REP,Fred Deutsch,1265
+Grant,State House,04,REP,Stephanie Sauder,1508
+Grant,State House,04,REP,Fred Deutsch,2040
+Hamlin,State House,04,REP,Stephanie Sauder,1789
+Hamlin,State House,04,REP,Fred Deutsch,1373
+Roberts,State House,04,REP,Stephanie Sauder,415
+Roberts,State House,04,REP,Fred Deutsch,556
+Codington,State House,05,DEM,Kahden Mooney,2917
+Codington,State House,05,REP,Byron I. Callies,4351
+Codington,State House,05,REP,Hugh M. Bartels,6058
+Lincoln,State House,06,REP,Aaron Aylward,3715
+Lincoln,State House,06,REP,Ernie Otten,5559
+Brookings,State House,07,DEM,Cole Sartell,3431
+Brookings,State House,07,REP,Mellissa Heermann,4461
+Brookings,State House,07,REP,Roger DeGroot,4980
+Brookings,State House,08,REP,Tim Reisch,1762
+Brookings,State House,08,REP,John Mills,2211
+Kingsbury,State House,08,REP,Tim Reisch,1369
+Kingsbury,State House,08,REP,John Mills,1349
+Lake,State House,08,REP,Tim Reisch,3094
+Lake,State House,08,REP,John Mills,2569
+Miner,State House,08,REP,Tim Reisch,777
+Miner,State House,08,REP,John Mills,316
+Minnehaha,State House,09,DEM,Nick Winkler,3183
+Minnehaha,State House,09,REP,Kenneth Teunissen,4142
+Minnehaha,State House,09,REP,Bethany Soye,5034
+Minnehaha,State House,10,DEM,Erin Healy,4613
+Minnehaha,State House,10,DEM,Kameron Nelson,3510
+Minnehaha,State House,10,REP,Tom E Sutton,2980
+Minnehaha,State House,10,REP,John G. Mogen,3114
+Minnehaha,State House,11,DEM,Margaret Kuipers,3775
+Minnehaha,State House,11,DEM,Kim Parke,3553
+Minnehaha,State House,11,REP,Chris Karr,4879
+Minnehaha,State House,11,REP,Brian K. Mulder,4988
+Lincoln,State House,12,DEM,Kristin Hayward,1323
+Lincoln,State House,12,DEM,Erin Royer,1447
+Lincoln,State House,12,REP,Greg Jamison,2450
+Lincoln,State House,12,REP,Amber Arlint,2564
+Minnehaha,State House,12,DEM,Kristin Hayward,2156
+Minnehaha,State House,12,DEM,Erin Royer,2179
+Minnehaha,State House,12,REP,Greg Jamison,2224
+Minnehaha,State House,12,REP,Amber Arlint,2087
+Lincoln,State House,13,REP,Tony Venhuizen,4616
+Lincoln,State House,13,REP,Sue Peterson,4456
+Minnehaha,State House,13,REP,Tony Venhuizen,1263
+Minnehaha,State House,13,REP,Sue Peterson,1423
+Minnehaha,State House,14,DEM,Wendy Mamer,4161
+Minnehaha,State House,14,DEM,Mike Huber,4570
+Minnehaha,State House,14,REP,Tyler Tordsen,5111
+Minnehaha,State House,14,REP,Taylor Rae Rehfeldt,6127
+Minnehaha,State House,15,DEM,Linda Duba,3545
+Minnehaha,State House,15,DEM,Kadyn Wittman,3194
+Minnehaha,State House,15,REP,Matt Rosburg,2761
+Minnehaha,State House,15,REP,Joni Tschetter,3097
+Lincoln,State House,16,DEM,Matt Ness,1383
+Lincoln,State House,16,REP,Kevin D. Jensen,2742
+Lincoln,State House,16,REP,Karla J. Lems,2856
+Turner,State House,16,DEM,Matt Ness,807
+Turner,State House,16,REP,Kevin D. Jensen,1953
+Turner,State House,16,REP,Karla J. Lems,2088
+Union,State House,16,DEM,Matt Ness,554
+Union,State House,16,REP,Kevin D. Jensen,1130
+Union,State House,16,REP,Karla J. Lems,1007
+Clay,State House,17,DEM,"Rebecca ""Bekki"" Engquist-Schroeder",2367
+Clay,State House,17,REP,"William ""Bill"" Shorma",1433
+Clay,State House,17,REP,Chris Kassin,2174
+Union,State House,17,DEM,"Rebecca ""Bekki"" Engquist-Schroeder",1219
+Union,State House,17,REP,"William ""Bill"" Shorma",2622
+Union,State House,17,REP,Chris Kassin,2764
+Clay,State House,18,DEM,Ryan D. Cwach,125
+Clay,State House,18,DEM,Jay Williams,60
+Clay,State House,18,REP,Julie Auch,174
+Clay,State House,18,REP,Mike Stevens,160
+Yankton,State House,18,DEM,Ryan D. Cwach,4384
+Yankton,State House,18,DEM,Jay Williams,1835
+Yankton,State House,18,REP,Julie Auch,4490
+Yankton,State House,18,REP,Mike Stevens,5068
+Bon Homme,State House,19,REP,Jessica Bahmuller,1257
+Bon Homme,State House,19,REP,Drew Peterson,1575
+Hanson,State House,19,REP,Jessica Bahmuller,1015
+Hanson,State House,19,REP,Drew Peterson,902
+Hutchinson,State House,19,REP,Jessica Bahmuller,1894
+Hutchinson,State House,19,REP,Drew Peterson,1974
+McCook,State House,19,REP,Jessica Bahmuller,1293
+McCook,State House,19,REP,Drew Peterson,1681
+Turner,State House,19,REP,Jessica Bahmuller,137
+Turner,State House,19,REP,Drew Peterson,191
+Davison,State House,20,REP,Ben Krohmer,4032
+Davison,State House,20,REP,Lance Koth,4490
+Jerauld,State House,20,REP,Ben Krohmer,414
+Jerauld,State House,20,REP,Lance Koth,566
+Miner,State House,20,REP,Ben Krohmer,32
+Miner,State House,20,REP,Lance Koth,45
+Sanborn,State House,20,REP,Ben Krohmer,494
+Sanborn,State House,20,REP,Lance Koth,620
+Aurora,State House,21,REP,Rocky Blare,461
+Aurora,State House,21,REP,Marty Overweg,859
+Charles Mix,State House,21,REP,Rocky Blare,1314
+Charles Mix,State House,21,REP,Marty Overweg,2130
+Douglas,State House,21,REP,Rocky Blare,586
+Douglas,State House,21,REP,Marty Overweg,1231
+Gregory,State House,21,REP,Rocky Blare,1303
+Gregory,State House,21,REP,Marty Overweg,994
+Tripp,State House,21,REP,Rocky Blare,1837
+Tripp,State House,21,REP,Marty Overweg,940
+Beadle,State House,22,DEM,Shane Milne,1538
+Beadle,State House,22,REP,Roger Chase,3639
+Beadle,State House,22,REP,Lynn Schneider,3871
+Clark,State House,22,DEM,Shane Milne,47
+Clark,State House,22,REP,Roger Chase,68
+Clark,State House,22,REP,Lynn Schneider,102
+Spink,State House,22,DEM,Shane Milne,743
+Spink,State House,22,REP,Roger Chase,1227
+Spink,State House,22,REP,Lynn Schneider,1669
+Brown,State House,23,REP,James D. Wangsness,432
+Brown,State House,23,REP,Scott Moore,609
+Campbell,State House,23,REP,James D. Wangsness,338
+Campbell,State House,23,REP,Scott Moore,498
+Edmunds,State House,23,REP,James D. Wangsness,723
+Edmunds,State House,23,REP,Scott Moore,1232
+Faulk,State House,23,REP,James D. Wangsness,460
+Faulk,State House,23,REP,Scott Moore,681
+Hand,State House,23,REP,James D. Wangsness,977
+Hand,State House,23,REP,Scott Moore,898
+McPherson,State House,23,REP,James D. Wangsness,504
+McPherson,State House,23,REP,Scott Moore,913
+Potter,State House,23,REP,James D. Wangsness,550
+Potter,State House,23,REP,Scott Moore,738
+Walworth,State House,23,REP,James D. Wangsness,909
+Walworth,State House,23,REP,Scott Moore,1396
+Haakon,State House,24,REP,Mike Weisgram,487
+Haakon,State House,24,REP,Will D. Mortenson,752
+Hughes,State House,24,REP,Mike Weisgram,4691
+Hughes,State House,24,REP,Will D. Mortenson,5125
+Hyde,State House,24,REP,Mike Weisgram,276
+Hyde,State House,24,REP,Will D. Mortenson,403
+Stanley,State House,24,REP,Mike Weisgram,925
+Stanley,State House,24,REP,Will D. Mortenson,1051
+Sully,State House,24,REP,Mike Weisgram,468
+Sully,State House,24,REP,Will D. Mortenson,542
+Minnehaha,State House,25,DEM,Dan Ahlers,3534
+Minnehaha,State House,25,DEM,David Kills A Hundred,1618
+Minnehaha,State House,25,REP,Jon Hansen,5419
+Minnehaha,State House,25,REP,Randy Gross,4782
+Moody,State House,25,DEM,Dan Ahlers,1001
+Moody,State House,25,DEM,David Kills A Hundred,642
+Moody,State House,25,REP,Jon Hansen,1314
+Moody,State House,25,REP,Randy Gross,1582
+Jones,State House,26A,DEM,Eric Emery,15
+Jones,State House,26A,REP,Joyce Glynn,114
+Mellette,State House,26A,DEM,Eric Emery,262
+Mellette,State House,26A,REP,Joyce Glynn,346
+Todd,State House,26A,DEM,Eric Emery,1484
+Todd,State House,26A,REP,Joyce Glynn,412
+Brule,State House,26B,REP,Rebecca Reimer,1557
+Buffalo,State House,26B,REP,Rebecca Reimer,174
+Hughes,State House,26B,REP,Rebecca Reimer,11
+Hyde,State House,26B,REP,Rebecca Reimer,7
+Jones,State House,26B,REP,Rebecca Reimer,278
+Lyman,State House,26B,REP,Rebecca Reimer,928
+Bennett,State House,27,DEM,Peri Pourier,404
+Bennett,State House,27,DEM,Norma Rendon,291
+Bennett,State House,27,REP,Liz May,630
+Bennett,State House,27,REP,Bud May,400
+Jackson,State House,27,DEM,Peri Pourier,313
+Jackson,State House,27,DEM,Norma Rendon,232
+Jackson,State House,27,REP,Liz May,575
+Jackson,State House,27,REP,Bud May,411
+Oglala Lakota,State House,27,DEM,Peri Pourier,2093
+Oglala Lakota,State House,27,DEM,Norma Rendon,1627
+Oglala Lakota,State House,27,REP,Liz May,252
+Oglala Lakota,State House,27,REP,Bud May,188
+Pennington,State House,27,DEM,Peri Pourier,259
+Pennington,State House,27,DEM,Norma Rendon,200
+Pennington,State House,27,REP,Liz May,1374
+Pennington,State House,27,REP,Bud May,1350
+Corson,State House,28A,DEM,Oren L Lesmeister,407
+Corson,State House,28A,REP,Ralph Lyon,498
+Dewey,State House,28A,DEM,Oren L Lesmeister,1037
+Dewey,State House,28A,REP,Ralph Lyon,514
+Perkins,State House,28A,DEM,Oren L Lesmeister,70
+Perkins,State House,28A,REP,Ralph Lyon,538
+Ziebach,State House,28A,DEM,Oren L Lesmeister,376
+Ziebach,State House,28A,REP,Ralph Lyon,297
+Butte,State House,28B,REP,Neal Pinnow,3028
+Butte,State House,28B,IND,Calvin Reilly,841
+Harding,State House,28B,REP,Neal Pinnow,577
+Harding,State House,28B,IND,Calvin Reilly,63
+Perkins,State House,28B,REP,Neal Pinnow,629
+Perkins,State House,28B,IND,Calvin Reilly,106
+Meade,State House,29,LIB,Sean Natchke,2227
+Meade,State House,29,REP,Gary L Cammack,5132
+Meade,State House,29,REP,Kirk Chaffee,5996
+Custer,State House,30,DEM,Bret Swanson,1201
+Custer,State House,30,REP,Dennis Krull,3048
+Custer,State House,30,REP,Trish Ladner,3165
+Fall River,State House,30,DEM,Bret Swanson,845
+Fall River,State House,30,REP,Dennis Krull,1773
+Fall River,State House,30,REP,Trish Ladner,2452
+Pennington,State House,30,DEM,Bret Swanson,1171
+Pennington,State House,30,REP,Dennis Krull,2817
+Pennington,State House,30,REP,Trish Ladner,2692
+Lawrence,State House,31,REP,Mary J. Fitzgerald,6116
+Lawrence,State House,31,REP,Scott Odenbach,7230
+Pennington,State House,32,DEM,Jonathan M. Old Horse,2848
+Pennington,State House,32,DEM,Christine Stephenson,3095
+Pennington,State House,32,REP,Becky J. Drury,3230
+Pennington,State House,32,REP,Steve Duffy,3374
+Meade,State House,33,DEM,Vince Vidal,567
+Meade,State House,33,REP,Curt Massie,989
+Meade,State House,33,REP,Phil Jensen,1229
+Pennington,State House,33,DEM,Vince Vidal,3241
+Pennington,State House,33,REP,Curt Massie,4744
+Pennington,State House,33,REP,Phil Jensen,5167
+Pennington,State House,34,DEM,Darla Drew,4149
+Pennington,State House,34,DEM,Jay Shultz,3000
+Pennington,State House,34,REP,Jess Olson,5869
+Pennington,State House,34,REP,Mike Derby,6350
+Pennington,State House,35,DEM,Pat Cromwell,2647
+Pennington,State House,35,DEM,David A. Hubbard,2402
+Pennington,State House,35,REP,Tony Randolph,5573
+Pennington,State House,35,REP,Tina L Mulally,5908
+Aurora,Judge of the Circuit Court,Position A First Circuit,NON,Chris S. Giles,573
+Bon Homme,Judge of the Circuit Court,Position A First Circuit,NON,Chris S. Giles,1142
+Brule,Judge of the Circuit Court,Position A First Circuit,NON,Chris S. Giles,865
+Buffalo,Judge of the Circuit Court,Position A First Circuit,NON,Chris S. Giles,119
+Charles Mix,Judge of the Circuit Court,Position A First Circuit,NON,Chris S. Giles,1279
+Clay,Judge of the Circuit Court,Position A First Circuit,NON,Chris S. Giles,1717
+Davison,Judge of the Circuit Court,Position A First Circuit,NON,Chris S. Giles,3557
+Douglas,Judge of the Circuit Court,Position A First Circuit,NON,Chris S. Giles,645
+Hanson,Judge of the Circuit Court,Position A First Circuit,NON,Chris S. Giles,771
+Hutchinson,Judge of the Circuit Court,Position A First Circuit,NON,Chris S. Giles,1505
+McCook,Judge of the Circuit Court,Position A First Circuit,NON,Chris S. Giles,1195
+Turner,Judge of the Circuit Court,Position A First Circuit,NON,Chris S. Giles,1634
+Union,Judge of the Circuit Court,Position A First Circuit,NON,Chris S. Giles,2988
+Yankton,Judge of the Circuit Court,Position A First Circuit,NON,Chris S. Giles,3706
+Aurora,Judge of the Circuit Court,Position B First Circuit,NON,David Knoff,548
+Bon Homme,Judge of the Circuit Court,Position B First Circuit,NON,David Knoff,1163
+Brule,Judge of the Circuit Court,Position B First Circuit,NON,David Knoff,818
+Buffalo,Judge of the Circuit Court,Position B First Circuit,NON,David Knoff,113
+Charles Mix,Judge of the Circuit Court,Position B First Circuit,NON,David Knoff,1257
+Clay,Judge of the Circuit Court,Position B First Circuit,NON,David Knoff,1695
+Davison,Judge of the Circuit Court,Position B First Circuit,NON,David Knoff,3238
+Douglas,Judge of the Circuit Court,Position B First Circuit,NON,David Knoff,618
+Hanson,Judge of the Circuit Court,Position B First Circuit,NON,David Knoff,642
+Hutchinson,Judge of the Circuit Court,Position B First Circuit,NON,David Knoff,1452
+McCook,Judge of the Circuit Court,Position B First Circuit,NON,David Knoff,1099
+Turner,Judge of the Circuit Court,Position B First Circuit,NON,David Knoff,1575
+Union,Judge of the Circuit Court,Position B First Circuit,NON,David Knoff,2857
+Yankton,Judge of the Circuit Court,Position B First Circuit,NON,David Knoff,4372
+Aurora,Judge of the Circuit Court,Position C First Circuit,NON,Bruce V. Anderson,568
+Bon Homme,Judge of the Circuit Court,Position C First Circuit,NON,Bruce V. Anderson,1174
+Brule,Judge of the Circuit Court,Position C First Circuit,NON,Bruce V. Anderson,870
+Buffalo,Judge of the Circuit Court,Position C First Circuit,NON,Bruce V. Anderson,124
+Charles Mix,Judge of the Circuit Court,Position C First Circuit,NON,Bruce V. Anderson,1816
+Clay,Judge of the Circuit Court,Position C First Circuit,NON,Bruce V. Anderson,1660
+Davison,Judge of the Circuit Court,Position C First Circuit,NON,Bruce V. Anderson,3293
+Douglas,Judge of the Circuit Court,Position C First Circuit,NON,Bruce V. Anderson,715
+Hanson,Judge of the Circuit Court,Position C First Circuit,NON,Bruce V. Anderson,639
+Hutchinson,Judge of the Circuit Court,Position C First Circuit,NON,Bruce V. Anderson,1512
+McCook,Judge of the Circuit Court,Position C First Circuit,NON,Bruce V. Anderson,1086
+Turner,Judge of the Circuit Court,Position C First Circuit,NON,Bruce V. Anderson,1577
+Union,Judge of the Circuit Court,Position C First Circuit,NON,Bruce V. Anderson,2834
+Yankton,Judge of the Circuit Court,Position C First Circuit,NON,Bruce V. Anderson,3696
+Aurora,Judge of the Circuit Court,Position D First Circuit,NON,Cheryle W. Gering,544
+Bon Homme,Judge of the Circuit Court,Position D First Circuit,NON,Cheryle W. Gering,1210
+Brule,Judge of the Circuit Court,Position D First Circuit,NON,Cheryle W. Gering,810
+Buffalo,Judge of the Circuit Court,Position D First Circuit,NON,Cheryle W. Gering,115
+Charles Mix,Judge of the Circuit Court,Position D First Circuit,NON,Cheryle W. Gering,1249
+Clay,Judge of the Circuit Court,Position D First Circuit,NON,Cheryle W. Gering,1765
+Davison,Judge of the Circuit Court,Position D First Circuit,NON,Cheryle W. Gering,3253
+Douglas,Judge of the Circuit Court,Position D First Circuit,NON,Cheryle W. Gering,622
+Hanson,Judge of the Circuit Court,Position D First Circuit,NON,Cheryle W. Gering,641
+Hutchinson,Judge of the Circuit Court,Position D First Circuit,NON,Cheryle W. Gering,1684
+McCook,Judge of the Circuit Court,Position D First Circuit,NON,Cheryle W. Gering,1097
+Turner,Judge of the Circuit Court,Position D First Circuit,NON,Cheryle W. Gering,1659
+Union,Judge of the Circuit Court,Position D First Circuit,NON,Cheryle W. Gering,2858
+Yankton,Judge of the Circuit Court,Position D First Circuit,NON,Cheryle W. Gering,4008
+Aurora,Judge of the Circuit Court,Position E First Circuit,NON,Patrick T. Smith,583
+Bon Homme,Judge of the Circuit Court,Position E First Circuit,NON,Patrick T. Smith,1122
+Brule,Judge of the Circuit Court,Position E First Circuit,NON,Patrick T. Smith,824
+Buffalo,Judge of the Circuit Court,Position E First Circuit,NON,Patrick T. Smith,117
+Charles Mix,Judge of the Circuit Court,Position E First Circuit,NON,Patrick T. Smith,1245
+Clay,Judge of the Circuit Court,Position E First Circuit,NON,Patrick T. Smith,1635
+Davison,Judge of the Circuit Court,Position E First Circuit,NON,Patrick T. Smith,3679
+Douglas,Judge of the Circuit Court,Position E First Circuit,NON,Patrick T. Smith,623
+Hanson,Judge of the Circuit Court,Position E First Circuit,NON,Patrick T. Smith,680
+Hutchinson,Judge of the Circuit Court,Position E First Circuit,NON,Patrick T. Smith,1467
+McCook,Judge of the Circuit Court,Position E First Circuit,NON,Patrick T. Smith,1079
+Turner,Judge of the Circuit Court,Position E First Circuit,NON,Patrick T. Smith,1552
+Union,Judge of the Circuit Court,Position E First Circuit,NON,Patrick T. Smith,2801
+Yankton,Judge of the Circuit Court,Position E First Circuit,NON,Patrick T. Smith,3590
+Aurora,Judge of the Circuit Court,Position F First Circuit,NON,Tami A. Bern,543
+Bon Homme,Judge of the Circuit Court,Position F First Circuit,NON,Tami A. Bern,1137
+Brule,Judge of the Circuit Court,Position F First Circuit,NON,Tami A. Bern,810
+Buffalo,Judge of the Circuit Court,Position F First Circuit,NON,Tami A. Bern,115
+Charles Mix,Judge of the Circuit Court,Position F First Circuit,NON,Tami A. Bern,1246
+Clay,Judge of the Circuit Court,Position F First Circuit,NON,Tami A. Bern,2241
+Davison,Judge of the Circuit Court,Position F First Circuit,NON,Tami A. Bern,3230
+Douglas,Judge of the Circuit Court,Position F First Circuit,NON,Tami A. Bern,613
+Hanson,Judge of the Circuit Court,Position F First Circuit,NON,Tami A. Bern,641
+Hutchinson,Judge of the Circuit Court,Position F First Circuit,NON,Tami A. Bern,1434
+McCook,Judge of the Circuit Court,Position F First Circuit,NON,Tami A. Bern,1085
+Turner,Judge of the Circuit Court,Position F First Circuit,NON,Tami A. Bern,1572
+Union,Judge of the Circuit Court,Position F First Circuit,NON,Tami A. Bern,2937
+Yankton,Judge of the Circuit Court,Position F First Circuit,NON,Tami A. Bern,3729
+Lincoln,Judge of the Circuit Court,Position A Second Circuit,NON,Robin Houwman,13704
+Minnehaha,Judge of the Circuit Court,Position A Second Circuit,NON,Robin Houwman,39393
+Lincoln,Judge of the Circuit Court,Position B Second Circuit,NON,Sandra H Hanson,13326
+Minnehaha,Judge of the Circuit Court,Position B Second Circuit,NON,Sandra H Hanson,31464
+Lincoln,Judge of the Circuit Court,Position C Second Circuit,NON,Doug Barnett,9964
+Lincoln,Judge of the Circuit Court,Position C Second Circuit,NON,Eric C. Johnson,5591
+Minnehaha,Judge of the Circuit Court,Position C Second Circuit,NON,Doug Barnett,25051
+Minnehaha,Judge of the Circuit Court,Position C Second Circuit,NON,Eric C. Johnson,14741
+Lincoln,Judge of the Circuit Court,Position D Second Circuit,NON,Natalie Damgaard,13015
+Minnehaha,Judge of the Circuit Court,Position D Second Circuit,NON,Natalie Damgaard,29813
+Lincoln,Judge of the Circuit Court,Position E Second Circuit,NON,John Pekas,11807
+Minnehaha,Judge of the Circuit Court,Position E Second Circuit,NON,John Pekas,30590
+Lincoln,Judge of the Circuit Court,Position F Second Circuit,NON,Camela Theeler,11133
+Minnehaha,Judge of the Circuit Court,Position F Second Circuit,NON,Camela Theeler,28760
+Lincoln,Judge of the Circuit Court,Position G Second Circuit,NON,Jennifer D. Mammenga,11147
+Minnehaha,Judge of the Circuit Court,Position G Second Circuit,NON,Jennifer D. Mammenga,28970
+Lincoln,Judge of the Circuit Court,Position H Second Circuit,NON,Susan M. Sabers,11377
+Minnehaha,Judge of the Circuit Court,Position H Second Circuit,NON,Susan M. Sabers,29304
+Lincoln,Judge of the Circuit Court,Position I Second Circuit,NON,Doug Hoffman,11252
+Minnehaha,Judge of the Circuit Court,Position I Second Circuit,NON,Doug Hoffman,28721
+Lincoln,Judge of the Circuit Court,Position J Second Circuit,NON,James Power,10913
+Minnehaha,Judge of the Circuit Court,Position J Second Circuit,NON,James Power,27706
+Lincoln,Judge of the Circuit Court,Position K Second Circuit,NON,Jon C. Sogn,11544
+Minnehaha,Judge of the Circuit Court,Position K Second Circuit,NON,Jon C. Sogn,28697
+Lincoln,Judge of the Circuit Court,Position L Second Circuit,NON,Rachel R. Rasmussen,11414
+Minnehaha,Judge of the Circuit Court,Position L Second Circuit,NON,Rachel R. Rasmussen,28750
+Beadle,Judge of the Circuit Court,Position A Third Circuit,NON,Carmen Means,3099
+Brookings,Judge of the Circuit Court,Position A Third Circuit,NON,Carmen Means,5290
+Clark,Judge of the Circuit Court,Position A Third Circuit,NON,Carmen Means,778
+Codington,Judge of the Circuit Court,Position A Third Circuit,NON,Carmen Means,5535
+Deuel,Judge of the Circuit Court,Position A Third Circuit,NON,Carmen Means,1037
+Grant,Judge of the Circuit Court,Position A Third Circuit,NON,Carmen Means,1479
+Hamlin,Judge of the Circuit Court,Position A Third Circuit,NON,Carmen Means,1162
+Hand,Judge of the Circuit Court,Position A Third Circuit,NON,Carmen Means,787
+Jerauld,Judge of the Circuit Court,Position A Third Circuit,NON,Carmen Means,414
+Kingsbury,Judge of the Circuit Court,Position A Third Circuit,NON,Carmen Means,1153
+Lake,Judge of the Circuit Court,Position A Third Circuit,NON,Carmen Means,2442
+Miner,Judge of the Circuit Court,Position A Third Circuit,NON,Carmen Means,389
+Moody,Judge of the Circuit Court,Position A Third Circuit,NON,Carmen Means,1124
+Sanborn,Judge of the Circuit Court,Position A Third Circuit,NON,Carmen Means,453
+Beadle,Judge of the Circuit Court,Position B Third Circuit,NON,Dawn M. Elshere,2840
+Brookings,Judge of the Circuit Court,Position B Third Circuit,NON,Dawn M. Elshere,5212
+Clark,Judge of the Circuit Court,Position B Third Circuit,NON,Dawn M. Elshere,736
+Codington,Judge of the Circuit Court,Position B Third Circuit,NON,Dawn M. Elshere,5620
+Deuel,Judge of the Circuit Court,Position B Third Circuit,NON,Dawn M. Elshere,1053
+Grant,Judge of the Circuit Court,Position B Third Circuit,NON,Dawn M. Elshere,1599
+Hamlin,Judge of the Circuit Court,Position B Third Circuit,NON,Dawn M. Elshere,1168
+Hand,Judge of the Circuit Court,Position B Third Circuit,NON,Dawn M. Elshere,779
+Jerauld,Judge of the Circuit Court,Position B Third Circuit,NON,Dawn M. Elshere,378
+Kingsbury,Judge of the Circuit Court,Position B Third Circuit,NON,Dawn M. Elshere,1120
+Lake,Judge of the Circuit Court,Position B Third Circuit,NON,Dawn M. Elshere,2287
+Miner,Judge of the Circuit Court,Position B Third Circuit,NON,Dawn M. Elshere,383
+Moody,Judge of the Circuit Court,Position B Third Circuit,NON,Dawn M. Elshere,1075
+Sanborn,Judge of the Circuit Court,Position B Third Circuit,NON,Dawn M. Elshere,440
+Beadle,Judge of the Circuit Court,Position C Third Circuit,NON,Kent A Shelton,3705
+Brookings,Judge of the Circuit Court,Position C Third Circuit,NON,Kent A Shelton,5010
+Clark,Judge of the Circuit Court,Position C Third Circuit,NON,Kent A Shelton,704
+Codington,Judge of the Circuit Court,Position C Third Circuit,NON,Kent A Shelton,4882
+Deuel,Judge of the Circuit Court,Position C Third Circuit,NON,Kent A Shelton,988
+Grant,Judge of the Circuit Court,Position C Third Circuit,NON,Kent A Shelton,1407
+Hamlin,Judge of the Circuit Court,Position C Third Circuit,NON,Kent A Shelton,1127
+Hand,Judge of the Circuit Court,Position C Third Circuit,NON,Kent A Shelton,828
+Jerauld,Judge of the Circuit Court,Position C Third Circuit,NON,Kent A Shelton,421
+Kingsbury,Judge of the Circuit Court,Position C Third Circuit,NON,Kent A Shelton,1140
+Lake,Judge of the Circuit Court,Position C Third Circuit,NON,Kent A Shelton,2243
+Miner,Judge of the Circuit Court,Position C Third Circuit,NON,Kent A Shelton,379
+Moody,Judge of the Circuit Court,Position C Third Circuit,NON,Kent A Shelton,1039
+Sanborn,Judge of the Circuit Court,Position C Third Circuit,NON,Kent A Shelton,468
+Beadle,Judge of the Circuit Court,Position D Third Circuit,NON,Gregory J. Stoltenburg,2872
+Brookings,Judge of the Circuit Court,Position D Third Circuit,NON,Gregory J. Stoltenburg,5646
+Clark,Judge of the Circuit Court,Position D Third Circuit,NON,Gregory J. Stoltenburg,710
+Codington,Judge of the Circuit Court,Position D Third Circuit,NON,Gregory J. Stoltenburg,5154
+Deuel,Judge of the Circuit Court,Position D Third Circuit,NON,Gregory J. Stoltenburg,1320
+Grant,Judge of the Circuit Court,Position D Third Circuit,NON,Gregory J. Stoltenburg,1428
+Hamlin,Judge of the Circuit Court,Position D Third Circuit,NON,Gregory J. Stoltenburg,1200
+Hand,Judge of the Circuit Court,Position D Third Circuit,NON,Gregory J. Stoltenburg,761
+Jerauld,Judge of the Circuit Court,Position D Third Circuit,NON,Gregory J. Stoltenburg,371
+Kingsbury,Judge of the Circuit Court,Position D Third Circuit,NON,Gregory J. Stoltenburg,1187
+Lake,Judge of the Circuit Court,Position D Third Circuit,NON,Gregory J. Stoltenburg,2279
+Miner,Judge of the Circuit Court,Position D Third Circuit,NON,Gregory J. Stoltenburg,412
+Moody,Judge of the Circuit Court,Position D Third Circuit,NON,Gregory J. Stoltenburg,1075
+Sanborn,Judge of the Circuit Court,Position D Third Circuit,NON,Gregory J. Stoltenburg,439
+Beadle,Judge of the Circuit Court,Position E Third Circuit,NON,Robert L. Spears,1870
+Beadle,Judge of the Circuit Court,Position E Third Circuit,NON,Michael R. Moore,2687
+Brookings,Judge of the Circuit Court,Position E Third Circuit,NON,Robert L. Spears,2699
+Brookings,Judge of the Circuit Court,Position E Third Circuit,NON,Michael R. Moore,2862
+Clark,Judge of the Circuit Court,Position E Third Circuit,NON,Robert L. Spears,509
+Clark,Judge of the Circuit Court,Position E Third Circuit,NON,Michael R. Moore,411
+Codington,Judge of the Circuit Court,Position E Third Circuit,NON,Robert L. Spears,4741
+Codington,Judge of the Circuit Court,Position E Third Circuit,NON,Michael R. Moore,2387
+Deuel,Judge of the Circuit Court,Position E Third Circuit,NON,Robert L. Spears,830
+Deuel,Judge of the Circuit Court,Position E Third Circuit,NON,Michael R. Moore,495
+Grant,Judge of the Circuit Court,Position E Third Circuit,NON,Robert L. Spears,909
+Grant,Judge of the Circuit Court,Position E Third Circuit,NON,Michael R. Moore,986
+Hamlin,Judge of the Circuit Court,Position E Third Circuit,NON,Robert L. Spears,914
+Hamlin,Judge of the Circuit Court,Position E Third Circuit,NON,Michael R. Moore,574
+Hand,Judge of the Circuit Court,Position E Third Circuit,NON,Robert L. Spears,332
+Hand,Judge of the Circuit Court,Position E Third Circuit,NON,Michael R. Moore,601
+Jerauld,Judge of the Circuit Court,Position E Third Circuit,NON,Robert L. Spears,197
+Jerauld,Judge of the Circuit Court,Position E Third Circuit,NON,Michael R. Moore,278
+Kingsbury,Judge of the Circuit Court,Position E Third Circuit,NON,Robert L. Spears,625
+Kingsbury,Judge of the Circuit Court,Position E Third Circuit,NON,Michael R. Moore,770
+Lake,Judge of the Circuit Court,Position E Third Circuit,NON,Robert L. Spears,969
+Lake,Judge of the Circuit Court,Position E Third Circuit,NON,Michael R. Moore,1433
+Miner,Judge of the Circuit Court,Position E Third Circuit,NON,Robert L. Spears,187
+Miner,Judge of the Circuit Court,Position E Third Circuit,NON,Michael R. Moore,264
+Moody,Judge of the Circuit Court,Position E Third Circuit,NON,Robert L. Spears,564
+Moody,Judge of the Circuit Court,Position E Third Circuit,NON,Michael R. Moore,657
+Sanborn,Judge of the Circuit Court,Position E Third Circuit,NON,Robert L. Spears,190
+Sanborn,Judge of the Circuit Court,Position E Third Circuit,NON,Michael R. Moore,394
+Beadle,Judge of the Circuit Court,Position F Third Circuit,NON,Patrick Pardy,2812
+Brookings,Judge of the Circuit Court,Position F Third Circuit,NON,Patrick Pardy,4931
+Clark,Judge of the Circuit Court,Position F Third Circuit,NON,Patrick Pardy,679
+Codington,Judge of the Circuit Court,Position F Third Circuit,NON,Patrick Pardy,4804
+Deuel,Judge of the Circuit Court,Position F Third Circuit,NON,Patrick Pardy,964
+Grant,Judge of the Circuit Court,Position F Third Circuit,NON,Patrick Pardy,1380
+Hamlin,Judge of the Circuit Court,Position F Third Circuit,NON,Patrick Pardy,1094
+Hand,Judge of the Circuit Court,Position F Third Circuit,NON,Patrick Pardy,739
+Jerauld,Judge of the Circuit Court,Position F Third Circuit,NON,Patrick Pardy,405
+Kingsbury,Judge of the Circuit Court,Position F Third Circuit,NON,Patrick Pardy,1183
+Lake,Judge of the Circuit Court,Position F Third Circuit,NON,Patrick Pardy,2783
+Miner,Judge of the Circuit Court,Position F Third Circuit,NON,Patrick Pardy,669
+Moody,Judge of the Circuit Court,Position F Third Circuit,NON,Patrick Pardy,1067
+Sanborn,Judge of the Circuit Court,Position F Third Circuit,NON,Patrick Pardy,480
+Butte,Judge of the Circuit Court,Position A Fourth Circuit,NON,Eric J. Strawn,2240
+Corson,Judge of the Circuit Court,Position A Fourth Circuit,NON,Eric J. Strawn,369
+Dewey,Judge of the Circuit Court,Position A Fourth Circuit,NON,Eric J. Strawn,554
+Harding,Judge of the Circuit Court,Position A Fourth Circuit,NON,Eric J. Strawn,354
+Lawrence,Judge of the Circuit Court,Position A Fourth Circuit,NON,Eric J. Strawn,6395
+Meade,Judge of the Circuit Court,Position A Fourth Circuit,NON,Eric J. Strawn,5373
+Perkins,Judge of the Circuit Court,Position A Fourth Circuit,NON,Eric J. Strawn,623
+Ziebach,Judge of the Circuit Court,Position A Fourth Circuit,NON,Eric J. Strawn,228
+Butte,Judge of the Circuit Court,Position B Fourth Circuit,NON,Michael W. Day,2602
+Corson,Judge of the Circuit Court,Position B Fourth Circuit,NON,Michael W. Day,373
+Dewey,Judge of the Circuit Court,Position B Fourth Circuit,NON,Michael W. Day,574
+Harding,Judge of the Circuit Court,Position B Fourth Circuit,NON,Michael W. Day,382
+Lawrence,Judge of the Circuit Court,Position B Fourth Circuit,NON,Michael W. Day,6013
+Meade,Judge of the Circuit Court,Position B Fourth Circuit,NON,Michael W. Day,5334
+Perkins,Judge of the Circuit Court,Position B Fourth Circuit,NON,Michael W. Day,625
+Ziebach,Judge of the Circuit Court,Position B Fourth Circuit,NON,Michael W. Day,237
+Butte,Judge of the Circuit Court,Position C Fourth Circuit,NON,Michelle Palmer Comer,2183
+Corson,Judge of the Circuit Court,Position C Fourth Circuit,NON,Michelle Palmer Comer,369
+Dewey,Judge of the Circuit Court,Position C Fourth Circuit,NON,Michelle Palmer Comer,558
+Harding,Judge of the Circuit Court,Position C Fourth Circuit,NON,Michelle Palmer Comer,352
+Lawrence,Judge of the Circuit Court,Position C Fourth Circuit,NON,Michelle Palmer Comer,6270
+Meade,Judge of the Circuit Court,Position C Fourth Circuit,NON,Michelle Palmer Comer,5307
+Perkins,Judge of the Circuit Court,Position C Fourth Circuit,NON,Michelle Palmer Comer,610
+Ziebach,Judge of the Circuit Court,Position C Fourth Circuit,NON,Michelle Palmer Comer,223
+Butte,Judge of the Circuit Court,Position D Fourth Circuit,NON,Tina M. Hogue,215
+Butte,Judge of the Circuit Court,Position D Fourth Circuit,NON,Chad R. Callahan,772
+Butte,Judge of the Circuit Court,Position D Fourth Circuit,NON,Jennifer Tomac,203
+Butte,Judge of the Circuit Court,Position D Fourth Circuit,NON,John H. Fitzgerald,1181
+Butte,Judge of the Circuit Court,Position D Fourth Circuit,NON,David V. Natvig,894
+Corson,Judge of the Circuit Court,Position D Fourth Circuit,NON,Tina M. Hogue,41
+Corson,Judge of the Circuit Court,Position D Fourth Circuit,NON,Chad R. Callahan,97
+Corson,Judge of the Circuit Court,Position D Fourth Circuit,NON,Jennifer Tomac,255
+Corson,Judge of the Circuit Court,Position D Fourth Circuit,NON,John H. Fitzgerald,58
+Corson,Judge of the Circuit Court,Position D Fourth Circuit,NON,David V. Natvig,80
+Dewey,Judge of the Circuit Court,Position D Fourth Circuit,NON,Tina M. Hogue,135
+Dewey,Judge of the Circuit Court,Position D Fourth Circuit,NON,Chad R. Callahan,138
+Dewey,Judge of the Circuit Court,Position D Fourth Circuit,NON,Jennifer Tomac,288
+Dewey,Judge of the Circuit Court,Position D Fourth Circuit,NON,John H. Fitzgerald,139
+Dewey,Judge of the Circuit Court,Position D Fourth Circuit,NON,David V. Natvig,103
+Harding,Judge of the Circuit Court,Position D Fourth Circuit,NON,Tina M. Hogue,30
+Harding,Judge of the Circuit Court,Position D Fourth Circuit,NON,Chad R. Callahan,96
+Harding,Judge of the Circuit Court,Position D Fourth Circuit,NON,Jennifer Tomac,79
+Harding,Judge of the Circuit Court,Position D Fourth Circuit,NON,John H. Fitzgerald,109
+Harding,Judge of the Circuit Court,Position D Fourth Circuit,NON,David V. Natvig,153
+Lawrence,Judge of the Circuit Court,Position D Fourth Circuit,NON,Tina M. Hogue,829
+Lawrence,Judge of the Circuit Court,Position D Fourth Circuit,NON,Chad R. Callahan,1527
+Lawrence,Judge of the Circuit Court,Position D Fourth Circuit,NON,Jennifer Tomac,734
+Lawrence,Judge of the Circuit Court,Position D Fourth Circuit,NON,John H. Fitzgerald,4123
+Lawrence,Judge of the Circuit Court,Position D Fourth Circuit,NON,David V. Natvig,1635
+Meade,Judge of the Circuit Court,Position D Fourth Circuit,NON,Tina M. Hogue,1106
+Meade,Judge of the Circuit Court,Position D Fourth Circuit,NON,Chad R. Callahan,1666
+Meade,Judge of the Circuit Court,Position D Fourth Circuit,NON,Jennifer Tomac,1033
+Meade,Judge of the Circuit Court,Position D Fourth Circuit,NON,John H. Fitzgerald,2325
+Meade,Judge of the Circuit Court,Position D Fourth Circuit,NON,David V. Natvig,1429
+Perkins,Judge of the Circuit Court,Position D Fourth Circuit,NON,Tina M. Hogue,51
+Perkins,Judge of the Circuit Court,Position D Fourth Circuit,NON,Chad R. Callahan,195
+Perkins,Judge of the Circuit Court,Position D Fourth Circuit,NON,Jennifer Tomac,266
+Perkins,Judge of the Circuit Court,Position D Fourth Circuit,NON,John H. Fitzgerald,125
+Perkins,Judge of the Circuit Court,Position D Fourth Circuit,NON,David V. Natvig,228
+Ziebach,Judge of the Circuit Court,Position D Fourth Circuit,NON,Tina M. Hogue,52
+Ziebach,Judge of the Circuit Court,Position D Fourth Circuit,NON,Chad R. Callahan,64
+Ziebach,Judge of the Circuit Court,Position D Fourth Circuit,NON,Jennifer Tomac,128
+Ziebach,Judge of the Circuit Court,Position D Fourth Circuit,NON,John H. Fitzgerald,65
+Ziebach,Judge of the Circuit Court,Position D Fourth Circuit,NON,David V. Natvig,53
+Brown,Judge of the Circuit Court,Position A Fifth Circuit,NON,Marshall C. Lovrien,8637
+Campbell,Judge of the Circuit Court,Position A Fifth Circuit,NON,Marshall C. Lovrien,357
+Day,Judge of the Circuit Court,Position A Fifth Circuit,NON,Marshall C. Lovrien,1202
+Edmunds,Judge of the Circuit Court,Position A Fifth Circuit,NON,Marshall C. Lovrien,919
+Faulk,Judge of the Circuit Court,Position A Fifth Circuit,NON,Marshall C. Lovrien,525
+Marshall,Judge of the Circuit Court,Position A Fifth Circuit,NON,Marshall C. Lovrien,826
+McPherson,Judge of the Circuit Court,Position A Fifth Circuit,NON,Marshall C. Lovrien,677
+Roberts,Judge of the Circuit Court,Position A Fifth Circuit,NON,Marshall C. Lovrien,1437
+Spink,Judge of the Circuit Court,Position A Fifth Circuit,NON,Marshall C. Lovrien,1504
+Walworth,Judge of the Circuit Court,Position A Fifth Circuit,NON,Marshall C. Lovrien,1028
+Brown,Judge of the Circuit Court,Position B Fifth Circuit,NON,Tony L. Portra,8467
+Campbell,Judge of the Circuit Court,Position B Fifth Circuit,NON,Tony L. Portra,334
+Day,Judge of the Circuit Court,Position B Fifth Circuit,NON,Tony L. Portra,1134
+Edmunds,Judge of the Circuit Court,Position B Fifth Circuit,NON,Tony L. Portra,875
+Faulk,Judge of the Circuit Court,Position B Fifth Circuit,NON,Tony L. Portra,514
+Marshall,Judge of the Circuit Court,Position B Fifth Circuit,NON,Tony L. Portra,840
+McPherson,Judge of the Circuit Court,Position B Fifth Circuit,NON,Tony L. Portra,651
+Roberts,Judge of the Circuit Court,Position B Fifth Circuit,NON,Tony L. Portra,1475
+Spink,Judge of the Circuit Court,Position B Fifth Circuit,NON,Tony L. Portra,1531
+Walworth,Judge of the Circuit Court,Position B Fifth Circuit,NON,Tony L. Portra,991
+Brown,Judge of the Circuit Court,Position C Fifth Circuit,NON,Gregory C. Magera,7683
+Campbell,Judge of the Circuit Court,Position C Fifth Circuit,NON,Gregory C. Magera,327
+Day,Judge of the Circuit Court,Position C Fifth Circuit,NON,Gregory C. Magera,1079
+Edmunds,Judge of the Circuit Court,Position C Fifth Circuit,NON,Gregory C. Magera,839
+Faulk,Judge of the Circuit Court,Position C Fifth Circuit,NON,Gregory C. Magera,451
+Marshall,Judge of the Circuit Court,Position C Fifth Circuit,NON,Gregory C. Magera,770
+McPherson,Judge of the Circuit Court,Position C Fifth Circuit,NON,Gregory C. Magera,637
+Roberts,Judge of the Circuit Court,Position C Fifth Circuit,NON,Gregory C. Magera,1365
+Spink,Judge of the Circuit Court,Position C Fifth Circuit,NON,Gregory C. Magera,1409
+Walworth,Judge of the Circuit Court,Position C Fifth Circuit,NON,Gregory C. Magera,970
+Brown,Judge of the Circuit Court,Position D Fifth Circuit,NON,Richard A. Sommers,7843
+Campbell,Judge of the Circuit Court,Position D Fifth Circuit,NON,Richard A. Sommers,338
+Day,Judge of the Circuit Court,Position D Fifth Circuit,NON,Richard A. Sommers,1255
+Edmunds,Judge of the Circuit Court,Position D Fifth Circuit,NON,Richard A. Sommers,875
+Faulk,Judge of the Circuit Court,Position D Fifth Circuit,NON,Richard A. Sommers,475
+Marshall,Judge of the Circuit Court,Position D Fifth Circuit,NON,Richard A. Sommers,1126
+McPherson,Judge of the Circuit Court,Position D Fifth Circuit,NON,Richard A. Sommers,658
+Roberts,Judge of the Circuit Court,Position D Fifth Circuit,NON,Richard A. Sommers,1482
+Spink,Judge of the Circuit Court,Position D Fifth Circuit,NON,Richard A. Sommers,1441
+Walworth,Judge of the Circuit Court,Position D Fifth Circuit,NON,Richard A. Sommers,981
+Bennett,Judge of the Circuit Court,Position A Sixth Circuit,NON,Christina Klinger,436
+Gregory,Judge of the Circuit Court,Position A Sixth Circuit,NON,Christina Klinger,836
+Haakon,Judge of the Circuit Court,Position A Sixth Circuit,NON,Christina Klinger,500
+Hughes,Judge of the Circuit Court,Position A Sixth Circuit,NON,Christina Klinger,4758
+Hyde,Judge of the Circuit Court,Position A Sixth Circuit,NON,Christina Klinger,314
+Jackson,Judge of the Circuit Court,Position A Sixth Circuit,NON,Christina Klinger,372
+Jones,Judge of the Circuit Court,Position A Sixth Circuit,NON,Christina Klinger,225
+Lyman,Judge of the Circuit Court,Position A Sixth Circuit,NON,Christina Klinger,543
+Mellette,Judge of the Circuit Court,Position A Sixth Circuit,NON,Christina Klinger,251
+Potter,Judge of the Circuit Court,Position A Sixth Circuit,NON,Christina Klinger,527
+Stanley,Judge of the Circuit Court,Position A Sixth Circuit,NON,Christina Klinger,921
+Sully,Judge of the Circuit Court,Position A Sixth Circuit,NON,Christina Klinger,445
+Todd,Judge of the Circuit Court,Position A Sixth Circuit,NON,Christina Klinger,540
+Tripp,Judge of the Circuit Court,Position A Sixth Circuit,NON,Christina Klinger,1087
+Bennett,Judge of the Circuit Court,Position B Sixth Circuit,NON,Margo Northrup,425
+Gregory,Judge of the Circuit Court,Position B Sixth Circuit,NON,Margo Northrup,796
+Haakon,Judge of the Circuit Court,Position B Sixth Circuit,NON,Margo Northrup,489
+Hughes,Judge of the Circuit Court,Position B Sixth Circuit,NON,Margo Northrup,4723
+Hyde,Judge of the Circuit Court,Position B Sixth Circuit,NON,Margo Northrup,317
+Jackson,Judge of the Circuit Court,Position B Sixth Circuit,NON,Margo Northrup,361
+Jones,Judge of the Circuit Court,Position B Sixth Circuit,NON,Margo Northrup,222
+Lyman,Judge of the Circuit Court,Position B Sixth Circuit,NON,Margo Northrup,512
+Mellette,Judge of the Circuit Court,Position B Sixth Circuit,NON,Margo Northrup,237
+Potter,Judge of the Circuit Court,Position B Sixth Circuit,NON,Margo Northrup,512
+Stanley,Judge of the Circuit Court,Position B Sixth Circuit,NON,Margo Northrup,921
+Sully,Judge of the Circuit Court,Position B Sixth Circuit,NON,Margo Northrup,454
+Todd,Judge of the Circuit Court,Position B Sixth Circuit,NON,Margo Northrup,497
+Tripp,Judge of the Circuit Court,Position B Sixth Circuit,NON,Margo Northrup,1056
+Bennett,Judge of the Circuit Court,Position C Sixth Circuit,NON,M. Bridget Mayer,411
+Gregory,Judge of the Circuit Court,Position C Sixth Circuit,NON,M. Bridget Mayer,807
+Haakon,Judge of the Circuit Court,Position C Sixth Circuit,NON,M. Bridget Mayer,484
+Hughes,Judge of the Circuit Court,Position C Sixth Circuit,NON,M. Bridget Mayer,4705
+Hyde,Judge of the Circuit Court,Position C Sixth Circuit,NON,M. Bridget Mayer,306
+Jackson,Judge of the Circuit Court,Position C Sixth Circuit,NON,M. Bridget Mayer,358
+Jones,Judge of the Circuit Court,Position C Sixth Circuit,NON,M. Bridget Mayer,221
+Lyman,Judge of the Circuit Court,Position C Sixth Circuit,NON,M. Bridget Mayer,511
+Mellette,Judge of the Circuit Court,Position C Sixth Circuit,NON,M. Bridget Mayer,240
+Potter,Judge of the Circuit Court,Position C Sixth Circuit,NON,M. Bridget Mayer,519
+Stanley,Judge of the Circuit Court,Position C Sixth Circuit,NON,M. Bridget Mayer,926
+Sully,Judge of the Circuit Court,Position C Sixth Circuit,NON,M. Bridget Mayer,440
+Todd,Judge of the Circuit Court,Position C Sixth Circuit,NON,M. Bridget Mayer,503
+Tripp,Judge of the Circuit Court,Position C Sixth Circuit,NON,M. Bridget Mayer,1119
+Bennett,Judge of the Circuit Court,Position D Sixth Circuit,NON,Bobbi J. Rank,422
+Gregory,Judge of the Circuit Court,Position D Sixth Circuit,NON,Bobbi J. Rank,916
+Haakon,Judge of the Circuit Court,Position D Sixth Circuit,NON,Bobbi J. Rank,477
+Hughes,Judge of the Circuit Court,Position D Sixth Circuit,NON,Bobbi J. Rank,4534
+Hyde,Judge of the Circuit Court,Position D Sixth Circuit,NON,Bobbi J. Rank,304
+Jackson,Judge of the Circuit Court,Position D Sixth Circuit,NON,Bobbi J. Rank,346
+Jones,Judge of the Circuit Court,Position D Sixth Circuit,NON,Bobbi J. Rank,215
+Lyman,Judge of the Circuit Court,Position D Sixth Circuit,NON,Bobbi J. Rank,535
+Mellette,Judge of the Circuit Court,Position D Sixth Circuit,NON,Bobbi J. Rank,248
+Potter,Judge of the Circuit Court,Position D Sixth Circuit,NON,Bobbi J. Rank,498
+Stanley,Judge of the Circuit Court,Position D Sixth Circuit,NON,Bobbi J. Rank,875
+Sully,Judge of the Circuit Court,Position D Sixth Circuit,NON,Bobbi J. Rank,427
+Todd,Judge of the Circuit Court,Position D Sixth Circuit,NON,Bobbi J. Rank,544
+Tripp,Judge of the Circuit Court,Position D Sixth Circuit,NON,Bobbi J. Rank,1375
+Custer,Judge of the Circuit Court,Position A Seventh Circuit,NON,Stacy Vinberg-Wickre,1928
+Fall River,Judge of the Circuit Court,Position A Seventh Circuit,NON,Stacy Vinberg-Wickre,1451
+Oglala Lakota,Judge of the Circuit Court,Position A Seventh Circuit,NON,Stacy Vinberg-Wickre,531
+Pennington,Judge of the Circuit Court,Position A Seventh Circuit,NON,Stacy Vinberg-Wickre,16708
+Custer,Judge of the Circuit Court,Position B Seventh Circuit,NON,Jeffrey R. Connolly,1903
+Fall River,Judge of the Circuit Court,Position B Seventh Circuit,NON,Jeffrey R. Connolly,1390
+Oglala Lakota,Judge of the Circuit Court,Position B Seventh Circuit,NON,Jeffrey R. Connolly,474
+Pennington,Judge of the Circuit Court,Position B Seventh Circuit,NON,Jeffrey R. Connolly,16803
+Custer,Judge of the Circuit Court,Position C Seventh Circuit,NON,Heidi L. Linngren,1957
+Fall River,Judge of the Circuit Court,Position C Seventh Circuit,NON,Heidi L. Linngren,1465
+Oglala Lakota,Judge of the Circuit Court,Position C Seventh Circuit,NON,Heidi L. Linngren,488
+Pennington,Judge of the Circuit Court,Position C Seventh Circuit,NON,Heidi L. Linngren,17839
+Custer,Judge of the Circuit Court,Position D Seventh Circuit,NON,Joshua K. Hendrickson,1845
+Fall River,Judge of the Circuit Court,Position D Seventh Circuit,NON,Joshua K. Hendrickson,1369
+Oglala Lakota,Judge of the Circuit Court,Position D Seventh Circuit,NON,Joshua K. Hendrickson,439
+Pennington,Judge of the Circuit Court,Position D Seventh Circuit,NON,Joshua K. Hendrickson,16133
+Custer,Judge of the Circuit Court,Position E Seventh Circuit,NON,Jane Wipf Pfeifle,1914
+Fall River,Judge of the Circuit Court,Position E Seventh Circuit,NON,Jane Wipf Pfeifle,1370
+Oglala Lakota,Judge of the Circuit Court,Position E Seventh Circuit,NON,Jane Wipf Pfeifle,477
+Pennington,Judge of the Circuit Court,Position E Seventh Circuit,NON,Jane Wipf Pfeifle,18347
+Custer,Judge of the Circuit Court,Position F Seventh Circuit,NON,Craig A Pfeifle,1871
+Fall River,Judge of the Circuit Court,Position F Seventh Circuit,NON,Craig A Pfeifle,1346
+Oglala Lakota,Judge of the Circuit Court,Position F Seventh Circuit,NON,Craig A Pfeifle,421
+Pennington,Judge of the Circuit Court,Position F Seventh Circuit,NON,Craig A Pfeifle,17905
+Custer,Judge of the Circuit Court,Position G Seventh Circuit,NON,Robert Gusinsky,1829
+Fall River,Judge of the Circuit Court,Position G Seventh Circuit,NON,Robert Gusinsky,1336
+Oglala Lakota,Judge of the Circuit Court,Position G Seventh Circuit,NON,Robert Gusinsky,414
+Pennington,Judge of the Circuit Court,Position G Seventh Circuit,NON,Robert Gusinsky,16322
+Custer,Judge of the Circuit Court,Position H Seventh Circuit,NON,Matthew M. Brown,2386
+Fall River,Judge of the Circuit Court,Position H Seventh Circuit,NON,Matthew M. Brown,1398
+Oglala Lakota,Judge of the Circuit Court,Position H Seventh Circuit,NON,Matthew M. Brown,494
+Pennington,Judge of the Circuit Court,Position H Seventh Circuit,NON,Matthew M. Brown,16406
+Aurora,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,846
+Aurora,Supreme Court Retention,3,,Patricia J. DeVaney - No,155
+Beadle,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,4076
+Beadle,Supreme Court Retention,3,,Patricia J. DeVaney - No,775
+Bennett,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,596
+Bennett,Supreme Court Retention,3,,Patricia J. DeVaney - No,231
+Bon Homme,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,1797
+Bon Homme,Supreme Court Retention,3,,Patricia J. DeVaney - No,401
+Brookings,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,7787
+Brookings,Supreme Court Retention,3,,Patricia J. DeVaney - No,1788
+Brown,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,9484
+Brown,Supreme Court Retention,3,,Patricia J. DeVaney - No,2076
+Brule,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,1400
+Brule,Supreme Court Retention,3,,Patricia J. DeVaney - No,346
+Buffalo,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,213
+Buffalo,Supreme Court Retention,3,,Patricia J. DeVaney - No,124
+Butte,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,2897
+Butte,Supreme Court Retention,3,,Patricia J. DeVaney - No,702
+Campbell,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,427
+Campbell,Supreme Court Retention,3,,Patricia J. DeVaney - No,102
+Charles Mix,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,2098
+Charles Mix,Supreme Court Retention,3,,Patricia J. DeVaney - No,535
+Clark,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,1104
+Clark,Supreme Court Retention,3,,Patricia J. DeVaney - No,212
+Clay,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,2988
+Clay,Supreme Court Retention,3,,Patricia J. DeVaney - No,828
+Codington,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,7309
+Codington,Supreme Court Retention,3,,Patricia J. DeVaney - No,1551
+Corson,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,554
+Corson,Supreme Court Retention,3,,Patricia J. DeVaney - No,248
+Custer,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,3333
+Custer,Supreme Court Retention,3,,Patricia J. DeVaney - No,784
+Davison,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,5069
+Davison,Supreme Court Retention,3,,Patricia J. DeVaney - No,1129
+Day,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,1684
+Day,Supreme Court Retention,3,,Patricia J. DeVaney - No,367
+Deuel,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,1411
+Deuel,Supreme Court Retention,3,,Patricia J. DeVaney - No,238
+Dewey,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,895
+Dewey,Supreme Court Retention,3,,Patricia J. DeVaney - No,438
+Douglas,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,1031
+Douglas,Supreme Court Retention,3,,Patricia J. DeVaney - No,213
+Edmunds,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,1180
+Edmunds,Supreme Court Retention,3,,Patricia J. DeVaney - No,270
+Fall River,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,2359
+Fall River,Supreme Court Retention,3,,Patricia J. DeVaney - No,645
+Faulk,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,661
+Faulk,Supreme Court Retention,3,,Patricia J. DeVaney - No,138
+Grant,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,2233
+Grant,Supreme Court Retention,3,,Patricia J. DeVaney - No,475
+Gregory,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,1416
+Gregory,Supreme Court Retention,3,,Patricia J. DeVaney - No,332
+Haakon,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,686
+Haakon,Supreme Court Retention,3,,Patricia J. DeVaney - No,145
+Hamlin,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,1786
+Hamlin,Supreme Court Retention,3,,Patricia J. DeVaney - No,315
+Hand,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,1135
+Hand,Supreme Court Retention,3,,Patricia J. DeVaney - No,172
+Hanson,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,1130
+Hanson,Supreme Court Retention,3,,Patricia J. DeVaney - No,212
+Harding,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,467
+Harding,Supreme Court Retention,3,,Patricia J. DeVaney - No,76
+Hughes,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,5793
+Hughes,Supreme Court Retention,3,,Patricia J. DeVaney - No,987
+Hutchinson,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,2246
+Hutchinson,Supreme Court Retention,3,,Patricia J. DeVaney - No,405
+Hyde,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,431
+Hyde,Supreme Court Retention,3,,Patricia J. DeVaney - No,82
+Jackson,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,585
+Jackson,Supreme Court Retention,3,,Patricia J. DeVaney - No,187
+Jerauld,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,608
+Jerauld,Supreme Court Retention,3,,Patricia J. DeVaney - No,127
+Jones,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,321
+Jones,Supreme Court Retention,3,,Patricia J. DeVaney - No,74
+Kingsbury,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,1807
+Kingsbury,Supreme Court Retention,3,,Patricia J. DeVaney - No,305
+Lake,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,3615
+Lake,Supreme Court Retention,3,,Patricia J. DeVaney - No,607
+Lawrence,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,7908
+Lawrence,Supreme Court Retention,3,,Patricia J. DeVaney - No,2241
+Lincoln,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,18511
+Lincoln,Supreme Court Retention,3,,Patricia J. DeVaney - No,3955
+Lyman,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,874
+Lyman,Supreme Court Retention,3,,Patricia J. DeVaney - No,236
+Marshall,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,1275
+Marshall,Supreme Court Retention,3,,Patricia J. DeVaney - No,300
+McCook,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,1793
+McCook,Supreme Court Retention,3,,Patricia J. DeVaney - No,364
+McPherson,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,801
+McPherson,Supreme Court Retention,3,,Patricia J. DeVaney - No,142
+Meade,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,7794
+Meade,Supreme Court Retention,3,,Patricia J. DeVaney - No,2045
+Mellette,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,412
+Mellette,Supreme Court Retention,3,,Patricia J. DeVaney - No,137
+Miner,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,667
+Miner,Supreme Court Retention,3,,Patricia J. DeVaney - No,114
+Minnehaha,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,47299
+Minnehaha,Supreme Court Retention,3,,Patricia J. DeVaney - No,12578
+Moody,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,1894
+Moody,Supreme Court Retention,3,,Patricia J. DeVaney - No,389
+Oglala Lakota,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,1112
+Oglala Lakota,Supreme Court Retention,3,,Patricia J. DeVaney - No,1018
+Pennington,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,28646
+Pennington,Supreme Court Retention,3,,Patricia J. DeVaney - No,8284
+Perkins,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,910
+Perkins,Supreme Court Retention,3,,Patricia J. DeVaney - No,189
+Potter,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,775
+Potter,Supreme Court Retention,3,,Patricia J. DeVaney - No,164
+Roberts,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,2427
+Roberts,Supreme Court Retention,3,,Patricia J. DeVaney - No,664
+Sanborn,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,698
+Sanborn,Supreme Court Retention,3,,Patricia J. DeVaney - No,133
+Spink,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,1882
+Spink,Supreme Court Retention,3,,Patricia J. DeVaney - No,400
+Stanley,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,1085
+Stanley,Supreme Court Retention,3,,Patricia J. DeVaney - No,207
+Sully,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,583
+Sully,Supreme Court Retention,3,,Patricia J. DeVaney - No,107
+Todd,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,917
+Todd,Supreme Court Retention,3,,Patricia J. DeVaney - No,710
+Tripp,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,1660
+Tripp,Supreme Court Retention,3,,Patricia J. DeVaney - No,328
+Turner,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,2687
+Turner,Supreme Court Retention,3,,Patricia J. DeVaney - No,558
+Union,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,4482
+Union,Supreme Court Retention,3,,Patricia J. DeVaney - No,1029
+Walworth,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,1421
+Walworth,Supreme Court Retention,3,,Patricia J. DeVaney - No,322
+Yankton,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,5758
+Yankton,Supreme Court Retention,3,,Patricia J. DeVaney - No,1451
+Ziebach,Supreme Court Retention,3,,Patricia J. DeVaney - Yes,397
+Ziebach,Supreme Court Retention,3,,Patricia J. DeVaney - No,190
+Aurora,Supreme Court Retention,2,,Mark E. Salter - Yes,826
+Aurora,Supreme Court Retention,2,,Mark E. Salter - No,165
+Beadle,Supreme Court Retention,2,,Mark E. Salter - Yes,4119
+Beadle,Supreme Court Retention,2,,Mark E. Salter - No,726
+Bennett,Supreme Court Retention,2,,Mark E. Salter - Yes,594
+Bennett,Supreme Court Retention,2,,Mark E. Salter - No,227
+Bon Homme,Supreme Court Retention,2,,Mark E. Salter - Yes,1797
+Bon Homme,Supreme Court Retention,2,,Mark E. Salter - No,391
+Brookings,Supreme Court Retention,2,,Mark E. Salter - Yes,7694
+Brookings,Supreme Court Retention,2,,Mark E. Salter - No,1758
+Brown,Supreme Court Retention,2,,Mark E. Salter - Yes,9299
+Brown,Supreme Court Retention,2,,Mark E. Salter - No,2081
+Brule,Supreme Court Retention,2,,Mark E. Salter - Yes,1383
+Brule,Supreme Court Retention,2,,Mark E. Salter - No,349
+Buffalo,Supreme Court Retention,2,,Mark E. Salter - Yes,213
+Buffalo,Supreme Court Retention,2,,Mark E. Salter - No,121
+Butte,Supreme Court Retention,2,,Mark E. Salter - Yes,2878
+Butte,Supreme Court Retention,2,,Mark E. Salter - No,707
+Campbell,Supreme Court Retention,2,,Mark E. Salter - Yes,424
+Campbell,Supreme Court Retention,2,,Mark E. Salter - No,96
+Charles Mix,Supreme Court Retention,2,,Mark E. Salter - Yes,2090
+Charles Mix,Supreme Court Retention,2,,Mark E. Salter - No,531
+Clark,Supreme Court Retention,2,,Mark E. Salter - Yes,1104
+Clark,Supreme Court Retention,2,,Mark E. Salter - No,203
+Clay,Supreme Court Retention,2,,Mark E. Salter - Yes,2917
+Clay,Supreme Court Retention,2,,Mark E. Salter - No,862
+Codington,Supreme Court Retention,2,,Mark E. Salter - Yes,7292
+Codington,Supreme Court Retention,2,,Mark E. Salter - No,1509
+Corson,Supreme Court Retention,2,,Mark E. Salter - Yes,526
+Corson,Supreme Court Retention,2,,Mark E. Salter - No,272
+Custer,Supreme Court Retention,2,,Mark E. Salter - Yes,3287
+Custer,Supreme Court Retention,2,,Mark E. Salter - No,795
+Davison,Supreme Court Retention,2,,Mark E. Salter - Yes,5096
+Davison,Supreme Court Retention,2,,Mark E. Salter - No,1063
+Day,Supreme Court Retention,2,,Mark E. Salter - Yes,1650
+Day,Supreme Court Retention,2,,Mark E. Salter - No,379
+Deuel,Supreme Court Retention,2,,Mark E. Salter - Yes,1386
+Deuel,Supreme Court Retention,2,,Mark E. Salter - No,238
+Dewey,Supreme Court Retention,2,,Mark E. Salter - Yes,862
+Dewey,Supreme Court Retention,2,,Mark E. Salter - No,467
+Douglas,Supreme Court Retention,2,,Mark E. Salter - Yes,1030
+Douglas,Supreme Court Retention,2,,Mark E. Salter - No,210
+Edmunds,Supreme Court Retention,2,,Mark E. Salter - Yes,1195
+Edmunds,Supreme Court Retention,2,,Mark E. Salter - No,253
+Fall River,Supreme Court Retention,2,,Mark E. Salter - Yes,2338
+Fall River,Supreme Court Retention,2,,Mark E. Salter - No,649
+Faulk,Supreme Court Retention,2,,Mark E. Salter - Yes,661
+Faulk,Supreme Court Retention,2,,Mark E. Salter - No,137
+Grant,Supreme Court Retention,2,,Mark E. Salter - Yes,2244
+Grant,Supreme Court Retention,2,,Mark E. Salter - No,458
+Gregory,Supreme Court Retention,2,,Mark E. Salter - Yes,1427
+Gregory,Supreme Court Retention,2,,Mark E. Salter - No,312
+Haakon,Supreme Court Retention,2,,Mark E. Salter - Yes,691
+Haakon,Supreme Court Retention,2,,Mark E. Salter - No,134
+Hamlin,Supreme Court Retention,2,,Mark E. Salter - Yes,1804
+Hamlin,Supreme Court Retention,2,,Mark E. Salter - No,291
+Hand,Supreme Court Retention,2,,Mark E. Salter - Yes,1128
+Hand,Supreme Court Retention,2,,Mark E. Salter - No,169
+Hanson,Supreme Court Retention,2,,Mark E. Salter - Yes,1121
+Hanson,Supreme Court Retention,2,,Mark E. Salter - No,206
+Harding,Supreme Court Retention,2,,Mark E. Salter - Yes,463
+Harding,Supreme Court Retention,2,,Mark E. Salter - No,77
+Hughes,Supreme Court Retention,2,,Mark E. Salter - Yes,5702
+Hughes,Supreme Court Retention,2,,Mark E. Salter - No,959
+Hutchinson,Supreme Court Retention,2,,Mark E. Salter - Yes,2271
+Hutchinson,Supreme Court Retention,2,,Mark E. Salter - No,374
+Hyde,Supreme Court Retention,2,,Mark E. Salter - Yes,427
+Hyde,Supreme Court Retention,2,,Mark E. Salter - No,79
+Jackson,Supreme Court Retention,2,,Mark E. Salter - Yes,583
+Jackson,Supreme Court Retention,2,,Mark E. Salter - No,179
+Jerauld,Supreme Court Retention,2,,Mark E. Salter - Yes,617
+Jerauld,Supreme Court Retention,2,,Mark E. Salter - No,119
+Jones,Supreme Court Retention,2,,Mark E. Salter - Yes,315
+Jones,Supreme Court Retention,2,,Mark E. Salter - No,78
+Kingsbury,Supreme Court Retention,2,,Mark E. Salter - Yes,1800
+Kingsbury,Supreme Court Retention,2,,Mark E. Salter - No,300
+Lake,Supreme Court Retention,2,,Mark E. Salter - Yes,3568
+Lake,Supreme Court Retention,2,,Mark E. Salter - No,610
+Lawrence,Supreme Court Retention,2,,Mark E. Salter - Yes,7865
+Lawrence,Supreme Court Retention,2,,Mark E. Salter - No,2230
+Lincoln,Supreme Court Retention,2,,Mark E. Salter - Yes,18519
+Lincoln,Supreme Court Retention,2,,Mark E. Salter - No,3874
+Lyman,Supreme Court Retention,2,,Mark E. Salter - Yes,864
+Lyman,Supreme Court Retention,2,,Mark E. Salter - No,234
+Marshall,Supreme Court Retention,2,,Mark E. Salter - Yes,1274
+Marshall,Supreme Court Retention,2,,Mark E. Salter - No,289
+McCook,Supreme Court Retention,2,,Mark E. Salter - Yes,1799
+McCook,Supreme Court Retention,2,,Mark E. Salter - No,359
+McPherson,Supreme Court Retention,2,,Mark E. Salter - Yes,786
+McPherson,Supreme Court Retention,2,,Mark E. Salter - No,147
+Meade,Supreme Court Retention,2,,Mark E. Salter - Yes,7690
+Meade,Supreme Court Retention,2,,Mark E. Salter - No,2070
+Mellette,Supreme Court Retention,2,,Mark E. Salter - Yes,394
+Mellette,Supreme Court Retention,2,,Mark E. Salter - No,121
+Miner,Supreme Court Retention,2,,Mark E. Salter - Yes,667
+Miner,Supreme Court Retention,2,,Mark E. Salter - No,105
+Minnehaha,Supreme Court Retention,2,,Mark E. Salter - Yes,47119
+Minnehaha,Supreme Court Retention,2,,Mark E. Salter - No,12590
+Moody,Supreme Court Retention,2,,Mark E. Salter - Yes,1851
+Moody,Supreme Court Retention,2,,Mark E. Salter - No,409
+Oglala Lakota,Supreme Court Retention,2,,Mark E. Salter - Yes,1059
+Oglala Lakota,Supreme Court Retention,2,,Mark E. Salter - No,1058
+Pennington,Supreme Court Retention,2,,Mark E. Salter - Yes,28543
+Pennington,Supreme Court Retention,2,,Mark E. Salter - No,8175
+Perkins,Supreme Court Retention,2,,Mark E. Salter - Yes,917
+Perkins,Supreme Court Retention,2,,Mark E. Salter - No,179
+Potter,Supreme Court Retention,2,,Mark E. Salter - Yes,770
+Potter,Supreme Court Retention,2,,Mark E. Salter - No,162
+Roberts,Supreme Court Retention,2,,Mark E. Salter - Yes,2376
+Roberts,Supreme Court Retention,2,,Mark E. Salter - No,691
+Sanborn,Supreme Court Retention,2,,Mark E. Salter - Yes,695
+Sanborn,Supreme Court Retention,2,,Mark E. Salter - No,134
+Spink,Supreme Court Retention,2,,Mark E. Salter - Yes,1858
+Spink,Supreme Court Retention,2,,Mark E. Salter - No,413
+Stanley,Supreme Court Retention,2,,Mark E. Salter - Yes,1074
+Stanley,Supreme Court Retention,2,,Mark E. Salter - No,201
+Sully,Supreme Court Retention,2,,Mark E. Salter - Yes,583
+Sully,Supreme Court Retention,2,,Mark E. Salter - No,99
+Todd,Supreme Court Retention,2,,Mark E. Salter - Yes,855
+Todd,Supreme Court Retention,2,,Mark E. Salter - No,762
+Tripp,Supreme Court Retention,2,,Mark E. Salter - Yes,1638
+Tripp,Supreme Court Retention,2,,Mark E. Salter - No,332
+Turner,Supreme Court Retention,2,,Mark E. Salter - Yes,2747
+Turner,Supreme Court Retention,2,,Mark E. Salter - No,514
+Union,Supreme Court Retention,2,,Mark E. Salter - Yes,4454
+Union,Supreme Court Retention,2,,Mark E. Salter - No,1020
+Walworth,Supreme Court Retention,2,,Mark E. Salter - Yes,1416
+Walworth,Supreme Court Retention,2,,Mark E. Salter - No,321
+Yankton,Supreme Court Retention,2,,Mark E. Salter - Yes,5710
+Yankton,Supreme Court Retention,2,,Mark E. Salter - No,1458
+Ziebach,Supreme Court Retention,2,,Mark E. Salter - Yes,379
+Ziebach,Supreme Court Retention,2,,Mark E. Salter - No,195
+Aurora,Constitutional Amendment D,,,Yes,553
+Aurora,Constitutional Amendment D,,,No,634
+Beadle,Constitutional Amendment D,,,Yes,3048
+Beadle,Constitutional Amendment D,,,No,2678
+Bennett,Constitutional Amendment D,,,Yes,590
+Bennett,Constitutional Amendment D,,,No,416
+Bon Homme,Constitutional Amendment D,,,Yes,1208
+Bon Homme,Constitutional Amendment D,,,No,1275
+Brookings,Constitutional Amendment D,,,Yes,6985
+Brookings,Constitutional Amendment D,,,No,5003
+Brown,Constitutional Amendment D,,,Yes,7646
+Brown,Constitutional Amendment D,,,No,5932
+Brule,Constitutional Amendment D,,,Yes,1094
+Brule,Constitutional Amendment D,,,No,956
+Buffalo,Constitutional Amendment D,,,Yes,275
+Buffalo,Constitutional Amendment D,,,No,104
+Butte,Constitutional Amendment D,,,Yes,2021
+Butte,Constitutional Amendment D,,,No,2104
+Campbell,Constitutional Amendment D,,,Yes,279
+Campbell,Constitutional Amendment D,,,No,355
+Charles Mix,Constitutional Amendment D,,,Yes,1446
+Charles Mix,Constitutional Amendment D,,,No,1522
+Clark,Constitutional Amendment D,,,Yes,765
+Clark,Constitutional Amendment D,,,No,757
+Clay,Constitutional Amendment D,,,Yes,3140
+Clay,Constitutional Amendment D,,,No,1482
+Codington,Constitutional Amendment D,,,Yes,5506
+Codington,Constitutional Amendment D,,,No,5292
+Corson,Constitutional Amendment D,,,Yes,525
+Corson,Constitutional Amendment D,,,No,384
+Custer,Constitutional Amendment D,,,Yes,2420
+Custer,Constitutional Amendment D,,,No,2571
+Davison,Constitutional Amendment D,,,Yes,3620
+Davison,Constitutional Amendment D,,,No,3441
+Day,Constitutional Amendment D,,,Yes,1325
+Day,Constitutional Amendment D,,,No,1135
+Deuel,Constitutional Amendment D,,,Yes,945
+Deuel,Constitutional Amendment D,,,No,1012
+Dewey,Constitutional Amendment D,,,Yes,1072
+Dewey,Constitutional Amendment D,,,No,453
+Douglas,Constitutional Amendment D,,,Yes,449
+Douglas,Constitutional Amendment D,,,No,956
+Edmunds,Constitutional Amendment D,,,Yes,678
+Edmunds,Constitutional Amendment D,,,No,952
+Fall River,Constitutional Amendment D,,,Yes,1790
+Fall River,Constitutional Amendment D,,,No,1747
+Faulk,Constitutional Amendment D,,,Yes,362
+Faulk,Constitutional Amendment D,,,No,550
+Grant,Constitutional Amendment D,,,Yes,1506
+Grant,Constitutional Amendment D,,,No,1591
+Gregory,Constitutional Amendment D,,,Yes,926
+Gregory,Constitutional Amendment D,,,No,1062
+Haakon,Constitutional Amendment D,,,Yes,304
+Haakon,Constitutional Amendment D,,,No,652
+Hamlin,Constitutional Amendment D,,,Yes,1063
+Hamlin,Constitutional Amendment D,,,No,1584
+Hand,Constitutional Amendment D,,,Yes,742
+Hand,Constitutional Amendment D,,,No,722
+Hanson,Constitutional Amendment D,,,Yes,711
+Hanson,Constitutional Amendment D,,,No,855
+Harding,Constitutional Amendment D,,,Yes,218
+Harding,Constitutional Amendment D,,,No,448
+Hughes,Constitutional Amendment D,,,Yes,4115
+Hughes,Constitutional Amendment D,,,No,3295
+Hutchinson,Constitutional Amendment D,,,Yes,1314
+Hutchinson,Constitutional Amendment D,,,No,1752
+Hyde,Constitutional Amendment D,,,Yes,265
+Hyde,Constitutional Amendment D,,,No,291
+Jackson,Constitutional Amendment D,,,Yes,462
+Jackson,Constitutional Amendment D,,,No,437
+Jerauld,Constitutional Amendment D,,,Yes,434
+Jerauld,Constitutional Amendment D,,,No,418
+Jones,Constitutional Amendment D,,,Yes,199
+Jones,Constitutional Amendment D,,,No,267
+Kingsbury,Constitutional Amendment D,,,Yes,1173
+Kingsbury,Constitutional Amendment D,,,No,1288
+Lake,Constitutional Amendment D,,,Yes,2540
+Lake,Constitutional Amendment D,,,No,2273
+Lawrence,Constitutional Amendment D,,,Yes,6772
+Lawrence,Constitutional Amendment D,,,No,5309
+Lincoln,Constitutional Amendment D,,,Yes,16156
+Lincoln,Constitutional Amendment D,,,No,11212
+Lyman,Constitutional Amendment D,,,Yes,740
+Lyman,Constitutional Amendment D,,,No,527
+Marshall,Constitutional Amendment D,,,Yes,1080
+Marshall,Constitutional Amendment D,,,No,724
+McCook,Constitutional Amendment D,,,Yes,1159
+McCook,Constitutional Amendment D,,,No,1326
+McPherson,Constitutional Amendment D,,,Yes,555
+McPherson,Constitutional Amendment D,,,No,513
+Meade,Constitutional Amendment D,,,Yes,5742
+Meade,Constitutional Amendment D,,,No,5958
+Mellette,Constitutional Amendment D,,,Yes,350
+Mellette,Constitutional Amendment D,,,No,262
+Miner,Constitutional Amendment D,,,Yes,504
+Miner,Constitutional Amendment D,,,No,448
+Minnehaha,Constitutional Amendment D,,,Yes,46352
+Minnehaha,Constitutional Amendment D,,,No,26782
+Moody,Constitutional Amendment D,,,Yes,1425
+Moody,Constitutional Amendment D,,,No,1168
+Oglala Lakota,Constitutional Amendment D,,,Yes,2087
+Oglala Lakota,Constitutional Amendment D,,,No,256
+Pennington,Constitutional Amendment D,,,Yes,25113
+Pennington,Constitutional Amendment D,,,No,19359
+Perkins,Constitutional Amendment D,,,Yes,543
+Perkins,Constitutional Amendment D,,,No,797
+Potter,Constitutional Amendment D,,,Yes,511
+Potter,Constitutional Amendment D,,,No,555
+Roberts,Constitutional Amendment D,,,Yes,2000
+Roberts,Constitutional Amendment D,,,No,1468
+Sanborn,Constitutional Amendment D,,,Yes,483
+Sanborn,Constitutional Amendment D,,,No,486
+Spink,Constitutional Amendment D,,,Yes,1416
+Spink,Constitutional Amendment D,,,No,1166
+Stanley,Constitutional Amendment D,,,Yes,724
+Stanley,Constitutional Amendment D,,,No,710
+Sully,Constitutional Amendment D,,,Yes,340
+Sully,Constitutional Amendment D,,,No,443
+Todd,Constitutional Amendment D,,,Yes,1535
+Todd,Constitutional Amendment D,,,No,347
+Tripp,Constitutional Amendment D,,,Yes,1012
+Tripp,Constitutional Amendment D,,,No,1195
+Turner,Constitutional Amendment D,,,Yes,1855
+Turner,Constitutional Amendment D,,,No,1887
+Union,Constitutional Amendment D,,,Yes,3538
+Union,Constitutional Amendment D,,,No,3025
+Walworth,Constitutional Amendment D,,,Yes,937
+Walworth,Constitutional Amendment D,,,No,1041
+Yankton,Constitutional Amendment D,,,Yes,4963
+Yankton,Constitutional Amendment D,,,No,3789
+Ziebach,Constitutional Amendment D,,,Yes,451
+Ziebach,Constitutional Amendment D,,,No,217
+Aurora,Initiated Measure 27,,,Yes,355
+Aurora,Initiated Measure 27,,,No,846
+Beadle,Initiated Measure 27,,,Yes,2477
+Beadle,Initiated Measure 27,,,No,3354
+Bennett,Initiated Measure 27,,,Yes,469
+Bennett,Initiated Measure 27,,,No,549
+Bon Homme,Initiated Measure 27,,,Yes,921
+Bon Homme,Initiated Measure 27,,,No,1599
+Brookings,Initiated Measure 27,,,Yes,6239
+Brookings,Initiated Measure 27,,,No,5999
+Brown,Initiated Measure 27,,,Yes,6694
+Brown,Initiated Measure 27,,,No,7141
+Brule,Initiated Measure 27,,,Yes,794
+Brule,Initiated Measure 27,,,No,1297
+Buffalo,Initiated Measure 27,,,Yes,250
+Buffalo,Initiated Measure 27,,,No,140
+Butte,Initiated Measure 27,,,Yes,1498
+Butte,Initiated Measure 27,,,No,2692
+Campbell,Initiated Measure 27,,,Yes,220
+Campbell,Initiated Measure 27,,,No,430
+Charles Mix,Initiated Measure 27,,,Yes,1024
+Charles Mix,Initiated Measure 27,,,No,1986
+Clark,Initiated Measure 27,,,Yes,518
+Clark,Initiated Measure 27,,,No,1056
+Clay,Initiated Measure 27,,,Yes,2920
+Clay,Initiated Measure 27,,,No,1771
+Codington,Initiated Measure 27,,,Yes,4843
+Codington,Initiated Measure 27,,,No,6193
+Corson,Initiated Measure 27,,,Yes,438
+Corson,Initiated Measure 27,,,No,482
+Custer,Initiated Measure 27,,,Yes,2124
+Custer,Initiated Measure 27,,,No,2926
+Davison,Initiated Measure 27,,,Yes,2927
+Davison,Initiated Measure 27,,,No,4242
+Day,Initiated Measure 27,,,Yes,1069
+Day,Initiated Measure 27,,,No,1418
+Deuel,Initiated Measure 27,,,Yes,630
+Deuel,Initiated Measure 27,,,No,1363
+Dewey,Initiated Measure 27,,,Yes,924
+Dewey,Initiated Measure 27,,,No,616
+Douglas,Initiated Measure 27,,,Yes,279
+Douglas,Initiated Measure 27,,,No,1153
+Edmunds,Initiated Measure 27,,,Yes,589
+Edmunds,Initiated Measure 27,,,No,1075
+Fall River,Initiated Measure 27,,,Yes,1629
+Fall River,Initiated Measure 27,,,No,1965
+Faulk,Initiated Measure 27,,,Yes,262
+Faulk,Initiated Measure 27,,,No,666
+Grant,Initiated Measure 27,,,Yes,1213
+Grant,Initiated Measure 27,,,No,1943
+Gregory,Initiated Measure 27,,,Yes,587
+Gregory,Initiated Measure 27,,,No,1425
+Haakon,Initiated Measure 27,,,Yes,176
+Haakon,Initiated Measure 27,,,No,799
+Hamlin,Initiated Measure 27,,,Yes,784
+Hamlin,Initiated Measure 27,,,No,1929
+Hand,Initiated Measure 27,,,Yes,428
+Hand,Initiated Measure 27,,,No,1060
+Hanson,Initiated Measure 27,,,Yes,477
+Hanson,Initiated Measure 27,,,No,1111
+Harding,Initiated Measure 27,,,Yes,121
+Harding,Initiated Measure 27,,,No,558
+Hughes,Initiated Measure 27,,,Yes,3476
+Hughes,Initiated Measure 27,,,No,4032
+Hutchinson,Initiated Measure 27,,,Yes,847
+Hutchinson,Initiated Measure 27,,,No,2269
+Hyde,Initiated Measure 27,,,Yes,171
+Hyde,Initiated Measure 27,,,No,393
+Jackson,Initiated Measure 27,,,Yes,362
+Jackson,Initiated Measure 27,,,No,555
+Jerauld,Initiated Measure 27,,,Yes,282
+Jerauld,Initiated Measure 27,,,No,574
+Jones,Initiated Measure 27,,,Yes,144
+Jones,Initiated Measure 27,,,No,328
+Kingsbury,Initiated Measure 27,,,Yes,930
+Kingsbury,Initiated Measure 27,,,No,1588
+Lake,Initiated Measure 27,,,Yes,2302
+Lake,Initiated Measure 27,,,No,2583
+Lawrence,Initiated Measure 27,,,Yes,5979
+Lawrence,Initiated Measure 27,,,No,6305
+Lincoln,Initiated Measure 27,,,Yes,13866
+Lincoln,Initiated Measure 27,,,No,14115
+Lyman,Initiated Measure 27,,,Yes,552
+Lyman,Initiated Measure 27,,,No,742
+Marshall,Initiated Measure 27,,,Yes,858
+Marshall,Initiated Measure 27,,,No,977
+McCook,Initiated Measure 27,,,Yes,939
+McCook,Initiated Measure 27,,,No,1584
+McPherson,Initiated Measure 27,,,Yes,304
+McPherson,Initiated Measure 27,,,No,784
+Meade,Initiated Measure 27,,,Yes,5147
+Meade,Initiated Measure 27,,,No,6729
+Mellette,Initiated Measure 27,,,Yes,295
+Mellette,Initiated Measure 27,,,No,326
+Miner,Initiated Measure 27,,,Yes,377
+Miner,Initiated Measure 27,,,No,602
+Minnehaha,Initiated Measure 27,,,Yes,40696
+Minnehaha,Initiated Measure 27,,,No,33648
+Moody,Initiated Measure 27,,,Yes,1168
+Moody,Initiated Measure 27,,,No,1470
+Oglala Lakota,Initiated Measure 27,,,Yes,1914
+Oglala Lakota,Initiated Measure 27,,,No,467
+Pennington,Initiated Measure 27,,,Yes,22542
+Pennington,Initiated Measure 27,,,No,22656
+Perkins,Initiated Measure 27,,,Yes,336
+Perkins,Initiated Measure 27,,,No,1021
+Potter,Initiated Measure 27,,,Yes,381
+Potter,Initiated Measure 27,,,No,701
+Roberts,Initiated Measure 27,,,Yes,1552
+Roberts,Initiated Measure 27,,,No,1959
+Sanborn,Initiated Measure 27,,,Yes,359
+Sanborn,Initiated Measure 27,,,No,629
+Spink,Initiated Measure 27,,,Yes,999
+Spink,Initiated Measure 27,,,No,1608
+Stanley,Initiated Measure 27,,,Yes,628
+Stanley,Initiated Measure 27,,,No,818
+Sully,Initiated Measure 27,,,Yes,284
+Sully,Initiated Measure 27,,,No,508
+Todd,Initiated Measure 27,,,Yes,1424
+Todd,Initiated Measure 27,,,No,472
+Tripp,Initiated Measure 27,,,Yes,593
+Tripp,Initiated Measure 27,,,No,1640
+Turner,Initiated Measure 27,,,Yes,1409
+Turner,Initiated Measure 27,,,No,2376
+Union,Initiated Measure 27,,,Yes,3311
+Union,Initiated Measure 27,,,No,3362
+Walworth,Initiated Measure 27,,,Yes,730
+Walworth,Initiated Measure 27,,,No,1279
+Yankton,Initiated Measure 27,,,Yes,4196
+Yankton,Initiated Measure 27,,,No,4669
+Ziebach,Initiated Measure 27,,,Yes,352
+Ziebach,Initiated Measure 27,,,No,326
+Yankton,James River Water Development District,,NON,Sandy Williams,996
+Yankton,James River Water Development District,,NON,Dan Klimisch,1759

--- a/2022/counties/20221108__sd__general__aurora__precinct.csv
+++ b/2022/counties/20221108__sd__general__aurora__precinct.csv
@@ -1,0 +1,191 @@
+county,precinct,office,district,candidate,party,votes
+Aurora,1,U.S. Senate,,Brian L. Bengs,DEM,31
+Aurora,1,U.S. Senate,,Tamara J Lesnar,LIB,10
+Aurora,1,U.S. Senate,,John R. Thune,REP,230
+Aurora,2,U.S. Senate,,Brian L. Bengs,DEM,15
+Aurora,2,U.S. Senate,,Tamara J Lesnar,LIB,7
+Aurora,2,U.S. Senate,,John R. Thune,REP,117
+Aurora,3,U.S. Senate,,Brian L. Bengs,DEM,51
+Aurora,3,U.S. Senate,,Tamara J Lesnar,LIB,22
+Aurora,3,U.S. Senate,,John R. Thune,REP,295
+Aurora,5,U.S. Senate,,Brian L. Bengs,DEM,31
+Aurora,5,U.S. Senate,,Tamara J Lesnar,LIB,9
+Aurora,5,U.S. Senate,,John R. Thune,REP,128
+Aurora,7,U.S. Senate,,Brian L. Bengs,DEM,42
+Aurora,7,U.S. Senate,,Tamara J Lesnar,LIB,18
+Aurora,7,U.S. Senate,,John R. Thune,REP,208
+Aurora,1,U.S. House,1,Collin Duprel,LIB,26
+Aurora,1,U.S. House,1,Dusty Johnson,REP,232
+Aurora,2,U.S. House,1,Collin Duprel,LIB,17
+Aurora,2,U.S. House,1,Dusty Johnson,REP,118
+Aurora,3,U.S. House,1,Collin Duprel,LIB,53
+Aurora,3,U.S. House,1,Dusty Johnson,REP,302
+Aurora,5,U.S. House,1,Collin Duprel,LIB,30
+Aurora,5,U.S. House,1,Dusty Johnson,REP,129
+Aurora,7,U.S. House,1,Collin Duprel,LIB,53
+Aurora,7,U.S. House,1,Dusty Johnson,REP,208
+Aurora,1,Governor,,Jamie Smith and Jennifer Keintz,DEM,58
+Aurora,1,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Aurora,1,Governor,,Kristi Noem and Larry Rhoden,REP,209
+Aurora,2,Governor,,Jamie Smith and Jennifer Keintz,DEM,22
+Aurora,2,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Aurora,2,Governor,,Kristi Noem and Larry Rhoden,REP,110
+Aurora,3,Governor,,Jamie Smith and Jennifer Keintz,DEM,99
+Aurora,3,Governor,,Tracey Quint and Ashley Strand,LIB,17
+Aurora,3,Governor,,Kristi Noem and Larry Rhoden,REP,256
+Aurora,5,Governor,,Jamie Smith and Jennifer Keintz,DEM,48
+Aurora,5,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Aurora,5,Governor,,Kristi Noem and Larry Rhoden,REP,118
+Aurora,7,Governor,,Jamie Smith and Jennifer Keintz,DEM,57
+Aurora,7,Governor,,Tracey Quint and Ashley Strand,LIB,9
+Aurora,7,Governor,,Kristi Noem and Larry Rhoden,REP,201
+Aurora,1,Secretary of State,,Thomas A Cool,DEM,61
+Aurora,1,Secretary of State,,Monae Johnson,REP,195
+Aurora,2,Secretary of State,,Thomas A Cool,DEM,32
+Aurora,2,Secretary of State,,Monae Johnson,REP,98
+Aurora,3,Secretary of State,,Thomas A Cool,DEM,122
+Aurora,3,Secretary of State,,Monae Johnson,REP,218
+Aurora,5,Secretary of State,,Thomas A Cool,DEM,55
+Aurora,5,Secretary of State,,Monae Johnson,REP,106
+Aurora,7,Secretary of State,,Thomas A Cool,DEM,81
+Aurora,7,Secretary of State,,Monae Johnson,REP,168
+Aurora,1,Attorney General,,Marty J. Jackley,REP,204
+Aurora,2,Attorney General,,Marty J. Jackley,REP,100
+Aurora,3,Attorney General,,Marty J. Jackley,REP,252
+Aurora,5,Attorney General,,Marty J. Jackley,REP,115
+Aurora,7,Attorney General,,Marty J. Jackley,REP,204
+Aurora,1,State Auditor,,Stephanie Marty,DEM,60
+Aurora,1,State Auditor,,Rene Meyer,LIB,10
+Aurora,1,State Auditor,,Richard Sattgast,REP,186
+Aurora,2,State Auditor,,Stephanie Marty,DEM,28
+Aurora,2,State Auditor,,Rene Meyer,LIB,9
+Aurora,2,State Auditor,,Richard Sattgast,REP,92
+Aurora,3,State Auditor,,Stephanie Marty,DEM,92
+Aurora,3,State Auditor,,Rene Meyer,LIB,28
+Aurora,3,State Auditor,,Richard Sattgast,REP,215
+Aurora,5,State Auditor,,Stephanie Marty,DEM,44
+Aurora,5,State Auditor,,Rene Meyer,LIB,9
+Aurora,5,State Auditor,,Richard Sattgast,REP,103
+Aurora,7,State Auditor,,Stephanie Marty,DEM,58
+Aurora,7,State Auditor,,Rene Meyer,LIB,20
+Aurora,7,State Auditor,,Richard Sattgast,REP,175
+Aurora,1,State Treasurer,,John Cunningham,DEM,58
+Aurora,1,State Treasurer,,Josh Haeder,REP,198
+Aurora,2,State Treasurer,,John Cunningham,DEM,24
+Aurora,2,State Treasurer,,Josh Haeder,REP,100
+Aurora,3,State Treasurer,,John Cunningham,DEM,102
+Aurora,3,State Treasurer,,Josh Haeder,REP,224
+Aurora,5,State Treasurer,,John Cunningham,DEM,51
+Aurora,5,State Treasurer,,Josh Haeder,REP,105
+Aurora,7,State Treasurer,,John Cunningham,DEM,67
+Aurora,7,State Treasurer,,Josh Haeder,REP,184
+Aurora,1,Commissioner of School and Public Lands,,Timothy Azure,DEM,52
+Aurora,1,Commissioner of School and Public Lands,,Brock Greenfield,REP,198
+Aurora,2,Commissioner of School and Public Lands,,Timothy Azure,DEM,24
+Aurora,2,Commissioner of School and Public Lands,,Brock Greenfield,REP,103
+Aurora,3,Commissioner of School and Public Lands,,Timothy Azure,DEM,99
+Aurora,3,Commissioner of School and Public Lands,,Brock Greenfield,REP,225
+Aurora,5,Commissioner of School and Public Lands,,Timothy Azure,DEM,45
+Aurora,5,Commissioner of School and Public Lands,,Brock Greenfield,REP,107
+Aurora,7,Commissioner of School and Public Lands,,Timothy Azure,DEM,62
+Aurora,7,Commissioner of School and Public Lands,,Brock Greenfield,REP,182
+Aurora,1,Public Utilities Commissioner,,Jeffrey Barth,DEM,52
+Aurora,1,Public Utilities Commissioner,,Chris Nelson,REP,209
+Aurora,2,Public Utilities Commissioner,,Jeffrey Barth,DEM,19
+Aurora,2,Public Utilities Commissioner,,Chris Nelson,REP,107
+Aurora,3,Public Utilities Commissioner,,Jeffrey Barth,DEM,50
+Aurora,3,Public Utilities Commissioner,,Chris Nelson,REP,309
+Aurora,5,Public Utilities Commissioner,,Jeffrey Barth,DEM,33
+Aurora,5,Public Utilities Commissioner,,Chris Nelson,REP,131
+Aurora,7,Public Utilities Commissioner,,Jeffrey Barth,DEM,40
+Aurora,7,Public Utilities Commissioner,,Chris Nelson,REP,217
+Aurora,1,State Senate,21,Dan Andersson,DEM,41
+Aurora,1,State Senate,21,Erin Tobin,REP,217
+Aurora,2,State Senate,21,Dan Andersson,DEM,21
+Aurora,2,State Senate,21,Erin Tobin,REP,111
+Aurora,3,State Senate,21,Dan Andersson,DEM,74
+Aurora,3,State Senate,21,Erin Tobin,REP,259
+Aurora,5,State Senate,21,Dan Andersson,DEM,39
+Aurora,5,State Senate,21,Erin Tobin,REP,127
+Aurora,7,State Senate,21,Dan Andersson,DEM,43
+Aurora,7,State Senate,21,Erin Tobin,REP,210
+Aurora,1,State House,21,Rocky Blare,REP,106
+Aurora,1,State House,21,Marty Overweg,REP,207
+Aurora,2,State House,21,Rocky Blare,REP,51
+Aurora,2,State House,21,Marty Overweg,REP,113
+Aurora,3,State House,21,Rocky Blare,REP,135
+Aurora,3,State House,21,Marty Overweg,REP,249
+Aurora,5,State House,21,Rocky Blare,REP,54
+Aurora,5,State House,21,Marty Overweg,REP,102
+Aurora,7,State House,21,Rocky Blare,REP,115
+Aurora,7,State House,21,Marty Overweg,REP,188
+Aurora,1,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,121
+Aurora,2,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,63
+Aurora,3,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,173
+Aurora,5,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,82
+Aurora,7,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,134
+Aurora,1,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,115
+Aurora,2,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,61
+Aurora,3,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,169
+Aurora,5,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,77
+Aurora,7,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,126
+Aurora,1,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,117
+Aurora,2,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,65
+Aurora,3,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,178
+Aurora,5,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,79
+Aurora,7,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,129
+Aurora,1,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,120
+Aurora,2,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,58
+Aurora,3,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,165
+Aurora,5,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,76
+Aurora,7,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,125
+Aurora,1,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,122
+Aurora,2,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,65
+Aurora,3,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,175
+Aurora,5,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,79
+Aurora,7,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,142
+Aurora,1,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,110
+Aurora,2,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,58
+Aurora,3,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,170
+Aurora,5,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,78
+Aurora,7,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,127
+Aurora,1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,187
+Aurora,1,Supreme Court Retention,3,Patricia J. DeVaney - No,,33
+Aurora,2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,91
+Aurora,2,Supreme Court Retention,3,Patricia J. DeVaney - No,,18
+Aurora,3,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,245
+Aurora,3,Supreme Court Retention,3,Patricia J. DeVaney - No,,52
+Aurora,5,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,125
+Aurora,5,Supreme Court Retention,3,Patricia J. DeVaney - No,,20
+Aurora,7,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,198
+Aurora,7,Supreme Court Retention,3,Patricia J. DeVaney - No,,32
+Aurora,1,Supreme Court Retention,2,Mark E. Salter - Yes,,186
+Aurora,1,Supreme Court Retention,2,Mark E. Salter - No,,29
+Aurora,2,Supreme Court Retention,2,Mark E. Salter - Yes,,87
+Aurora,2,Supreme Court Retention,2,Mark E. Salter - No,,22
+Aurora,3,Supreme Court Retention,2,Mark E. Salter - Yes,,242
+Aurora,3,Supreme Court Retention,2,Mark E. Salter - No,,53
+Aurora,5,Supreme Court Retention,2,Mark E. Salter - Yes,,120
+Aurora,5,Supreme Court Retention,2,Mark E. Salter - No,,24
+Aurora,7,Supreme Court Retention,2,Mark E. Salter - Yes,,191
+Aurora,7,Supreme Court Retention,2,Mark E. Salter - No,,37
+Aurora,1,Constitutional Amendment D,,Yes,,116
+Aurora,1,Constitutional Amendment D,,No,,149
+Aurora,2,Constitutional Amendment D,,Yes,,49
+Aurora,2,Constitutional Amendment D,,No,,86
+Aurora,3,Constitutional Amendment D,,Yes,,177
+Aurora,3,Constitutional Amendment D,,No,,180
+Aurora,5,Constitutional Amendment D,,Yes,,76
+Aurora,5,Constitutional Amendment D,,No,,88
+Aurora,7,Constitutional Amendment D,,Yes,,135
+Aurora,7,Constitutional Amendment D,,No,,131
+Aurora,1,Initiated Measure 27,,Yes,,76
+Aurora,1,Initiated Measure 27,,No,,193
+Aurora,2,Initiated Measure 27,,Yes,,32
+Aurora,2,Initiated Measure 27,,No,,106
+Aurora,3,Initiated Measure 27,,Yes,,113
+Aurora,3,Initiated Measure 27,,No,,249
+Aurora,5,Initiated Measure 27,,Yes,,43
+Aurora,5,Initiated Measure 27,,No,,122
+Aurora,7,Initiated Measure 27,,Yes,,91
+Aurora,7,Initiated Measure 27,,No,,176

--- a/2022/counties/20221108__sd__general__beadle__precinct.csv
+++ b/2022/counties/20221108__sd__general__beadle__precinct.csv
@@ -1,0 +1,352 @@
+county,precinct,office,district,candidate,party,votes
+Beadle,1,U.S. Senate,,Brian L. Bengs,DEM,232
+Beadle,1,U.S. Senate,,Tamara J Lesnar,LIB,38
+Beadle,1,U.S. Senate,,John R. Thune,REP,663
+Beadle,2,U.S. Senate,,Brian L. Bengs,DEM,161
+Beadle,2,U.S. Senate,,Tamara J Lesnar,LIB,18
+Beadle,2,U.S. Senate,,John R. Thune,REP,573
+Beadle,3,U.S. Senate,,Brian L. Bengs,DEM,129
+Beadle,3,U.S. Senate,,Tamara J Lesnar,LIB,13
+Beadle,3,U.S. Senate,,John R. Thune,REP,478
+Beadle,4,U.S. Senate,,Brian L. Bengs,DEM,123
+Beadle,4,U.S. Senate,,Tamara J Lesnar,LIB,14
+Beadle,4,U.S. Senate,,John R. Thune,REP,453
+Beadle,5,U.S. Senate,,Brian L. Bengs,DEM,275
+Beadle,5,U.S. Senate,,Tamara J Lesnar,LIB,38
+Beadle,5,U.S. Senate,,John R. Thune,REP,724
+Beadle,6,U.S. Senate,,Brian L. Bengs,DEM,124
+Beadle,6,U.S. Senate,,Tamara J Lesnar,LIB,23
+Beadle,6,U.S. Senate,,John R. Thune,REP,471
+Beadle,8,U.S. Senate,,Brian L. Bengs,DEM,24
+Beadle,8,U.S. Senate,,Tamara J Lesnar,LIB,4
+Beadle,8,U.S. Senate,,John R. Thune,REP,239
+Beadle,9,U.S. Senate,,Brian L. Bengs,DEM,48
+Beadle,9,U.S. Senate,,Tamara J Lesnar,LIB,8
+Beadle,9,U.S. Senate,,John R. Thune,REP,190
+Beadle,7,U.S. Senate,,Brian L. Bengs,DEM,98
+Beadle,7,U.S. Senate,,Tamara J Lesnar,LIB,26
+Beadle,7,U.S. Senate,,John R. Thune,REP,650
+Beadle,1,U.S. House,1,Collin Duprel,LIB,167
+Beadle,1,U.S. House,1,Dusty Johnson,REP,707
+Beadle,2,U.S. House,1,Collin Duprel,LIB,118
+Beadle,2,U.S. House,1,Dusty Johnson,REP,605
+Beadle,3,U.S. House,1,Collin Duprel,LIB,82
+Beadle,3,U.S. House,1,Dusty Johnson,REP,504
+Beadle,4,U.S. House,1,Collin Duprel,LIB,82
+Beadle,4,U.S. House,1,Dusty Johnson,REP,487
+Beadle,5,U.S. House,1,Collin Duprel,LIB,183
+Beadle,5,U.S. House,1,Dusty Johnson,REP,806
+Beadle,6,U.S. House,1,Collin Duprel,LIB,94
+Beadle,6,U.S. House,1,Dusty Johnson,REP,490
+Beadle,8,U.S. House,1,Collin Duprel,LIB,25
+Beadle,8,U.S. House,1,Dusty Johnson,REP,235
+Beadle,9,U.S. House,1,Collin Duprel,LIB,38
+Beadle,9,U.S. House,1,Dusty Johnson,REP,204
+Beadle,7,U.S. House,1,Collin Duprel,LIB,81
+Beadle,7,U.S. House,1,Dusty Johnson,REP,674
+Beadle,1,Governor,,Jamie Smith and Jennifer Keintz,DEM,308
+Beadle,1,Governor,,Tracey Quint and Ashley Strand,LIB,54
+Beadle,1,Governor,,Kristi Noem and Larry Rhoden,REP,574
+Beadle,2,Governor,,Jamie Smith and Jennifer Keintz,DEM,230
+Beadle,2,Governor,,Tracey Quint and Ashley Strand,LIB,28
+Beadle,2,Governor,,Kristi Noem and Larry Rhoden,REP,492
+Beadle,3,Governor,,Jamie Smith and Jennifer Keintz,DEM,195
+Beadle,3,Governor,,Tracey Quint and Ashley Strand,LIB,11
+Beadle,3,Governor,,Kristi Noem and Larry Rhoden,REP,409
+Beadle,4,Governor,,Jamie Smith and Jennifer Keintz,DEM,176
+Beadle,4,Governor,,Tracey Quint and Ashley Strand,LIB,15
+Beadle,4,Governor,,Kristi Noem and Larry Rhoden,REP,401
+Beadle,5,Governor,,Jamie Smith and Jennifer Keintz,DEM,377
+Beadle,5,Governor,,Tracey Quint and Ashley Strand,LIB,47
+Beadle,5,Governor,,Kristi Noem and Larry Rhoden,REP,611
+Beadle,6,Governor,,Jamie Smith and Jennifer Keintz,DEM,176
+Beadle,6,Governor,,Tracey Quint and Ashley Strand,LIB,25
+Beadle,6,Governor,,Kristi Noem and Larry Rhoden,REP,417
+Beadle,8,Governor,,Jamie Smith and Jennifer Keintz,DEM,40
+Beadle,8,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Beadle,8,Governor,,Kristi Noem and Larry Rhoden,REP,226
+Beadle,9,Governor,,Jamie Smith and Jennifer Keintz,DEM,63
+Beadle,9,Governor,,Tracey Quint and Ashley Strand,LIB,13
+Beadle,9,Governor,,Kristi Noem and Larry Rhoden,REP,172
+Beadle,7,Governor,,Jamie Smith and Jennifer Keintz,DEM,151
+Beadle,7,Governor,,Tracey Quint and Ashley Strand,LIB,23
+Beadle,7,Governor,,Kristi Noem and Larry Rhoden,REP,599
+Beadle,1,Secretary of State,,Thomas A Cool,DEM,327
+Beadle,1,Secretary of State,,Monae Johnson,REP,567
+Beadle,2,Secretary of State,,Thomas A Cool,DEM,233
+Beadle,2,Secretary of State,,Monae Johnson,REP,481
+Beadle,3,Secretary of State,,Thomas A Cool,DEM,186
+Beadle,3,Secretary of State,,Monae Johnson,REP,403
+Beadle,4,Secretary of State,,Thomas A Cool,DEM,174
+Beadle,4,Secretary of State,,Monae Johnson,REP,396
+Beadle,5,Secretary of State,,Thomas A Cool,DEM,392
+Beadle,5,Secretary of State,,Monae Johnson,REP,611
+Beadle,6,Secretary of State,,Thomas A Cool,DEM,186
+Beadle,6,Secretary of State,,Monae Johnson,REP,409
+Beadle,8,Secretary of State,,Thomas A Cool,DEM,36
+Beadle,8,Secretary of State,,Monae Johnson,REP,221
+Beadle,9,Secretary of State,,Thomas A Cool,DEM,73
+Beadle,9,Secretary of State,,Monae Johnson,REP,160
+Beadle,7,Secretary of State,,Thomas A Cool,DEM,185
+Beadle,7,Secretary of State,,Monae Johnson,REP,559
+Beadle,1,Attorney General,,Marty J. Jackley,REP,713
+Beadle,2,Attorney General,,Marty J. Jackley,REP,605
+Beadle,3,Attorney General,,Marty J. Jackley,REP,505
+Beadle,4,Attorney General,,Marty J. Jackley,REP,481
+Beadle,5,Attorney General,,Marty J. Jackley,REP,806
+Beadle,6,Attorney General,,Marty J. Jackley,REP,501
+Beadle,8,Attorney General,,Marty J. Jackley,REP,231
+Beadle,9,Attorney General,,Marty J. Jackley,REP,200
+Beadle,7,Attorney General,,Marty J. Jackley,REP,668
+Beadle,1,State Auditor,,Stephanie Marty,DEM,281
+Beadle,1,State Auditor,,Rene Meyer,LIB,55
+Beadle,1,State Auditor,,Richard Sattgast,REP,558
+Beadle,2,State Auditor,,Stephanie Marty,DEM,195
+Beadle,2,State Auditor,,Rene Meyer,LIB,30
+Beadle,2,State Auditor,,Richard Sattgast,REP,492
+Beadle,3,State Auditor,,Stephanie Marty,DEM,153
+Beadle,3,State Auditor,,Rene Meyer,LIB,15
+Beadle,3,State Auditor,,Richard Sattgast,REP,432
+Beadle,4,State Auditor,,Stephanie Marty,DEM,140
+Beadle,4,State Auditor,,Rene Meyer,LIB,15
+Beadle,4,State Auditor,,Richard Sattgast,REP,416
+Beadle,5,State Auditor,,Stephanie Marty,DEM,316
+Beadle,5,State Auditor,,Rene Meyer,LIB,45
+Beadle,5,State Auditor,,Richard Sattgast,REP,653
+Beadle,6,State Auditor,,Stephanie Marty,DEM,164
+Beadle,6,State Auditor,,Rene Meyer,LIB,20
+Beadle,6,State Auditor,,Richard Sattgast,REP,408
+Beadle,8,State Auditor,,Stephanie Marty,DEM,32
+Beadle,8,State Auditor,,Rene Meyer,LIB,4
+Beadle,8,State Auditor,,Richard Sattgast,REP,227
+Beadle,9,State Auditor,,Stephanie Marty,DEM,52
+Beadle,9,State Auditor,,Rene Meyer,LIB,12
+Beadle,9,State Auditor,,Richard Sattgast,REP,169
+Beadle,7,State Auditor,,Stephanie Marty,DEM,131
+Beadle,7,State Auditor,,Rene Meyer,LIB,28
+Beadle,7,State Auditor,,Richard Sattgast,REP,583
+Beadle,1,State Treasurer,,John Cunningham,DEM,219
+Beadle,1,State Treasurer,,Josh Haeder,REP,699
+Beadle,2,State Treasurer,,John Cunningham,DEM,155
+Beadle,2,State Treasurer,,Josh Haeder,REP,584
+Beadle,3,State Treasurer,,John Cunningham,DEM,111
+Beadle,3,State Treasurer,,Josh Haeder,REP,505
+Beadle,4,State Treasurer,,John Cunningham,DEM,101
+Beadle,4,State Treasurer,,Josh Haeder,REP,485
+Beadle,5,State Treasurer,,John Cunningham,DEM,224
+Beadle,5,State Treasurer,,Josh Haeder,REP,799
+Beadle,6,State Treasurer,,John Cunningham,DEM,116
+Beadle,6,State Treasurer,,Josh Haeder,REP,490
+Beadle,8,State Treasurer,,John Cunningham,DEM,24
+Beadle,8,State Treasurer,,Josh Haeder,REP,242
+Beadle,9,State Treasurer,,John Cunningham,DEM,47
+Beadle,9,State Treasurer,,Josh Haeder,REP,196
+Beadle,7,State Treasurer,,John Cunningham,DEM,109
+Beadle,7,State Treasurer,,Josh Haeder,REP,656
+Beadle,1,Commissioner of School and Public Lands,,Timothy Azure,DEM,297
+Beadle,1,Commissioner of School and Public Lands,,Brock Greenfield,REP,590
+Beadle,2,Commissioner of School and Public Lands,,Timothy Azure,DEM,214
+Beadle,2,Commissioner of School and Public Lands,,Brock Greenfield,REP,496
+Beadle,3,Commissioner of School and Public Lands,,Timothy Azure,DEM,164
+Beadle,3,Commissioner of School and Public Lands,,Brock Greenfield,REP,425
+Beadle,4,Commissioner of School and Public Lands,,Timothy Azure,DEM,155
+Beadle,4,Commissioner of School and Public Lands,,Brock Greenfield,REP,408
+Beadle,5,Commissioner of School and Public Lands,,Timothy Azure,DEM,361
+Beadle,5,Commissioner of School and Public Lands,,Brock Greenfield,REP,634
+Beadle,6,Commissioner of School and Public Lands,,Timothy Azure,DEM,165
+Beadle,6,Commissioner of School and Public Lands,,Brock Greenfield,REP,423
+Beadle,8,Commissioner of School and Public Lands,,Timothy Azure,DEM,34
+Beadle,8,Commissioner of School and Public Lands,,Brock Greenfield,REP,229
+Beadle,9,Commissioner of School and Public Lands,,Timothy Azure,DEM,56
+Beadle,9,Commissioner of School and Public Lands,,Brock Greenfield,REP,175
+Beadle,7,Commissioner of School and Public Lands,,Timothy Azure,DEM,147
+Beadle,7,Commissioner of School and Public Lands,,Brock Greenfield,REP,586
+Beadle,1,Public Utilities Commissioner,,Jeffrey Barth,DEM,272
+Beadle,1,Public Utilities Commissioner,,Chris Nelson,REP,625
+Beadle,2,Public Utilities Commissioner,,Jeffrey Barth,DEM,194
+Beadle,2,Public Utilities Commissioner,,Chris Nelson,REP,529
+Beadle,3,Public Utilities Commissioner,,Jeffrey Barth,DEM,147
+Beadle,3,Public Utilities Commissioner,,Chris Nelson,REP,451
+Beadle,4,Public Utilities Commissioner,,Jeffrey Barth,DEM,143
+Beadle,4,Public Utilities Commissioner,,Chris Nelson,REP,427
+Beadle,5,Public Utilities Commissioner,,Jeffrey Barth,DEM,310
+Beadle,5,Public Utilities Commissioner,,Chris Nelson,REP,696
+Beadle,6,Public Utilities Commissioner,,Jeffrey Barth,DEM,165
+Beadle,6,Public Utilities Commissioner,,Chris Nelson,REP,429
+Beadle,8,Public Utilities Commissioner,,Jeffrey Barth,DEM,32
+Beadle,8,Public Utilities Commissioner,,Chris Nelson,REP,229
+Beadle,9,Public Utilities Commissioner,,Jeffrey Barth,DEM,55
+Beadle,9,Public Utilities Commissioner,,Chris Nelson,REP,176
+Beadle,7,Public Utilities Commissioner,,Jeffrey Barth,DEM,143
+Beadle,7,Public Utilities Commissioner,,Chris Nelson,REP,601
+Beadle,1,State Senate,22,David Wheeler,REP,697
+Beadle,2,State Senate,22,David Wheeler,REP,594
+Beadle,3,State Senate,22,David Wheeler,REP,481
+Beadle,4,State Senate,22,David Wheeler,REP,450
+Beadle,5,State Senate,22,David Wheeler,REP,813
+Beadle,6,State Senate,22,David Wheeler,REP,498
+Beadle,8,State Senate,22,David Wheeler,REP,234
+Beadle,9,State Senate,22,David Wheeler,REP,187
+Beadle,7,State Senate,22,David Wheeler,REP,630
+Beadle,1,State House,22,Shane Milne,DEM,288
+Beadle,1,State House,22,Roger Chase,REP,542
+Beadle,1,State House,22,Lynn Schneider,REP,565
+Beadle,2,State House,22,Shane Milne,DEM,192
+Beadle,2,State House,22,Roger Chase,REP,477
+Beadle,2,State House,22,Lynn Schneider,REP,505
+Beadle,3,State House,22,Shane Milne,DEM,157
+Beadle,3,State House,22,Roger Chase,REP,395
+Beadle,3,State House,22,Lynn Schneider,REP,439
+Beadle,4,State House,22,Shane Milne,DEM,150
+Beadle,4,State House,22,Roger Chase,REP,378
+Beadle,4,State House,22,Lynn Schneider,REP,406
+Beadle,5,State House,22,Shane Milne,DEM,331
+Beadle,5,State House,22,Roger Chase,REP,597
+Beadle,5,State House,22,Lynn Schneider,REP,659
+Beadle,6,State House,22,Shane Milne,DEM,165
+Beadle,6,State House,22,Roger Chase,REP,407
+Beadle,6,State House,22,Lynn Schneider,REP,390
+Beadle,8,State House,22,Shane Milne,DEM,33
+Beadle,8,State House,22,Roger Chase,REP,188
+Beadle,8,State House,22,Lynn Schneider,REP,215
+Beadle,9,State House,22,Shane Milne,DEM,59
+Beadle,9,State House,22,Roger Chase,REP,150
+Beadle,9,State House,22,Lynn Schneider,REP,160
+Beadle,7,State House,22,Shane Milne,DEM,163
+Beadle,7,State House,22,Roger Chase,REP,505
+Beadle,7,State House,22,Lynn Schneider,REP,532
+Beadle,1,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,513
+Beadle,2,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,409
+Beadle,3,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,324
+Beadle,4,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,335
+Beadle,5,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,557
+Beadle,6,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,318
+Beadle,8,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,111
+Beadle,9,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,115
+Beadle,7,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,417
+Beadle,1,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,446
+Beadle,2,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,388
+Beadle,3,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,302
+Beadle,4,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,314
+Beadle,5,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,500
+Beadle,6,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,290
+Beadle,8,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,106
+Beadle,9,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,108
+Beadle,7,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,386
+Beadle,1,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,584
+Beadle,2,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,502
+Beadle,3,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,408
+Beadle,4,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,413
+Beadle,5,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,669
+Beadle,6,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,390
+Beadle,8,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,148
+Beadle,9,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,131
+Beadle,7,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,460
+Beadle,1,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,460
+Beadle,2,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,388
+Beadle,3,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,299
+Beadle,4,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,321
+Beadle,5,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,495
+Beadle,6,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,301
+Beadle,8,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,111
+Beadle,9,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,108
+Beadle,7,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,389
+Beadle,1,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,339
+Beadle,1,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,406
+Beadle,2,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,253
+Beadle,2,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,350
+Beadle,3,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,181
+Beadle,3,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,309
+Beadle,4,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,182
+Beadle,4,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,314
+Beadle,5,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,336
+Beadle,5,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,466
+Beadle,6,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,208
+Beadle,6,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,275
+Beadle,8,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,71
+Beadle,8,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,114
+Beadle,9,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,76
+Beadle,9,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,98
+Beadle,7,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,224
+Beadle,7,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,355
+Beadle,1,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,444
+Beadle,2,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,371
+Beadle,3,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,298
+Beadle,4,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,318
+Beadle,5,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,501
+Beadle,6,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,294
+Beadle,8,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,105
+Beadle,9,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,107
+Beadle,7,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,374
+Beadle,1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,627
+Beadle,1,Supreme Court Retention,3,Patricia J. DeVaney - No,,155
+Beadle,2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,544
+Beadle,2,Supreme Court Retention,3,Patricia J. DeVaney - No,,105
+Beadle,3,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,450
+Beadle,3,Supreme Court Retention,3,Patricia J. DeVaney - No,,60
+Beadle,4,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,420
+Beadle,4,Supreme Court Retention,3,Patricia J. DeVaney - No,,76
+Beadle,5,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,747
+Beadle,5,Supreme Court Retention,3,Patricia J. DeVaney - No,,126
+Beadle,6,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,431
+Beadle,6,Supreme Court Retention,3,Patricia J. DeVaney - No,,83
+Beadle,8,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,172
+Beadle,8,Supreme Court Retention,3,Patricia J. DeVaney - No,,33
+Beadle,9,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,152
+Beadle,9,Supreme Court Retention,3,Patricia J. DeVaney - No,,33
+Beadle,7,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,533
+Beadle,7,Supreme Court Retention,3,Patricia J. DeVaney - No,,104
+Beadle,1,Supreme Court Retention,2,Mark E. Salter - Yes,,638
+Beadle,1,Supreme Court Retention,2,Mark E. Salter - No,,143
+Beadle,2,Supreme Court Retention,2,Mark E. Salter - Yes,,544
+Beadle,2,Supreme Court Retention,2,Mark E. Salter - No,,105
+Beadle,3,Supreme Court Retention,2,Mark E. Salter - Yes,,457
+Beadle,3,Supreme Court Retention,2,Mark E. Salter - No,,52
+Beadle,4,Supreme Court Retention,2,Mark E. Salter - Yes,,428
+Beadle,4,Supreme Court Retention,2,Mark E. Salter - No,,66
+Beadle,5,Supreme Court Retention,2,Mark E. Salter - Yes,,744
+Beadle,5,Supreme Court Retention,2,Mark E. Salter - No,,128
+Beadle,6,Supreme Court Retention,2,Mark E. Salter - Yes,,433
+Beadle,6,Supreme Court Retention,2,Mark E. Salter - No,,78
+Beadle,8,Supreme Court Retention,2,Mark E. Salter - Yes,,176
+Beadle,8,Supreme Court Retention,2,Mark E. Salter - No,,33
+Beadle,9,Supreme Court Retention,2,Mark E. Salter - Yes,,156
+Beadle,9,Supreme Court Retention,2,Mark E. Salter - No,,28
+Beadle,7,Supreme Court Retention,2,Mark E. Salter - Yes,,543
+Beadle,7,Supreme Court Retention,2,Mark E. Salter - No,,93
+Beadle,1,Constitutional Amendment D,,Yes,,554
+Beadle,1,Constitutional Amendment D,,No,,372
+Beadle,2,Constitutional Amendment D,,Yes,,393
+Beadle,2,Constitutional Amendment D,,No,,350
+Beadle,3,Constitutional Amendment D,,Yes,,311
+Beadle,3,Constitutional Amendment D,,No,,305
+Beadle,4,Constitutional Amendment D,,Yes,,317
+Beadle,4,Constitutional Amendment D,,No,,257
+Beadle,5,Constitutional Amendment D,,Yes,,599
+Beadle,5,Constitutional Amendment D,,No,,409
+Beadle,6,Constitutional Amendment D,,Yes,,334
+Beadle,6,Constitutional Amendment D,,No,,282
+Beadle,8,Constitutional Amendment D,,Yes,,90
+Beadle,8,Constitutional Amendment D,,No,,159
+Beadle,9,Constitutional Amendment D,,Yes,,115
+Beadle,9,Constitutional Amendment D,,No,,118
+Beadle,7,Constitutional Amendment D,,Yes,,335
+Beadle,7,Constitutional Amendment D,,No,,426
+Beadle,1,Initiated Measure 27,,Yes,,492
+Beadle,1,Initiated Measure 27,,No,,444
+Beadle,2,Initiated Measure 27,,Yes,,352
+Beadle,2,Initiated Measure 27,,No,,400
+Beadle,3,Initiated Measure 27,,Yes,,256
+Beadle,3,Initiated Measure 27,,No,,371
+Beadle,4,Initiated Measure 27,,Yes,,235
+Beadle,4,Initiated Measure 27,,No,,351
+Beadle,5,Initiated Measure 27,,Yes,,495
+Beadle,5,Initiated Measure 27,,No,,539
+Beadle,6,Initiated Measure 27,,Yes,,253
+Beadle,6,Initiated Measure 27,,No,,364
+Beadle,8,Initiated Measure 27,,Yes,,63
+Beadle,8,Initiated Measure 27,,No,,198
+Beadle,9,Initiated Measure 27,,Yes,,91
+Beadle,9,Initiated Measure 27,,No,,154
+Beadle,7,Initiated Measure 27,,Yes,,240
+Beadle,7,Initiated Measure 27,,No,,533

--- a/2022/counties/20221108__sd__general__bennett__precinct.csv
+++ b/2022/counties/20221108__sd__general__bennett__precinct.csv
@@ -1,0 +1,153 @@
+county,precinct,office,district,candidate,party,votes
+Bennett,Allen Precinct,U.S. Senate,,Brian L. Bengs,DEM,128
+Bennett,Allen Precinct,U.S. Senate,,Tamara J Lesnar,LIB,11
+Bennett,Allen Precinct,U.S. Senate,,John R. Thune,REP,78
+Bennett,Martin City Precinct,U.S. Senate,,Brian L. Bengs,DEM,88
+Bennett,Martin City Precinct,U.S. Senate,,Tamara J Lesnar,LIB,15
+Bennett,Martin City Precinct,U.S. Senate,,John R. Thune,REP,209
+Bennett,Martin Rural 26/27 Precinct,U.S. Senate,,Brian L. Bengs,DEM,69
+Bennett,Martin Rural 26/27 Precinct,U.S. Senate,,Tamara J Lesnar,LIB,12
+Bennett,Martin Rural 26/27 Precinct,U.S. Senate,,John R. Thune,REP,260
+Bennett,Vetal/Tuthill Precinct,U.S. Senate,,Brian L. Bengs,DEM,10
+Bennett,Vetal/Tuthill Precinct,U.S. Senate,,Tamara J Lesnar,LIB,3
+Bennett,Vetal/Tuthill Precinct,U.S. Senate,,John R. Thune,REP,137
+Bennett,Allen Precinct,U.S. House,1,Collin Duprel,LIB,91
+Bennett,Allen Precinct,U.S. House,1,Dusty Johnson,REP,94
+Bennett,Martin City Precinct,U.S. House,1,Collin Duprel,LIB,76
+Bennett,Martin City Precinct,U.S. House,1,Dusty Johnson,REP,217
+Bennett,Martin Rural 26/27 Precinct,U.S. House,1,Collin Duprel,LIB,71
+Bennett,Martin Rural 26/27 Precinct,U.S. House,1,Dusty Johnson,REP,261
+Bennett,Vetal/Tuthill Precinct,U.S. House,1,Collin Duprel,LIB,20
+Bennett,Vetal/Tuthill Precinct,U.S. House,1,Dusty Johnson,REP,127
+Bennett,Allen Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,158
+Bennett,Allen Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,8
+Bennett,Allen Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,56
+Bennett,Martin City Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,115
+Bennett,Martin City Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,14
+Bennett,Martin City Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,182
+Bennett,Martin Rural 26/27 Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,82
+Bennett,Martin Rural 26/27 Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,15
+Bennett,Martin Rural 26/27 Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,242
+Bennett,Vetal/Tuthill Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,13
+Bennett,Vetal/Tuthill Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Bennett,Vetal/Tuthill Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,139
+Bennett,Allen Precinct,Secretary of State,,Thomas A Cool,DEM,155
+Bennett,Allen Precinct,Secretary of State,,Monae Johnson,REP,56
+Bennett,Martin City Precinct,Secretary of State,,Thomas A Cool,DEM,121
+Bennett,Martin City Precinct,Secretary of State,,Monae Johnson,REP,173
+Bennett,Martin Rural 26/27 Precinct,Secretary of State,,Thomas A Cool,DEM,78
+Bennett,Martin Rural 26/27 Precinct,Secretary of State,,Monae Johnson,REP,237
+Bennett,Vetal/Tuthill Precinct,Secretary of State,,Thomas A Cool,DEM,14
+Bennett,Vetal/Tuthill Precinct,Secretary of State,,Monae Johnson,REP,127
+Bennett,Allen Precinct,Attorney General,,Marty J. Jackley,REP,93
+Bennett,Martin City Precinct,Attorney General,,Marty J. Jackley,REP,217
+Bennett,Martin Rural 26/27 Precinct,Attorney General,,Marty J. Jackley,REP,254
+Bennett,Vetal/Tuthill Precinct,Attorney General,,Marty J. Jackley,REP,125
+Bennett,Allen Precinct,State Auditor,,Stephanie Marty,DEM,151
+Bennett,Allen Precinct,State Auditor,,Rene Meyer,LIB,9
+Bennett,Allen Precinct,State Auditor,,Richard Sattgast,REP,49
+Bennett,Martin City Precinct,State Auditor,,Stephanie Marty,DEM,111
+Bennett,Martin City Precinct,State Auditor,,Rene Meyer,LIB,23
+Bennett,Martin City Precinct,State Auditor,,Richard Sattgast,REP,161
+Bennett,Martin Rural 26/27 Precinct,State Auditor,,Stephanie Marty,DEM,92
+Bennett,Martin Rural 26/27 Precinct,State Auditor,,Rene Meyer,LIB,11
+Bennett,Martin Rural 26/27 Precinct,State Auditor,,Richard Sattgast,REP,220
+Bennett,Vetal/Tuthill Precinct,State Auditor,,Stephanie Marty,DEM,13
+Bennett,Vetal/Tuthill Precinct,State Auditor,,Rene Meyer,LIB,5
+Bennett,Vetal/Tuthill Precinct,State Auditor,,Richard Sattgast,REP,117
+Bennett,Allen Precinct,State Treasurer,,John Cunningham,DEM,156
+Bennett,Allen Precinct,State Treasurer,,Josh Haeder,REP,53
+Bennett,Martin City Precinct,State Treasurer,,John Cunningham,DEM,112
+Bennett,Martin City Precinct,State Treasurer,,Josh Haeder,REP,177
+Bennett,Martin Rural 26/27 Precinct,State Treasurer,,John Cunningham,DEM,91
+Bennett,Martin Rural 26/27 Precinct,State Treasurer,,Josh Haeder,REP,229
+Bennett,Vetal/Tuthill Precinct,State Treasurer,,John Cunningham,DEM,15
+Bennett,Vetal/Tuthill Precinct,State Treasurer,,Josh Haeder,REP,123
+Bennett,Allen Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,156
+Bennett,Allen Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,50
+Bennett,Martin City Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,116
+Bennett,Martin City Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,171
+Bennett,Martin Rural 26/27 Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,84
+Bennett,Martin Rural 26/27 Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,228
+Bennett,Vetal/Tuthill Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,14
+Bennett,Vetal/Tuthill Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,123
+Bennett,Allen Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,149
+Bennett,Allen Precinct,Public Utilities Commissioner,,Chris Nelson,REP,58
+Bennett,Martin City Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,105
+Bennett,Martin City Precinct,Public Utilities Commissioner,,Chris Nelson,REP,186
+Bennett,Martin Rural 26/27 Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,83
+Bennett,Martin Rural 26/27 Precinct,Public Utilities Commissioner,,Chris Nelson,REP,235
+Bennett,Vetal/Tuthill Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,11
+Bennett,Vetal/Tuthill Precinct,Public Utilities Commissioner,,Chris Nelson,REP,131
+Bennett,Allen Precinct,State Senate,27,Red Dawn Foster,DEM,168
+Bennett,Allen Precinct,State Senate,27,David Jones,REP,54
+Bennett,Martin City Precinct,State Senate,27,Red Dawn Foster,DEM,120
+Bennett,Martin City Precinct,State Senate,27,David Jones,REP,188
+Bennett,Martin Rural 26/27 Precinct,State Senate,27,Red Dawn Foster,DEM,89
+Bennett,Martin Rural 26/27 Precinct,State Senate,27,David Jones,REP,251
+Bennett,Vetal/Tuthill Precinct,State Senate,27,Red Dawn Foster,DEM,10
+Bennett,Vetal/Tuthill Precinct,State Senate,27,David Jones,REP,141
+Bennett,Allen Precinct,State House,27,Peri Pourier,DEM,155
+Bennett,Allen Precinct,State House,27,Norma Rendon,DEM,112
+Bennett,Allen Precinct,State House,27,Liz May,REP,54
+Bennett,Allen Precinct,State House,27,Bud May,REP,39
+Bennett,Martin City Precinct,State House,27,Peri Pourier,DEM,134
+Bennett,Martin City Precinct,State House,27,Norma Rendon,DEM,96
+Bennett,Martin City Precinct,State House,27,Liz May,REP,188
+Bennett,Martin City Precinct,State House,27,Bud May,REP,118
+Bennett,Martin Rural 26/27 Precinct,State House,27,Peri Pourier,DEM,95
+Bennett,Martin Rural 26/27 Precinct,State House,27,Norma Rendon,DEM,70
+Bennett,Martin Rural 26/27 Precinct,State House,27,Liz May,REP,253
+Bennett,Martin Rural 26/27 Precinct,State House,27,Bud May,REP,154
+Bennett,Vetal/Tuthill Precinct,State House,27,Peri Pourier,DEM,20
+Bennett,Vetal/Tuthill Precinct,State House,27,Norma Rendon,DEM,13
+Bennett,Vetal/Tuthill Precinct,State House,27,Liz May,REP,135
+Bennett,Vetal/Tuthill Precinct,State House,27,Bud May,REP,89
+Bennett,Allen Precinct,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,71
+Bennett,Martin City Precinct,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,152
+Bennett,Martin Rural 26/27 Precinct,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,154
+Bennett,Vetal/Tuthill Precinct,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,59
+Bennett,Allen Precinct,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,64
+Bennett,Martin City Precinct,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,150
+Bennett,Martin Rural 26/27 Precinct,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,154
+Bennett,Vetal/Tuthill Precinct,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,57
+Bennett,Allen Precinct,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,58
+Bennett,Martin City Precinct,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,144
+Bennett,Martin Rural 26/27 Precinct,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,149
+Bennett,Vetal/Tuthill Precinct,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,60
+Bennett,Allen Precinct,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,62
+Bennett,Martin City Precinct,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,147
+Bennett,Martin Rural 26/27 Precinct,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,156
+Bennett,Vetal/Tuthill Precinct,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,57
+Bennett,Allen Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,108
+Bennett,Allen Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,67
+Bennett,Martin City Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,207
+Bennett,Martin City Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,55
+Bennett,Martin Rural 26/27 Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,197
+Bennett,Martin Rural 26/27 Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,77
+Bennett,Vetal/Tuthill Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,84
+Bennett,Vetal/Tuthill Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,32
+Bennett,Allen Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,104
+Bennett,Allen Precinct,Supreme Court Retention,2,Mark E. Salter - No,,73
+Bennett,Martin City Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,204
+Bennett,Martin City Precinct,Supreme Court Retention,2,Mark E. Salter - No,,56
+Bennett,Martin Rural 26/27 Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,197
+Bennett,Martin Rural 26/27 Precinct,Supreme Court Retention,2,Mark E. Salter - No,,74
+Bennett,Vetal/Tuthill Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,89
+Bennett,Vetal/Tuthill Precinct,Supreme Court Retention,2,Mark E. Salter - No,,24
+Bennett,Allen Precinct,Constitutional Amendment D,,Yes,,165
+Bennett,Allen Precinct,Constitutional Amendment D,,No,,45
+Bennett,Martin City Precinct,Constitutional Amendment D,,Yes,,205
+Bennett,Martin City Precinct,Constitutional Amendment D,,No,,104
+Bennett,Martin Rural 26/27 Precinct,Constitutional Amendment D,,Yes,,168
+Bennett,Martin Rural 26/27 Precinct,Constitutional Amendment D,,No,,169
+Bennett,Vetal/Tuthill Precinct,Constitutional Amendment D,,Yes,,52
+Bennett,Vetal/Tuthill Precinct,Constitutional Amendment D,,No,,98
+Bennett,Allen Precinct,Initiated Measure 27,,Yes,,142
+Bennett,Allen Precinct,Initiated Measure 27,,No,,69
+Bennett,Martin City Precinct,Initiated Measure 27,,Yes,,166
+Bennett,Martin City Precinct,Initiated Measure 27,,No,,145
+Bennett,Martin Rural 26/27 Precinct,Initiated Measure 27,,Yes,,135
+Bennett,Martin Rural 26/27 Precinct,Initiated Measure 27,,No,,209
+Bennett,Vetal/Tuthill Precinct,Initiated Measure 27,,Yes,,26
+Bennett,Vetal/Tuthill Precinct,Initiated Measure 27,,No,,126

--- a/2022/counties/20221108__sd__general__bon_homme__precinct.csv
+++ b/2022/counties/20221108__sd__general__bon_homme__precinct.csv
@@ -1,0 +1,191 @@
+county,precinct,office,district,candidate,party,votes
+Bon Homme,1,U.S. Senate,,Brian L. Bengs,DEM,62
+Bon Homme,1,U.S. Senate,,Tamara J Lesnar,LIB,12
+Bon Homme,1,U.S. Senate,,John R. Thune,REP,396
+Bon Homme,2,U.S. Senate,,Brian L. Bengs,DEM,70
+Bon Homme,2,U.S. Senate,,Tamara J Lesnar,LIB,10
+Bon Homme,2,U.S. Senate,,John R. Thune,REP,364
+Bon Homme,3,U.S. Senate,,Brian L. Bengs,DEM,137
+Bon Homme,3,U.S. Senate,,Tamara J Lesnar,LIB,35
+Bon Homme,3,U.S. Senate,,John R. Thune,REP,468
+Bon Homme,4,U.S. Senate,,Brian L. Bengs,DEM,96
+Bon Homme,4,U.S. Senate,,Tamara J Lesnar,LIB,16
+Bon Homme,4,U.S. Senate,,John R. Thune,REP,346
+Bon Homme,5,U.S. Senate,,Brian L. Bengs,DEM,88
+Bon Homme,5,U.S. Senate,,Tamara J Lesnar,LIB,18
+Bon Homme,5,U.S. Senate,,John R. Thune,REP,436
+Bon Homme,1,U.S. House,1,Collin Duprel,LIB,49
+Bon Homme,1,U.S. House,1,Dusty Johnson,REP,397
+Bon Homme,2,U.S. House,1,Collin Duprel,LIB,55
+Bon Homme,2,U.S. House,1,Dusty Johnson,REP,370
+Bon Homme,3,U.S. House,1,Collin Duprel,LIB,126
+Bon Homme,3,U.S. House,1,Dusty Johnson,REP,490
+Bon Homme,4,U.S. House,1,Collin Duprel,LIB,72
+Bon Homme,4,U.S. House,1,Dusty Johnson,REP,358
+Bon Homme,5,U.S. House,1,Collin Duprel,LIB,86
+Bon Homme,5,U.S. House,1,Dusty Johnson,REP,442
+Bon Homme,1,Governor,,Jamie Smith and Jennifer Keintz,DEM,84
+Bon Homme,1,Governor,,Tracey Quint and Ashley Strand,LIB,10
+Bon Homme,1,Governor,,Kristi Noem and Larry Rhoden,REP,380
+Bon Homme,2,Governor,,Jamie Smith and Jennifer Keintz,DEM,111
+Bon Homme,2,Governor,,Tracey Quint and Ashley Strand,LIB,6
+Bon Homme,2,Governor,,Kristi Noem and Larry Rhoden,REP,332
+Bon Homme,3,Governor,,Jamie Smith and Jennifer Keintz,DEM,205
+Bon Homme,3,Governor,,Tracey Quint and Ashley Strand,LIB,24
+Bon Homme,3,Governor,,Kristi Noem and Larry Rhoden,REP,416
+Bon Homme,4,Governor,,Jamie Smith and Jennifer Keintz,DEM,123
+Bon Homme,4,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Bon Homme,4,Governor,,Kristi Noem and Larry Rhoden,REP,320
+Bon Homme,5,Governor,,Jamie Smith and Jennifer Keintz,DEM,127
+Bon Homme,5,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Bon Homme,5,Governor,,Kristi Noem and Larry Rhoden,REP,410
+Bon Homme,1,Secretary of State,,Thomas A Cool,DEM,94
+Bon Homme,1,Secretary of State,,Monae Johnson,REP,349
+Bon Homme,2,Secretary of State,,Thomas A Cool,DEM,115
+Bon Homme,2,Secretary of State,,Monae Johnson,REP,313
+Bon Homme,3,Secretary of State,,Thomas A Cool,DEM,228
+Bon Homme,3,Secretary of State,,Monae Johnson,REP,385
+Bon Homme,4,Secretary of State,,Thomas A Cool,DEM,159
+Bon Homme,4,Secretary of State,,Monae Johnson,REP,259
+Bon Homme,5,Secretary of State,,Thomas A Cool,DEM,118
+Bon Homme,5,Secretary of State,,Monae Johnson,REP,411
+Bon Homme,1,Attorney General,,Marty J. Jackley,REP,397
+Bon Homme,2,Attorney General,,Marty J. Jackley,REP,330
+Bon Homme,3,Attorney General,,Marty J. Jackley,REP,472
+Bon Homme,4,Attorney General,,Marty J. Jackley,REP,337
+Bon Homme,5,Attorney General,,Marty J. Jackley,REP,427
+Bon Homme,1,State Auditor,,Stephanie Marty,DEM,80
+Bon Homme,1,State Auditor,,Rene Meyer,LIB,15
+Bon Homme,1,State Auditor,,Richard Sattgast,REP,354
+Bon Homme,2,State Auditor,,Stephanie Marty,DEM,100
+Bon Homme,2,State Auditor,,Rene Meyer,LIB,18
+Bon Homme,2,State Auditor,,Richard Sattgast,REP,298
+Bon Homme,3,State Auditor,,Stephanie Marty,DEM,183
+Bon Homme,3,State Auditor,,Rene Meyer,LIB,30
+Bon Homme,3,State Auditor,,Richard Sattgast,REP,376
+Bon Homme,4,State Auditor,,Stephanie Marty,DEM,138
+Bon Homme,4,State Auditor,,Rene Meyer,LIB,17
+Bon Homme,4,State Auditor,,Richard Sattgast,REP,258
+Bon Homme,5,State Auditor,,Stephanie Marty,DEM,105
+Bon Homme,5,State Auditor,,Rene Meyer,LIB,21
+Bon Homme,5,State Auditor,,Richard Sattgast,REP,398
+Bon Homme,1,State Treasurer,,John Cunningham,DEM,78
+Bon Homme,1,State Treasurer,,Josh Haeder,REP,361
+Bon Homme,2,State Treasurer,,John Cunningham,DEM,98
+Bon Homme,2,State Treasurer,,Josh Haeder,REP,317
+Bon Homme,3,State Treasurer,,John Cunningham,DEM,197
+Bon Homme,3,State Treasurer,,Josh Haeder,REP,384
+Bon Homme,4,State Treasurer,,John Cunningham,DEM,143
+Bon Homme,4,State Treasurer,,Josh Haeder,REP,265
+Bon Homme,5,State Treasurer,,John Cunningham,DEM,106
+Bon Homme,5,State Treasurer,,Josh Haeder,REP,418
+Bon Homme,1,Commissioner of School and Public Lands,,Timothy Azure,DEM,79
+Bon Homme,1,Commissioner of School and Public Lands,,Brock Greenfield,REP,362
+Bon Homme,2,Commissioner of School and Public Lands,,Timothy Azure,DEM,98
+Bon Homme,2,Commissioner of School and Public Lands,,Brock Greenfield,REP,316
+Bon Homme,3,Commissioner of School and Public Lands,,Timothy Azure,DEM,180
+Bon Homme,3,Commissioner of School and Public Lands,,Brock Greenfield,REP,402
+Bon Homme,4,Commissioner of School and Public Lands,,Timothy Azure,DEM,133
+Bon Homme,4,Commissioner of School and Public Lands,,Brock Greenfield,REP,268
+Bon Homme,5,Commissioner of School and Public Lands,,Timothy Azure,DEM,108
+Bon Homme,5,Commissioner of School and Public Lands,,Brock Greenfield,REP,405
+Bon Homme,1,Public Utilities Commissioner,,Jeffrey Barth,DEM,76
+Bon Homme,1,Public Utilities Commissioner,,Chris Nelson,REP,384
+Bon Homme,2,Public Utilities Commissioner,,Jeffrey Barth,DEM,93
+Bon Homme,2,Public Utilities Commissioner,,Chris Nelson,REP,325
+Bon Homme,3,Public Utilities Commissioner,,Jeffrey Barth,DEM,175
+Bon Homme,3,Public Utilities Commissioner,,Chris Nelson,REP,424
+Bon Homme,4,Public Utilities Commissioner,,Jeffrey Barth,DEM,126
+Bon Homme,4,Public Utilities Commissioner,,Chris Nelson,REP,299
+Bon Homme,5,Public Utilities Commissioner,,Jeffrey Barth,DEM,104
+Bon Homme,5,Public Utilities Commissioner,,Chris Nelson,REP,423
+Bon Homme,1,State Senate,19,Russell Graeff,DEM,60
+Bon Homme,1,State Senate,19,Kyle Schoenfish,REP,395
+Bon Homme,2,State Senate,19,Russell Graeff,DEM,88
+Bon Homme,2,State Senate,19,Kyle Schoenfish,REP,338
+Bon Homme,3,State Senate,19,Russell Graeff,DEM,166
+Bon Homme,3,State Senate,19,Kyle Schoenfish,REP,436
+Bon Homme,4,State Senate,19,Russell Graeff,DEM,99
+Bon Homme,4,State Senate,19,Kyle Schoenfish,REP,333
+Bon Homme,5,State Senate,19,Russell Graeff,DEM,99
+Bon Homme,5,State Senate,19,Kyle Schoenfish,REP,434
+Bon Homme,1,State House,19,Jessica Bahmuller,REP,267
+Bon Homme,1,State House,19,Drew Peterson,REP,303
+Bon Homme,2,State House,19,Jessica Bahmuller,REP,201
+Bon Homme,2,State House,19,Drew Peterson,REP,310
+Bon Homme,3,State House,19,Jessica Bahmuller,REP,302
+Bon Homme,3,State House,19,Drew Peterson,REP,352
+Bon Homme,4,State House,19,Jessica Bahmuller,REP,214
+Bon Homme,4,State House,19,Drew Peterson,REP,255
+Bon Homme,5,State House,19,Jessica Bahmuller,REP,273
+Bon Homme,5,State House,19,Drew Peterson,REP,355
+Bon Homme,1,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,226
+Bon Homme,2,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,206
+Bon Homme,3,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,275
+Bon Homme,4,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,203
+Bon Homme,5,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,232
+Bon Homme,1,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,231
+Bon Homme,2,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,205
+Bon Homme,3,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,280
+Bon Homme,4,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,206
+Bon Homme,5,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,241
+Bon Homme,1,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,234
+Bon Homme,2,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,222
+Bon Homme,3,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,272
+Bon Homme,4,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,200
+Bon Homme,5,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,246
+Bon Homme,1,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,240
+Bon Homme,2,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,214
+Bon Homme,3,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,290
+Bon Homme,4,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,209
+Bon Homme,5,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,257
+Bon Homme,1,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,222
+Bon Homme,2,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,200
+Bon Homme,3,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,274
+Bon Homme,4,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,195
+Bon Homme,5,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,231
+Bon Homme,1,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,220
+Bon Homme,2,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,203
+Bon Homme,3,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,276
+Bon Homme,4,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,200
+Bon Homme,5,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,238
+Bon Homme,1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,342
+Bon Homme,1,Supreme Court Retention,3,Patricia J. DeVaney - No,,71
+Bon Homme,2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,313
+Bon Homme,2,Supreme Court Retention,3,Patricia J. DeVaney - No,,81
+Bon Homme,3,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,436
+Bon Homme,3,Supreme Court Retention,3,Patricia J. DeVaney - No,,103
+Bon Homme,4,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,320
+Bon Homme,4,Supreme Court Retention,3,Patricia J. DeVaney - No,,67
+Bon Homme,5,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,386
+Bon Homme,5,Supreme Court Retention,3,Patricia J. DeVaney - No,,79
+Bon Homme,1,Supreme Court Retention,2,Mark E. Salter - Yes,,341
+Bon Homme,1,Supreme Court Retention,2,Mark E. Salter - No,,67
+Bon Homme,2,Supreme Court Retention,2,Mark E. Salter - Yes,,305
+Bon Homme,2,Supreme Court Retention,2,Mark E. Salter - No,,86
+Bon Homme,3,Supreme Court Retention,2,Mark E. Salter - Yes,,445
+Bon Homme,3,Supreme Court Retention,2,Mark E. Salter - No,,95
+Bon Homme,4,Supreme Court Retention,2,Mark E. Salter - Yes,,323
+Bon Homme,4,Supreme Court Retention,2,Mark E. Salter - No,,62
+Bon Homme,5,Supreme Court Retention,2,Mark E. Salter - Yes,,383
+Bon Homme,5,Supreme Court Retention,2,Mark E. Salter - No,,81
+Bon Homme,1,Constitutional Amendment D,,Yes,,220
+Bon Homme,1,Constitutional Amendment D,,No,,246
+Bon Homme,2,Constitutional Amendment D,,Yes,,198
+Bon Homme,2,Constitutional Amendment D,,No,,229
+Bon Homme,3,Constitutional Amendment D,,Yes,,339
+Bon Homme,3,Constitutional Amendment D,,No,,276
+Bon Homme,4,Constitutional Amendment D,,Yes,,210
+Bon Homme,4,Constitutional Amendment D,,No,,232
+Bon Homme,5,Constitutional Amendment D,,Yes,,241
+Bon Homme,5,Constitutional Amendment D,,No,,292
+Bon Homme,1,Initiated Measure 27,,Yes,,150
+Bon Homme,1,Initiated Measure 27,,No,,324
+Bon Homme,2,Initiated Measure 27,,Yes,,149
+Bon Homme,2,Initiated Measure 27,,No,,284
+Bon Homme,3,Initiated Measure 27,,Yes,,254
+Bon Homme,3,Initiated Measure 27,,No,,378
+Bon Homme,4,Initiated Measure 27,,Yes,,152
+Bon Homme,4,Initiated Measure 27,,No,,290
+Bon Homme,5,Initiated Measure 27,,Yes,,216
+Bon Homme,5,Initiated Measure 27,,No,,323

--- a/2022/counties/20221108__sd__general__brookings__precinct.csv
+++ b/2022/counties/20221108__sd__general__brookings__precinct.csv
@@ -1,0 +1,379 @@
+county,precinct,office,district,candidate,party,votes
+Brookings,Absentee Precinct,U.S. Senate,,Brian L. Bengs,DEM,1976
+Brookings,Absentee Precinct,U.S. Senate,,Tamara J Lesnar,LIB,158
+Brookings,Absentee Precinct,U.S. Senate,,John R. Thune,REP,2701
+Brookings,Aurora Little Hall,U.S. Senate,,Brian L. Bengs,DEM,111
+Brookings,Aurora Little Hall,U.S. Senate,,Tamara J Lesnar,LIB,26
+Brookings,Aurora Little Hall,U.S. Senate,,John R. Thune,REP,400
+Brookings,Bethel Baptist,U.S. Senate,,Brian L. Bengs,DEM,524
+Brookings,Bethel Baptist,U.S. Senate,,Tamara J Lesnar,LIB,94
+Brookings,Bethel Baptist,U.S. Senate,,John R. Thune,REP,1383
+Brookings,Brookings Activity Center,U.S. Senate,,Brian L. Bengs,DEM,649
+Brookings,Brookings Activity Center,U.S. Senate,,Tamara J Lesnar,LIB,102
+Brookings,Brookings Activity Center,U.S. Senate,,John R. Thune,REP,977
+Brookings,Bruce Community Room,U.S. Senate,,Brian L. Bengs,DEM,67
+Brookings,Bruce Community Room,U.S. Senate,,Tamara J Lesnar,LIB,15
+Brookings,Bruce Community Room,U.S. Senate,,John R. Thune,REP,300
+Brookings,Elkton Community Center,U.S. Senate,,Brian L. Bengs,DEM,41
+Brookings,Elkton Community Center,U.S. Senate,,Tamara J Lesnar,LIB,20
+Brookings,Elkton Community Center,U.S. Senate,,John R. Thune,REP,288
+Brookings,Holy Life Tabernacle,U.S. Senate,,Brian L. Bengs,DEM,228
+Brookings,Holy Life Tabernacle,U.S. Senate,,Tamara J Lesnar,LIB,46
+Brookings,Holy Life Tabernacle,U.S. Senate,,John R. Thune,REP,618
+Brookings,Volga Community Center,U.S. Senate,,Brian L. Bengs,DEM,167
+Brookings,Volga Community Center,U.S. Senate,,Tamara J Lesnar,LIB,56
+Brookings,Volga Community Center,U.S. Senate,,John R. Thune,REP,905
+Brookings,White McKnight Hall,U.S. Senate,,Brian L. Bengs,DEM,53
+Brookings,White McKnight Hall,U.S. Senate,,Tamara J Lesnar,LIB,28
+Brookings,White McKnight Hall,U.S. Senate,,John R. Thune,REP,418
+Brookings,Absentee Precinct,U.S. House,1,Collin Duprel,LIB,1235
+Brookings,Absentee Precinct,U.S. House,1,Dusty Johnson,REP,3137
+Brookings,Aurora Little Hall,U.S. House,1,Collin Duprel,LIB,121
+Brookings,Aurora Little Hall,U.S. House,1,Dusty Johnson,REP,402
+Brookings,Bethel Baptist,U.S. House,1,Collin Duprel,LIB,410
+Brookings,Bethel Baptist,U.S. House,1,Dusty Johnson,REP,1487
+Brookings,Brookings Activity Center,U.S. House,1,Collin Duprel,LIB,492
+Brookings,Brookings Activity Center,U.S. House,1,Dusty Johnson,REP,1114
+Brookings,Bruce Community Room,U.S. House,1,Collin Duprel,LIB,53
+Brookings,Bruce Community Room,U.S. House,1,Dusty Johnson,REP,321
+Brookings,Elkton Community Center,U.S. House,1,Collin Duprel,LIB,50
+Brookings,Elkton Community Center,U.S. House,1,Dusty Johnson,REP,288
+Brookings,Holy Life Tabernacle,U.S. House,1,Collin Duprel,LIB,173
+Brookings,Holy Life Tabernacle,U.S. House,1,Dusty Johnson,REP,672
+Brookings,Volga Community Center,U.S. House,1,Collin Duprel,LIB,171
+Brookings,Volga Community Center,U.S. House,1,Dusty Johnson,REP,926
+Brookings,White McKnight Hall,U.S. House,1,Collin Duprel,LIB,52
+Brookings,White McKnight Hall,U.S. House,1,Dusty Johnson,REP,436
+Brookings,Absentee Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,2498
+Brookings,Absentee Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,102
+Brookings,Absentee Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,2264
+Brookings,Aurora Little Hall,Governor,,Jamie Smith and Jennifer Keintz,DEM,147
+Brookings,Aurora Little Hall,Governor,,Tracey Quint and Ashley Strand,LIB,18
+Brookings,Aurora Little Hall,Governor,,Kristi Noem and Larry Rhoden,REP,381
+Brookings,Bethel Baptist,Governor,,Jamie Smith and Jennifer Keintz,DEM,772
+Brookings,Bethel Baptist,Governor,,Tracey Quint and Ashley Strand,LIB,57
+Brookings,Bethel Baptist,Governor,,Kristi Noem and Larry Rhoden,REP,1176
+Brookings,Brookings Activity Center,Governor,,Jamie Smith and Jennifer Keintz,DEM,838
+Brookings,Brookings Activity Center,Governor,,Tracey Quint and Ashley Strand,LIB,71
+Brookings,Brookings Activity Center,Governor,,Kristi Noem and Larry Rhoden,REP,828
+Brookings,Bruce Community Room,Governor,,Jamie Smith and Jennifer Keintz,DEM,95
+Brookings,Bruce Community Room,Governor,,Tracey Quint and Ashley Strand,LIB,10
+Brookings,Bruce Community Room,Governor,,Kristi Noem and Larry Rhoden,REP,280
+Brookings,Elkton Community Center,Governor,,Jamie Smith and Jennifer Keintz,DEM,71
+Brookings,Elkton Community Center,Governor,,Tracey Quint and Ashley Strand,LIB,14
+Brookings,Elkton Community Center,Governor,,Kristi Noem and Larry Rhoden,REP,260
+Brookings,Holy Life Tabernacle,Governor,,Jamie Smith and Jennifer Keintz,DEM,312
+Brookings,Holy Life Tabernacle,Governor,,Tracey Quint and Ashley Strand,LIB,34
+Brookings,Holy Life Tabernacle,Governor,,Kristi Noem and Larry Rhoden,REP,549
+Brookings,Volga Community Center,Governor,,Jamie Smith and Jennifer Keintz,DEM,277
+Brookings,Volga Community Center,Governor,,Tracey Quint and Ashley Strand,LIB,40
+Brookings,Volga Community Center,Governor,,Kristi Noem and Larry Rhoden,REP,832
+Brookings,White McKnight Hall,Governor,,Jamie Smith and Jennifer Keintz,DEM,86
+Brookings,White McKnight Hall,Governor,,Tracey Quint and Ashley Strand,LIB,11
+Brookings,White McKnight Hall,Governor,,Kristi Noem and Larry Rhoden,REP,404
+Brookings,Absentee Precinct,Secretary of State,,Thomas A Cool,DEM,2346
+Brookings,Absentee Precinct,Secretary of State,,Monae Johnson,REP,2287
+Brookings,Aurora Little Hall,Secretary of State,,Thomas A Cool,DEM,152
+Brookings,Aurora Little Hall,Secretary of State,,Monae Johnson,REP,363
+Brookings,Bethel Baptist,Secretary of State,,Thomas A Cool,DEM,702
+Brookings,Bethel Baptist,Secretary of State,,Monae Johnson,REP,1165
+Brookings,Brookings Activity Center,Secretary of State,,Thomas A Cool,DEM,802
+Brookings,Brookings Activity Center,Secretary of State,,Monae Johnson,REP,822
+Brookings,Bruce Community Room,Secretary of State,,Thomas A Cool,DEM,92
+Brookings,Bruce Community Room,Secretary of State,,Monae Johnson,REP,270
+Brookings,Elkton Community Center,Secretary of State,,Thomas A Cool,DEM,68
+Brookings,Elkton Community Center,Secretary of State,,Monae Johnson,REP,261
+Brookings,Holy Life Tabernacle,Secretary of State,,Thomas A Cool,DEM,304
+Brookings,Holy Life Tabernacle,Secretary of State,,Monae Johnson,REP,542
+Brookings,Volga Community Center,Secretary of State,,Thomas A Cool,DEM,294
+Brookings,Volga Community Center,Secretary of State,,Monae Johnson,REP,793
+Brookings,White McKnight Hall,Secretary of State,,Thomas A Cool,DEM,101
+Brookings,White McKnight Hall,Secretary of State,,Monae Johnson,REP,371
+Brookings,Absentee Precinct,Attorney General,,Marty J. Jackley,REP,3222
+Brookings,Aurora Little Hall,Attorney General,,Marty J. Jackley,REP,420
+Brookings,Bethel Baptist,Attorney General,,Marty J. Jackley,REP,1504
+Brookings,Brookings Activity Center,Attorney General,,Marty J. Jackley,REP,1119
+Brookings,Bruce Community Room,Attorney General,,Marty J. Jackley,REP,314
+Brookings,Elkton Community Center,Attorney General,,Marty J. Jackley,REP,293
+Brookings,Holy Life Tabernacle,Attorney General,,Marty J. Jackley,REP,666
+Brookings,Volga Community Center,Attorney General,,Marty J. Jackley,REP,939
+Brookings,White McKnight Hall,Attorney General,,Marty J. Jackley,REP,427
+Brookings,Absentee Precinct,State Auditor,,Stephanie Marty,DEM,2162
+Brookings,Absentee Precinct,State Auditor,,Rene Meyer,LIB,213
+Brookings,Absentee Precinct,State Auditor,,Richard Sattgast,REP,2206
+Brookings,Aurora Little Hall,State Auditor,,Stephanie Marty,DEM,132
+Brookings,Aurora Little Hall,State Auditor,,Rene Meyer,LIB,33
+Brookings,Aurora Little Hall,State Auditor,,Richard Sattgast,REP,334
+Brookings,Bethel Baptist,State Auditor,,Stephanie Marty,DEM,588
+Brookings,Bethel Baptist,State Auditor,,Rene Meyer,LIB,128
+Brookings,Bethel Baptist,State Auditor,,Richard Sattgast,REP,1125
+Brookings,Brookings Activity Center,State Auditor,,Stephanie Marty,DEM,690
+Brookings,Brookings Activity Center,State Auditor,,Rene Meyer,LIB,133
+Brookings,Brookings Activity Center,State Auditor,,Richard Sattgast,REP,765
+Brookings,Bruce Community Room,State Auditor,,Stephanie Marty,DEM,70
+Brookings,Bruce Community Room,State Auditor,,Rene Meyer,LIB,18
+Brookings,Bruce Community Room,State Auditor,,Richard Sattgast,REP,275
+Brookings,Elkton Community Center,State Auditor,,Stephanie Marty,DEM,57
+Brookings,Elkton Community Center,State Auditor,,Rene Meyer,LIB,28
+Brookings,Elkton Community Center,State Auditor,,Richard Sattgast,REP,234
+Brookings,Holy Life Tabernacle,State Auditor,,Stephanie Marty,DEM,243
+Brookings,Holy Life Tabernacle,State Auditor,,Rene Meyer,LIB,51
+Brookings,Holy Life Tabernacle,State Auditor,,Richard Sattgast,REP,533
+Brookings,Volga Community Center,State Auditor,,Stephanie Marty,DEM,224
+Brookings,Volga Community Center,State Auditor,,Rene Meyer,LIB,79
+Brookings,Volga Community Center,State Auditor,,Richard Sattgast,REP,763
+Brookings,White McKnight Hall,State Auditor,,Stephanie Marty,DEM,80
+Brookings,White McKnight Hall,State Auditor,,Rene Meyer,LIB,26
+Brookings,White McKnight Hall,State Auditor,,Richard Sattgast,REP,367
+Brookings,Absentee Precinct,State Treasurer,,John Cunningham,DEM,2183
+Brookings,Absentee Precinct,State Treasurer,,Josh Haeder,REP,2364
+Brookings,Aurora Little Hall,State Treasurer,,John Cunningham,DEM,140
+Brookings,Aurora Little Hall,State Treasurer,,Josh Haeder,REP,360
+Brookings,Bethel Baptist,State Treasurer,,John Cunningham,DEM,608
+Brookings,Bethel Baptist,State Treasurer,,Josh Haeder,REP,1217
+Brookings,Brookings Activity Center,State Treasurer,,John Cunningham,DEM,724
+Brookings,Brookings Activity Center,State Treasurer,,Josh Haeder,REP,846
+Brookings,Bruce Community Room,State Treasurer,,John Cunningham,DEM,72
+Brookings,Bruce Community Room,State Treasurer,,Josh Haeder,REP,289
+Brookings,Elkton Community Center,State Treasurer,,John Cunningham,DEM,61
+Brookings,Elkton Community Center,State Treasurer,,Josh Haeder,REP,254
+Brookings,Holy Life Tabernacle,State Treasurer,,John Cunningham,DEM,253
+Brookings,Holy Life Tabernacle,State Treasurer,,Josh Haeder,REP,558
+Brookings,Volga Community Center,State Treasurer,,John Cunningham,DEM,235
+Brookings,Volga Community Center,State Treasurer,,Josh Haeder,REP,823
+Brookings,White McKnight Hall,State Treasurer,,John Cunningham,DEM,80
+Brookings,White McKnight Hall,State Treasurer,,Josh Haeder,REP,385
+Brookings,Absentee Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,2140
+Brookings,Absentee Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,2322
+Brookings,Aurora Little Hall,Commissioner of School and Public Lands,,Timothy Azure,DEM,135
+Brookings,Aurora Little Hall,Commissioner of School and Public Lands,,Brock Greenfield,REP,373
+Brookings,Bethel Baptist,Commissioner of School and Public Lands,,Timothy Azure,DEM,630
+Brookings,Bethel Baptist,Commissioner of School and Public Lands,,Brock Greenfield,REP,1172
+Brookings,Brookings Activity Center,Commissioner of School and Public Lands,,Timothy Azure,DEM,719
+Brookings,Brookings Activity Center,Commissioner of School and Public Lands,,Brock Greenfield,REP,832
+Brookings,Bruce Community Room,Commissioner of School and Public Lands,,Timothy Azure,DEM,72
+Brookings,Bruce Community Room,Commissioner of School and Public Lands,,Brock Greenfield,REP,283
+Brookings,Elkton Community Center,Commissioner of School and Public Lands,,Timothy Azure,DEM,59
+Brookings,Elkton Community Center,Commissioner of School and Public Lands,,Brock Greenfield,REP,252
+Brookings,Holy Life Tabernacle,Commissioner of School and Public Lands,,Timothy Azure,DEM,260
+Brookings,Holy Life Tabernacle,Commissioner of School and Public Lands,,Brock Greenfield,REP,537
+Brookings,Volga Community Center,Commissioner of School and Public Lands,,Timothy Azure,DEM,240
+Brookings,Volga Community Center,Commissioner of School and Public Lands,,Brock Greenfield,REP,810
+Brookings,White McKnight Hall,Commissioner of School and Public Lands,,Timothy Azure,DEM,74
+Brookings,White McKnight Hall,Commissioner of School and Public Lands,,Brock Greenfield,REP,384
+Brookings,Absentee Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,2007
+Brookings,Absentee Precinct,Public Utilities Commissioner,,Chris Nelson,REP,2584
+Brookings,Aurora Little Hall,Public Utilities Commissioner,,Jeffrey Barth,DEM,127
+Brookings,Aurora Little Hall,Public Utilities Commissioner,,Chris Nelson,REP,389
+Brookings,Bethel Baptist,Public Utilities Commissioner,,Jeffrey Barth,DEM,565
+Brookings,Bethel Baptist,Public Utilities Commissioner,,Chris Nelson,REP,1284
+Brookings,Brookings Activity Center,Public Utilities Commissioner,,Jeffrey Barth,DEM,683
+Brookings,Brookings Activity Center,Public Utilities Commissioner,,Chris Nelson,REP,906
+Brookings,Bruce Community Room,Public Utilities Commissioner,,Jeffrey Barth,DEM,76
+Brookings,Bruce Community Room,Public Utilities Commissioner,,Chris Nelson,REP,293
+Brookings,Elkton Community Center,Public Utilities Commissioner,,Jeffrey Barth,DEM,51
+Brookings,Elkton Community Center,Public Utilities Commissioner,,Chris Nelson,REP,270
+Brookings,Holy Life Tabernacle,Public Utilities Commissioner,,Jeffrey Barth,DEM,233
+Brookings,Holy Life Tabernacle,Public Utilities Commissioner,,Chris Nelson,REP,592
+Brookings,Volga Community Center,Public Utilities Commissioner,,Jeffrey Barth,DEM,208
+Brookings,Volga Community Center,Public Utilities Commissioner,,Chris Nelson,REP,877
+Brookings,White McKnight Hall,Public Utilities Commissioner,,Jeffrey Barth,DEM,63
+Brookings,White McKnight Hall,Public Utilities Commissioner,,Chris Nelson,REP,410
+Brookings,Absentee Precinct,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,2037
+Brookings,Aurora Little Hall,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,240
+Brookings,Bethel Baptist,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,878
+Brookings,Brookings Activity Center,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,655
+Brookings,Bruce Community Room,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,182
+Brookings,Elkton Community Center,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,168
+Brookings,Holy Life Tabernacle,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,380
+Brookings,Volga Community Center,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,527
+Brookings,White McKnight Hall,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,223
+Brookings,Absentee Precinct,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,1990
+Brookings,Aurora Little Hall,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,243
+Brookings,Bethel Baptist,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,858
+Brookings,Brookings Activity Center,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,655
+Brookings,Bruce Community Room,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,180
+Brookings,Elkton Community Center,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,164
+Brookings,Holy Life Tabernacle,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,375
+Brookings,Volga Community Center,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,527
+Brookings,White McKnight Hall,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,220
+Brookings,Absentee Precinct,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,1900
+Brookings,Aurora Little Hall,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,232
+Brookings,Bethel Baptist,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,833
+Brookings,Brookings Activity Center,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,622
+Brookings,Bruce Community Room,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,173
+Brookings,Elkton Community Center,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,163
+Brookings,Holy Life Tabernacle,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,367
+Brookings,Volga Community Center,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,505
+Brookings,White McKnight Hall,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,215
+Brookings,Absentee Precinct,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,2182
+Brookings,Aurora Little Hall,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,252
+Brookings,Bethel Baptist,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,897
+Brookings,Brookings Activity Center,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,691
+Brookings,Bruce Community Room,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,187
+Brookings,Elkton Community Center,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,197
+Brookings,Holy Life Tabernacle,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,411
+Brookings,Volga Community Center,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,575
+Brookings,White McKnight Hall,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,254
+Brookings,Absentee Precinct,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,993
+Brookings,Absentee Precinct,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,1161
+Brookings,Aurora Little Hall,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,128
+Brookings,Aurora Little Hall,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,112
+Brookings,Bethel Baptist,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,424
+Brookings,Bethel Baptist,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,455
+Brookings,Brookings Activity Center,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,351
+Brookings,Brookings Activity Center,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,374
+Brookings,Bruce Community Room,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,103
+Brookings,Bruce Community Room,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,92
+Brookings,Elkton Community Center,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,68
+Brookings,Elkton Community Center,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,108
+Brookings,Holy Life Tabernacle,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,187
+Brookings,Holy Life Tabernacle,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,203
+Brookings,Volga Community Center,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,348
+Brookings,Volga Community Center,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,216
+Brookings,White McKnight Hall,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,97
+Brookings,White McKnight Hall,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,141
+Brookings,Absentee Precinct,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,1877
+Brookings,Aurora Little Hall,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,222
+Brookings,Bethel Baptist,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,814
+Brookings,Brookings Activity Center,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,618
+Brookings,Bruce Community Room,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,170
+Brookings,Elkton Community Center,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,163
+Brookings,Holy Life Tabernacle,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,365
+Brookings,Volga Community Center,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,493
+Brookings,White McKnight Hall,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,209
+Brookings,Absentee Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,3082
+Brookings,Absentee Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,743
+Brookings,Aurora Little Hall,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,340
+Brookings,Aurora Little Hall,Supreme Court Retention,3,Patricia J. DeVaney - No,,65
+Brookings,Bethel Baptist,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1235
+Brookings,Bethel Baptist,Supreme Court Retention,3,Patricia J. DeVaney - No,,268
+Brookings,Brookings Activity Center,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,979
+Brookings,Brookings Activity Center,Supreme Court Retention,3,Patricia J. DeVaney - No,,314
+Brookings,Bruce Community Room,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,256
+Brookings,Bruce Community Room,Supreme Court Retention,3,Patricia J. DeVaney - No,,47
+Brookings,Elkton Community Center,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,246
+Brookings,Elkton Community Center,Supreme Court Retention,3,Patricia J. DeVaney - No,,45
+Brookings,Holy Life Tabernacle,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,546
+Brookings,Holy Life Tabernacle,Supreme Court Retention,3,Patricia J. DeVaney - No,,111
+Brookings,Volga Community Center,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,759
+Brookings,Volga Community Center,Supreme Court Retention,3,Patricia J. DeVaney - No,,137
+Brookings,White McKnight Hall,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,344
+Brookings,White McKnight Hall,Supreme Court Retention,3,Patricia J. DeVaney - No,,58
+Brookings,Absentee Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,3054
+Brookings,Absentee Precinct,Supreme Court Retention,2,Mark E. Salter - No,,717
+Brookings,Aurora Little Hall,Supreme Court Retention,2,Mark E. Salter - Yes,,337
+Brookings,Aurora Little Hall,Supreme Court Retention,2,Mark E. Salter - No,,60
+Brookings,Bethel Baptist,Supreme Court Retention,2,Mark E. Salter - Yes,,1225
+Brookings,Bethel Baptist,Supreme Court Retention,2,Mark E. Salter - No,,256
+Brookings,Brookings Activity Center,Supreme Court Retention,2,Mark E. Salter - Yes,,953
+Brookings,Brookings Activity Center,Supreme Court Retention,2,Mark E. Salter - No,,330
+Brookings,Bruce Community Room,Supreme Court Retention,2,Mark E. Salter - Yes,,258
+Brookings,Bruce Community Room,Supreme Court Retention,2,Mark E. Salter - No,,42
+Brookings,Elkton Community Center,Supreme Court Retention,2,Mark E. Salter - Yes,,242
+Brookings,Elkton Community Center,Supreme Court Retention,2,Mark E. Salter - No,,44
+Brookings,Holy Life Tabernacle,Supreme Court Retention,2,Mark E. Salter - Yes,,540
+Brookings,Holy Life Tabernacle,Supreme Court Retention,2,Mark E. Salter - No,,116
+Brookings,Volga Community Center,Supreme Court Retention,2,Mark E. Salter - Yes,,748
+Brookings,Volga Community Center,Supreme Court Retention,2,Mark E. Salter - No,,132
+Brookings,White McKnight Hall,Supreme Court Retention,2,Mark E. Salter - Yes,,337
+Brookings,White McKnight Hall,Supreme Court Retention,2,Mark E. Salter - No,,61
+Brookings,Absentee Precinct,Constitutional Amendment D,,Yes,,3066
+Brookings,Absentee Precinct,Constitutional Amendment D,,No,,1664
+Brookings,Aurora Little Hall,Constitutional Amendment D,,Yes,,261
+Brookings,Aurora Little Hall,Constitutional Amendment D,,No,,257
+Brookings,Bethel Baptist,Constitutional Amendment D,,Yes,,1053
+Brookings,Bethel Baptist,Constitutional Amendment D,,No,,870
+Brookings,Brookings Activity Center,Constitutional Amendment D,,Yes,,1103
+Brookings,Brookings Activity Center,Constitutional Amendment D,,No,,559
+Brookings,Bruce Community Room,Constitutional Amendment D,,Yes,,160
+Brookings,Bruce Community Room,Constitutional Amendment D,,No,,207
+Brookings,Elkton Community Center,Constitutional Amendment D,,Yes,,161
+Brookings,Elkton Community Center,Constitutional Amendment D,,No,,188
+Brookings,Holy Life Tabernacle,Constitutional Amendment D,,Yes,,474
+Brookings,Holy Life Tabernacle,Constitutional Amendment D,,No,,398
+Brookings,Volga Community Center,Constitutional Amendment D,,Yes,,504
+Brookings,Volga Community Center,Constitutional Amendment D,,No,,588
+Brookings,White McKnight Hall,Constitutional Amendment D,,Yes,,203
+Brookings,White McKnight Hall,Constitutional Amendment D,,No,,272
+Brookings,Absentee Precinct,Initiated Measure 27,,Yes,,2565
+Brookings,Absentee Precinct,Initiated Measure 27,,No,,2226
+Brookings,Aurora Little Hall,Initiated Measure 27,,Yes,,259
+Brookings,Aurora Little Hall,Initiated Measure 27,,No,,274
+Brookings,Bethel Baptist,Initiated Measure 27,,Yes,,965
+Brookings,Bethel Baptist,Initiated Measure 27,,No,,994
+Brookings,Brookings Activity Center,Initiated Measure 27,,Yes,,1102
+Brookings,Brookings Activity Center,Initiated Measure 27,,No,,616
+Brookings,Bruce Community Room,Initiated Measure 27,,Yes,,134
+Brookings,Bruce Community Room,Initiated Measure 27,,No,,246
+Brookings,Elkton Community Center,Initiated Measure 27,,Yes,,143
+Brookings,Elkton Community Center,Initiated Measure 27,,No,,207
+Brookings,Holy Life Tabernacle,Initiated Measure 27,,Yes,,451
+Brookings,Holy Life Tabernacle,Initiated Measure 27,,No,,441
+Brookings,Volga Community Center,Initiated Measure 27,,Yes,,472
+Brookings,Volga Community Center,Initiated Measure 27,,No,,653
+Brookings,White McKnight Hall,Initiated Measure 27,,Yes,,148
+Brookings,White McKnight Hall,Initiated Measure 27,,No,,342
+Brookings,Absentee Precinct,State Senate,07,Tim Reed,REP,2631
+Brookings,Absentee Precinct,State Senate,08,Casey Crabtree,REP,574
+Brookings,Aurora Little Hall,State Senate,07,Tim Reed,REP,311
+Brookings,Aurora Little Hall,State Senate,08,Casey Crabtree,REP,97
+Brookings,Bethel Baptist,State Senate,07,Tim Reed,REP,1479
+Brookings,Bethel Baptist,State Senate,08,Casey Crabtree,REP,39
+Brookings,Brookings Activity Center,State Senate,07,Tim Reed,REP,1080
+Brookings,Brookings Activity Center,State Senate,08,Casey Crabtree,REP,83
+Brookings,Bruce Community Room,State Senate,07,Tim Reed,REP,20
+Brookings,Bruce Community Room,State Senate,08,Casey Crabtree,REP,274
+Brookings,Elkton Community Center,State Senate,07,Tim Reed,REP,7
+Brookings,Elkton Community Center,State Senate,08,Casey Crabtree,REP,251
+Brookings,Holy Life Tabernacle,State Senate,07,Tim Reed,REP,648
+Brookings,Holy Life Tabernacle,State Senate,08,Casey Crabtree,REP,15
+Brookings,Volga Community Center,State Senate,07,Tim Reed,REP,72
+Brookings,Volga Community Center,State Senate,08,Casey Crabtree,REP,793
+Brookings,White McKnight Hall 10 of 23,State Senate,07,Tim Reed,REP,15
+Brookings,White McKnight Hall 10 of 23,State Senate,08,Casey Crabtree,REP,380
+Brookings,Absentee Precinct,State House,07,Cole Sartell,DEM,1758
+Brookings,Absentee Precinct,State House,07,Mellissa Heermann,REP,1826
+Brookings,Absentee Precinct,State House,07,Roger DeGroot,REP,2089
+Brookings,Absentee Precinct,State House,08,Tim Reisch,REP,405
+Brookings,Absentee Precinct,State House,08,John Mills,REP,509
+Brookings,Aurora Little Hall,State House,07,Cole Sartell,DEM,114
+Brookings,Aurora Little Hall,State House,07,Mellissa Heermann,REP,226
+Brookings,Aurora Little Hall,State House,07,Roger DeGroot,REP,258
+Brookings,Aurora Little Hall,State House,08,Tim Reisch,REP,73
+Brookings,Aurora Little Hall,State House,08,John Mills,REP,83
+Brookings,Bethel Baptist,State House,07,Cole Sartell,DEM,608
+Brookings,Bethel Baptist,State House,07,Mellissa Heermann,REP,1108
+Brookings,Bethel Baptist,State House,07,Roger DeGroot,REP,1187
+Brookings,Bethel Baptist,State House,08,Tim Reisch,REP,25
+Brookings,Bethel Baptist,State House,08,John Mills,REP,35
+Brookings,Brookings Activity Center,State House,07,Cole Sartell,DEM,684
+Brookings,Brookings Activity Center,State House,07,Mellissa Heermann,REP,724
+Brookings,Brookings Activity Center,State House,07,Roger DeGroot,REP,799
+Brookings,Brookings Activity Center,State House,08,Tim Reisch,REP,47
+Brookings,Brookings Activity Center,State House,08,John Mills,REP,66
+Brookings,Bruce Community Room,State House,07,Cole Sartell,DEM,4
+Brookings,Bruce Community Room,State House,07,Mellissa Heermann,REP,15
+Brookings,Bruce Community Room,State House,07,Roger DeGroot,REP,17
+Brookings,Bruce Community Room,State House,08,Tim Reisch,REP,180
+Brookings,Bruce Community Room,State House,08,John Mills,REP,251
+Brookings,Elkton Community Center,State House,07,Cole Sartell,DEM,0
+Brookings,Elkton Community Center,State House,07,Mellissa Heermann,REP,5
+Brookings,Elkton Community Center,State House,07,Roger DeGroot,REP,6
+Brookings,Elkton Community Center,State House,08,Tim Reisch,REP,191
+Brookings,Elkton Community Center,State House,08,John Mills,REP,225
+Brookings,Holy Life Tabernacle,State House,07,Cole Sartell,DEM,242
+Brookings,Holy Life Tabernacle,State House,07,Mellissa Heermann,REP,502
+Brookings,Holy Life Tabernacle,State House,07,Roger DeGroot,REP,552
+Brookings,Holy Life Tabernacle,State House,08,Tim Reisch,REP,10
+Brookings,Holy Life Tabernacle,State House,08,John Mills,REP,10
+Brookings,Volga Community Center,State House,07,Cole Sartell,DEM,20
+Brookings,Volga Community Center,State House,07,Mellissa Heermann,REP,47
+Brookings,Volga Community Center,State House,07,Roger DeGroot,REP,57
+Brookings,Volga Community Center,State House,08,Tim Reisch,REP,573
+Brookings,Volga Community Center,State House,08,John Mills,REP,704
+Brookings,White McKnight Hall 11 of 23,State House,07,Cole Sartell,DEM,1
+Brookings,White McKnight Hall 11 of 23,State House,07,Mellissa Heermann,REP,8
+Brookings,White McKnight Hall 11 of 23,State House,07,Roger DeGroot,REP,15
+Brookings,White McKnight Hall 11 of 23,State House,08,Tim Reisch,REP,258
+Brookings,White McKnight Hall 11 of 23,State House,08,John Mills,REP,328

--- a/2022/counties/20221108__sd__general__brown__precinct.csv
+++ b/2022/counties/20221108__sd__general__brown__precinct.csv
@@ -1,0 +1,529 @@
+county,precinct,office,district,candidate,party,votes
+Brown,Absentee Precinct,U.S. Senate,,Brian L. Bengs,DEM,2037
+Brown,Absentee Precinct,U.S. Senate,,Tamara J Lesnar,LIB,136
+Brown,Absentee Precinct,U.S. Senate,,John R. Thune,REP,3354
+Brown,AmericInn Event Center,U.S. Senate,,Brian L. Bengs,DEM,379
+Brown,AmericInn Event Center,U.S. Senate,,Tamara J Lesnar,LIB,68
+Brown,AmericInn Event Center,U.S. Senate,,John R. Thune,REP,1449
+Brown,Hotel and Convention,U.S. Senate,,Brian L. Bengs,DEM,404
+Brown,Hotel and Convention,U.S. Senate,,Tamara J Lesnar,LIB,82
+Brown,Hotel and Convention,U.S. Senate,,John R. Thune,REP,1430
+Brown,Claremont City Hall,U.S. Senate,,Brian L. Bengs,DEM,31
+Brown,Claremont City Hall,U.S. Senate,,Tamara J Lesnar,LIB,2
+Brown,Claremont City Hall,U.S. Senate,,John R. Thune,REP,94
+Brown,Columbia Legion,U.S. Senate,,Brian L. Bengs,DEM,32
+Brown,Columbia Legion,U.S. Senate,,Tamara J Lesnar,LIB,7
+Brown,Columbia Legion,U.S. Senate,,John R. Thune,REP,151
+Brown,?,U.S. Senate,,Brian L. Bengs,DEM,673
+Brown,?,U.S. Senate,,Tamara J Lesnar,LIB,100
+Brown,?,U.S. Senate,,John R. Thune,REP,1636
+Brown,?,U.S. Senate,,Brian L. Bengs,DEM,46
+Brown,?,U.S. Senate,,Tamara J Lesnar,LIB,13
+Brown,?,U.S. Senate,,John R. Thune,REP,149
+Brown,Groton Community Center,U.S. Senate,,Brian L. Bengs,DEM,116
+Brown,Groton Community Center,U.S. Senate,,Tamara J Lesnar,LIB,17
+Brown,Groton Community Center,U.S. Senate,,John R. Thune,REP,591
+Brown,Hecla Community Center,U.S. Senate,,Brian L. Bengs,DEM,34
+Brown,Hecla Community Center,U.S. Senate,,Tamara J Lesnar,LIB,4
+Brown,Hecla Community Center,U.S. Senate,,John R. Thune,REP,151
+Brown,Stratford Communty Center,U.S. Senate,,Brian L. Bengs,DEM,39
+Brown,Stratford Communty Center,U.S. Senate,,Tamara J Lesnar,LIB,5
+Brown,Stratford Communty Center,U.S. Senate,,John R. Thune,REP,104
+Brown,Warner Community Center,U.S. Senate,,Brian L. Bengs,DEM,71
+Brown,Warner Community Center,U.S. Senate,,Tamara J Lesnar,LIB,6
+Brown,Warner Community Center,U.S. Senate,,John R. Thune,REP,327
+Brown,Westport Town Hall,U.S. Senate,,Brian L. Bengs,DEM,31
+Brown,Westport Town Hall,U.S. Senate,,Tamara J Lesnar,LIB,11
+Brown,Westport Town Hall,U.S. Senate,,John R. Thune,REP,141
+Brown,Absentee Precinct,U.S. House,1,Collin Duprel,LIB,1279
+Brown,Absentee Precinct,U.S. House,1,Dusty Johnson,REP,3800
+Brown,AmericInn Event Center,U.S. House,1,Collin Duprel,LIB,293
+Brown,AmericInn Event Center,U.S. House,1,Dusty Johnson,REP,1550
+Brown,Hotel and Convention,U.S. House,1,Collin Duprel,LIB,318
+Brown,Hotel and Convention,U.S. House,1,Dusty Johnson,REP,1508
+Brown,Claremont City Hall,U.S. House,1,Collin Duprel,LIB,17
+Brown,Claremont City Hall,U.S. House,1,Dusty Johnson,REP,102
+Brown,Columbia Legion,U.S. House,1,Collin Duprel,LIB,25
+Brown,Columbia Legion,U.S. House,1,Dusty Johnson,REP,158
+Brown,?,U.S. House,1,Collin Duprel,LIB,507
+Brown,?,U.S. House,1,Dusty Johnson,REP,1765
+Brown,?,U.S. House,1,Collin Duprel,LIB,37
+Brown,?,U.S. House,1,Dusty Johnson,REP,166
+Brown,Groton Community Center,U.S. House,1,Collin Duprel,LIB,82
+Brown,Groton Community Center,U.S. House,1,Dusty Johnson,REP,615
+Brown,Hecla Community Center,U.S. House,1,Collin Duprel,LIB,20
+Brown,Hecla Community Center,U.S. House,1,Dusty Johnson,REP,160
+Brown,Stratford Communty Center,U.S. House,1,Collin Duprel,LIB,31
+Brown,Stratford Communty Center,U.S. House,1,Dusty Johnson,REP,108
+Brown,Warner Community Center,U.S. House,1,Collin Duprel,LIB,48
+Brown,Warner Community Center,U.S. House,1,Dusty Johnson,REP,344
+Brown,Westport Town Hall,U.S. House,1,Collin Duprel,LIB,27
+Brown,Westport Town Hall,U.S. House,1,Dusty Johnson,REP,149
+Brown,Absentee Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,2572
+Brown,Absentee Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,109
+Brown,Absentee Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,2869
+Brown,AmericInn Event Center,Governor,,Jamie Smith and Jennifer Keintz,DEM,555
+Brown,AmericInn Event Center,Governor,,Tracey Quint and Ashley Strand,LIB,47
+Brown,AmericInn Event Center,Governor,,Kristi Noem and Larry Rhoden,REP,1299
+Brown,Hotel and Convention,Governor,,Jamie Smith and Jennifer Keintz,DEM,584
+Brown,Hotel and Convention,Governor,,Tracey Quint and Ashley Strand,LIB,50
+Brown,Hotel and Convention,Governor,,Kristi Noem and Larry Rhoden,REP,1279
+Brown,Claremont City Hall,Governor,,Jamie Smith and Jennifer Keintz,DEM,42
+Brown,Claremont City Hall,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Brown,Claremont City Hall,Governor,,Kristi Noem and Larry Rhoden,REP,84
+Brown,Columbia Legion,Governor,,Jamie Smith and Jennifer Keintz,DEM,58
+Brown,Columbia Legion,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Brown,Columbia Legion,Governor,,Kristi Noem and Larry Rhoden,REP,132
+Brown,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,865
+Brown,?,Governor,,Tracey Quint and Ashley Strand,LIB,84
+Brown,?,Governor,,Kristi Noem and Larry Rhoden,REP,1465
+Brown,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,62
+Brown,?,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Brown,?,Governor,,Kristi Noem and Larry Rhoden,REP,143
+Brown,Groton Community Center,Governor,,Jamie Smith and Jennifer Keintz,DEM,189
+Brown,Groton Community Center,Governor,,Tracey Quint and Ashley Strand,LIB,15
+Brown,Groton Community Center,Governor,,Kristi Noem and Larry Rhoden,REP,520
+Brown,Hecla Community Center,Governor,,Jamie Smith and Jennifer Keintz,DEM,44
+Brown,Hecla Community Center,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Brown,Hecla Community Center,Governor,,Kristi Noem and Larry Rhoden,REP,142
+Brown,Stratford Communty Center,Governor,,Jamie Smith and Jennifer Keintz,DEM,52
+Brown,Stratford Communty Center,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Brown,Stratford Communty Center,Governor,,Kristi Noem and Larry Rhoden,REP,93
+Brown,Warner Community Center,Governor,,Jamie Smith and Jennifer Keintz,DEM,107
+Brown,Warner Community Center,Governor,,Tracey Quint and Ashley Strand,LIB,13
+Brown,Warner Community Center,Governor,,Kristi Noem and Larry Rhoden,REP,288
+Brown,Westport Town Hall,Governor,,Jamie Smith and Jennifer Keintz,DEM,37
+Brown,Westport Town Hall,Governor,,Tracey Quint and Ashley Strand,LIB,6
+Brown,Westport Town Hall,Governor,,Kristi Noem and Larry Rhoden,REP,142
+Brown,Absentee Precinct,Secretary of State,,Thomas A Cool,DEM,2470
+Brown,Absentee Precinct,Secretary of State,,Monae Johnson,REP,2812
+Brown,AmericInn Event Center,Secretary of State,,Thomas A Cool,DEM,580
+Brown,AmericInn Event Center,Secretary of State,,Monae Johnson,REP,1214
+Brown,Hotel and Convention,Secretary of State,,Thomas A Cool,DEM,618
+Brown,Hotel and Convention,Secretary of State,,Monae Johnson,REP,1212
+Brown,Claremont City Hall,Secretary of State,,Thomas A Cool,DEM,41
+Brown,Claremont City Hall,Secretary of State,,Monae Johnson,REP,77
+Brown,Columbia Legion,Secretary of State,,Thomas A Cool,DEM,58
+Brown,Columbia Legion,Secretary of State,,Monae Johnson,REP,125
+Brown,?,Secretary of State,,Thomas A Cool,DEM,866
+Brown,?,Secretary of State,,Monae Johnson,REP,1405
+Brown,?,Secretary of State,,Thomas A Cool,DEM,74
+Brown,?,Secretary of State,,Monae Johnson,REP,124
+Brown,Groton Community Center,Secretary of State,,Thomas A Cool,DEM,206
+Brown,Groton Community Center,Secretary of State,,Monae Johnson,REP,458
+Brown,Hecla Community Center,Secretary of State,,Thomas A Cool,DEM,52
+Brown,Hecla Community Center,Secretary of State,,Monae Johnson,REP,119
+Brown,Stratford Communty Center,Secretary of State,,Thomas A Cool,DEM,53
+Brown,Stratford Communty Center,Secretary of State,,Monae Johnson,REP,79
+Brown,Warner Community Center,Secretary of State,,Thomas A Cool,DEM,117
+Brown,Warner Community Center,Secretary of State,,Monae Johnson,REP,255
+Brown,Westport Town Hall,Secretary of State,,Thomas A Cool,DEM,49
+Brown,Westport Town Hall,Secretary of State,,Monae Johnson,REP,127
+Brown,Absentee Precinct,Attorney General,,Marty J. Jackley,REP,3792
+Brown,AmericInn Event Center,Attorney General,,Marty J. Jackley,REP,1514
+Brown,Hotel and Convention,Attorney General,,Marty J. Jackley,REP,1488
+Brown,Claremont City Hall,Attorney General,,Marty J. Jackley,REP,95
+Brown,Columbia Legion,Attorney General,,Marty J. Jackley,REP,151
+Brown,?,Attorney General,,Marty J. Jackley,REP,1739
+Brown,?,Attorney General,,Marty J. Jackley,REP,159
+Brown,Groton Community Center,Attorney General,,Marty J. Jackley,REP,567
+Brown,Hecla Community Center,Attorney General,,Marty J. Jackley,REP,149
+Brown,Stratford Communty Center,Attorney General,,Marty J. Jackley,REP,106
+Brown,Warner Community Center,Attorney General,,Marty J. Jackley,REP,325
+Brown,Westport Town Hall,Attorney General,,Marty J. Jackley,REP,143
+Brown,Absentee Precinct,State Auditor,,Stephanie Marty,DEM,2288
+Brown,Absentee Precinct,State Auditor,,Rene Meyer,LIB,218
+Brown,Absentee Precinct,State Auditor,,Richard Sattgast,REP,2807
+Brown,AmericInn Event Center,State Auditor,,Stephanie Marty,DEM,473
+Brown,AmericInn Event Center,State Auditor,,Rene Meyer,LIB,104
+Brown,AmericInn Event Center,State Auditor,,Richard Sattgast,REP,1203
+Brown,Hotel and Convention,State Auditor,,Stephanie Marty,DEM,494
+Brown,Hotel and Convention,State Auditor,,Rene Meyer,LIB,105
+Brown,Hotel and Convention,State Auditor,,Richard Sattgast,REP,1199
+Brown,Claremont City Hall,State Auditor,,Stephanie Marty,DEM,44
+Brown,Claremont City Hall,State Auditor,,Rene Meyer,LIB,4
+Brown,Claremont City Hall,State Auditor,,Richard Sattgast,REP,70
+Brown,Columbia Legion,State Auditor,,Stephanie Marty,DEM,54
+Brown,Columbia Legion,State Auditor,,Rene Meyer,LIB,3
+Brown,Columbia Legion,State Auditor,,Richard Sattgast,REP,126
+Brown,?,State Auditor,,Stephanie Marty,DEM,782
+Brown,?,State Auditor,,Rene Meyer,LIB,139
+Brown,?,State Auditor,,Richard Sattgast,REP,1335
+Brown,?,State Auditor,,Stephanie Marty,DEM,69
+Brown,?,State Auditor,,Rene Meyer,LIB,12
+Brown,?,State Auditor,,Richard Sattgast,REP,117
+Brown,Groton Community Center,State Auditor,,Stephanie Marty,DEM,182
+Brown,Groton Community Center,State Auditor,,Rene Meyer,LIB,34
+Brown,Groton Community Center,State Auditor,,Richard Sattgast,REP,437
+Brown,Hecla Community Center,State Auditor,,Stephanie Marty,DEM,51
+Brown,Hecla Community Center,State Auditor,,Rene Meyer,LIB,7
+Brown,Hecla Community Center,State Auditor,,Richard Sattgast,REP,119
+Brown,Stratford Communty Center,State Auditor,,Stephanie Marty,DEM,47
+Brown,Stratford Communty Center,State Auditor,,Rene Meyer,LIB,13
+Brown,Stratford Communty Center,State Auditor,,Richard Sattgast,REP,77
+Brown,Warner Community Center,State Auditor,,Stephanie Marty,DEM,106
+Brown,Warner Community Center,State Auditor,,Rene Meyer,LIB,23
+Brown,Warner Community Center,State Auditor,,Richard Sattgast,REP,234
+Brown,Westport Town Hall,State Auditor,,Stephanie Marty,DEM,47
+Brown,Westport Town Hall,State Auditor,,Rene Meyer,LIB,9
+Brown,Westport Town Hall,State Auditor,,Richard Sattgast,REP,114
+Brown,Absentee Precinct,State Treasurer,,John Cunningham,DEM,2291
+Brown,Absentee Precinct,State Treasurer,,Josh Haeder,REP,3009
+Brown,AmericInn Event Center,State Treasurer,,John Cunningham,DEM,473
+Brown,AmericInn Event Center,State Treasurer,,Josh Haeder,REP,1302
+Brown,Hotel and Convention,State Treasurer,,John Cunningham,DEM,514
+Brown,Hotel and Convention,State Treasurer,,Josh Haeder,REP,1292
+Brown,Claremont City Hall,State Treasurer,,John Cunningham,DEM,35
+Brown,Claremont City Hall,State Treasurer,,Josh Haeder,REP,82
+Brown,Columbia Legion,State Treasurer,,John Cunningham,DEM,53
+Brown,Columbia Legion,State Treasurer,,Josh Haeder,REP,128
+Brown,?,State Treasurer,,John Cunningham,DEM,784
+Brown,?,State Treasurer,,Josh Haeder,REP,1479
+Brown,?,State Treasurer,,John Cunningham,DEM,67
+Brown,?,State Treasurer,,Josh Haeder,REP,126
+Brown,Groton Community Center,State Treasurer,,John Cunningham,DEM,183
+Brown,Groton Community Center,State Treasurer,,Josh Haeder,REP,473
+Brown,Hecla Community Center,State Treasurer,,John Cunningham,DEM,51
+Brown,Hecla Community Center,State Treasurer,,Josh Haeder,REP,122
+Brown,Stratford Communty Center,State Treasurer,,John Cunningham,DEM,49
+Brown,Stratford Communty Center,State Treasurer,,Josh Haeder,REP,86
+Brown,Warner Community Center,State Treasurer,,John Cunningham,DEM,103
+Brown,Warner Community Center,State Treasurer,,Josh Haeder,REP,265
+Brown,Westport Town Hall,State Treasurer,,John Cunningham,DEM,54
+Brown,Westport Town Hall,State Treasurer,,Josh Haeder,REP,118
+Brown,Absentee Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,2309
+Brown,Absentee Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,2923
+Brown,AmericInn Event Center,Commissioner of School and Public Lands,,Timothy Azure,DEM,499
+Brown,AmericInn Event Center,Commissioner of School and Public Lands,,Brock Greenfield,REP,1262
+Brown,Hotel and Convention,Commissioner of School and Public Lands,,Timothy Azure,DEM,511
+Brown,Hotel and Convention,Commissioner of School and Public Lands,,Brock Greenfield,REP,1282
+Brown,Claremont City Hall,Commissioner of School and Public Lands,,Timothy Azure,DEM,41
+Brown,Claremont City Hall,Commissioner of School and Public Lands,,Brock Greenfield,REP,81
+Brown,Columbia Legion,Commissioner of School and Public Lands,,Timothy Azure,DEM,50
+Brown,Columbia Legion,Commissioner of School and Public Lands,,Brock Greenfield,REP,132
+Brown,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,808
+Brown,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,1441
+Brown,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,59
+Brown,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,134
+Brown,Groton Community Center,Commissioner of School and Public Lands,,Timothy Azure,DEM,170
+Brown,Groton Community Center,Commissioner of School and Public Lands,,Brock Greenfield,REP,497
+Brown,Hecla Community Center,Commissioner of School and Public Lands,,Timothy Azure,DEM,47
+Brown,Hecla Community Center,Commissioner of School and Public Lands,,Brock Greenfield,REP,128
+Brown,Stratford Communty Center,Commissioner of School and Public Lands,,Timothy Azure,DEM,48
+Brown,Stratford Communty Center,Commissioner of School and Public Lands,,Brock Greenfield,REP,83
+Brown,Warner Community Center,Commissioner of School and Public Lands,,Timothy Azure,DEM,117
+Brown,Warner Community Center,Commissioner of School and Public Lands,,Brock Greenfield,REP,256
+Brown,Westport Town Hall,Commissioner of School and Public Lands,,Timothy Azure,DEM,44
+Brown,Westport Town Hall,Commissioner of School and Public Lands,,Brock Greenfield,REP,132
+Brown,Absentee Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,2128
+Brown,Absentee Precinct,Public Utilities Commissioner,,Chris Nelson,REP,3196
+Brown,AmericInn Event Center,Public Utilities Commissioner,,Jeffrey Barth,DEM,418
+Brown,AmericInn Event Center,Public Utilities Commissioner,,Chris Nelson,REP,1367
+Brown,Hotel and Convention,Public Utilities Commissioner,,Jeffrey Barth,DEM,476
+Brown,Hotel and Convention,Public Utilities Commissioner,,Chris Nelson,REP,1347
+Brown,Claremont City Hall,Public Utilities Commissioner,,Jeffrey Barth,DEM,30
+Brown,Claremont City Hall,Public Utilities Commissioner,,Chris Nelson,REP,86
+Brown,Columbia Legion,Public Utilities Commissioner,,Jeffrey Barth,DEM,52
+Brown,Columbia Legion,Public Utilities Commissioner,,Chris Nelson,REP,130
+Brown,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,736
+Brown,?,Public Utilities Commissioner,,Chris Nelson,REP,1530
+Brown,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,63
+Brown,?,Public Utilities Commissioner,,Chris Nelson,REP,130
+Brown,Groton Community Center,Public Utilities Commissioner,,Jeffrey Barth,DEM,151
+Brown,Groton Community Center,Public Utilities Commissioner,,Chris Nelson,REP,523
+Brown,Hecla Community Center,Public Utilities Commissioner,,Jeffrey Barth,DEM,41
+Brown,Hecla Community Center,Public Utilities Commissioner,,Chris Nelson,REP,136
+Brown,Stratford Communty Center,Public Utilities Commissioner,,Jeffrey Barth,DEM,36
+Brown,Stratford Communty Center,Public Utilities Commissioner,,Chris Nelson,REP,96
+Brown,Warner Community Center,Public Utilities Commissioner,,Jeffrey Barth,DEM,100
+Brown,Warner Community Center,Public Utilities Commissioner,,Chris Nelson,REP,280
+Brown,Westport Town Hall,Public Utilities Commissioner,,Jeffrey Barth,DEM,49
+Brown,Westport Town Hall,Public Utilities Commissioner,,Chris Nelson,REP,125
+Brown,Absentee Precinct,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,3515
+Brown,AmericInn Event Center,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,1240
+Brown,Hotel and Convention,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,1192
+Brown,Claremont City Hall,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,81
+Brown,Columbia Legion,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,110
+Brown,?,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,1399
+Brown,?,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,123
+Brown,Groton Community Center,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,443
+Brown,Hecla Community Center,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,96
+Brown,Stratford Communty Center,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,83
+Brown,Warner Community Center,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,245
+Brown,Westport Town Hall,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,110
+Brown,Absentee Precinct,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,3477
+Brown,AmericInn Event Center,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,1224
+Brown,Hotel and Convention,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,1148
+Brown,Claremont City Hall,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,77
+Brown,Columbia Legion,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,108
+Brown,?,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,1382
+Brown,?,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,116
+Brown,Groton Community Center,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,425
+Brown,Hecla Community Center,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,96
+Brown,Stratford Communty Center,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,77
+Brown,Warner Community Center,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,242
+Brown,Westport Town Hall,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,95
+Brown,Absentee Precinct,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,3099
+Brown,AmericInn Event Center,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,1116
+Brown,Hotel and Convention,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,1085
+Brown,Claremont City Hall,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,71
+Brown,Columbia Legion,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,93
+Brown,?,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,1286
+Brown,?,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,113
+Brown,Groton Community Center,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,383
+Brown,Hecla Community Center,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,80
+Brown,Stratford Communty Center,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,66
+Brown,Warner Community Center,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,210
+Brown,Westport Town Hall,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,81
+Brown,Absentee Precinct,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,3183
+Brown,AmericInn Event Center,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,1128
+Brown,Hotel and Convention,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,1081
+Brown,Claremont City Hall,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,81
+Brown,Columbia Legion,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,106
+Brown,?,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,1266
+Brown,?,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,119
+Brown,Groton Community Center,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,410
+Brown,Hecla Community Center,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,84
+Brown,Stratford Communty Center,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,70
+Brown,Warner Community Center,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,222
+Brown,Westport Town Hall,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,93
+Brown,Absentee Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,3818
+Brown,Absentee Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,845
+Brown,AmericInn Event Center,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1316
+Brown,AmericInn Event Center,Supreme Court Retention,3,Patricia J. DeVaney - No,,264
+Brown,Hotel and Convention,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1318
+Brown,Hotel and Convention,Supreme Court Retention,3,Patricia J. DeVaney - No,,282
+Brown,Claremont City Hall,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,87
+Brown,Claremont City Hall,Supreme Court Retention,3,Patricia J. DeVaney - No,,17
+Brown,Columbia Legion,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,124
+Brown,Columbia Legion,Supreme Court Retention,3,Patricia J. DeVaney - No,,29
+Brown,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1555
+Brown,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,399
+Brown,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,146
+Brown,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,33
+Brown,Groton Community Center,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,506
+Brown,Groton Community Center,Supreme Court Retention,3,Patricia J. DeVaney - No,,88
+Brown,Hecla Community Center,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,127
+Brown,Hecla Community Center,Supreme Court Retention,3,Patricia J. DeVaney - No,,27
+Brown,Stratford Communty Center,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,85
+Brown,Stratford Communty Center,Supreme Court Retention,3,Patricia J. DeVaney - No,,20
+Brown,Warner Community Center,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,282
+Brown,Warner Community Center,Supreme Court Retention,3,Patricia J. DeVaney - No,,46
+Brown,Westport Town Hall,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,120
+Brown,Westport Town Hall,Supreme Court Retention,3,Patricia J. DeVaney - No,,26
+Brown,Absentee Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,3741
+Brown,Absentee Precinct,Supreme Court Retention,2,Mark E. Salter - No,,841
+Brown,AmericInn Event Center,Supreme Court Retention,2,Mark E. Salter - Yes,,1308
+Brown,AmericInn Event Center,Supreme Court Retention,2,Mark E. Salter - No,,264
+Brown,Hotel and Convention,Supreme Court Retention,2,Mark E. Salter - Yes,,1297
+Brown,Hotel and Convention,Supreme Court Retention,2,Mark E. Salter - No,,278
+Brown,Claremont City Hall,Supreme Court Retention,2,Mark E. Salter - Yes,,87
+Brown,Claremont City Hall,Supreme Court Retention,2,Mark E. Salter - No,,15
+Brown,Columbia Legion,Supreme Court Retention,2,Mark E. Salter - Yes,,123
+Brown,Columbia Legion,Supreme Court Retention,2,Mark E. Salter - No,,28
+Brown,?,Supreme Court Retention,2,Mark E. Salter - Yes,,1510
+Brown,?,Supreme Court Retention,2,Mark E. Salter - No,,411
+Brown,?,Supreme Court Retention,2,Mark E. Salter - Yes,,147
+Brown,?,Supreme Court Retention,2,Mark E. Salter - No,,29
+Brown,Groton Community Center,Supreme Court Retention,2,Mark E. Salter - Yes,,494
+Brown,Groton Community Center,Supreme Court Retention,2,Mark E. Salter - No,,88
+Brown,Hecla Community Center,Supreme Court Retention,2,Mark E. Salter - Yes,,117
+Brown,Hecla Community Center,Supreme Court Retention,2,Mark E. Salter - No,,30
+Brown,Stratford Communty Center,Supreme Court Retention,2,Mark E. Salter - Yes,,85
+Brown,Stratford Communty Center,Supreme Court Retention,2,Mark E. Salter - No,,20
+Brown,Warner Community Center,Supreme Court Retention,2,Mark E. Salter - Yes,,274
+Brown,Warner Community Center,Supreme Court Retention,2,Mark E. Salter - No,,50
+Brown,Westport Town Hall,Supreme Court Retention,2,Mark E. Salter - Yes,,116
+Brown,Westport Town Hall,Supreme Court Retention,2,Mark E. Salter - No,,27
+Brown,Absentee Precinct,Constitutional Amendment D,,Yes,,3353
+Brown,Absentee Precinct,Constitutional Amendment D,,No,,2100
+Brown,AmericInn Event Center,Constitutional Amendment D,,Yes,,963
+Brown,AmericInn Event Center,Constitutional Amendment D,,No,,873
+Brown,Hotel and Convention,Constitutional Amendment D,,Yes,,952
+Brown,Hotel and Convention,Constitutional Amendment D,,No,,902
+Brown,Claremont City Hall,Constitutional Amendment D,,Yes,,61
+Brown,Claremont City Hall,Constitutional Amendment D,,No,,60
+Brown,Columbia Legion,Constitutional Amendment D,,Yes,,102
+Brown,Columbia Legion,Constitutional Amendment D,,No,,88
+Brown,?,Constitutional Amendment D,,Yes,,1367
+Brown,?,Constitutional Amendment D,,No,,968
+Brown,?,Constitutional Amendment D,,Yes,,107
+Brown,?,Constitutional Amendment D,,No,,100
+Brown,Groton Community Center,Constitutional Amendment D,,Yes,,353
+Brown,Groton Community Center,Constitutional Amendment D,,No,,336
+Brown,Hecla Community Center,Constitutional Amendment D,,Yes,,84
+Brown,Hecla Community Center,Constitutional Amendment D,,No,,98
+Brown,Stratford Communty Center,Constitutional Amendment D,,Yes,,71
+Brown,Stratford Communty Center,Constitutional Amendment D,,No,,68
+Brown,Warner Community Center,Constitutional Amendment D,,Yes,,161
+Brown,Warner Community Center,Constitutional Amendment D,,No,,234
+Brown,Westport Town Hall,Constitutional Amendment D,,Yes,,72
+Brown,Westport Town Hall,Constitutional Amendment D,,No,,105
+Brown,Absentee Precinct,Initiated Measure 27,,Yes,,2676
+Brown,Absentee Precinct,Initiated Measure 27,,No,,2822
+Brown,AmericInn Event Center,Initiated Measure 27,,Yes,,920
+Brown,AmericInn Event Center,Initiated Measure 27,,No,,962
+Brown,Hotel and Convention,Initiated Measure 27,,Yes,,923
+Brown,Hotel and Convention,Initiated Measure 27,,No,,983
+Brown,Claremont City Hall,Initiated Measure 27,,Yes,,58
+Brown,Claremont City Hall,Initiated Measure 27,,No,,65
+Brown,Columbia Legion,Initiated Measure 27,,Yes,,85
+Brown,Columbia Legion,Initiated Measure 27,,No,,107
+Brown,?,Initiated Measure 27,,Yes,,1335
+Brown,?,Initiated Measure 27,,No,,1066
+Brown,?,Initiated Measure 27,,Yes,,74
+Brown,?,Initiated Measure 27,,No,,136
+Brown,Groton Community Center,Initiated Measure 27,,Yes,,275
+Brown,Groton Community Center,Initiated Measure 27,,No,,432
+Brown,Hecla Community Center,Initiated Measure 27,,Yes,,73
+Brown,Hecla Community Center,Initiated Measure 27,,No,,116
+Brown,Stratford Communty Center,Initiated Measure 27,,Yes,,52
+Brown,Stratford Communty Center,Initiated Measure 27,,No,,89
+Brown,Warner Community Center,Initiated Measure 27,,Yes,,157
+Brown,Warner Community Center,Initiated Measure 27,,No,,248
+Brown,Westport Town Hall,Initiated Measure 27,,Yes,,66
+Brown,Westport Town Hall,Initiated Measure 27,,No,,115
+Brown,Absentee Precinct,State Senate,01,Michael H. Rohl,REP,537
+Brown,Absentee Precinct,State Senate,01,Susan Wismer,IND,375
+Brown,Absentee Precinct,State Senate,03,Al Novstrup,REP,2365
+Brown,Absentee Precinct,State Senate,23,Bryan J. Breitling,REP,259
+Brown,AmericInn Event Center Best Western Ramkota,State Senate,01,Michael H. Rohl,REP,169
+Brown,AmericInn Event Center Best Western Ramkota,State Senate,01,Susan Wismer,IND,52
+Brown,AmericInn Event Center Best Western Ramkota,State Senate,03,Al Novstrup,REP,1113
+Brown,AmericInn Event Center Best Western Ramkota,State Senate,23,Bryan J. Breitling,REP,60
+Brown,Hotel and Convention Center,State Senate,01,Michael H. Rohl,REP,256
+Brown,Hotel and Convention Center,State Senate,01,Susan Wismer,IND,108
+Brown,Hotel and Convention Center,State Senate,03,Al Novstrup,REP,912
+Brown,Hotel and Convention Center,State Senate,23,Bryan J. Breitling,REP,164
+Brown,Claremont City Hall,State Senate,01,Michael H. Rohl,REP,80
+Brown,Claremont City Hall,State Senate,01,Susan Wismer,IND,43
+Brown,Claremont City Hall,State Senate,03,Al Novstrup,REP,1
+Brown,Claremont City Hall,State Senate,23,Bryan J. Breitling,REP,0
+Brown,Columbia Legion,State Senate,01,Michael H. Rohl,REP,113
+Brown,Columbia Legion,State Senate,01,Susan Wismer,IND,63
+Brown,Columbia Legion,State Senate,03,Al Novstrup,REP,9
+Brown,Columbia Legion,State Senate,23,Bryan J. Breitling,REP,0
+Brown,Courthouse Community Room,State Senate,01,Michael H. Rohl,REP,119
+Brown,Courthouse Community Room,State Senate,01,Susan Wismer,IND,45
+Brown,Courthouse Community Room,State Senate,03,Al Novstrup,REP,1251
+Brown,Courthouse Community Room,State Senate,23,Bryan J. Breitling,REP,190
+Brown,Frederick Community Center,State Senate,01,Michael H. Rohl,REP,118
+Brown,Frederick Community Center,State Senate,01,Susan Wismer,IND,72
+Brown,Frederick Community Center,State Senate,03,Al Novstrup,REP,4
+Brown,Frederick Community Center,State Senate,23,Bryan J. Breitling,REP,0
+Brown,Groton Community Center,State Senate,01,Michael H. Rohl,REP,435
+Brown,Groton Community Center,State Senate,01,Susan Wismer,IND,208
+Brown,Groton Community Center,State Senate,03,Al Novstrup,REP,16
+Brown,Groton Community Center,State Senate,23,Bryan J. Breitling,REP,2
+Brown,Hecla Community Center,State Senate,01,Michael H. Rohl,REP,115
+Brown,Hecla Community Center,State Senate,01,Susan Wismer,IND,67
+Brown,Hecla Community Center,State Senate,03,Al Novstrup,REP,3
+Brown,Hecla Community Center,State Senate,23,Bryan J. Breitling,REP,0
+Brown,Stratford Communty Center,State Senate,01,Michael H. Rohl,REP,83
+Brown,Stratford Communty Center,State Senate,01,Susan Wismer,IND,48
+Brown,Stratford Communty Center,State Senate,03,Al Novstrup,REP,4
+Brown,Stratford Communty Center,State Senate,23,Bryan J. Breitling,REP,0
+Brown,Warner Community Center,State Senate,01,Michael H. Rohl,REP,243
+Brown,Warner Community Center,State Senate,01,Susan Wismer,IND,107
+Brown,Warner Community Center,State Senate,03,Al Novstrup,REP,14
+Brown,Warner Community Center,State Senate,23,Bryan J. Breitling,REP,4
+Brown,Westport Town Hall 10 of 21,State Senate,01,Michael H. Rohl,REP,106
+Brown,Westport Town Hall 10 of 21,State Senate,01,Susan Wismer,IND,61
+Brown,Westport Town Hall 10 of 21,State Senate,03,Al Novstrup,REP,6
+Brown,Westport Town Hall 10 of 21,State Senate,23,Bryan J. Breitling,REP,0
+Brown,Absentee Precinct,State House,01,Steven D. McCleerey,DEM,388
+Brown,Absentee Precinct,State House,01,Kay F. Nikolas,DEM,384
+Brown,Absentee Precinct,State House,01,Joe Donnell,REP,465
+Brown,Absentee Precinct,State House,01,Tamara St John,REP,482
+Brown,Absentee Precinct,State House,03,Brandei Schaefbauer,REP,1976
+Brown,Absentee Precinct,State House,03,Carl E. Perry,REP,2147
+Brown,Absentee Precinct,State House,23,James D. Wangsness,REP,179
+Brown,Absentee Precinct,State House,23,Scott Moore,REP,232
+Brown,AmericInn Event Center,State House,01,Steven D. McCleerey,DEM,51
+Brown,AmericInn Event Center,State House,01,Kay F. Nikolas,DEM,41
+Brown,AmericInn Event Center,State House,01,Joe Donnell,REP,147
+Brown,AmericInn Event Center,State House,01,Tamara St John,REP,142
+Brown,AmericInn Event Center,State House,03,Brandei Schaefbauer,REP,868
+Brown,AmericInn Event Center,State House,03,Carl E. Perry,REP,974
+Brown,AmericInn Event Center,State House,23,James D. Wangsness,REP,40
+Brown,AmericInn Event Center,State House,23,Scott Moore,REP,55
+Brown,Best Western Ramkota Hotel and Convention,State House,01,Steven D. McCleerey,DEM,84
+Brown,Best Western Ramkota Hotel and Convention,State House,01,Kay F. Nikolas,DEM,82
+Brown,Best Western Ramkota Hotel and Convention,State House,01,Joe Donnell,REP,252
+Brown,Best Western Ramkota Hotel and Convention,State House,01,Tamara St John,REP,231
+Brown,Best Western Ramkota Hotel and Convention,State House,03,Brandei Schaefbauer,REP,757
+Brown,Best Western Ramkota Hotel and Convention,State House,03,Carl E. Perry,REP,787
+Brown,Best Western Ramkota Hotel and Convention,State House,23,James D. Wangsness,REP,104
+Brown,Best Western Ramkota Hotel and Convention,State House,23,Scott Moore,REP,150
+Brown,Center Claremont City Hall,State House,01,Steven D. McCleerey,DEM,46
+Brown,Center Claremont City Hall,State House,01,Kay F. Nikolas,DEM,35
+Brown,Center Claremont City Hall,State House,01,Joe Donnell,REP,63
+Brown,Center Claremont City Hall,State House,01,Tamara St John,REP,70
+Brown,Center Claremont City Hall,State House,03,Brandei Schaefbauer,REP,1
+Brown,Center Claremont City Hall,State House,03,Carl E. Perry,REP,1
+Brown,Center Claremont City Hall,State House,23,James D. Wangsness,REP,0
+Brown,Center Claremont City Hall,State House,23,Scott Moore,REP,0
+Brown,Columbia Legion,State House,01,Steven D. McCleerey,DEM,49
+Brown,Columbia Legion,State House,01,Kay F. Nikolas,DEM,45
+Brown,Columbia Legion,State House,01,Joe Donnell,REP,100
+Brown,Columbia Legion,State House,01,Tamara St John,REP,100
+Brown,Columbia Legion,State House,03,Brandei Schaefbauer,REP,8
+Brown,Columbia Legion,State House,03,Carl E. Perry,REP,6
+Brown,Columbia Legion,State House,23,James D. Wangsness,REP,0
+Brown,Columbia Legion,State House,23,Scott Moore,REP,0
+Brown,Courthouse Community Room,State House,01,Steven D. McCleerey,DEM,29
+Brown,Courthouse Community Room,State House,01,Kay F. Nikolas,DEM,39
+Brown,Courthouse Community Room,State House,01,Joe Donnell,REP,112
+Brown,Courthouse Community Room,State House,01,Tamara St John,REP,105
+Brown,Courthouse Community Room,State House,03,Brandei Schaefbauer,REP,975
+Brown,Courthouse Community Room,State House,03,Carl E. Perry,REP,1095
+Brown,Courthouse Community Room,State House,23,James D. Wangsness,REP,103
+Brown,Courthouse Community Room,State House,23,Scott Moore,REP,166
+Brown,Frederick Community Center,State House,01,Steven D. McCleerey,DEM,70
+Brown,Frederick Community Center,State House,01,Kay F. Nikolas,DEM,65
+Brown,Frederick Community Center,State House,01,Joe Donnell,REP,99
+Brown,Frederick Community Center,State House,01,Tamara St John,REP,108
+Brown,Frederick Community Center,State House,03,Brandei Schaefbauer,REP,4
+Brown,Frederick Community Center,State House,03,Carl E. Perry,REP,2
+Brown,Frederick Community Center,State House,23,James D. Wangsness,REP,0
+Brown,Frederick Community Center,State House,23,Scott Moore,REP,0
+Brown,Groton Community Center,State House,01,Steven D. McCleerey,DEM,180
+Brown,Groton Community Center,State House,01,Kay F. Nikolas,DEM,169
+Brown,Groton Community Center,State House,01,Joe Donnell,REP,401
+Brown,Groton Community Center,State House,01,Tamara St John,REP,383
+Brown,Groton Community Center,State House,03,Brandei Schaefbauer,REP,17
+Brown,Groton Community Center,State House,03,Carl E. Perry,REP,14
+Brown,Groton Community Center,State House,23,James D. Wangsness,REP,2
+Brown,Groton Community Center,State House,23,Scott Moore,REP,2
+Brown,Hecla Community Center,State House,01,Steven D. McCleerey,DEM,58
+Brown,Hecla Community Center,State House,01,Kay F. Nikolas,DEM,50
+Brown,Hecla Community Center,State House,01,Joe Donnell,REP,104
+Brown,Hecla Community Center,State House,01,Tamara St John,REP,107
+Brown,Hecla Community Center,State House,03,Brandei Schaefbauer,REP,2
+Brown,Hecla Community Center,State House,03,Carl E. Perry,REP,3
+Brown,Hecla Community Center,State House,23,James D. Wangsness,REP,0
+Brown,Hecla Community Center,State House,23,Scott Moore,REP,0
+Brown,Stratford Communty Center,State House,01,Steven D. McCleerey,DEM,49
+Brown,Stratford Communty Center,State House,01,Kay F. Nikolas,DEM,46
+Brown,Stratford Communty Center,State House,01,Joe Donnell,REP,65
+Brown,Stratford Communty Center,State House,01,Tamara St John,REP,63
+Brown,Stratford Communty Center,State House,03,Brandei Schaefbauer,REP,2
+Brown,Stratford Communty Center,State House,03,Carl E. Perry,REP,4
+Brown,Stratford Communty Center,State House,23,James D. Wangsness,REP,0
+Brown,Stratford Communty Center,State House,23,Scott Moore,REP,0
+Brown,Warner Community Center,State House,01,Steven D. McCleerey,DEM,109
+Brown,Warner Community Center,State House,01,Kay F. Nikolas,DEM,116
+Brown,Warner Community Center,State House,01,Joe Donnell,REP,206
+Brown,Warner Community Center,State House,01,Tamara St John,REP,208
+Brown,Warner Community Center,State House,03,Brandei Schaefbauer,REP,11
+Brown,Warner Community Center,State House,03,Carl E. Perry,REP,11
+Brown,Warner Community Center,State House,23,James D. Wangsness,REP,4
+Brown,Warner Community Center,State House,23,Scott Moore,REP,4
+Brown,Westport Town Hall 11 of 21,State House,01,Steven D. McCleerey,DEM,49
+Brown,Westport Town Hall 11 of 21,State House,01,Kay F. Nikolas,DEM,48
+Brown,Westport Town Hall 11 of 21,State House,01,Joe Donnell,REP,91
+Brown,Westport Town Hall 11 of 21,State House,01,Tamara St John,REP,97
+Brown,Westport Town Hall 11 of 21,State House,03,Brandei Schaefbauer,REP,4
+Brown,Westport Town Hall 11 of 21,State House,03,Carl E. Perry,REP,6
+Brown,Westport Town Hall 11 of 21,State House,23,James D. Wangsness,REP,0
+Brown,Westport Town Hall 11 of 21,State House,23,Scott Moore,REP,0

--- a/2022/counties/20221108__sd__general__brule__precinct.csv
+++ b/2022/counties/20221108__sd__general__brule__precinct.csv
@@ -1,0 +1,149 @@
+county,precinct,office,district,candidate,party,votes
+Brule,01,U.S. Senate,,Brian L. Bengs,DEM,297
+Brule,01,U.S. Senate,,Tamara J Lesnar,LIB,37
+Brule,01,U.S. Senate,,John R. Thune,REP,794
+Brule,02,U.S. Senate,,Brian L. Bengs,DEM,56
+Brule,02,U.S. Senate,,Tamara J Lesnar,LIB,36
+Brule,02,U.S. Senate,,John R. Thune,REP,384
+Brule,03,U.S. Senate,,Brian L. Bengs,DEM,54
+Brule,03,U.S. Senate,,Tamara J Lesnar,LIB,17
+Brule,03,U.S. Senate,,John R. Thune,REP,271
+Brule,04,U.S. Senate,,Brian L. Bengs,DEM,21
+Brule,04,U.S. Senate,,Tamara J Lesnar,LIB,7
+Brule,04,U.S. Senate,,John R. Thune,REP,124
+Brule,01,U.S. House,1,Collin Duprel,LIB,195
+Brule,01,U.S. House,1,Dusty Johnson,REP,866
+Brule,02,U.S. House,1,Collin Duprel,LIB,84
+Brule,02,U.S. House,1,Dusty Johnson,REP,390
+Brule,03,U.S. House,1,Collin Duprel,LIB,65
+Brule,03,U.S. House,1,Dusty Johnson,REP,270
+Brule,04,U.S. House,1,Collin Duprel,LIB,23
+Brule,04,U.S. House,1,Dusty Johnson,REP,126
+Brule,01,Governor,,Jamie Smith and Jennifer Keintz,DEM,399
+Brule,01,Governor,,Tracey Quint and Ashley Strand,LIB,23
+Brule,01,Governor,,Kristi Noem and Larry Rhoden,REP,708
+Brule,02,Governor,,Jamie Smith and Jennifer Keintz,DEM,87
+Brule,02,Governor,,Tracey Quint and Ashley Strand,LIB,20
+Brule,02,Governor,,Kristi Noem and Larry Rhoden,REP,377
+Brule,03,Governor,,Jamie Smith and Jennifer Keintz,DEM,72
+Brule,03,Governor,,Tracey Quint and Ashley Strand,LIB,12
+Brule,03,Governor,,Kristi Noem and Larry Rhoden,REP,263
+Brule,04,Governor,,Jamie Smith and Jennifer Keintz,DEM,31
+Brule,04,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Brule,04,Governor,,Kristi Noem and Larry Rhoden,REP,115
+Brule,01,Secretary of State,,Thomas A Cool,DEM,406
+Brule,01,Secretary of State,,Monae Johnson,REP,659
+Brule,02,Secretary of State,,Thomas A Cool,DEM,125
+Brule,02,Secretary of State,,Monae Johnson,REP,326
+Brule,03,Secretary of State,,Thomas A Cool,DEM,84
+Brule,03,Secretary of State,,Monae Johnson,REP,245
+Brule,04,Secretary of State,,Thomas A Cool,DEM,38
+Brule,04,Secretary of State,,Monae Johnson,REP,100
+Brule,01,Attorney General,,Marty J. Jackley,REP,859
+Brule,02,Attorney General,,Marty J. Jackley,REP,355
+Brule,03,Attorney General,,Marty J. Jackley,REP,272
+Brule,04,Attorney General,,Marty J. Jackley,REP,120
+Brule,01,State Auditor,,Stephanie Marty,DEM,332
+Brule,01,State Auditor,,Rene Meyer,LIB,59
+Brule,01,State Auditor,,Richard Sattgast,REP,670
+Brule,02,State Auditor,,Stephanie Marty,DEM,90
+Brule,02,State Auditor,,Rene Meyer,LIB,30
+Brule,02,State Auditor,,Richard Sattgast,REP,329
+Brule,03,State Auditor,,Stephanie Marty,DEM,73
+Brule,03,State Auditor,,Rene Meyer,LIB,16
+Brule,03,State Auditor,,Richard Sattgast,REP,232
+Brule,04,State Auditor,,Stephanie Marty,DEM,32
+Brule,04,State Auditor,,Rene Meyer,LIB,1
+Brule,04,State Auditor,,Richard Sattgast,REP,108
+Brule,01,State Treasurer,,John Cunningham,DEM,363
+Brule,01,State Treasurer,,Josh Haeder,REP,684
+Brule,02,State Treasurer,,John Cunningham,DEM,90
+Brule,02,State Treasurer,,Josh Haeder,REP,348
+Brule,03,State Treasurer,,John Cunningham,DEM,84
+Brule,03,State Treasurer,,Josh Haeder,REP,235
+Brule,04,State Treasurer,,John Cunningham,DEM,31
+Brule,04,State Treasurer,,Josh Haeder,REP,108
+Brule,01,Commissioner of School and Public Lands,,Timothy Azure,DEM,352
+Brule,01,Commissioner of School and Public Lands,,Brock Greenfield,REP,684
+Brule,02,Commissioner of School and Public Lands,,Timothy Azure,DEM,96
+Brule,02,Commissioner of School and Public Lands,,Brock Greenfield,REP,335
+Brule,03,Commissioner of School and Public Lands,,Timothy Azure,DEM,71
+Brule,03,Commissioner of School and Public Lands,,Brock Greenfield,REP,242
+Brule,04,Commissioner of School and Public Lands,,Timothy Azure,DEM,32
+Brule,04,Commissioner of School and Public Lands,,Brock Greenfield,REP,107
+Brule,01,Public Utilities Commissioner,,Jeffrey Barth,DEM,328
+Brule,01,Public Utilities Commissioner,,Chris Nelson,REP,734
+Brule,02,Public Utilities Commissioner,,Jeffrey Barth,DEM,76
+Brule,02,Public Utilities Commissioner,,Chris Nelson,REP,381
+Brule,03,Public Utilities Commissioner,,Jeffrey Barth,DEM,61
+Brule,03,Public Utilities Commissioner,,Chris Nelson,REP,268
+Brule,04,Public Utilities Commissioner,,Jeffrey Barth,DEM,26
+Brule,04,Public Utilities Commissioner,,Chris Nelson,REP,118
+Brule,01,State Senate,26,Shawn Bordeaux,DEM,443
+Brule,01,State Senate,26,Joel Koskan,REP,553
+Brule,02,State Senate,26,Shawn Bordeaux,DEM,142
+Brule,02,State Senate,26,Joel Koskan,REP,266
+Brule,03,State Senate,26,Shawn Bordeaux,DEM,101
+Brule,03,State Senate,26,Joel Koskan,REP,186
+Brule,04,State Senate,26,Shawn Bordeaux,DEM,47
+Brule,04,State Senate,26,Joel Koskan,REP,72
+Brule,01,State House,26B,Rebecca Reimer,REP,777
+Brule,02,State House,26B,Rebecca Reimer,REP,383
+Brule,03,State House,26B,Rebecca Reimer,REP,271
+Brule,04,State House,26B,Rebecca Reimer,REP,126
+Brule,01,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,461
+Brule,02,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,208
+Brule,03,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,133
+Brule,04,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,63
+Brule,01,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,440
+Brule,02,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,197
+Brule,03,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,126
+Brule,04,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,55
+Brule,01,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,460
+Brule,02,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,213
+Brule,03,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,137
+Brule,04,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,60
+Brule,01,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,431
+Brule,02,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,197
+Brule,03,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,129
+Brule,04,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,53
+Brule,01,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,439
+Brule,02,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,203
+Brule,03,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,124
+Brule,04,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,58
+Brule,01,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,441
+Brule,02,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,192
+Brule,03,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,123
+Brule,04,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,54
+Brule,01,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,739
+Brule,01,Supreme Court Retention,3,Patricia J. DeVaney - No,,189
+Brule,02,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,329
+Brule,02,Supreme Court Retention,3,Patricia J. DeVaney - No,,72
+Brule,03,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,232
+Brule,03,Supreme Court Retention,3,Patricia J. DeVaney - No,,64
+Brule,04,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,100
+Brule,04,Supreme Court Retention,3,Patricia J. DeVaney - No,,21
+Brule,01,Supreme Court Retention,2,Mark E. Salter - Yes,,724
+Brule,01,Supreme Court Retention,2,Mark E. Salter - No,,197
+Brule,02,Supreme Court Retention,2,Mark E. Salter - Yes,,331
+Brule,02,Supreme Court Retention,2,Mark E. Salter - No,,67
+Brule,03,Supreme Court Retention,2,Mark E. Salter - Yes,,226
+Brule,03,Supreme Court Retention,2,Mark E. Salter - No,,67
+Brule,04,Supreme Court Retention,2,Mark E. Salter - Yes,,102
+Brule,04,Supreme Court Retention,2,Mark E. Salter - No,,18
+Brule,01,Constitutional Amendment D,,Yes,,645
+Brule,01,Constitutional Amendment D,,No,,452
+Brule,02,Constitutional Amendment D,,Yes,,209
+Brule,02,Constitutional Amendment D,,No,,254
+Brule,03,Constitutional Amendment D,,Yes,,170
+Brule,03,Constitutional Amendment D,,No,,173
+Brule,04,Constitutional Amendment D,,Yes,,70
+Brule,04,Constitutional Amendment D,,No,,77
+Brule,01,Initiated Measure 27,,Yes,,486
+Brule,01,Initiated Measure 27,,No,,629
+Brule,02,Initiated Measure 27,,Yes,,146
+Brule,02,Initiated Measure 27,,No,,330
+Brule,03,Initiated Measure 27,,Yes,,130
+Brule,03,Initiated Measure 27,,No,,219
+Brule,04,Initiated Measure 27,,Yes,,32
+Brule,04,Initiated Measure 27,,No,,119

--- a/2022/counties/20221108__sd__general__buffalo__precinct.csv
+++ b/2022/counties/20221108__sd__general__buffalo__precinct.csv
@@ -1,0 +1,112 @@
+county,precinct,office,district,candidate,party,votes
+Buffalo,1,U.S. Senate,,Brian L. Bengs,DEM,19
+Buffalo,1,U.S. Senate,,Tamara J Lesnar,LIB,4
+Buffalo,1,U.S. Senate,,John R. Thune,REP,78
+Buffalo,2,U.S. Senate,,Brian L. Bengs,DEM,20
+Buffalo,2,U.S. Senate,,Tamara J Lesnar,LIB,1
+Buffalo,2,U.S. Senate,,John R. Thune,REP,35
+Buffalo,3,U.S. Senate,,Brian L. Bengs,DEM,163
+Buffalo,3,U.S. Senate,,Tamara J Lesnar,LIB,10
+Buffalo,3,U.S. Senate,,John R. Thune,REP,60
+Buffalo,1,U.S. House,1,Collin Duprel,LIB,17
+Buffalo,1,U.S. House,1,Dusty Johnson,REP,85
+Buffalo,2,U.S. House,1,Collin Duprel,LIB,10
+Buffalo,2,U.S. House,1,Dusty Johnson,REP,42
+Buffalo,3,U.S. House,1,Collin Duprel,LIB,112
+Buffalo,3,U.S. House,1,Dusty Johnson,REP,84
+Buffalo,1,Governor,,Jamie Smith and Jennifer Keintz,DEM,17
+Buffalo,1,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Buffalo,1,Governor,,Kristi Noem and Larry Rhoden,REP,83
+Buffalo,2,Governor,,Jamie Smith and Jennifer Keintz,DEM,31
+Buffalo,2,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Buffalo,2,Governor,,Kristi Noem and Larry Rhoden,REP,27
+Buffalo,3,Governor,,Jamie Smith and Jennifer Keintz,DEM,186
+Buffalo,3,Governor,,Tracey Quint and Ashley Strand,LIB,12
+Buffalo,3,Governor,,Kristi Noem and Larry Rhoden,REP,34
+Buffalo,1,Secretary of State,,Thomas A Cool,DEM,23
+Buffalo,1,Secretary of State,,Monae Johnson,REP,73
+Buffalo,2,Secretary of State,,Thomas A Cool,DEM,31
+Buffalo,2,Secretary of State,,Monae Johnson,REP,24
+Buffalo,3,Secretary of State,,Thomas A Cool,DEM,190
+Buffalo,3,Secretary of State,,Monae Johnson,REP,37
+Buffalo,1,Attorney General,,Marty J. Jackley,REP,78
+Buffalo,2,Attorney General,,Marty J. Jackley,REP,38
+Buffalo,3,Attorney General,,Marty J. Jackley,REP,93
+Buffalo,1,State Auditor,,Stephanie Marty,DEM,20
+Buffalo,1,State Auditor,,Rene Meyer,LIB,3
+Buffalo,1,State Auditor,,Richard Sattgast,REP,76
+Buffalo,2,State Auditor,,Stephanie Marty,DEM,32
+Buffalo,2,State Auditor,,Rene Meyer,LIB,3
+Buffalo,2,State Auditor,,Richard Sattgast,REP,21
+Buffalo,3,State Auditor,,Stephanie Marty,DEM,179
+Buffalo,3,State Auditor,,Rene Meyer,LIB,15
+Buffalo,3,State Auditor,,Richard Sattgast,REP,33
+Buffalo,1,State Treasurer,,John Cunningham,DEM,21
+Buffalo,1,State Treasurer,,Josh Haeder,REP,78
+Buffalo,2,State Treasurer,,John Cunningham,DEM,32
+Buffalo,2,State Treasurer,,Josh Haeder,REP,22
+Buffalo,3,State Treasurer,,John Cunningham,DEM,183
+Buffalo,3,State Treasurer,,Josh Haeder,REP,39
+Buffalo,1,Commissioner of School and Public Lands,,Timothy Azure,DEM,19
+Buffalo,1,Commissioner of School and Public Lands,,Brock Greenfield,REP,78
+Buffalo,2,Commissioner of School and Public Lands,,Timothy Azure,DEM,32
+Buffalo,2,Commissioner of School and Public Lands,,Brock Greenfield,REP,23
+Buffalo,3,Commissioner of School and Public Lands,,Timothy Azure,DEM,190
+Buffalo,3,Commissioner of School and Public Lands,,Brock Greenfield,REP,32
+Buffalo,1,Public Utilities Commissioner,,Jeffrey Barth,DEM,20
+Buffalo,1,Public Utilities Commissioner,,Chris Nelson,REP,80
+Buffalo,2,Public Utilities Commissioner,,Jeffrey Barth,DEM,26
+Buffalo,2,Public Utilities Commissioner,,Chris Nelson,REP,29
+Buffalo,3,Public Utilities Commissioner,,Jeffrey Barth,DEM,176
+Buffalo,3,Public Utilities Commissioner,,Chris Nelson,REP,44
+Buffalo,1,State Senate,26,Shawn Bordeaux,DEM,25
+Buffalo,1,State Senate,26,Joel Koskan,REP,64
+Buffalo,2,State Senate,26,Shawn Bordeaux,DEM,35
+Buffalo,2,State Senate,26,Joel Koskan,REP,16
+Buffalo,3,State Senate,26,Shawn Bordeaux,DEM,203
+Buffalo,3,State Senate,26,Joel Koskan,REP,26
+Buffalo,1,State House,26B,Rebecca Reimer,REP,78
+Buffalo,2,State House,26B,Rebecca Reimer,REP,33
+Buffalo,3,State House,26B,Rebecca Reimer,REP,63
+Buffalo,1,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,52
+Buffalo,2,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,17
+Buffalo,3,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,50
+Buffalo,1,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,48
+Buffalo,2,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,16
+Buffalo,3,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,49
+Buffalo,1,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,50
+Buffalo,2,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,19
+Buffalo,3,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,55
+Buffalo,1,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,48
+Buffalo,2,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,19
+Buffalo,3,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,48
+Buffalo,1,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,48
+Buffalo,2,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,19
+Buffalo,3,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,50
+Buffalo,1,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,47
+Buffalo,2,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,16
+Buffalo,3,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,52
+Buffalo,1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,69
+Buffalo,1,Supreme Court Retention,3,Patricia J. DeVaney - No,,17
+Buffalo,2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,32
+Buffalo,2,Supreme Court Retention,3,Patricia J. DeVaney - No,,17
+Buffalo,3,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,112
+Buffalo,3,Supreme Court Retention,3,Patricia J. DeVaney - No,,90
+Buffalo,1,Supreme Court Retention,2,Mark E. Salter - Yes,,72
+Buffalo,1,Supreme Court Retention,2,Mark E. Salter - No,,15
+Buffalo,2,Supreme Court Retention,2,Mark E. Salter - Yes,,33
+Buffalo,2,Supreme Court Retention,2,Mark E. Salter - No,,16
+Buffalo,3,Supreme Court Retention,2,Mark E. Salter - Yes,,108
+Buffalo,3,Supreme Court Retention,2,Mark E. Salter - No,,90
+Buffalo,1,Constitutional Amendment D,,Yes,,41
+Buffalo,1,Constitutional Amendment D,,No,,58
+Buffalo,2,Constitutional Amendment D,,Yes,,43
+Buffalo,2,Constitutional Amendment D,,No,,12
+Buffalo,3,Constitutional Amendment D,,Yes,,191
+Buffalo,3,Constitutional Amendment D,,No,,34
+Buffalo,1,Initiated Measure 27,,Yes,,31
+Buffalo,1,Initiated Measure 27,,No,,72
+Buffalo,2,Initiated Measure 27,,Yes,,38
+Buffalo,2,Initiated Measure 27,,No,,19
+Buffalo,3,Initiated Measure 27,,Yes,,181
+Buffalo,3,Initiated Measure 27,,No,,49

--- a/2022/counties/20221108__sd__general__butte__precinct.csv
+++ b/2022/counties/20221108__sd__general__butte__precinct.csv
@@ -1,0 +1,703 @@
+county,precinct,office,district,candidate,party,votes
+Butte,06,U.S. Senate,,Brian L. Bengs,DEM,0
+Butte,06,U.S. Senate,,Tamara J Lesnar,LIB,3
+Butte,06,U.S. Senate,,John R. Thune,REP,38
+Butte,08,U.S. Senate,,Brian L. Bengs,DEM,0
+Butte,08,U.S. Senate,,Tamara J Lesnar,LIB,0
+Butte,08,U.S. Senate,,John R. Thune,REP,20
+Butte,11,U.S. Senate,,Brian L. Bengs,DEM,6
+Butte,11,U.S. Senate,,Tamara J Lesnar,LIB,6
+Butte,11,U.S. Senate,,John R. Thune,REP,61
+Butte,12,U.S. Senate,,Brian L. Bengs,DEM,9
+Butte,12,U.S. Senate,,Tamara J Lesnar,LIB,6
+Butte,12,U.S. Senate,,John R. Thune,REP,67
+Butte,13,U.S. Senate,,Brian L. Bengs,DEM,25
+Butte,13,U.S. Senate,,Tamara J Lesnar,LIB,23
+Butte,13,U.S. Senate,,John R. Thune,REP,151
+Butte,14,U.S. Senate,,Brian L. Bengs,DEM,20
+Butte,14,U.S. Senate,,Tamara J Lesnar,LIB,20
+Butte,14,U.S. Senate,,John R. Thune,REP,226
+Butte,16,U.S. Senate,,Brian L. Bengs,DEM,77
+Butte,16,U.S. Senate,,Tamara J Lesnar,LIB,45
+Butte,16,U.S. Senate,,John R. Thune,REP,576
+Butte,17,U.S. Senate,,Brian L. Bengs,DEM,40
+Butte,17,U.S. Senate,,Tamara J Lesnar,LIB,21
+Butte,17,U.S. Senate,,John R. Thune,REP,312
+Butte,18,U.S. Senate,,Brian L. Bengs,DEM,14
+Butte,18,U.S. Senate,,Tamara J Lesnar,LIB,15
+Butte,18,U.S. Senate,,John R. Thune,REP,78
+Butte,20,U.S. Senate,,Brian L. Bengs,DEM,30
+Butte,20,U.S. Senate,,Tamara J Lesnar,LIB,12
+Butte,20,U.S. Senate,,John R. Thune,REP,167
+Butte,21,U.S. Senate,,Brian L. Bengs,DEM,42
+Butte,21,U.S. Senate,,Tamara J Lesnar,LIB,17
+Butte,21,U.S. Senate,,John R. Thune,REP,156
+Butte,22,U.S. Senate,,Brian L. Bengs,DEM,35
+Butte,22,U.S. Senate,,Tamara J Lesnar,LIB,21
+Butte,22,U.S. Senate,,John R. Thune,REP,123
+Butte,23,U.S. Senate,,Brian L. Bengs,DEM,39
+Butte,23,U.S. Senate,,Tamara J Lesnar,LIB,12
+Butte,23,U.S. Senate,,John R. Thune,REP,149
+Butte,24,U.S. Senate,,Brian L. Bengs,DEM,58
+Butte,24,U.S. Senate,,Tamara J Lesnar,LIB,19
+Butte,24,U.S. Senate,,John R. Thune,REP,218
+Butte,25,U.S. Senate,,Brian L. Bengs,DEM,64
+Butte,25,U.S. Senate,,Tamara J Lesnar,LIB,17
+Butte,25,U.S. Senate,,John R. Thune,REP,307
+Butte,26,U.S. Senate,,Brian L. Bengs,DEM,34
+Butte,26,U.S. Senate,,Tamara J Lesnar,LIB,22
+Butte,26,U.S. Senate,,John R. Thune,REP,180
+Butte,27,U.S. Senate,,Brian L. Bengs,DEM,36
+Butte,27,U.S. Senate,,Tamara J Lesnar,LIB,12
+Butte,27,U.S. Senate,,John R. Thune,REP,164
+Butte,28,U.S. Senate,,Brian L. Bengs,DEM,68
+Butte,28,U.S. Senate,,Tamara J Lesnar,LIB,21
+Butte,28,U.S. Senate,,John R. Thune,REP,276
+Butte,06,U.S. House,1,Collin Duprel,LIB,16
+Butte,06,U.S. House,1,Dusty Johnson,REP,26
+Butte,08,U.S. House,1,Collin Duprel,LIB,5
+Butte,08,U.S. House,1,Dusty Johnson,REP,16
+Butte,11,U.S. House,1,Collin Duprel,LIB,15
+Butte,11,U.S. House,1,Dusty Johnson,REP,57
+Butte,12,U.S. House,1,Collin Duprel,LIB,25
+Butte,12,U.S. House,1,Dusty Johnson,REP,57
+Butte,13,U.S. House,1,Collin Duprel,LIB,68
+Butte,13,U.S. House,1,Dusty Johnson,REP,123
+Butte,14,U.S. House,1,Collin Duprel,LIB,102
+Butte,14,U.S. House,1,Dusty Johnson,REP,164
+Butte,16,U.S. House,1,Collin Duprel,LIB,156
+Butte,16,U.S. House,1,Dusty Johnson,REP,521
+Butte,17,U.S. House,1,Collin Duprel,LIB,70
+Butte,17,U.S. House,1,Dusty Johnson,REP,292
+Butte,18,U.S. House,1,Collin Duprel,LIB,35
+Butte,18,U.S. House,1,Dusty Johnson,REP,69
+Butte,20,U.S. House,1,Collin Duprel,LIB,61
+Butte,20,U.S. House,1,Dusty Johnson,REP,142
+Butte,21,U.S. House,1,Collin Duprel,LIB,62
+Butte,21,U.S. House,1,Dusty Johnson,REP,148
+Butte,22,U.S. House,1,Collin Duprel,LIB,49
+Butte,22,U.S. House,1,Dusty Johnson,REP,121
+Butte,23,U.S. House,1,Collin Duprel,LIB,49
+Butte,23,U.S. House,1,Dusty Johnson,REP,152
+Butte,24,U.S. House,1,Collin Duprel,LIB,75
+Butte,24,U.S. House,1,Dusty Johnson,REP,212
+Butte,25,U.S. House,1,Collin Duprel,LIB,65
+Butte,25,U.S. House,1,Dusty Johnson,REP,308
+Butte,26,U.S. House,1,Collin Duprel,LIB,55
+Butte,26,U.S. House,1,Dusty Johnson,REP,172
+Butte,27,U.S. House,1,Collin Duprel,LIB,40
+Butte,27,U.S. House,1,Dusty Johnson,REP,163
+Butte,28,U.S. House,1,Collin Duprel,LIB,74
+Butte,28,U.S. House,1,Dusty Johnson,REP,278
+Butte,06,Governor,,Jamie Smith and Jennifer Keintz,DEM,1
+Butte,06,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Butte,06,Governor,,Kristi Noem and Larry Rhoden,REP,38
+Butte,08,Governor,,Jamie Smith and Jennifer Keintz,DEM,0
+Butte,08,Governor,,Tracey Quint and Ashley Strand,LIB,0
+Butte,08,Governor,,Kristi Noem and Larry Rhoden,REP,21
+Butte,11,Governor,,Jamie Smith and Jennifer Keintz,DEM,12
+Butte,11,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Butte,11,Governor,,Kristi Noem and Larry Rhoden,REP,60
+Butte,12,Governor,,Jamie Smith and Jennifer Keintz,DEM,12
+Butte,12,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Butte,12,Governor,,Kristi Noem and Larry Rhoden,REP,72
+Butte,13,Governor,,Jamie Smith and Jennifer Keintz,DEM,36
+Butte,13,Governor,,Tracey Quint and Ashley Strand,LIB,6
+Butte,13,Governor,,Kristi Noem and Larry Rhoden,REP,163
+Butte,14,Governor,,Jamie Smith and Jennifer Keintz,DEM,34
+Butte,14,Governor,,Tracey Quint and Ashley Strand,LIB,11
+Butte,14,Governor,,Kristi Noem and Larry Rhoden,REP,224
+Butte,16,Governor,,Jamie Smith and Jennifer Keintz,DEM,107
+Butte,16,Governor,,Tracey Quint and Ashley Strand,LIB,21
+Butte,16,Governor,,Kristi Noem and Larry Rhoden,REP,580
+Butte,17,Governor,,Jamie Smith and Jennifer Keintz,DEM,61
+Butte,17,Governor,,Tracey Quint and Ashley Strand,LIB,10
+Butte,17,Governor,,Kristi Noem and Larry Rhoden,REP,305
+Butte,18,Governor,,Jamie Smith and Jennifer Keintz,DEM,22
+Butte,18,Governor,,Tracey Quint and Ashley Strand,LIB,6
+Butte,18,Governor,,Kristi Noem and Larry Rhoden,REP,76
+Butte,20,Governor,,Jamie Smith and Jennifer Keintz,DEM,45
+Butte,20,Governor,,Tracey Quint and Ashley Strand,LIB,8
+Butte,20,Governor,,Kristi Noem and Larry Rhoden,REP,156
+Butte,21,Governor,,Jamie Smith and Jennifer Keintz,DEM,62
+Butte,21,Governor,,Tracey Quint and Ashley Strand,LIB,13
+Butte,21,Governor,,Kristi Noem and Larry Rhoden,REP,141
+Butte,22,Governor,,Jamie Smith and Jennifer Keintz,DEM,44
+Butte,22,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Butte,22,Governor,,Kristi Noem and Larry Rhoden,REP,128
+Butte,23,Governor,,Jamie Smith and Jennifer Keintz,DEM,47
+Butte,23,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Butte,23,Governor,,Kristi Noem and Larry Rhoden,REP,152
+Butte,24,Governor,,Jamie Smith and Jennifer Keintz,DEM,73
+Butte,24,Governor,,Tracey Quint and Ashley Strand,LIB,12
+Butte,24,Governor,,Kristi Noem and Larry Rhoden,REP,211
+Butte,25,Governor,,Jamie Smith and Jennifer Keintz,DEM,86
+Butte,25,Governor,,Tracey Quint and Ashley Strand,LIB,9
+Butte,25,Governor,,Kristi Noem and Larry Rhoden,REP,296
+Butte,26,Governor,,Jamie Smith and Jennifer Keintz,DEM,47
+Butte,26,Governor,,Tracey Quint and Ashley Strand,LIB,20
+Butte,26,Governor,,Kristi Noem and Larry Rhoden,REP,170
+Butte,27,Governor,,Jamie Smith and Jennifer Keintz,DEM,43
+Butte,27,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Butte,27,Governor,,Kristi Noem and Larry Rhoden,REP,166
+Butte,28,Governor,,Jamie Smith and Jennifer Keintz,DEM,91
+Butte,28,Governor,,Tracey Quint and Ashley Strand,LIB,18
+Butte,28,Governor,,Kristi Noem and Larry Rhoden,REP,252
+Butte,06,Secretary of State,,Thomas A Cool,DEM,2
+Butte,06,Secretary of State,,Monae Johnson,REP,37
+Butte,08,Secretary of State,,Thomas A Cool,DEM,0
+Butte,08,Secretary of State,,Monae Johnson,REP,21
+Butte,11,Secretary of State,,Thomas A Cool,DEM,8
+Butte,11,Secretary of State,,Monae Johnson,REP,62
+Butte,12,Secretary of State,,Thomas A Cool,DEM,12
+Butte,12,Secretary of State,,Monae Johnson,REP,70
+Butte,13,Secretary of State,,Thomas A Cool,DEM,32
+Butte,13,Secretary of State,,Monae Johnson,REP,166
+Butte,14,Secretary of State,,Thomas A Cool,DEM,37
+Butte,14,Secretary of State,,Monae Johnson,REP,224
+Butte,16,Secretary of State,,Thomas A Cool,DEM,110
+Butte,16,Secretary of State,,Monae Johnson,REP,575
+Butte,17,Secretary of State,,Thomas A Cool,DEM,59
+Butte,17,Secretary of State,,Monae Johnson,REP,307
+Butte,18,Secretary of State,,Thomas A Cool,DEM,27
+Butte,18,Secretary of State,,Monae Johnson,REP,75
+Butte,20,Secretary of State,,Thomas A Cool,DEM,43
+Butte,20,Secretary of State,,Monae Johnson,REP,159
+Butte,21,Secretary of State,,Thomas A Cool,DEM,57
+Butte,21,Secretary of State,,Monae Johnson,REP,146
+Butte,22,Secretary of State,,Thomas A Cool,DEM,37
+Butte,22,Secretary of State,,Monae Johnson,REP,134
+Butte,23,Secretary of State,,Thomas A Cool,DEM,47
+Butte,23,Secretary of State,,Monae Johnson,REP,146
+Butte,24,Secretary of State,,Thomas A Cool,DEM,75
+Butte,24,Secretary of State,,Monae Johnson,REP,207
+Butte,25,Secretary of State,,Thomas A Cool,DEM,89
+Butte,25,Secretary of State,,Monae Johnson,REP,296
+Butte,26,Secretary of State,,Thomas A Cool,DEM,53
+Butte,26,Secretary of State,,Monae Johnson,REP,175
+Butte,27,Secretary of State,,Thomas A Cool,DEM,45
+Butte,27,Secretary of State,,Monae Johnson,REP,162
+Butte,28,Secretary of State,,Thomas A Cool,DEM,91
+Butte,28,Secretary of State,,Monae Johnson,REP,263
+Butte,06,Attorney General,,Marty J. Jackley,REP,37
+Butte,08,Attorney General,,Marty J. Jackley,REP,21
+Butte,11,Attorney General,,Marty J. Jackley,REP,64
+Butte,12,Attorney General,,Marty J. Jackley,REP,69
+Butte,13,Attorney General,,Marty J. Jackley,REP,177
+Butte,14,Attorney General,,Marty J. Jackley,REP,221
+Butte,16,Attorney General,,Marty J. Jackley,REP,592
+Butte,17,Attorney General,,Marty J. Jackley,REP,312
+Butte,18,Attorney General,,Marty J. Jackley,REP,78
+Butte,20,Attorney General,,Marty J. Jackley,REP,174
+Butte,21,Attorney General,,Marty J. Jackley,REP,167
+Butte,22,Attorney General,,Marty J. Jackley,REP,135
+Butte,23,Attorney General,,Marty J. Jackley,REP,163
+Butte,24,Attorney General,,Marty J. Jackley,REP,227
+Butte,25,Attorney General,,Marty J. Jackley,REP,325
+Butte,26,Attorney General,,Marty J. Jackley,REP,195
+Butte,27,Attorney General,,Marty J. Jackley,REP,178
+Butte,28,Attorney General,,Marty J. Jackley,REP,289
+Butte,06,State Auditor,,Stephanie Marty,DEM,2
+Butte,06,State Auditor,,Rene Meyer,LIB,1
+Butte,06,State Auditor,,Richard Sattgast,REP,38
+Butte,08,State Auditor,,Stephanie Marty,DEM,0
+Butte,08,State Auditor,,Rene Meyer,LIB,0
+Butte,08,State Auditor,,Richard Sattgast,REP,21
+Butte,11,State Auditor,,Stephanie Marty,DEM,8
+Butte,11,State Auditor,,Rene Meyer,LIB,2
+Butte,11,State Auditor,,Richard Sattgast,REP,60
+Butte,12,State Auditor,,Stephanie Marty,DEM,11
+Butte,12,State Auditor,,Rene Meyer,LIB,5
+Butte,12,State Auditor,,Richard Sattgast,REP,65
+Butte,13,State Auditor,,Stephanie Marty,DEM,28
+Butte,13,State Auditor,,Rene Meyer,LIB,18
+Butte,13,State Auditor,,Richard Sattgast,REP,147
+Butte,14,State Auditor,,Stephanie Marty,DEM,31
+Butte,14,State Auditor,,Rene Meyer,LIB,20
+Butte,14,State Auditor,,Richard Sattgast,REP,204
+Butte,16,State Auditor,,Stephanie Marty,DEM,101
+Butte,16,State Auditor,,Rene Meyer,LIB,45
+Butte,16,State Auditor,,Richard Sattgast,REP,537
+Butte,17,State Auditor,,Stephanie Marty,DEM,52
+Butte,17,State Auditor,,Rene Meyer,LIB,26
+Butte,17,State Auditor,,Richard Sattgast,REP,283
+Butte,18,State Auditor,,Stephanie Marty,DEM,19
+Butte,18,State Auditor,,Rene Meyer,LIB,13
+Butte,18,State Auditor,,Richard Sattgast,REP,69
+Butte,20,State Auditor,,Stephanie Marty,DEM,41
+Butte,20,State Auditor,,Rene Meyer,LIB,15
+Butte,20,State Auditor,,Richard Sattgast,REP,143
+Butte,21,State Auditor,,Stephanie Marty,DEM,53
+Butte,21,State Auditor,,Rene Meyer,LIB,19
+Butte,21,State Auditor,,Richard Sattgast,REP,131
+Butte,22,State Auditor,,Stephanie Marty,DEM,41
+Butte,22,State Auditor,,Rene Meyer,LIB,19
+Butte,22,State Auditor,,Richard Sattgast,REP,115
+Butte,23,State Auditor,,Stephanie Marty,DEM,41
+Butte,23,State Auditor,,Rene Meyer,LIB,13
+Butte,23,State Auditor,,Richard Sattgast,REP,141
+Butte,24,State Auditor,,Stephanie Marty,DEM,72
+Butte,24,State Auditor,,Rene Meyer,LIB,15
+Butte,24,State Auditor,,Richard Sattgast,REP,197
+Butte,25,State Auditor,,Stephanie Marty,DEM,78
+Butte,25,State Auditor,,Rene Meyer,LIB,13
+Butte,25,State Auditor,,Richard Sattgast,REP,295
+Butte,26,State Auditor,,Stephanie Marty,DEM,47
+Butte,26,State Auditor,,Rene Meyer,LIB,27
+Butte,26,State Auditor,,Richard Sattgast,REP,155
+Butte,27,State Auditor,,Stephanie Marty,DEM,41
+Butte,27,State Auditor,,Rene Meyer,LIB,7
+Butte,27,State Auditor,,Richard Sattgast,REP,159
+Butte,28,State Auditor,,Stephanie Marty,DEM,73
+Butte,28,State Auditor,,Rene Meyer,LIB,18
+Butte,28,State Auditor,,Richard Sattgast,REP,256
+Butte,06,State Treasurer,,John Cunningham,DEM,3
+Butte,06,State Treasurer,,Josh Haeder,REP,38
+Butte,08,State Treasurer,,John Cunningham,DEM,0
+Butte,08,State Treasurer,,Josh Haeder,REP,20
+Butte,11,State Treasurer,,John Cunningham,DEM,7
+Butte,11,State Treasurer,,Josh Haeder,REP,62
+Butte,12,State Treasurer,,John Cunningham,DEM,11
+Butte,12,State Treasurer,,Josh Haeder,REP,69
+Butte,13,State Treasurer,,John Cunningham,DEM,26
+Butte,13,State Treasurer,,Josh Haeder,REP,163
+Butte,14,State Treasurer,,John Cunningham,DEM,33
+Butte,14,State Treasurer,,Josh Haeder,REP,222
+Butte,16,State Treasurer,,John Cunningham,DEM,102
+Butte,16,State Treasurer,,Josh Haeder,REP,574
+Butte,17,State Treasurer,,John Cunningham,DEM,64
+Butte,17,State Treasurer,,Josh Haeder,REP,296
+Butte,18,State Treasurer,,John Cunningham,DEM,25
+Butte,18,State Treasurer,,Josh Haeder,REP,74
+Butte,20,State Treasurer,,John Cunningham,DEM,43
+Butte,20,State Treasurer,,Josh Haeder,REP,158
+Butte,21,State Treasurer,,John Cunningham,DEM,56
+Butte,21,State Treasurer,,Josh Haeder,REP,144
+Butte,22,State Treasurer,,John Cunningham,DEM,35
+Butte,22,State Treasurer,,Josh Haeder,REP,137
+Butte,23,State Treasurer,,John Cunningham,DEM,40
+Butte,23,State Treasurer,,Josh Haeder,REP,153
+Butte,24,State Treasurer,,John Cunningham,DEM,73
+Butte,24,State Treasurer,,Josh Haeder,REP,207
+Butte,25,State Treasurer,,John Cunningham,DEM,80
+Butte,25,State Treasurer,,Josh Haeder,REP,298
+Butte,26,State Treasurer,,John Cunningham,DEM,46
+Butte,26,State Treasurer,,Josh Haeder,REP,174
+Butte,27,State Treasurer,,John Cunningham,DEM,40
+Butte,27,State Treasurer,,Josh Haeder,REP,167
+Butte,28,State Treasurer,,John Cunningham,DEM,85
+Butte,28,State Treasurer,,Josh Haeder,REP,261
+Butte,06,Commissioner of School and Public Lands,,Timothy Azure,DEM,1
+Butte,06,Commissioner of School and Public Lands,,Brock Greenfield,REP,40
+Butte,08,Commissioner of School and Public Lands,,Timothy Azure,DEM,0
+Butte,08,Commissioner of School and Public Lands,,Brock Greenfield,REP,21
+Butte,11,Commissioner of School and Public Lands,,Timothy Azure,DEM,7
+Butte,11,Commissioner of School and Public Lands,,Brock Greenfield,REP,64
+Butte,12,Commissioner of School and Public Lands,,Timothy Azure,DEM,10
+Butte,12,Commissioner of School and Public Lands,,Brock Greenfield,REP,72
+Butte,13,Commissioner of School and Public Lands,,Timothy Azure,DEM,26
+Butte,13,Commissioner of School and Public Lands,,Brock Greenfield,REP,160
+Butte,14,Commissioner of School and Public Lands,,Timothy Azure,DEM,35
+Butte,14,Commissioner of School and Public Lands,,Brock Greenfield,REP,217
+Butte,16,Commissioner of School and Public Lands,,Timothy Azure,DEM,98
+Butte,16,Commissioner of School and Public Lands,,Brock Greenfield,REP,574
+Butte,17,Commissioner of School and Public Lands,,Timothy Azure,DEM,59
+Butte,17,Commissioner of School and Public Lands,,Brock Greenfield,REP,298
+Butte,18,Commissioner of School and Public Lands,,Timothy Azure,DEM,26
+Butte,18,Commissioner of School and Public Lands,,Brock Greenfield,REP,73
+Butte,20,Commissioner of School and Public Lands,,Timothy Azure,DEM,35
+Butte,20,Commissioner of School and Public Lands,,Brock Greenfield,REP,161
+Butte,21,Commissioner of School and Public Lands,,Timothy Azure,DEM,55
+Butte,21,Commissioner of School and Public Lands,,Brock Greenfield,REP,147
+Butte,22,Commissioner of School and Public Lands,,Timothy Azure,DEM,35
+Butte,22,Commissioner of School and Public Lands,,Brock Greenfield,REP,137
+Butte,23,Commissioner of School and Public Lands,,Timothy Azure,DEM,39
+Butte,23,Commissioner of School and Public Lands,,Brock Greenfield,REP,153
+Butte,24,Commissioner of School and Public Lands,,Timothy Azure,DEM,73
+Butte,24,Commissioner of School and Public Lands,,Brock Greenfield,REP,205
+Butte,25,Commissioner of School and Public Lands,,Timothy Azure,DEM,85
+Butte,25,Commissioner of School and Public Lands,,Brock Greenfield,REP,290
+Butte,26,Commissioner of School and Public Lands,,Timothy Azure,DEM,47
+Butte,26,Commissioner of School and Public Lands,,Brock Greenfield,REP,171
+Butte,27,Commissioner of School and Public Lands,,Timothy Azure,DEM,37
+Butte,27,Commissioner of School and Public Lands,,Brock Greenfield,REP,171
+Butte,28,Commissioner of School and Public Lands,,Timothy Azure,DEM,83
+Butte,28,Commissioner of School and Public Lands,,Brock Greenfield,REP,262
+Butte,06,Public Utilities Commissioner,,Jeffrey Barth,DEM,3
+Butte,06,Public Utilities Commissioner,,Chris Nelson,REP,38
+Butte,08,Public Utilities Commissioner,,Jeffrey Barth,DEM,0
+Butte,08,Public Utilities Commissioner,,Chris Nelson,REP,20
+Butte,11,Public Utilities Commissioner,,Jeffrey Barth,DEM,6
+Butte,11,Public Utilities Commissioner,,Chris Nelson,REP,64
+Butte,12,Public Utilities Commissioner,,Jeffrey Barth,DEM,11
+Butte,12,Public Utilities Commissioner,,Chris Nelson,REP,71
+Butte,13,Public Utilities Commissioner,,Jeffrey Barth,DEM,27
+Butte,13,Public Utilities Commissioner,,Chris Nelson,REP,165
+Butte,14,Public Utilities Commissioner,,Jeffrey Barth,DEM,28
+Butte,14,Public Utilities Commissioner,,Chris Nelson,REP,228
+Butte,16,Public Utilities Commissioner,,Jeffrey Barth,DEM,104
+Butte,16,Public Utilities Commissioner,,Chris Nelson,REP,585
+Butte,17,Public Utilities Commissioner,,Jeffrey Barth,DEM,62
+Butte,17,Public Utilities Commissioner,,Chris Nelson,REP,302
+Butte,18,Public Utilities Commissioner,,Jeffrey Barth,DEM,18
+Butte,18,Public Utilities Commissioner,,Chris Nelson,REP,82
+Butte,20,Public Utilities Commissioner,,Jeffrey Barth,DEM,37
+Butte,20,Public Utilities Commissioner,,Chris Nelson,REP,165
+Butte,21,Public Utilities Commissioner,,Jeffrey Barth,DEM,52
+Butte,21,Public Utilities Commissioner,,Chris Nelson,REP,149
+Butte,22,Public Utilities Commissioner,,Jeffrey Barth,DEM,37
+Butte,22,Public Utilities Commissioner,,Chris Nelson,REP,136
+Butte,23,Public Utilities Commissioner,,Jeffrey Barth,DEM,40
+Butte,23,Public Utilities Commissioner,,Chris Nelson,REP,155
+Butte,24,Public Utilities Commissioner,,Jeffrey Barth,DEM,69
+Butte,24,Public Utilities Commissioner,,Chris Nelson,REP,215
+Butte,25,Public Utilities Commissioner,,Jeffrey Barth,DEM,73
+Butte,25,Public Utilities Commissioner,,Chris Nelson,REP,307
+Butte,26,Public Utilities Commissioner,,Jeffrey Barth,DEM,46
+Butte,26,Public Utilities Commissioner,,Chris Nelson,REP,174
+Butte,27,Public Utilities Commissioner,,Jeffrey Barth,DEM,37
+Butte,27,Public Utilities Commissioner,,Chris Nelson,REP,171
+Butte,28,Public Utilities Commissioner,,Jeffrey Barth,DEM,76
+Butte,28,Public Utilities Commissioner,,Chris Nelson,REP,271
+Butte,06,State Senate,28,Ryan M. Maher,REP,37
+Butte,08,State Senate,28,Ryan M. Maher,REP,19
+Butte,11,State Senate,28,Ryan M. Maher,REP,60
+Butte,12,State Senate,28,Ryan M. Maher,REP,68
+Butte,13,State Senate,28,Ryan M. Maher,REP,167
+Butte,14,State Senate,28,Ryan M. Maher,REP,216
+Butte,16,State Senate,28,Ryan M. Maher,REP,577
+Butte,17,State Senate,28,Ryan M. Maher,REP,305
+Butte,18,State Senate,28,Ryan M. Maher,REP,80
+Butte,20,State Senate,28,Ryan M. Maher,REP,164
+Butte,21,State Senate,28,Ryan M. Maher,REP,154
+Butte,22,State Senate,28,Ryan M. Maher,REP,131
+Butte,23,State Senate,28,Ryan M. Maher,REP,160
+Butte,24,State Senate,28,Ryan M. Maher,REP,220
+Butte,25,State Senate,28,Ryan M. Maher,REP,320
+Butte,26,State Senate,28,Ryan M. Maher,REP,182
+Butte,27,State Senate,28,Ryan M. Maher,REP,176
+Butte,28,State Senate,28,Ryan M. Maher,REP,286
+Butte,06,State House,28B,Neal Pinnow,REP,35
+Butte,06,State House,28B,Calvin Reilly,IND,6
+Butte,08,State House,28B,Neal Pinnow,REP,18
+Butte,08,State House,28B,Calvin Reilly,IND,1
+Butte,11,State House,28B,Neal Pinnow,REP,60
+Butte,11,State House,28B,Calvin Reilly,IND,11
+Butte,12,State House,28B,Neal Pinnow,REP,68
+Butte,12,State House,28B,Calvin Reilly,IND,13
+Butte,13,State House,28B,Neal Pinnow,REP,157
+Butte,13,State House,28B,Calvin Reilly,IND,30
+Butte,14,State House,28B,Neal Pinnow,REP,207
+Butte,14,State House,28B,Calvin Reilly,IND,38
+Butte,16,State House,28B,Neal Pinnow,REP,535
+Butte,16,State House,28B,Calvin Reilly,IND,121
+Butte,17,State House,28B,Neal Pinnow,REP,289
+Butte,17,State House,28B,Calvin Reilly,IND,65
+Butte,18,State House,28B,Neal Pinnow,REP,65
+Butte,18,State House,28B,Calvin Reilly,IND,30
+Butte,20,State House,28B,Neal Pinnow,REP,151
+Butte,20,State House,28B,Calvin Reilly,IND,39
+Butte,21,State House,28B,Neal Pinnow,REP,133
+Butte,21,State House,28B,Calvin Reilly,IND,68
+Butte,22,State House,28B,Neal Pinnow,REP,109
+Butte,22,State House,28B,Calvin Reilly,IND,56
+Butte,23,State House,28B,Neal Pinnow,REP,141
+Butte,23,State House,28B,Calvin Reilly,IND,52
+Butte,24,State House,28B,Neal Pinnow,REP,198
+Butte,24,State House,28B,Calvin Reilly,IND,71
+Butte,25,State House,28B,Neal Pinnow,REP,299
+Butte,25,State House,28B,Calvin Reilly,IND,57
+Butte,26,State House,28B,Neal Pinnow,REP,147
+Butte,26,State House,28B,Calvin Reilly,IND,67
+Butte,27,State House,28B,Neal Pinnow,REP,161
+Butte,27,State House,28B,Calvin Reilly,IND,34
+Butte,28,State House,28B,Neal Pinnow,REP,255
+Butte,28,State House,28B,Calvin Reilly,IND,82
+Butte,06,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,23
+Butte,08,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,13
+Butte,11,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,36
+Butte,12,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,40
+Butte,13,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,105
+Butte,14,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,122
+Butte,16,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,397
+Butte,17,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,202
+Butte,18,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,53
+Butte,20,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,111
+Butte,21,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,105
+Butte,22,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,82
+Butte,23,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,113
+Butte,24,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,153
+Butte,25,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,209
+Butte,26,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,130
+Butte,27,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,125
+Butte,28,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,221
+Butte,06,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,28
+Butte,08,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,16
+Butte,11,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,40
+Butte,12,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,44
+Butte,13,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,114
+Butte,14,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,127
+Butte,16,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,460
+Butte,17,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,246
+Butte,18,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,55
+Butte,20,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,122
+Butte,21,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,129
+Butte,22,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,101
+Butte,23,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,135
+Butte,24,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,184
+Butte,25,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,241
+Butte,26,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,152
+Butte,27,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,152
+Butte,28,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,256
+Butte,06,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,23
+Butte,08,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,13
+Butte,11,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,35
+Butte,12,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,37
+Butte,13,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,108
+Butte,14,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,122
+Butte,16,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,380
+Butte,17,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,197
+Butte,18,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,49
+Butte,20,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,110
+Butte,21,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,100
+Butte,22,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,80
+Butte,23,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,110
+Butte,24,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,153
+Butte,25,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,206
+Butte,26,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,128
+Butte,27,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,120
+Butte,28,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,212
+Butte,06,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,1
+Butte,06,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,3
+Butte,06,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,2
+Butte,06,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,7
+Butte,06,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,19
+Butte,08,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,2
+Butte,08,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,1
+Butte,08,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,0
+Butte,08,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,10
+Butte,08,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,4
+Butte,11,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,1
+Butte,11,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,13
+Butte,11,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,1
+Butte,11,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,22
+Butte,11,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,16
+Butte,12,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,5
+Butte,12,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,12
+Butte,12,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,2
+Butte,12,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,15
+Butte,12,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,27
+Butte,13,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,13
+Butte,13,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,15
+Butte,13,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,11
+Butte,13,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,61
+Butte,13,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,67
+Butte,14,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,19
+Butte,14,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,31
+Butte,14,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,13
+Butte,14,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,63
+Butte,14,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,70
+Butte,16,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,26
+Butte,16,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,146
+Butte,16,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,45
+Butte,16,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,189
+Butte,16,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,161
+Butte,17,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,15
+Butte,17,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,74
+Butte,17,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,12
+Butte,17,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,106
+Butte,17,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,72
+Butte,18,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,12
+Butte,18,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,13
+Butte,18,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,5
+Butte,18,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,17
+Butte,18,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,32
+Butte,20,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,12
+Butte,20,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,22
+Butte,20,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,9
+Butte,20,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,57
+Butte,20,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,59
+Butte,21,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,10
+Butte,21,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,41
+Butte,21,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,12
+Butte,21,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,69
+Butte,21,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,37
+Butte,22,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,8
+Butte,22,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,20
+Butte,22,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,9
+Butte,22,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,66
+Butte,22,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,37
+Butte,23,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,8
+Butte,23,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,38
+Butte,23,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,10
+Butte,23,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,65
+Butte,23,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,43
+Butte,24,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,15
+Butte,24,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,66
+Butte,24,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,14
+Butte,24,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,90
+Butte,24,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,54
+Butte,25,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,19
+Butte,25,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,93
+Butte,25,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,26
+Butte,25,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,86
+Butte,25,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,66
+Butte,26,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,15
+Butte,26,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,36
+Butte,26,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,14
+Butte,26,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,76
+Butte,26,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,45
+Butte,27,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,8
+Butte,27,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,65
+Butte,27,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,5
+Butte,27,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,63
+Butte,27,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,41
+Butte,28,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,26
+Butte,28,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,83
+Butte,28,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,13
+Butte,28,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,119
+Butte,28,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,44
+Butte,06,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,25
+Butte,06,Supreme Court Retention,3,Patricia J. DeVaney - No,,7
+Butte,08,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,16
+Butte,08,Supreme Court Retention,3,Patricia J. DeVaney - No,,1
+Butte,11,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,48
+Butte,11,Supreme Court Retention,3,Patricia J. DeVaney - No,,12
+Butte,12,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,57
+Butte,12,Supreme Court Retention,3,Patricia J. DeVaney - No,,12
+Butte,13,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,142
+Butte,13,Supreme Court Retention,3,Patricia J. DeVaney - No,,23
+Butte,14,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,184
+Butte,14,Supreme Court Retention,3,Patricia J. DeVaney - No,,35
+Butte,16,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,487
+Butte,16,Supreme Court Retention,3,Patricia J. DeVaney - No,,122
+Butte,17,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,259
+Butte,17,Supreme Court Retention,3,Patricia J. DeVaney - No,,58
+Butte,18,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,72
+Butte,18,Supreme Court Retention,3,Patricia J. DeVaney - No,,25
+Butte,20,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,151
+Butte,20,Supreme Court Retention,3,Patricia J. DeVaney - No,,39
+Butte,21,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,147
+Butte,21,Supreme Court Retention,3,Patricia J. DeVaney - No,,42
+Butte,22,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,115
+Butte,22,Supreme Court Retention,3,Patricia J. DeVaney - No,,41
+Butte,23,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,160
+Butte,23,Supreme Court Retention,3,Patricia J. DeVaney - No,,28
+Butte,24,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,191
+Butte,24,Supreme Court Retention,3,Patricia J. DeVaney - No,,57
+Butte,25,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,279
+Butte,25,Supreme Court Retention,3,Patricia J. DeVaney - No,,58
+Butte,26,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,155
+Butte,26,Supreme Court Retention,3,Patricia J. DeVaney - No,,43
+Butte,27,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,162
+Butte,27,Supreme Court Retention,3,Patricia J. DeVaney - No,,25
+Butte,28,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,247
+Butte,28,Supreme Court Retention,3,Patricia J. DeVaney - No,,74
+Butte,06,Supreme Court Retention,2,Mark E. Salter - Yes,,26
+Butte,06,Supreme Court Retention,2,Mark E. Salter - No,,6
+Butte,08,Supreme Court Retention,2,Mark E. Salter - Yes,,16
+Butte,08,Supreme Court Retention,2,Mark E. Salter - No,,1
+Butte,11,Supreme Court Retention,2,Mark E. Salter - Yes,,48
+Butte,11,Supreme Court Retention,2,Mark E. Salter - No,,12
+Butte,12,Supreme Court Retention,2,Mark E. Salter - Yes,,52
+Butte,12,Supreme Court Retention,2,Mark E. Salter - No,,15
+Butte,13,Supreme Court Retention,2,Mark E. Salter - Yes,,142
+Butte,13,Supreme Court Retention,2,Mark E. Salter - No,,24
+Butte,14,Supreme Court Retention,2,Mark E. Salter - Yes,,179
+Butte,14,Supreme Court Retention,2,Mark E. Salter - No,,38
+Butte,16,Supreme Court Retention,2,Mark E. Salter - Yes,,486
+Butte,16,Supreme Court Retention,2,Mark E. Salter - No,,123
+Butte,17,Supreme Court Retention,2,Mark E. Salter - Yes,,271
+Butte,17,Supreme Court Retention,2,Mark E. Salter - No,,49
+Butte,18,Supreme Court Retention,2,Mark E. Salter - Yes,,71
+Butte,18,Supreme Court Retention,2,Mark E. Salter - No,,25
+Butte,20,Supreme Court Retention,2,Mark E. Salter - Yes,,148
+Butte,20,Supreme Court Retention,2,Mark E. Salter - No,,40
+Butte,21,Supreme Court Retention,2,Mark E. Salter - Yes,,143
+Butte,21,Supreme Court Retention,2,Mark E. Salter - No,,44
+Butte,22,Supreme Court Retention,2,Mark E. Salter - Yes,,112
+Butte,22,Supreme Court Retention,2,Mark E. Salter - No,,42
+Butte,23,Supreme Court Retention,2,Mark E. Salter - Yes,,155
+Butte,23,Supreme Court Retention,2,Mark E. Salter - No,,29
+Butte,24,Supreme Court Retention,2,Mark E. Salter - Yes,,189
+Butte,24,Supreme Court Retention,2,Mark E. Salter - No,,59
+Butte,25,Supreme Court Retention,2,Mark E. Salter - Yes,,282
+Butte,25,Supreme Court Retention,2,Mark E. Salter - No,,55
+Butte,26,Supreme Court Retention,2,Mark E. Salter - Yes,,153
+Butte,26,Supreme Court Retention,2,Mark E. Salter - No,,44
+Butte,27,Supreme Court Retention,2,Mark E. Salter - Yes,,160
+Butte,27,Supreme Court Retention,2,Mark E. Salter - No,,25
+Butte,28,Supreme Court Retention,2,Mark E. Salter - Yes,,245
+Butte,28,Supreme Court Retention,2,Mark E. Salter - No,,76
+Butte,06,Constitutional Amendment D,,Yes,,9
+Butte,06,Constitutional Amendment D,,No,,32
+Butte,08,Constitutional Amendment D,,Yes,,0
+Butte,08,Constitutional Amendment D,,No,,21
+Butte,11,Constitutional Amendment D,,Yes,,22
+Butte,11,Constitutional Amendment D,,No,,48
+Butte,12,Constitutional Amendment D,,Yes,,38
+Butte,12,Constitutional Amendment D,,No,,47
+Butte,13,Constitutional Amendment D,,Yes,,78
+Butte,13,Constitutional Amendment D,,No,,122
+Butte,14,Constitutional Amendment D,,Yes,,114
+Butte,14,Constitutional Amendment D,,No,,149
+Butte,16,Constitutional Amendment D,,Yes,,297
+Butte,16,Constitutional Amendment D,,No,,401
+Butte,17,Constitutional Amendment D,,Yes,,152
+Butte,17,Constitutional Amendment D,,No,,221
+Butte,18,Constitutional Amendment D,,Yes,,61
+Butte,18,Constitutional Amendment D,,No,,42
+Butte,20,Constitutional Amendment D,,Yes,,105
+Butte,20,Constitutional Amendment D,,No,,101
+Butte,21,Constitutional Amendment D,,Yes,,128
+Butte,21,Constitutional Amendment D,,No,,81
+Butte,22,Constitutional Amendment D,,Yes,,96
+Butte,22,Constitutional Amendment D,,No,,81
+Butte,23,Constitutional Amendment D,,Yes,,118
+Butte,23,Constitutional Amendment D,,No,,82
+Butte,24,Constitutional Amendment D,,Yes,,169
+Butte,24,Constitutional Amendment D,,No,,119
+Butte,25,Constitutional Amendment D,,Yes,,186
+Butte,25,Constitutional Amendment D,,No,,204
+Butte,26,Constitutional Amendment D,,Yes,,135
+Butte,26,Constitutional Amendment D,,No,,94
+Butte,27,Constitutional Amendment D,,Yes,,117
+Butte,27,Constitutional Amendment D,,No,,92
+Butte,28,Constitutional Amendment D,,Yes,,196
+Butte,28,Constitutional Amendment D,,No,,167
+Butte,06,Initiated Measure 27,,Yes,,4
+Butte,06,Initiated Measure 27,,No,,38
+Butte,08,Initiated Measure 27,,Yes,,0
+Butte,08,Initiated Measure 27,,No,,21
+Butte,11,Initiated Measure 27,,Yes,,22
+Butte,11,Initiated Measure 27,,No,,49
+Butte,12,Initiated Measure 27,,Yes,,17
+Butte,12,Initiated Measure 27,,No,,69
+Butte,13,Initiated Measure 27,,Yes,,41
+Butte,13,Initiated Measure 27,,No,,162
+Butte,14,Initiated Measure 27,,Yes,,57
+Butte,14,Initiated Measure 27,,No,,212
+Butte,16,Initiated Measure 27,,Yes,,223
+Butte,16,Initiated Measure 27,,No,,483
+Butte,17,Initiated Measure 27,,Yes,,111
+Butte,17,Initiated Measure 27,,No,,264
+Butte,18,Initiated Measure 27,,Yes,,52
+Butte,18,Initiated Measure 27,,No,,55
+Butte,20,Initiated Measure 27,,Yes,,72
+Butte,20,Initiated Measure 27,,No,,138
+Butte,21,Initiated Measure 27,,Yes,,107
+Butte,21,Initiated Measure 27,,No,,105
+Butte,22,Initiated Measure 27,,Yes,,94
+Butte,22,Initiated Measure 27,,No,,85
+Butte,23,Initiated Measure 27,,Yes,,95
+Butte,23,Initiated Measure 27,,No,,112
+Butte,24,Initiated Measure 27,,Yes,,137
+Butte,24,Initiated Measure 27,,No,,159
+Butte,25,Initiated Measure 27,,Yes,,134
+Butte,25,Initiated Measure 27,,No,,260
+Butte,26,Initiated Measure 27,,Yes,,104
+Butte,26,Initiated Measure 27,,No,,131
+Butte,27,Initiated Measure 27,,Yes,,79
+Butte,27,Initiated Measure 27,,No,,135
+Butte,28,Initiated Measure 27,,Yes,,149
+Butte,28,Initiated Measure 27,,No,,214

--- a/2022/counties/20221108__sd__general__campbell__precinct.csv
+++ b/2022/counties/20221108__sd__general__campbell__precinct.csv
@@ -1,0 +1,176 @@
+county,precinct,office,district,candidate,party,votes
+Campbell,1,U.S. Senate,,Brian L. Bengs,DEM,12
+Campbell,1,U.S. Senate,,Tamara J Lesnar,LIB,6
+Campbell,1,U.S. Senate,,John R. Thune,REP,99
+Campbell,2,U.S. Senate,,Brian L. Bengs,DEM,15
+Campbell,2,U.S. Senate,,Tamara J Lesnar,LIB,6
+Campbell,2,U.S. Senate,,John R. Thune,REP,125
+Campbell,3,U.S. Senate,,Brian L. Bengs,DEM,15
+Campbell,3,U.S. Senate,,Tamara J Lesnar,LIB,5
+Campbell,3,U.S. Senate,,John R. Thune,REP,104
+Campbell,4,U.S. Senate,,Brian L. Bengs,DEM,11
+Campbell,4,U.S. Senate,,Tamara J Lesnar,LIB,3
+Campbell,4,U.S. Senate,,John R. Thune,REP,120
+Campbell,5,U.S. Senate,,Brian L. Bengs,DEM,13
+Campbell,5,U.S. Senate,,Tamara J Lesnar,LIB,6
+Campbell,5,U.S. Senate,,John R. Thune,REP,123
+Campbell,1,U.S. House,1,Collin Duprel,LIB,9
+Campbell,1,U.S. House,1,Dusty Johnson,REP,105
+Campbell,2,U.S. House,1,Collin Duprel,LIB,15
+Campbell,2,U.S. House,1,Dusty Johnson,REP,128
+Campbell,3,U.S. House,1,Collin Duprel,LIB,12
+Campbell,3,U.S. House,1,Dusty Johnson,REP,109
+Campbell,4,U.S. House,1,Collin Duprel,LIB,9
+Campbell,4,U.S. House,1,Dusty Johnson,REP,120
+Campbell,5,U.S. House,1,Collin Duprel,LIB,19
+Campbell,5,U.S. House,1,Dusty Johnson,REP,121
+Campbell,1,Governor,,Jamie Smith and Jennifer Keintz,DEM,21
+Campbell,1,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Campbell,1,Governor,,Kristi Noem and Larry Rhoden,REP,93
+Campbell,2,Governor,,Jamie Smith and Jennifer Keintz,DEM,21
+Campbell,2,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Campbell,2,Governor,,Kristi Noem and Larry Rhoden,REP,122
+Campbell,3,Governor,,Jamie Smith and Jennifer Keintz,DEM,18
+Campbell,3,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Campbell,3,Governor,,Kristi Noem and Larry Rhoden,REP,106
+Campbell,4,Governor,,Jamie Smith and Jennifer Keintz,DEM,14
+Campbell,4,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Campbell,4,Governor,,Kristi Noem and Larry Rhoden,REP,116
+Campbell,5,Governor,,Jamie Smith and Jennifer Keintz,DEM,19
+Campbell,5,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Campbell,5,Governor,,Kristi Noem and Larry Rhoden,REP,124
+Campbell,1,Secretary of State,,Thomas A Cool,DEM,16
+Campbell,1,Secretary of State,,Monae Johnson,REP,96
+Campbell,2,Secretary of State,,Thomas A Cool,DEM,23
+Campbell,2,Secretary of State,,Monae Johnson,REP,116
+Campbell,3,Secretary of State,,Thomas A Cool,DEM,20
+Campbell,3,Secretary of State,,Monae Johnson,REP,96
+Campbell,4,Secretary of State,,Thomas A Cool,DEM,16
+Campbell,4,Secretary of State,,Monae Johnson,REP,114
+Campbell,5,Secretary of State,,Thomas A Cool,DEM,20
+Campbell,5,Secretary of State,,Monae Johnson,REP,120
+Campbell,1,Attorney General,,Marty J. Jackley,REP,97
+Campbell,2,Attorney General,,Marty J. Jackley,REP,128
+Campbell,3,Attorney General,,Marty J. Jackley,REP,103
+Campbell,4,Attorney General,,Marty J. Jackley,REP,120
+Campbell,5,Attorney General,,Marty J. Jackley,REP,128
+Campbell,1,State Auditor,,Stephanie Marty,DEM,14
+Campbell,1,State Auditor,,Rene Meyer,LIB,6
+Campbell,1,State Auditor,,Richard Sattgast,REP,89
+Campbell,2,State Auditor,,Stephanie Marty,DEM,22
+Campbell,2,State Auditor,,Rene Meyer,LIB,7
+Campbell,2,State Auditor,,Richard Sattgast,REP,112
+Campbell,3,State Auditor,,Stephanie Marty,DEM,20
+Campbell,3,State Auditor,,Rene Meyer,LIB,2
+Campbell,3,State Auditor,,Richard Sattgast,REP,97
+Campbell,4,State Auditor,,Stephanie Marty,DEM,11
+Campbell,4,State Auditor,,Rene Meyer,LIB,5
+Campbell,4,State Auditor,,Richard Sattgast,REP,112
+Campbell,5,State Auditor,,Stephanie Marty,DEM,17
+Campbell,5,State Auditor,,Rene Meyer,LIB,5
+Campbell,5,State Auditor,,Richard Sattgast,REP,119
+Campbell,1,State Treasurer,,John Cunningham,DEM,15
+Campbell,1,State Treasurer,,Josh Haeder,REP,96
+Campbell,2,State Treasurer,,John Cunningham,DEM,19
+Campbell,2,State Treasurer,,Josh Haeder,REP,121
+Campbell,3,State Treasurer,,John Cunningham,DEM,23
+Campbell,3,State Treasurer,,Josh Haeder,REP,95
+Campbell,4,State Treasurer,,John Cunningham,DEM,11
+Campbell,4,State Treasurer,,Josh Haeder,REP,115
+Campbell,5,State Treasurer,,John Cunningham,DEM,15
+Campbell,5,State Treasurer,,Josh Haeder,REP,126
+Campbell,1,Commissioner of School and Public Lands,,Timothy Azure,DEM,13
+Campbell,1,Commissioner of School and Public Lands,,Brock Greenfield,REP,98
+Campbell,2,Commissioner of School and Public Lands,,Timothy Azure,DEM,21
+Campbell,2,Commissioner of School and Public Lands,,Brock Greenfield,REP,118
+Campbell,3,Commissioner of School and Public Lands,,Timothy Azure,DEM,20
+Campbell,3,Commissioner of School and Public Lands,,Brock Greenfield,REP,96
+Campbell,4,Commissioner of School and Public Lands,,Timothy Azure,DEM,13
+Campbell,4,Commissioner of School and Public Lands,,Brock Greenfield,REP,111
+Campbell,5,Commissioner of School and Public Lands,,Timothy Azure,DEM,14
+Campbell,5,Commissioner of School and Public Lands,,Brock Greenfield,REP,126
+Campbell,1,Public Utilities Commissioner,,Jeffrey Barth,DEM,13
+Campbell,1,Public Utilities Commissioner,,Chris Nelson,REP,101
+Campbell,2,Public Utilities Commissioner,,Jeffrey Barth,DEM,18
+Campbell,2,Public Utilities Commissioner,,Chris Nelson,REP,123
+Campbell,3,Public Utilities Commissioner,,Jeffrey Barth,DEM,18
+Campbell,3,Public Utilities Commissioner,,Chris Nelson,REP,101
+Campbell,4,Public Utilities Commissioner,,Jeffrey Barth,DEM,8
+Campbell,4,Public Utilities Commissioner,,Chris Nelson,REP,118
+Campbell,5,Public Utilities Commissioner,,Jeffrey Barth,DEM,15
+Campbell,5,Public Utilities Commissioner,,Chris Nelson,REP,128
+Campbell,1,State Senate,23,Bryan J. Breitling,REP,95
+Campbell,2,State Senate,23,Bryan J. Breitling,REP,120
+Campbell,3,State Senate,23,Bryan J. Breitling,REP,101
+Campbell,4,State Senate,23,Bryan J. Breitling,REP,110
+Campbell,5,State Senate,23,Bryan J. Breitling,REP,123
+Campbell,1,State House,23,James D. Wangsness,REP,61
+Campbell,1,State House,23,Scott Moore,REP,85
+Campbell,2,State House,23,James D. Wangsness,REP,79
+Campbell,2,State House,23,Scott Moore,REP,115
+Campbell,3,State House,23,James D. Wangsness,REP,54
+Campbell,3,State House,23,Scott Moore,REP,92
+Campbell,4,State House,23,James D. Wangsness,REP,74
+Campbell,4,State House,23,Scott Moore,REP,92
+Campbell,5,State House,23,James D. Wangsness,REP,70
+Campbell,5,State House,23,Scott Moore,REP,114
+Campbell,1,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,66
+Campbell,2,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,82
+Campbell,3,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,66
+Campbell,4,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,71
+Campbell,5,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,72
+Campbell,1,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,68
+Campbell,2,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,77
+Campbell,3,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,59
+Campbell,4,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,60
+Campbell,5,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,70
+Campbell,1,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,61
+Campbell,2,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,79
+Campbell,3,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,58
+Campbell,4,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,58
+Campbell,5,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,71
+Campbell,1,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,63
+Campbell,2,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,81
+Campbell,3,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,61
+Campbell,4,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,63
+Campbell,5,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,70
+Campbell,1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,76
+Campbell,1,Supreme Court Retention,3,Patricia J. DeVaney - No,,16
+Campbell,2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,102
+Campbell,2,Supreme Court Retention,3,Patricia J. DeVaney - No,,22
+Campbell,3,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,76
+Campbell,3,Supreme Court Retention,3,Patricia J. DeVaney - No,,22
+Campbell,4,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,84
+Campbell,4,Supreme Court Retention,3,Patricia J. DeVaney - No,,25
+Campbell,5,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,89
+Campbell,5,Supreme Court Retention,3,Patricia J. DeVaney - No,,17
+Campbell,1,Supreme Court Retention,2,Mark E. Salter - Yes,,78
+Campbell,1,Supreme Court Retention,2,Mark E. Salter - No,,14
+Campbell,2,Supreme Court Retention,2,Mark E. Salter - Yes,,100
+Campbell,2,Supreme Court Retention,2,Mark E. Salter - No,,22
+Campbell,3,Supreme Court Retention,2,Mark E. Salter - Yes,,74
+Campbell,3,Supreme Court Retention,2,Mark E. Salter - No,,20
+Campbell,4,Supreme Court Retention,2,Mark E. Salter - Yes,,83
+Campbell,4,Supreme Court Retention,2,Mark E. Salter - No,,23
+Campbell,5,Supreme Court Retention,2,Mark E. Salter - Yes,,89
+Campbell,5,Supreme Court Retention,2,Mark E. Salter - No,,17
+Campbell,1,Constitutional Amendment D,,Yes,,54
+Campbell,1,Constitutional Amendment D,,No,,59
+Campbell,2,Constitutional Amendment D,,Yes,,78
+Campbell,2,Constitutional Amendment D,,No,,66
+Campbell,3,Constitutional Amendment D,,Yes,,43
+Campbell,3,Constitutional Amendment D,,No,,72
+Campbell,4,Constitutional Amendment D,,Yes,,50
+Campbell,4,Constitutional Amendment D,,No,,77
+Campbell,5,Constitutional Amendment D,,Yes,,54
+Campbell,5,Constitutional Amendment D,,No,,81
+Campbell,1,Initiated Measure 27,,Yes,,43
+Campbell,1,Initiated Measure 27,,No,,75
+Campbell,2,Initiated Measure 27,,Yes,,54
+Campbell,2,Initiated Measure 27,,No,,89
+Campbell,3,Initiated Measure 27,,Yes,,33
+Campbell,3,Initiated Measure 27,,No,,86
+Campbell,4,Initiated Measure 27,,Yes,,43
+Campbell,4,Initiated Measure 27,,No,,87
+Campbell,5,Initiated Measure 27,,Yes,,47
+Campbell,5,Initiated Measure 27,,No,,93

--- a/2022/counties/20221108__sd__general__charles_mix__precinct.csv
+++ b/2022/counties/20221108__sd__general__charles_mix__precinct.csv
@@ -1,0 +1,495 @@
+county,precinct,office,district,candidate,party,votes
+Charles Mix,01,U.S. Senate,,Brian L. Bengs,DEM,85
+Charles Mix,01,U.S. Senate,,Tamara J Lesnar,LIB,17
+Charles Mix,01,U.S. Senate,,John R. Thune,REP,299
+Charles Mix,02,U.S. Senate,,Brian L. Bengs,DEM,37
+Charles Mix,02,U.S. Senate,,Tamara J Lesnar,LIB,4
+Charles Mix,02,U.S. Senate,,John R. Thune,REP,126
+Charles Mix,03,U.S. Senate,,Brian L. Bengs,DEM,156
+Charles Mix,03,U.S. Senate,,Tamara J Lesnar,LIB,21
+Charles Mix,03,U.S. Senate,,John R. Thune,REP,226
+Charles Mix,04,U.S. Senate,,Brian L. Bengs,DEM,64
+Charles Mix,04,U.S. Senate,,Tamara J Lesnar,LIB,4
+Charles Mix,04,U.S. Senate,,John R. Thune,REP,80
+Charles Mix,05,U.S. Senate,,Brian L. Bengs,DEM,70
+Charles Mix,05,U.S. Senate,,Tamara J Lesnar,LIB,9
+Charles Mix,05,U.S. Senate,,John R. Thune,REP,227
+Charles Mix,06,U.S. Senate,,Brian L. Bengs,DEM,72
+Charles Mix,06,U.S. Senate,,Tamara J Lesnar,LIB,8
+Charles Mix,06,U.S. Senate,,John R. Thune,REP,87
+Charles Mix,07,U.S. Senate,,Brian L. Bengs,DEM,28
+Charles Mix,07,U.S. Senate,,Tamara J Lesnar,LIB,2
+Charles Mix,07,U.S. Senate,,John R. Thune,REP,89
+Charles Mix,08,U.S. Senate,,Brian L. Bengs,DEM,17
+Charles Mix,08,U.S. Senate,,Tamara J Lesnar,LIB,4
+Charles Mix,08,U.S. Senate,,John R. Thune,REP,142
+Charles Mix,09,U.S. Senate,,Brian L. Bengs,DEM,35
+Charles Mix,09,U.S. Senate,,Tamara J Lesnar,LIB,8
+Charles Mix,09,U.S. Senate,,John R. Thune,REP,312
+Charles Mix,10,U.S. Senate,,Brian L. Bengs,DEM,9
+Charles Mix,10,U.S. Senate,,Tamara J Lesnar,LIB,5
+Charles Mix,10,U.S. Senate,,John R. Thune,REP,120
+Charles Mix,11,U.S. Senate,,Brian L. Bengs,DEM,63
+Charles Mix,11,U.S. Senate,,Tamara J Lesnar,LIB,15
+Charles Mix,11,U.S. Senate,,John R. Thune,REP,515
+Charles Mix,12,U.S. Senate,,Brian L. Bengs,DEM,14
+Charles Mix,12,U.S. Senate,,Tamara J Lesnar,LIB,3
+Charles Mix,12,U.S. Senate,,John R. Thune,REP,57
+Charles Mix,13,U.S. Senate,,Brian L. Bengs,DEM,16
+Charles Mix,13,U.S. Senate,,Tamara J Lesnar,LIB,0
+Charles Mix,13,U.S. Senate,,John R. Thune,REP,43
+Charles Mix,01,U.S. House,1,Collin Duprel,LIB,68
+Charles Mix,01,U.S. House,1,Dusty Johnson,REP,303
+Charles Mix,02,U.S. House,1,Collin Duprel,LIB,41
+Charles Mix,02,U.S. House,1,Dusty Johnson,REP,118
+Charles Mix,03,U.S. House,1,Collin Duprel,LIB,124
+Charles Mix,03,U.S. House,1,Dusty Johnson,REP,258
+Charles Mix,04,U.S. House,1,Collin Duprel,LIB,48
+Charles Mix,04,U.S. House,1,Dusty Johnson,REP,89
+Charles Mix,05,U.S. House,1,Collin Duprel,LIB,53
+Charles Mix,05,U.S. House,1,Dusty Johnson,REP,242
+Charles Mix,06,U.S. House,1,Collin Duprel,LIB,63
+Charles Mix,06,U.S. House,1,Dusty Johnson,REP,93
+Charles Mix,07,U.S. House,1,Collin Duprel,LIB,20
+Charles Mix,07,U.S. House,1,Dusty Johnson,REP,98
+Charles Mix,08,U.S. House,1,Collin Duprel,LIB,16
+Charles Mix,08,U.S. House,1,Dusty Johnson,REP,143
+Charles Mix,09,U.S. House,1,Collin Duprel,LIB,29
+Charles Mix,09,U.S. House,1,Dusty Johnson,REP,312
+Charles Mix,10,U.S. House,1,Collin Duprel,LIB,10
+Charles Mix,10,U.S. House,1,Dusty Johnson,REP,125
+Charles Mix,11,U.S. House,1,Collin Duprel,LIB,73
+Charles Mix,11,U.S. House,1,Dusty Johnson,REP,510
+Charles Mix,12,U.S. House,1,Collin Duprel,LIB,14
+Charles Mix,12,U.S. House,1,Dusty Johnson,REP,57
+Charles Mix,13,U.S. House,1,Collin Duprel,LIB,13
+Charles Mix,13,U.S. House,1,Dusty Johnson,REP,43
+Charles Mix,01,Governor,,Jamie Smith and Jennifer Keintz,DEM,99
+Charles Mix,01,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Charles Mix,01,Governor,,Kristi Noem and Larry Rhoden,REP,302
+Charles Mix,02,Governor,,Jamie Smith and Jennifer Keintz,DEM,42
+Charles Mix,02,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Charles Mix,02,Governor,,Kristi Noem and Larry Rhoden,REP,117
+Charles Mix,03,Governor,,Jamie Smith and Jennifer Keintz,DEM,190
+Charles Mix,03,Governor,,Tracey Quint and Ashley Strand,LIB,12
+Charles Mix,03,Governor,,Kristi Noem and Larry Rhoden,REP,197
+Charles Mix,04,Governor,,Jamie Smith and Jennifer Keintz,DEM,77
+Charles Mix,04,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Charles Mix,04,Governor,,Kristi Noem and Larry Rhoden,REP,72
+Charles Mix,05,Governor,,Jamie Smith and Jennifer Keintz,DEM,89
+Charles Mix,05,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Charles Mix,05,Governor,,Kristi Noem and Larry Rhoden,REP,219
+Charles Mix,06,Governor,,Jamie Smith and Jennifer Keintz,DEM,92
+Charles Mix,06,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Charles Mix,06,Governor,,Kristi Noem and Larry Rhoden,REP,70
+Charles Mix,07,Governor,,Jamie Smith and Jennifer Keintz,DEM,39
+Charles Mix,07,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Charles Mix,07,Governor,,Kristi Noem and Larry Rhoden,REP,77
+Charles Mix,08,Governor,,Jamie Smith and Jennifer Keintz,DEM,27
+Charles Mix,08,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Charles Mix,08,Governor,,Kristi Noem and Larry Rhoden,REP,133
+Charles Mix,09,Governor,,Jamie Smith and Jennifer Keintz,DEM,50
+Charles Mix,09,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Charles Mix,09,Governor,,Kristi Noem and Larry Rhoden,REP,301
+Charles Mix,10,Governor,,Jamie Smith and Jennifer Keintz,DEM,12
+Charles Mix,10,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Charles Mix,10,Governor,,Kristi Noem and Larry Rhoden,REP,123
+Charles Mix,11,Governor,,Jamie Smith and Jennifer Keintz,DEM,99
+Charles Mix,11,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Charles Mix,11,Governor,,Kristi Noem and Larry Rhoden,REP,481
+Charles Mix,12,Governor,,Jamie Smith and Jennifer Keintz,DEM,16
+Charles Mix,12,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Charles Mix,12,Governor,,Kristi Noem and Larry Rhoden,REP,54
+Charles Mix,13,Governor,,Jamie Smith and Jennifer Keintz,DEM,17
+Charles Mix,13,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Charles Mix,13,Governor,,Kristi Noem and Larry Rhoden,REP,41
+Charles Mix,01,Secretary of State,,Thomas A Cool,DEM,120
+Charles Mix,01,Secretary of State,,Monae Johnson,REP,256
+Charles Mix,02,Secretary of State,,Thomas A Cool,DEM,61
+Charles Mix,02,Secretary of State,,Monae Johnson,REP,106
+Charles Mix,03,Secretary of State,,Thomas A Cool,DEM,205
+Charles Mix,03,Secretary of State,,Monae Johnson,REP,180
+Charles Mix,04,Secretary of State,,Thomas A Cool,DEM,87
+Charles Mix,04,Secretary of State,,Monae Johnson,REP,58
+Charles Mix,05,Secretary of State,,Thomas A Cool,DEM,99
+Charles Mix,05,Secretary of State,,Monae Johnson,REP,198
+Charles Mix,06,Secretary of State,,Thomas A Cool,DEM,97
+Charles Mix,06,Secretary of State,,Monae Johnson,REP,66
+Charles Mix,07,Secretary of State,,Thomas A Cool,DEM,38
+Charles Mix,07,Secretary of State,,Monae Johnson,REP,80
+Charles Mix,08,Secretary of State,,Thomas A Cool,DEM,48
+Charles Mix,08,Secretary of State,,Monae Johnson,REP,105
+Charles Mix,09,Secretary of State,,Thomas A Cool,DEM,80
+Charles Mix,09,Secretary of State,,Monae Johnson,REP,263
+Charles Mix,10,Secretary of State,,Thomas A Cool,DEM,21
+Charles Mix,10,Secretary of State,,Monae Johnson,REP,115
+Charles Mix,11,Secretary of State,,Thomas A Cool,DEM,157
+Charles Mix,11,Secretary of State,,Monae Johnson,REP,415
+Charles Mix,12,Secretary of State,,Thomas A Cool,DEM,30
+Charles Mix,12,Secretary of State,,Monae Johnson,REP,40
+Charles Mix,13,Secretary of State,,Thomas A Cool,DEM,20
+Charles Mix,13,Secretary of State,,Monae Johnson,REP,37
+Charles Mix,01,Attorney General,,Marty J. Jackley,REP,303
+Charles Mix,02,Attorney General,,Marty J. Jackley,REP,124
+Charles Mix,03,Attorney General,,Marty J. Jackley,REP,257
+Charles Mix,04,Attorney General,,Marty J. Jackley,REP,84
+Charles Mix,05,Attorney General,,Marty J. Jackley,REP,231
+Charles Mix,06,Attorney General,,Marty J. Jackley,REP,102
+Charles Mix,07,Attorney General,,Marty J. Jackley,REP,99
+Charles Mix,08,Attorney General,,Marty J. Jackley,REP,120
+Charles Mix,09,Attorney General,,Marty J. Jackley,REP,271
+Charles Mix,10,Attorney General,,Marty J. Jackley,REP,112
+Charles Mix,11,Attorney General,,Marty J. Jackley,REP,437
+Charles Mix,12,Attorney General,,Marty J. Jackley,REP,57
+Charles Mix,13,Attorney General,,Marty J. Jackley,REP,42
+Charles Mix,01,State Auditor,,Stephanie Marty,DEM,99
+Charles Mix,01,State Auditor,,Rene Meyer,LIB,19
+Charles Mix,01,State Auditor,,Richard Sattgast,REP,257
+Charles Mix,02,State Auditor,,Stephanie Marty,DEM,59
+Charles Mix,02,State Auditor,,Rene Meyer,LIB,4
+Charles Mix,02,State Auditor,,Richard Sattgast,REP,100
+Charles Mix,03,State Auditor,,Stephanie Marty,DEM,188
+Charles Mix,03,State Auditor,,Rene Meyer,LIB,22
+Charles Mix,03,State Auditor,,Richard Sattgast,REP,178
+Charles Mix,04,State Auditor,,Stephanie Marty,DEM,80
+Charles Mix,04,State Auditor,,Rene Meyer,LIB,4
+Charles Mix,04,State Auditor,,Richard Sattgast,REP,56
+Charles Mix,05,State Auditor,,Stephanie Marty,DEM,90
+Charles Mix,05,State Auditor,,Rene Meyer,LIB,6
+Charles Mix,05,State Auditor,,Richard Sattgast,REP,198
+Charles Mix,06,State Auditor,,Stephanie Marty,DEM,85
+Charles Mix,06,State Auditor,,Rene Meyer,LIB,9
+Charles Mix,06,State Auditor,,Richard Sattgast,REP,68
+Charles Mix,07,State Auditor,,Stephanie Marty,DEM,31
+Charles Mix,07,State Auditor,,Rene Meyer,LIB,6
+Charles Mix,07,State Auditor,,Richard Sattgast,REP,81
+Charles Mix,08,State Auditor,,Stephanie Marty,DEM,28
+Charles Mix,08,State Auditor,,Rene Meyer,LIB,8
+Charles Mix,08,State Auditor,,Richard Sattgast,REP,111
+Charles Mix,09,State Auditor,,Stephanie Marty,DEM,49
+Charles Mix,09,State Auditor,,Rene Meyer,LIB,8
+Charles Mix,09,State Auditor,,Richard Sattgast,REP,286
+Charles Mix,10,State Auditor,,Stephanie Marty,DEM,9
+Charles Mix,10,State Auditor,,Rene Meyer,LIB,2
+Charles Mix,10,State Auditor,,Richard Sattgast,REP,118
+Charles Mix,11,State Auditor,,Stephanie Marty,DEM,102
+Charles Mix,11,State Auditor,,Rene Meyer,LIB,18
+Charles Mix,11,State Auditor,,Richard Sattgast,REP,425
+Charles Mix,12,State Auditor,,Stephanie Marty,DEM,16
+Charles Mix,12,State Auditor,,Rene Meyer,LIB,5
+Charles Mix,12,State Auditor,,Richard Sattgast,REP,48
+Charles Mix,13,State Auditor,,Stephanie Marty,DEM,20
+Charles Mix,13,State Auditor,,Rene Meyer,LIB,1
+Charles Mix,13,State Auditor,,Richard Sattgast,REP,37
+Charles Mix,01,State Treasurer,,John Cunningham,DEM,111
+Charles Mix,01,State Treasurer,,Josh Haeder,REP,260
+Charles Mix,02,State Treasurer,,John Cunningham,DEM,60
+Charles Mix,02,State Treasurer,,Josh Haeder,REP,104
+Charles Mix,03,State Treasurer,,John Cunningham,DEM,193
+Charles Mix,03,State Treasurer,,Josh Haeder,REP,186
+Charles Mix,04,State Treasurer,,John Cunningham,DEM,81
+Charles Mix,04,State Treasurer,,Josh Haeder,REP,59
+Charles Mix,05,State Treasurer,,John Cunningham,DEM,94
+Charles Mix,05,State Treasurer,,Josh Haeder,REP,195
+Charles Mix,06,State Treasurer,,John Cunningham,DEM,91
+Charles Mix,06,State Treasurer,,Josh Haeder,REP,68
+Charles Mix,07,State Treasurer,,John Cunningham,DEM,37
+Charles Mix,07,State Treasurer,,Josh Haeder,REP,79
+Charles Mix,08,State Treasurer,,John Cunningham,DEM,30
+Charles Mix,08,State Treasurer,,Josh Haeder,REP,115
+Charles Mix,09,State Treasurer,,John Cunningham,DEM,49
+Charles Mix,09,State Treasurer,,Josh Haeder,REP,291
+Charles Mix,10,State Treasurer,,John Cunningham,DEM,10
+Charles Mix,10,State Treasurer,,Josh Haeder,REP,120
+Charles Mix,11,State Treasurer,,John Cunningham,DEM,93
+Charles Mix,11,State Treasurer,,Josh Haeder,REP,450
+Charles Mix,12,State Treasurer,,John Cunningham,DEM,19
+Charles Mix,12,State Treasurer,,Josh Haeder,REP,47
+Charles Mix,13,State Treasurer,,John Cunningham,DEM,18
+Charles Mix,13,State Treasurer,,Josh Haeder,REP,40
+Charles Mix,01,Commissioner of School and Public Lands,,Timothy Azure,DEM,102
+Charles Mix,01,Commissioner of School and Public Lands,,Brock Greenfield,REP,261
+Charles Mix,02,Commissioner of School and Public Lands,,Timothy Azure,DEM,55
+Charles Mix,02,Commissioner of School and Public Lands,,Brock Greenfield,REP,105
+Charles Mix,03,Commissioner of School and Public Lands,,Timothy Azure,DEM,188
+Charles Mix,03,Commissioner of School and Public Lands,,Brock Greenfield,REP,185
+Charles Mix,04,Commissioner of School and Public Lands,,Timothy Azure,DEM,76
+Charles Mix,04,Commissioner of School and Public Lands,,Brock Greenfield,REP,65
+Charles Mix,05,Commissioner of School and Public Lands,,Timothy Azure,DEM,94
+Charles Mix,05,Commissioner of School and Public Lands,,Brock Greenfield,REP,200
+Charles Mix,06,Commissioner of School and Public Lands,,Timothy Azure,DEM,90
+Charles Mix,06,Commissioner of School and Public Lands,,Brock Greenfield,REP,69
+Charles Mix,07,Commissioner of School and Public Lands,,Timothy Azure,DEM,35
+Charles Mix,07,Commissioner of School and Public Lands,,Brock Greenfield,REP,80
+Charles Mix,08,Commissioner of School and Public Lands,,Timothy Azure,DEM,32
+Charles Mix,08,Commissioner of School and Public Lands,,Brock Greenfield,REP,110
+Charles Mix,09,Commissioner of School and Public Lands,,Timothy Azure,DEM,46
+Charles Mix,09,Commissioner of School and Public Lands,,Brock Greenfield,REP,288
+Charles Mix,10,Commissioner of School and Public Lands,,Timothy Azure,DEM,10
+Charles Mix,10,Commissioner of School and Public Lands,,Brock Greenfield,REP,116
+Charles Mix,11,Commissioner of School and Public Lands,,Timothy Azure,DEM,94
+Charles Mix,11,Commissioner of School and Public Lands,,Brock Greenfield,REP,430
+Charles Mix,12,Commissioner of School and Public Lands,,Timothy Azure,DEM,17
+Charles Mix,12,Commissioner of School and Public Lands,,Brock Greenfield,REP,47
+Charles Mix,13,Commissioner of School and Public Lands,,Timothy Azure,DEM,19
+Charles Mix,13,Commissioner of School and Public Lands,,Brock Greenfield,REP,37
+Charles Mix,01,Public Utilities Commissioner,,Jeffrey Barth,DEM,105
+Charles Mix,01,Public Utilities Commissioner,,Chris Nelson,REP,272
+Charles Mix,02,Public Utilities Commissioner,,Jeffrey Barth,DEM,50
+Charles Mix,02,Public Utilities Commissioner,,Chris Nelson,REP,114
+Charles Mix,03,Public Utilities Commissioner,,Jeffrey Barth,DEM,179
+Charles Mix,03,Public Utilities Commissioner,,Chris Nelson,REP,202
+Charles Mix,04,Public Utilities Commissioner,,Jeffrey Barth,DEM,73
+Charles Mix,04,Public Utilities Commissioner,,Chris Nelson,REP,69
+Charles Mix,05,Public Utilities Commissioner,,Jeffrey Barth,DEM,80
+Charles Mix,05,Public Utilities Commissioner,,Chris Nelson,REP,222
+Charles Mix,06,Public Utilities Commissioner,,Jeffrey Barth,DEM,88
+Charles Mix,06,Public Utilities Commissioner,,Chris Nelson,REP,77
+Charles Mix,07,Public Utilities Commissioner,,Jeffrey Barth,DEM,28
+Charles Mix,07,Public Utilities Commissioner,,Chris Nelson,REP,88
+Charles Mix,08,Public Utilities Commissioner,,Jeffrey Barth,DEM,25
+Charles Mix,08,Public Utilities Commissioner,,Chris Nelson,REP,131
+Charles Mix,09,Public Utilities Commissioner,,Jeffrey Barth,DEM,40
+Charles Mix,09,Public Utilities Commissioner,,Chris Nelson,REP,310
+Charles Mix,10,Public Utilities Commissioner,,Jeffrey Barth,DEM,9
+Charles Mix,10,Public Utilities Commissioner,,Chris Nelson,REP,128
+Charles Mix,11,Public Utilities Commissioner,,Jeffrey Barth,DEM,74
+Charles Mix,11,Public Utilities Commissioner,,Chris Nelson,REP,495
+Charles Mix,12,Public Utilities Commissioner,,Jeffrey Barth,DEM,17
+Charles Mix,12,Public Utilities Commissioner,,Chris Nelson,REP,54
+Charles Mix,13,Public Utilities Commissioner,,Jeffrey Barth,DEM,15
+Charles Mix,13,Public Utilities Commissioner,,Chris Nelson,REP,43
+Charles Mix,01,State Senate,21,Dan Andersson,DEM,105
+Charles Mix,01,State Senate,21,Erin Tobin,REP,275
+Charles Mix,02,State Senate,21,Dan Andersson,DEM,56
+Charles Mix,02,State Senate,21,Erin Tobin,REP,109
+Charles Mix,03,State Senate,21,Dan Andersson,DEM,185
+Charles Mix,03,State Senate,21,Erin Tobin,REP,202
+Charles Mix,04,State Senate,21,Dan Andersson,DEM,75
+Charles Mix,04,State Senate,21,Erin Tobin,REP,66
+Charles Mix,05,State Senate,21,Dan Andersson,DEM,80
+Charles Mix,05,State Senate,21,Erin Tobin,REP,221
+Charles Mix,06,State Senate,21,Dan Andersson,DEM,82
+Charles Mix,06,State Senate,21,Erin Tobin,REP,80
+Charles Mix,07,State Senate,21,Dan Andersson,DEM,32
+Charles Mix,07,State Senate,21,Erin Tobin,REP,87
+Charles Mix,08,State Senate,21,Dan Andersson,DEM,19
+Charles Mix,08,State Senate,21,Erin Tobin,REP,139
+Charles Mix,09,State Senate,21,Dan Andersson,DEM,37
+Charles Mix,09,State Senate,21,Erin Tobin,REP,310
+Charles Mix,10,State Senate,21,Dan Andersson,DEM,8
+Charles Mix,10,State Senate,21,Erin Tobin,REP,128
+Charles Mix,11,State Senate,21,Dan Andersson,DEM,76
+Charles Mix,11,State Senate,21,Erin Tobin,REP,493
+Charles Mix,12,State Senate,21,Dan Andersson,DEM,15
+Charles Mix,12,State Senate,21,Erin Tobin,REP,57
+Charles Mix,13,State Senate,21,Dan Andersson,DEM,20
+Charles Mix,13,State Senate,21,Erin Tobin,REP,38
+Charles Mix,01,State House,21,Rocky Blare,REP,169
+Charles Mix,01,State House,21,Marty Overweg,REP,248
+Charles Mix,02,State House,21,Rocky Blare,REP,68
+Charles Mix,02,State House,21,Marty Overweg,REP,107
+Charles Mix,03,State House,21,Rocky Blare,REP,150
+Charles Mix,03,State House,21,Marty Overweg,REP,193
+Charles Mix,04,State House,21,Rocky Blare,REP,45
+Charles Mix,04,State House,21,Marty Overweg,REP,74
+Charles Mix,05,State House,21,Rocky Blare,REP,111
+Charles Mix,05,State House,21,Marty Overweg,REP,211
+Charles Mix,06,State House,21,Rocky Blare,REP,61
+Charles Mix,06,State House,21,Marty Overweg,REP,84
+Charles Mix,07,State House,21,Rocky Blare,REP,58
+Charles Mix,07,State House,21,Marty Overweg,REP,78
+Charles Mix,08,State House,21,Rocky Blare,REP,72
+Charles Mix,08,State House,21,Marty Overweg,REP,134
+Charles Mix,09,State House,21,Rocky Blare,REP,166
+Charles Mix,09,State House,21,Marty Overweg,REP,303
+Charles Mix,10,State House,21,Rocky Blare,REP,58
+Charles Mix,10,State House,21,Marty Overweg,REP,117
+Charles Mix,11,State House,21,Rocky Blare,REP,298
+Charles Mix,11,State House,21,Marty Overweg,REP,489
+Charles Mix,12,State House,21,Rocky Blare,REP,34
+Charles Mix,12,State House,21,Marty Overweg,REP,57
+Charles Mix,13,State House,21,Rocky Blare,REP,24
+Charles Mix,13,State House,21,Marty Overweg,REP,35
+Charles Mix,01,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,180
+Charles Mix,02,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,74
+Charles Mix,03,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,154
+Charles Mix,04,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,55
+Charles Mix,05,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,138
+Charles Mix,06,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,68
+Charles Mix,07,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,61
+Charles Mix,08,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,80
+Charles Mix,09,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,160
+Charles Mix,10,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,41
+Charles Mix,11,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,209
+Charles Mix,12,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,33
+Charles Mix,13,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,26
+Charles Mix,01,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,173
+Charles Mix,02,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,75
+Charles Mix,03,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,155
+Charles Mix,04,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,54
+Charles Mix,05,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,137
+Charles Mix,06,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,66
+Charles Mix,07,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,60
+Charles Mix,08,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,78
+Charles Mix,09,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,157
+Charles Mix,10,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,40
+Charles Mix,11,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,202
+Charles Mix,12,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,35
+Charles Mix,13,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,25
+Charles Mix,01,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,259
+Charles Mix,02,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,107
+Charles Mix,03,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,269
+Charles Mix,04,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,77
+Charles Mix,05,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,178
+Charles Mix,06,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,86
+Charles Mix,07,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,77
+Charles Mix,08,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,102
+Charles Mix,09,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,211
+Charles Mix,10,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,60
+Charles Mix,11,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,306
+Charles Mix,12,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,45
+Charles Mix,13,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,39
+Charles Mix,01,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,179
+Charles Mix,02,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,68
+Charles Mix,03,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,158
+Charles Mix,04,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,57
+Charles Mix,05,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,134
+Charles Mix,06,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,64
+Charles Mix,07,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,59
+Charles Mix,08,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,78
+Charles Mix,09,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,156
+Charles Mix,10,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,39
+Charles Mix,11,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,198
+Charles Mix,12,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,32
+Charles Mix,13,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,27
+Charles Mix,01,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,173
+Charles Mix,02,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,71
+Charles Mix,03,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,153
+Charles Mix,04,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,53
+Charles Mix,05,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,130
+Charles Mix,06,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,66
+Charles Mix,07,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,61
+Charles Mix,08,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,80
+Charles Mix,09,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,153
+Charles Mix,10,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,41
+Charles Mix,11,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,205
+Charles Mix,12,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,32
+Charles Mix,13,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,27
+Charles Mix,01,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,175
+Charles Mix,02,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,69
+Charles Mix,03,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,158
+Charles Mix,04,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,60
+Charles Mix,05,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,140
+Charles Mix,06,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,63
+Charles Mix,07,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,59
+Charles Mix,08,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,77
+Charles Mix,09,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,152
+Charles Mix,10,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,39
+Charles Mix,11,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,197
+Charles Mix,12,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,33
+Charles Mix,13,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,24
+Charles Mix,01,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,263
+Charles Mix,01,Supreme Court Retention,3,Patricia J. DeVaney - No,,69
+Charles Mix,02,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,113
+Charles Mix,02,Supreme Court Retention,3,Patricia J. DeVaney - No,,32
+Charles Mix,03,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,244
+Charles Mix,03,Supreme Court Retention,3,Patricia J. DeVaney - No,,98
+Charles Mix,04,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,89
+Charles Mix,04,Supreme Court Retention,3,Patricia J. DeVaney - No,,39
+Charles Mix,05,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,221
+Charles Mix,05,Supreme Court Retention,3,Patricia J. DeVaney - No,,50
+Charles Mix,06,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,99
+Charles Mix,06,Supreme Court Retention,3,Patricia J. DeVaney - No,,46
+Charles Mix,07,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,84
+Charles Mix,07,Supreme Court Retention,3,Patricia J. DeVaney - No,,22
+Charles Mix,08,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,118
+Charles Mix,08,Supreme Court Retention,3,Patricia J. DeVaney - No,,20
+Charles Mix,09,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,259
+Charles Mix,09,Supreme Court Retention,3,Patricia J. DeVaney - No,,47
+Charles Mix,10,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,105
+Charles Mix,10,Supreme Court Retention,3,Patricia J. DeVaney - No,,14
+Charles Mix,11,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,400
+Charles Mix,11,Supreme Court Retention,3,Patricia J. DeVaney - No,,78
+Charles Mix,12,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,55
+Charles Mix,12,Supreme Court Retention,3,Patricia J. DeVaney - No,,11
+Charles Mix,13,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,48
+Charles Mix,13,Supreme Court Retention,3,Patricia J. DeVaney - No,,9
+Charles Mix,01,Supreme Court Retention,2,Mark E. Salter - Yes,,270
+Charles Mix,01,Supreme Court Retention,2,Mark E. Salter - No,,65
+Charles Mix,02,Supreme Court Retention,2,Mark E. Salter - Yes,,110
+Charles Mix,02,Supreme Court Retention,2,Mark E. Salter - No,,34
+Charles Mix,03,Supreme Court Retention,2,Mark E. Salter - Yes,,233
+Charles Mix,03,Supreme Court Retention,2,Mark E. Salter - No,,108
+Charles Mix,04,Supreme Court Retention,2,Mark E. Salter - Yes,,81
+Charles Mix,04,Supreme Court Retention,2,Mark E. Salter - No,,41
+Charles Mix,05,Supreme Court Retention,2,Mark E. Salter - Yes,,217
+Charles Mix,05,Supreme Court Retention,2,Mark E. Salter - No,,51
+Charles Mix,06,Supreme Court Retention,2,Mark E. Salter - Yes,,100
+Charles Mix,06,Supreme Court Retention,2,Mark E. Salter - No,,44
+Charles Mix,07,Supreme Court Retention,2,Mark E. Salter - Yes,,78
+Charles Mix,07,Supreme Court Retention,2,Mark E. Salter - No,,26
+Charles Mix,08,Supreme Court Retention,2,Mark E. Salter - Yes,,123
+Charles Mix,08,Supreme Court Retention,2,Mark E. Salter - No,,14
+Charles Mix,09,Supreme Court Retention,2,Mark E. Salter - Yes,,261
+Charles Mix,09,Supreme Court Retention,2,Mark E. Salter - No,,45
+Charles Mix,10,Supreme Court Retention,2,Mark E. Salter - Yes,,107
+Charles Mix,10,Supreme Court Retention,2,Mark E. Salter - No,,12
+Charles Mix,11,Supreme Court Retention,2,Mark E. Salter - Yes,,408
+Charles Mix,11,Supreme Court Retention,2,Mark E. Salter - No,,71
+Charles Mix,12,Supreme Court Retention,2,Mark E. Salter - Yes,,55
+Charles Mix,12,Supreme Court Retention,2,Mark E. Salter - No,,11
+Charles Mix,13,Supreme Court Retention,2,Mark E. Salter - Yes,,47
+Charles Mix,13,Supreme Court Retention,2,Mark E. Salter - No,,9
+Charles Mix,01,Constitutional Amendment D,,Yes,,156
+Charles Mix,01,Constitutional Amendment D,,No,,223
+Charles Mix,02,Constitutional Amendment D,,Yes,,67
+Charles Mix,02,Constitutional Amendment D,,No,,94
+Charles Mix,03,Constitutional Amendment D,,Yes,,262
+Charles Mix,03,Constitutional Amendment D,,No,,124
+Charles Mix,04,Constitutional Amendment D,,Yes,,97
+Charles Mix,04,Constitutional Amendment D,,No,,50
+Charles Mix,05,Constitutional Amendment D,,Yes,,154
+Charles Mix,05,Constitutional Amendment D,,No,,148
+Charles Mix,06,Constitutional Amendment D,,Yes,,112
+Charles Mix,06,Constitutional Amendment D,,No,,51
+Charles Mix,07,Constitutional Amendment D,,Yes,,55
+Charles Mix,07,Constitutional Amendment D,,No,,63
+Charles Mix,08,Constitutional Amendment D,,Yes,,61
+Charles Mix,08,Constitutional Amendment D,,No,,94
+Charles Mix,09,Constitutional Amendment D,,Yes,,124
+Charles Mix,09,Constitutional Amendment D,,No,,217
+Charles Mix,10,Constitutional Amendment D,,Yes,,63
+Charles Mix,10,Constitutional Amendment D,,No,,68
+Charles Mix,11,Constitutional Amendment D,,Yes,,228
+Charles Mix,11,Constitutional Amendment D,,No,,324
+Charles Mix,12,Constitutional Amendment D,,Yes,,37
+Charles Mix,12,Constitutional Amendment D,,No,,37
+Charles Mix,13,Constitutional Amendment D,,Yes,,30
+Charles Mix,13,Constitutional Amendment D,,No,,29
+Charles Mix,01,Initiated Measure 27,,Yes,,98
+Charles Mix,01,Initiated Measure 27,,No,,282
+Charles Mix,02,Initiated Measure 27,,Yes,,36
+Charles Mix,02,Initiated Measure 27,,No,,129
+Charles Mix,03,Initiated Measure 27,,Yes,,191
+Charles Mix,03,Initiated Measure 27,,No,,205
+Charles Mix,04,Initiated Measure 27,,Yes,,74
+Charles Mix,04,Initiated Measure 27,,No,,77
+Charles Mix,05,Initiated Measure 27,,Yes,,125
+Charles Mix,05,Initiated Measure 27,,No,,179
+Charles Mix,06,Initiated Measure 27,,Yes,,109
+Charles Mix,06,Initiated Measure 27,,No,,56
+Charles Mix,07,Initiated Measure 27,,Yes,,39
+Charles Mix,07,Initiated Measure 27,,No,,79
+Charles Mix,08,Initiated Measure 27,,Yes,,39
+Charles Mix,08,Initiated Measure 27,,No,,120
+Charles Mix,09,Initiated Measure 27,,Yes,,70
+Charles Mix,09,Initiated Measure 27,,No,,275
+Charles Mix,10,Initiated Measure 27,,Yes,,32
+Charles Mix,10,Initiated Measure 27,,No,,98
+Charles Mix,11,Initiated Measure 27,,Yes,,154
+Charles Mix,11,Initiated Measure 27,,No,,410
+Charles Mix,12,Initiated Measure 27,,Yes,,32
+Charles Mix,12,Initiated Measure 27,,No,,42
+Charles Mix,13,Initiated Measure 27,,Yes,,25
+Charles Mix,13,Initiated Measure 27,,No,,34

--- a/2022/counties/20221108__sd__general__clark__precinct.csv
+++ b/2022/counties/20221108__sd__general__clark__precinct.csv
@@ -1,0 +1,469 @@
+county,precinct,office,district,candidate,party,votes
+Clark,01,U.S. Senate,,Brian L. Bengs,DEM,19
+Clark,01,U.S. Senate,,Tamara J Lesnar,LIB,8
+Clark,01,U.S. Senate,,John R. Thune,REP,108
+Clark,02,U.S. Senate,,Brian L. Bengs,DEM,16
+Clark,02,U.S. Senate,,Tamara J Lesnar,LIB,4
+Clark,02,U.S. Senate,,John R. Thune,REP,76
+Clark,03,U.S. Senate,,Brian L. Bengs,DEM,11
+Clark,03,U.S. Senate,,Tamara J Lesnar,LIB,2
+Clark,03,U.S. Senate,,John R. Thune,REP,77
+Clark,04,U.S. Senate,,Brian L. Bengs,DEM,12
+Clark,04,U.S. Senate,,Tamara J Lesnar,LIB,5
+Clark,04,U.S. Senate,,John R. Thune,REP,73
+Clark,06,U.S. Senate,,Brian L. Bengs,DEM,20
+Clark,06,U.S. Senate,,Tamara J Lesnar,LIB,4
+Clark,06,U.S. Senate,,John R. Thune,REP,146
+Clark,07,U.S. Senate,,Brian L. Bengs,DEM,12
+Clark,07,U.S. Senate,,Tamara J Lesnar,LIB,2
+Clark,07,U.S. Senate,,John R. Thune,REP,155
+Clark,08,U.S. Senate,,Brian L. Bengs,DEM,18
+Clark,08,U.S. Senate,,Tamara J Lesnar,LIB,5
+Clark,08,U.S. Senate,,John R. Thune,REP,141
+Clark,09,U.S. Senate,,Brian L. Bengs,DEM,18
+Clark,09,U.S. Senate,,Tamara J Lesnar,LIB,5
+Clark,09,U.S. Senate,,John R. Thune,REP,111
+Clark,10,U.S. Senate,,Brian L. Bengs,DEM,18
+Clark,10,U.S. Senate,,Tamara J Lesnar,LIB,1
+Clark,10,U.S. Senate,,John R. Thune,REP,71
+Clark,11,U.S. Senate,,Brian L. Bengs,DEM,26
+Clark,11,U.S. Senate,,Tamara J Lesnar,LIB,5
+Clark,11,U.S. Senate,,John R. Thune,REP,117
+Clark,12,U.S. Senate,,Brian L. Bengs,DEM,34
+Clark,12,U.S. Senate,,Tamara J Lesnar,LIB,9
+Clark,12,U.S. Senate,,John R. Thune,REP,111
+Clark,13,U.S. Senate,,Brian L. Bengs,DEM,26
+Clark,13,U.S. Senate,,Tamara J Lesnar,LIB,6
+Clark,13,U.S. Senate,,John R. Thune,REP,121
+Clark,01,U.S. House,1,Collin Duprel,LIB,19
+Clark,01,U.S. House,1,Dusty Johnson,REP,112
+Clark,02,U.S. House,1,Collin Duprel,LIB,13
+Clark,02,U.S. House,1,Dusty Johnson,REP,80
+Clark,03,U.S. House,1,Collin Duprel,LIB,10
+Clark,03,U.S. House,1,Dusty Johnson,REP,77
+Clark,04,U.S. House,1,Collin Duprel,LIB,15
+Clark,04,U.S. House,1,Dusty Johnson,REP,75
+Clark,06,U.S. House,1,Collin Duprel,LIB,16
+Clark,06,U.S. House,1,Dusty Johnson,REP,151
+Clark,07,U.S. House,1,Collin Duprel,LIB,11
+Clark,07,U.S. House,1,Dusty Johnson,REP,153
+Clark,08,U.S. House,1,Collin Duprel,LIB,18
+Clark,08,U.S. House,1,Dusty Johnson,REP,141
+Clark,09,U.S. House,1,Collin Duprel,LIB,14
+Clark,09,U.S. House,1,Dusty Johnson,REP,116
+Clark,10,U.S. House,1,Collin Duprel,LIB,14
+Clark,10,U.S. House,1,Dusty Johnson,REP,72
+Clark,11,U.S. House,1,Collin Duprel,LIB,19
+Clark,11,U.S. House,1,Dusty Johnson,REP,116
+Clark,12,U.S. House,1,Collin Duprel,LIB,38
+Clark,12,U.S. House,1,Dusty Johnson,REP,106
+Clark,13,U.S. House,1,Collin Duprel,LIB,26
+Clark,13,U.S. House,1,Dusty Johnson,REP,121
+Clark,01,Governor,,Jamie Smith and Jennifer Keintz,DEM,28
+Clark,01,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Clark,01,Governor,,Kristi Noem and Larry Rhoden,REP,102
+Clark,02,Governor,,Jamie Smith and Jennifer Keintz,DEM,16
+Clark,02,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Clark,02,Governor,,Kristi Noem and Larry Rhoden,REP,79
+Clark,03,Governor,,Jamie Smith and Jennifer Keintz,DEM,20
+Clark,03,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Clark,03,Governor,,Kristi Noem and Larry Rhoden,REP,69
+Clark,04,Governor,,Jamie Smith and Jennifer Keintz,DEM,19
+Clark,04,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Clark,04,Governor,,Kristi Noem and Larry Rhoden,REP,66
+Clark,06,Governor,,Jamie Smith and Jennifer Keintz,DEM,31
+Clark,06,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Clark,06,Governor,,Kristi Noem and Larry Rhoden,REP,147
+Clark,07,Governor,,Jamie Smith and Jennifer Keintz,DEM,19
+Clark,07,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Clark,07,Governor,,Kristi Noem and Larry Rhoden,REP,144
+Clark,08,Governor,,Jamie Smith and Jennifer Keintz,DEM,39
+Clark,08,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Clark,08,Governor,,Kristi Noem and Larry Rhoden,REP,121
+Clark,09,Governor,,Jamie Smith and Jennifer Keintz,DEM,34
+Clark,09,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Clark,09,Governor,,Kristi Noem and Larry Rhoden,REP,96
+Clark,10,Governor,,Jamie Smith and Jennifer Keintz,DEM,23
+Clark,10,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Clark,10,Governor,,Kristi Noem and Larry Rhoden,REP,67
+Clark,11,Governor,,Jamie Smith and Jennifer Keintz,DEM,38
+Clark,11,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Clark,11,Governor,,Kristi Noem and Larry Rhoden,REP,114
+Clark,12,Governor,,Jamie Smith and Jennifer Keintz,DEM,40
+Clark,12,Governor,,Tracey Quint and Ashley Strand,LIB,6
+Clark,12,Governor,,Kristi Noem and Larry Rhoden,REP,104
+Clark,13,Governor,,Jamie Smith and Jennifer Keintz,DEM,34
+Clark,13,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Clark,13,Governor,,Kristi Noem and Larry Rhoden,REP,114
+Clark,01,Secretary of State,,Thomas A Cool,DEM,33
+Clark,01,Secretary of State,,Monae Johnson,REP,97
+Clark,02,Secretary of State,,Thomas A Cool,DEM,27
+Clark,02,Secretary of State,,Monae Johnson,REP,60
+Clark,03,Secretary of State,,Thomas A Cool,DEM,18
+Clark,03,Secretary of State,,Monae Johnson,REP,64
+Clark,04,Secretary of State,,Thomas A Cool,DEM,19
+Clark,04,Secretary of State,,Monae Johnson,REP,64
+Clark,06,Secretary of State,,Thomas A Cool,DEM,32
+Clark,06,Secretary of State,,Monae Johnson,REP,124
+Clark,07,Secretary of State,,Thomas A Cool,DEM,19
+Clark,07,Secretary of State,,Monae Johnson,REP,138
+Clark,08,Secretary of State,,Thomas A Cool,DEM,44
+Clark,08,Secretary of State,,Monae Johnson,REP,109
+Clark,09,Secretary of State,,Thomas A Cool,DEM,25
+Clark,09,Secretary of State,,Monae Johnson,REP,91
+Clark,10,Secretary of State,,Thomas A Cool,DEM,29
+Clark,10,Secretary of State,,Monae Johnson,REP,60
+Clark,11,Secretary of State,,Thomas A Cool,DEM,45
+Clark,11,Secretary of State,,Monae Johnson,REP,91
+Clark,12,Secretary of State,,Thomas A Cool,DEM,48
+Clark,12,Secretary of State,,Monae Johnson,REP,97
+Clark,13,Secretary of State,,Thomas A Cool,DEM,42
+Clark,13,Secretary of State,,Monae Johnson,REP,96
+Clark,01,Attorney General,,Marty J. Jackley,REP,112
+Clark,02,Attorney General,,Marty J. Jackley,REP,74
+Clark,03,Attorney General,,Marty J. Jackley,REP,73
+Clark,04,Attorney General,,Marty J. Jackley,REP,75
+Clark,06,Attorney General,,Marty J. Jackley,REP,144
+Clark,07,Attorney General,,Marty J. Jackley,REP,141
+Clark,08,Attorney General,,Marty J. Jackley,REP,141
+Clark,09,Attorney General,,Marty J. Jackley,REP,100
+Clark,10,Attorney General,,Marty J. Jackley,REP,74
+Clark,11,Attorney General,,Marty J. Jackley,REP,109
+Clark,12,Attorney General,,Marty J. Jackley,REP,111
+Clark,13,Attorney General,,Marty J. Jackley,REP,119
+Clark,01,State Auditor,,Stephanie Marty,DEM,25
+Clark,01,State Auditor,,Rene Meyer,LIB,9
+Clark,01,State Auditor,,Richard Sattgast,REP,98
+Clark,02,State Auditor,,Stephanie Marty,DEM,19
+Clark,02,State Auditor,,Rene Meyer,LIB,2
+Clark,02,State Auditor,,Richard Sattgast,REP,63
+Clark,03,State Auditor,,Stephanie Marty,DEM,15
+Clark,03,State Auditor,,Rene Meyer,LIB,1
+Clark,03,State Auditor,,Richard Sattgast,REP,69
+Clark,04,State Auditor,,Stephanie Marty,DEM,18
+Clark,04,State Auditor,,Rene Meyer,LIB,5
+Clark,04,State Auditor,,Richard Sattgast,REP,60
+Clark,06,State Auditor,,Stephanie Marty,DEM,27
+Clark,06,State Auditor,,Rene Meyer,LIB,7
+Clark,06,State Auditor,,Richard Sattgast,REP,124
+Clark,07,State Auditor,,Stephanie Marty,DEM,17
+Clark,07,State Auditor,,Rene Meyer,LIB,7
+Clark,07,State Auditor,,Richard Sattgast,REP,139
+Clark,08,State Auditor,,Stephanie Marty,DEM,43
+Clark,08,State Auditor,,Rene Meyer,LIB,5
+Clark,08,State Auditor,,Richard Sattgast,REP,100
+Clark,09,State Auditor,,Stephanie Marty,DEM,27
+Clark,09,State Auditor,,Rene Meyer,LIB,5
+Clark,09,State Auditor,,Richard Sattgast,REP,84
+Clark,10,State Auditor,,Stephanie Marty,DEM,25
+Clark,10,State Auditor,,Rene Meyer,LIB,4
+Clark,10,State Auditor,,Richard Sattgast,REP,62
+Clark,11,State Auditor,,Stephanie Marty,DEM,40
+Clark,11,State Auditor,,Rene Meyer,LIB,7
+Clark,11,State Auditor,,Richard Sattgast,REP,90
+Clark,12,State Auditor,,Stephanie Marty,DEM,43
+Clark,12,State Auditor,,Rene Meyer,LIB,10
+Clark,12,State Auditor,,Richard Sattgast,REP,91
+Clark,13,State Auditor,,Stephanie Marty,DEM,34
+Clark,13,State Auditor,,Rene Meyer,LIB,3
+Clark,13,State Auditor,,Richard Sattgast,REP,102
+Clark,01,State Treasurer,,John Cunningham,DEM,30
+Clark,01,State Treasurer,,Josh Haeder,REP,99
+Clark,02,State Treasurer,,John Cunningham,DEM,20
+Clark,02,State Treasurer,,Josh Haeder,REP,65
+Clark,03,State Treasurer,,John Cunningham,DEM,14
+Clark,03,State Treasurer,,Josh Haeder,REP,69
+Clark,04,State Treasurer,,John Cunningham,DEM,21
+Clark,04,State Treasurer,,Josh Haeder,REP,59
+Clark,06,State Treasurer,,John Cunningham,DEM,28
+Clark,06,State Treasurer,,Josh Haeder,REP,127
+Clark,07,State Treasurer,,John Cunningham,DEM,18
+Clark,07,State Treasurer,,Josh Haeder,REP,143
+Clark,08,State Treasurer,,John Cunningham,DEM,37
+Clark,08,State Treasurer,,Josh Haeder,REP,114
+Clark,09,State Treasurer,,John Cunningham,DEM,24
+Clark,09,State Treasurer,,Josh Haeder,REP,90
+Clark,10,State Treasurer,,John Cunningham,DEM,21
+Clark,10,State Treasurer,,Josh Haeder,REP,71
+Clark,11,State Treasurer,,John Cunningham,DEM,40
+Clark,11,State Treasurer,,Josh Haeder,REP,94
+Clark,12,State Treasurer,,John Cunningham,DEM,44
+Clark,12,State Treasurer,,Josh Haeder,REP,98
+Clark,13,State Treasurer,,John Cunningham,DEM,36
+Clark,13,State Treasurer,,Josh Haeder,REP,99
+Clark,01,Commissioner of School and Public Lands,,Timothy Azure,DEM,32
+Clark,01,Commissioner of School and Public Lands,,Brock Greenfield,REP,97
+Clark,02,Commissioner of School and Public Lands,,Timothy Azure,DEM,25
+Clark,02,Commissioner of School and Public Lands,,Brock Greenfield,REP,70
+Clark,03,Commissioner of School and Public Lands,,Timothy Azure,DEM,19
+Clark,03,Commissioner of School and Public Lands,,Brock Greenfield,REP,69
+Clark,04,Commissioner of School and Public Lands,,Timothy Azure,DEM,19
+Clark,04,Commissioner of School and Public Lands,,Brock Greenfield,REP,68
+Clark,06,Commissioner of School and Public Lands,,Timothy Azure,DEM,38
+Clark,06,Commissioner of School and Public Lands,,Brock Greenfield,REP,124
+Clark,07,Commissioner of School and Public Lands,,Timothy Azure,DEM,21
+Clark,07,Commissioner of School and Public Lands,,Brock Greenfield,REP,139
+Clark,08,Commissioner of School and Public Lands,,Timothy Azure,DEM,35
+Clark,08,Commissioner of School and Public Lands,,Brock Greenfield,REP,123
+Clark,09,Commissioner of School and Public Lands,,Timothy Azure,DEM,41
+Clark,09,Commissioner of School and Public Lands,,Brock Greenfield,REP,82
+Clark,10,Commissioner of School and Public Lands,,Timothy Azure,DEM,33
+Clark,10,Commissioner of School and Public Lands,,Brock Greenfield,REP,57
+Clark,11,Commissioner of School and Public Lands,,Timothy Azure,DEM,41
+Clark,11,Commissioner of School and Public Lands,,Brock Greenfield,REP,102
+Clark,12,Commissioner of School and Public Lands,,Timothy Azure,DEM,50
+Clark,12,Commissioner of School and Public Lands,,Brock Greenfield,REP,94
+Clark,13,Commissioner of School and Public Lands,,Timothy Azure,DEM,46
+Clark,13,Commissioner of School and Public Lands,,Brock Greenfield,REP,98
+Clark,01,Public Utilities Commissioner,,Jeffrey Barth,DEM,29
+Clark,01,Public Utilities Commissioner,,Chris Nelson,REP,106
+Clark,02,Public Utilities Commissioner,,Jeffrey Barth,DEM,24
+Clark,02,Public Utilities Commissioner,,Chris Nelson,REP,66
+Clark,03,Public Utilities Commissioner,,Jeffrey Barth,DEM,12
+Clark,03,Public Utilities Commissioner,,Chris Nelson,REP,72
+Clark,04,Public Utilities Commissioner,,Jeffrey Barth,DEM,14
+Clark,04,Public Utilities Commissioner,,Chris Nelson,REP,73
+Clark,06,Public Utilities Commissioner,,Jeffrey Barth,DEM,28
+Clark,06,Public Utilities Commissioner,,Chris Nelson,REP,133
+Clark,07,Public Utilities Commissioner,,Jeffrey Barth,DEM,18
+Clark,07,Public Utilities Commissioner,,Chris Nelson,REP,144
+Clark,08,Public Utilities Commissioner,,Jeffrey Barth,DEM,32
+Clark,08,Public Utilities Commissioner,,Chris Nelson,REP,123
+Clark,09,Public Utilities Commissioner,,Jeffrey Barth,DEM,19
+Clark,09,Public Utilities Commissioner,,Chris Nelson,REP,103
+Clark,10,Public Utilities Commissioner,,Jeffrey Barth,DEM,21
+Clark,10,Public Utilities Commissioner,,Chris Nelson,REP,68
+Clark,11,Public Utilities Commissioner,,Jeffrey Barth,DEM,32
+Clark,11,Public Utilities Commissioner,,Chris Nelson,REP,106
+Clark,12,Public Utilities Commissioner,,Jeffrey Barth,DEM,40
+Clark,12,Public Utilities Commissioner,,Chris Nelson,REP,104
+Clark,13,Public Utilities Commissioner,,Jeffrey Barth,DEM,28
+Clark,13,Public Utilities Commissioner,,Chris Nelson,REP,112
+Clark,01,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,71
+Clark,02,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,45
+Clark,03,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,51
+Clark,04,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,44
+Clark,06,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,66
+Clark,07,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,65
+Clark,08,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,82
+Clark,09,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,62
+Clark,10,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,57
+Clark,11,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,76
+Clark,12,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,84
+Clark,13,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,75
+Clark,01,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,70
+Clark,02,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,41
+Clark,03,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,43
+Clark,04,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,46
+Clark,06,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,65
+Clark,07,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,62
+Clark,08,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,81
+Clark,09,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,55
+Clark,10,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,51
+Clark,11,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,68
+Clark,12,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,83
+Clark,13,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,71
+Clark,01,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,68
+Clark,02,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,33
+Clark,03,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,41
+Clark,04,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,41
+Clark,06,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,62
+Clark,07,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,58
+Clark,08,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,81
+Clark,09,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,51
+Clark,10,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,56
+Clark,11,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,64
+Clark,12,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,78
+Clark,13,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,71
+Clark,01,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,69
+Clark,02,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,37
+Clark,03,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,40
+Clark,04,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,42
+Clark,06,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,64
+Clark,07,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,59
+Clark,08,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,81
+Clark,09,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,52
+Clark,10,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,52
+Clark,11,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,64
+Clark,12,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,78
+Clark,13,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,72
+Clark,01,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,43
+Clark,01,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,37
+Clark,02,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,37
+Clark,02,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,14
+Clark,03,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,29
+Clark,03,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,25
+Clark,04,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,31
+Clark,04,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,24
+Clark,06,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,49
+Clark,06,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,41
+Clark,07,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,29
+Clark,07,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,44
+Clark,08,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,57
+Clark,08,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,46
+Clark,09,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,36
+Clark,09,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,32
+Clark,10,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,31
+Clark,10,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,32
+Clark,11,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,49
+Clark,11,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,34
+Clark,12,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,71
+Clark,12,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,40
+Clark,13,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,47
+Clark,13,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,42
+Clark,01,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,63
+Clark,02,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,31
+Clark,03,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,39
+Clark,04,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,42
+Clark,06,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,66
+Clark,07,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,55
+Clark,08,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,77
+Clark,09,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,48
+Clark,10,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,50
+Clark,11,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,63
+Clark,12,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,78
+Clark,13,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,67
+Clark,01,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,88
+Clark,01,Supreme Court Retention,3,Patricia J. DeVaney - No,,27
+Clark,02,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,63
+Clark,02,Supreme Court Retention,3,Patricia J. DeVaney - No,,15
+Clark,03,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,63
+Clark,03,Supreme Court Retention,3,Patricia J. DeVaney - No,,13
+Clark,04,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,62
+Clark,04,Supreme Court Retention,3,Patricia J. DeVaney - No,,13
+Clark,06,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,100
+Clark,06,Supreme Court Retention,3,Patricia J. DeVaney - No,,26
+Clark,07,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,119
+Clark,07,Supreme Court Retention,3,Patricia J. DeVaney - No,,17
+Clark,08,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,117
+Clark,08,Supreme Court Retention,3,Patricia J. DeVaney - No,,27
+Clark,09,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,92
+Clark,09,Supreme Court Retention,3,Patricia J. DeVaney - No,,15
+Clark,10,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,77
+Clark,10,Supreme Court Retention,3,Patricia J. DeVaney - No,,10
+Clark,11,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,109
+Clark,11,Supreme Court Retention,3,Patricia J. DeVaney - No,,12
+Clark,12,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,109
+Clark,12,Supreme Court Retention,3,Patricia J. DeVaney - No,,22
+Clark,13,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,105
+Clark,13,Supreme Court Retention,3,Patricia J. DeVaney - No,,15
+Clark,01,Supreme Court Retention,2,Mark E. Salter - Yes,,89
+Clark,01,Supreme Court Retention,2,Mark E. Salter - No,,27
+Clark,02,Supreme Court Retention,2,Mark E. Salter - Yes,,63
+Clark,02,Supreme Court Retention,2,Mark E. Salter - No,,13
+Clark,03,Supreme Court Retention,2,Mark E. Salter - Yes,,67
+Clark,03,Supreme Court Retention,2,Mark E. Salter - No,,10
+Clark,04,Supreme Court Retention,2,Mark E. Salter - Yes,,64
+Clark,04,Supreme Court Retention,2,Mark E. Salter - No,,9
+Clark,06,Supreme Court Retention,2,Mark E. Salter - Yes,,99
+Clark,06,Supreme Court Retention,2,Mark E. Salter - No,,25
+Clark,07,Supreme Court Retention,2,Mark E. Salter - Yes,,118
+Clark,07,Supreme Court Retention,2,Mark E. Salter - No,,20
+Clark,08,Supreme Court Retention,2,Mark E. Salter - Yes,,122
+Clark,08,Supreme Court Retention,2,Mark E. Salter - No,,21
+Clark,09,Supreme Court Retention,2,Mark E. Salter - Yes,,86
+Clark,09,Supreme Court Retention,2,Mark E. Salter - No,,18
+Clark,10,Supreme Court Retention,2,Mark E. Salter - Yes,,78
+Clark,10,Supreme Court Retention,2,Mark E. Salter - No,,8
+Clark,11,Supreme Court Retention,2,Mark E. Salter - Yes,,107
+Clark,11,Supreme Court Retention,2,Mark E. Salter - No,,13
+Clark,12,Supreme Court Retention,2,Mark E. Salter - Yes,,104
+Clark,12,Supreme Court Retention,2,Mark E. Salter - No,,26
+Clark,13,Supreme Court Retention,2,Mark E. Salter - Yes,,107
+Clark,13,Supreme Court Retention,2,Mark E. Salter - No,,13
+Clark,01,Constitutional Amendment D,,Yes,,64
+Clark,01,Constitutional Amendment D,,No,,73
+Clark,02,Constitutional Amendment D,,Yes,,44
+Clark,02,Constitutional Amendment D,,No,,47
+Clark,03,Constitutional Amendment D,,Yes,,43
+Clark,03,Constitutional Amendment D,,No,,42
+Clark,04,Constitutional Amendment D,,Yes,,41
+Clark,04,Constitutional Amendment D,,No,,45
+Clark,06,Constitutional Amendment D,,Yes,,71
+Clark,06,Constitutional Amendment D,,No,,73
+Clark,07,Constitutional Amendment D,,Yes,,80
+Clark,07,Constitutional Amendment D,,No,,82
+Clark,08,Constitutional Amendment D,,Yes,,88
+Clark,08,Constitutional Amendment D,,No,,67
+Clark,09,Constitutional Amendment D,,Yes,,50
+Clark,09,Constitutional Amendment D,,No,,81
+Clark,10,Constitutional Amendment D,,Yes,,38
+Clark,10,Constitutional Amendment D,,No,,53
+Clark,11,Constitutional Amendment D,,Yes,,83
+Clark,11,Constitutional Amendment D,,No,,60
+Clark,12,Constitutional Amendment D,,Yes,,83
+Clark,12,Constitutional Amendment D,,No,,67
+Clark,13,Constitutional Amendment D,,Yes,,80
+Clark,13,Constitutional Amendment D,,No,,67
+Clark,01,Initiated Measure 27,,Yes,,49
+Clark,01,Initiated Measure 27,,No,,85
+Clark,02,Initiated Measure 27,,Yes,,25
+Clark,02,Initiated Measure 27,,No,,72
+Clark,03,Initiated Measure 27,,Yes,,32
+Clark,03,Initiated Measure 27,,No,,57
+Clark,04,Initiated Measure 27,,Yes,,32
+Clark,04,Initiated Measure 27,,No,,56
+Clark,06,Initiated Measure 27,,Yes,,46
+Clark,06,Initiated Measure 27,,No,,115
+Clark,07,Initiated Measure 27,,Yes,,28
+Clark,07,Initiated Measure 27,,No,,137
+Clark,08,Initiated Measure 27,,Yes,,65
+Clark,08,Initiated Measure 27,,No,,94
+Clark,09,Initiated Measure 27,,Yes,,33
+Clark,09,Initiated Measure 27,,No,,101
+Clark,10,Initiated Measure 27,,Yes,,36
+Clark,10,Initiated Measure 27,,No,,55
+Clark,11,Initiated Measure 27,,Yes,,66
+Clark,11,Initiated Measure 27,,No,,83
+Clark,12,Initiated Measure 27,,Yes,,61
+Clark,12,Initiated Measure 27,,No,,93
+Clark,13,Initiated Measure 27,,Yes,,45
+Clark,13,Initiated Measure 27,,No,,108
+Clark,01,State Senate,04,John Wiik,REP,101
+Clark,02,State Senate,04,John Wiik,REP,64
+Clark,03,State Senate,04,John Wiik,REP,13
+Clark,03,State Senate,22,David Wheeler,REP,50
+Clark,04,State Senate,04,John Wiik,REP,69
+Clark,06,State Senate,04,John Wiik,REP,127
+Clark,07,State Senate,04,John Wiik,REP,136
+Clark,08,State Senate,04,John Wiik,REP,119
+Clark,09,State Senate,04,John Wiik,REP,55
+Clark,09,State Senate,22,David Wheeler,REP,32
+Clark,10,State Senate,04,John Wiik,REP,44
+Clark,10,State Senate,22,David Wheeler,REP,22
+Clark,11,State Senate,04,John Wiik,REP,101
+Clark,12,State Senate,04,John Wiik,REP,104
+Clark,13 10 of 22,State Senate,04,John Wiik,REP,109
+Clark,01,State House,04,Stephanie Sauder,REP,61
+Clark,01,State House,04,Fred Deutsch,REP,92
+Clark,02,State House,04,Stephanie Sauder,REP,49
+Clark,02,State House,04,Fred Deutsch,REP,52
+Clark,03,State House,04,Stephanie Sauder,REP,5
+Clark,03,State House,04,Fred Deutsch,REP,10
+Clark,03,State House,22,Shane Milne,DEM,20
+Clark,03,State House,22,Roger Chase,REP,31
+Clark,03,State House,22,Lynn Schneider,REP,54
+Clark,04,State House,04,Stephanie Sauder,REP,47
+Clark,04,State House,04,Fred Deutsch,REP,54
+Clark,06,State House,04,Stephanie Sauder,REP,96
+Clark,06,State House,04,Fred Deutsch,REP,91
+Clark,07,State House,04,Stephanie Sauder,REP,124
+Clark,07,State House,04,Fred Deutsch,REP,96
+Clark,08,State House,04,Stephanie Sauder,REP,111
+Clark,08,State House,04,Fred Deutsch,REP,84
+Clark,09,State House,04,Stephanie Sauder,REP,44
+Clark,09,State House,04,Fred Deutsch,REP,45
+Clark,09,State House,22,Shane Milne,DEM,7
+Clark,09,State House,22,Roger Chase,REP,24
+Clark,09,State House,22,Lynn Schneider,REP,29
+Clark,10,State House,04,Stephanie Sauder,REP,37
+Clark,10,State House,04,Fred Deutsch,REP,34
+Clark,10,State House,22,Shane Milne,DEM,20
+Clark,10,State House,22,Roger Chase,REP,13
+Clark,10,State House,22,Lynn Schneider,REP,19
+Clark,11,State House,04,Stephanie Sauder,REP,70
+Clark,11,State House,04,Fred Deutsch,REP,69
+Clark,12,State House,04,Stephanie Sauder,REP,86
+Clark,12,State House,04,Fred Deutsch,REP,81
+Clark,13 11 of 22,State House,04,Stephanie Sauder,REP,83
+Clark,13 11 of 22,State House,04,Fred Deutsch,REP,88

--- a/2022/counties/20221108__sd__general__clay__precinct.csv
+++ b/2022/counties/20221108__sd__general__clay__precinct.csv
@@ -1,0 +1,421 @@
+county,precinct,office,district,candidate,party,votes
+Clay,01,U.S. Senate,,Brian L. Bengs,DEM,79
+Clay,01,U.S. Senate,,Tamara J Lesnar,LIB,10
+Clay,01,U.S. Senate,,John R. Thune,REP,288
+Clay,02,U.S. Senate,,Brian L. Bengs,DEM,79
+Clay,02,U.S. Senate,,Tamara J Lesnar,LIB,15
+Clay,02,U.S. Senate,,John R. Thune,REP,219
+Clay,03,U.S. Senate,,Brian L. Bengs,DEM,293
+Clay,03,U.S. Senate,,Tamara J Lesnar,LIB,30
+Clay,03,U.S. Senate,,John R. Thune,REP,608
+Clay,C1,U.S. Senate,,Brian L. Bengs,DEM,227
+Clay,C1,U.S. Senate,,Tamara J Lesnar,LIB,10
+Clay,C1,U.S. Senate,,John R. Thune,REP,85
+Clay,C2,U.S. Senate,,Brian L. Bengs,DEM,95
+Clay,C2,U.S. Senate,,Tamara J Lesnar,LIB,11
+Clay,C2,U.S. Senate,,John R. Thune,REP,41
+Clay,E1,U.S. Senate,,Brian L. Bengs,DEM,139
+Clay,E1,U.S. Senate,,Tamara J Lesnar,LIB,6
+Clay,E1,U.S. Senate,,John R. Thune,REP,144
+Clay,E2,U.S. Senate,,Brian L. Bengs,DEM,51
+Clay,E2,U.S. Senate,,Tamara J Lesnar,LIB,7
+Clay,E2,U.S. Senate,,John R. Thune,REP,48
+Clay,S1,U.S. Senate,,Brian L. Bengs,DEM,337
+Clay,S1,U.S. Senate,,Tamara J Lesnar,LIB,19
+Clay,S1,U.S. Senate,,John R. Thune,REP,401
+Clay,S2,U.S. Senate,,Brian L. Bengs,DEM,282
+Clay,S2,U.S. Senate,,Tamara J Lesnar,LIB,12
+Clay,S2,U.S. Senate,,John R. Thune,REP,243
+Clay,W1,U.S. Senate,,Brian L. Bengs,DEM,270
+Clay,W1,U.S. Senate,,Tamara J Lesnar,LIB,16
+Clay,W1,U.S. Senate,,John R. Thune,REP,280
+Clay,W2,U.S. Senate,,Brian L. Bengs,DEM,190
+Clay,W2,U.S. Senate,,Tamara J Lesnar,LIB,13
+Clay,W2,U.S. Senate,,John R. Thune,REP,165
+Clay,01,U.S. House,1,Collin Duprel,LIB,55
+Clay,01,U.S. House,1,Dusty Johnson,REP,296
+Clay,02,U.S. House,1,Collin Duprel,LIB,56
+Clay,02,U.S. House,1,Dusty Johnson,REP,245
+Clay,03,U.S. House,1,Collin Duprel,LIB,171
+Clay,03,U.S. House,1,Dusty Johnson,REP,674
+Clay,C1,U.S. House,1,Collin Duprel,LIB,116
+Clay,C1,U.S. House,1,Dusty Johnson,REP,132
+Clay,C2,U.S. House,1,Collin Duprel,LIB,61
+Clay,C2,U.S. House,1,Dusty Johnson,REP,66
+Clay,E1,U.S. House,1,Collin Duprel,LIB,85
+Clay,E1,U.S. House,1,Dusty Johnson,REP,160
+Clay,E2,U.S. House,1,Collin Duprel,LIB,41
+Clay,E2,U.S. House,1,Dusty Johnson,REP,53
+Clay,S1,U.S. House,1,Collin Duprel,LIB,183
+Clay,S1,U.S. House,1,Dusty Johnson,REP,486
+Clay,S2,U.S. House,1,Collin Duprel,LIB,128
+Clay,S2,U.S. House,1,Dusty Johnson,REP,316
+Clay,W1,U.S. House,1,Collin Duprel,LIB,167
+Clay,W1,U.S. House,1,Dusty Johnson,REP,328
+Clay,W2,U.S. House,1,Collin Duprel,LIB,100
+Clay,W2,U.S. House,1,Dusty Johnson,REP,215
+Clay,01,Governor,,Jamie Smith and Jennifer Keintz,DEM,111
+Clay,01,Governor,,Tracey Quint and Ashley Strand,LIB,8
+Clay,01,Governor,,Kristi Noem and Larry Rhoden,REP,263
+Clay,02,Governor,,Jamie Smith and Jennifer Keintz,DEM,114
+Clay,02,Governor,,Tracey Quint and Ashley Strand,LIB,14
+Clay,02,Governor,,Kristi Noem and Larry Rhoden,REP,189
+Clay,03,Governor,,Jamie Smith and Jennifer Keintz,DEM,405
+Clay,03,Governor,,Tracey Quint and Ashley Strand,LIB,21
+Clay,03,Governor,,Kristi Noem and Larry Rhoden,REP,510
+Clay,C1,Governor,,Jamie Smith and Jennifer Keintz,DEM,256
+Clay,C1,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Clay,C1,Governor,,Kristi Noem and Larry Rhoden,REP,64
+Clay,C2,Governor,,Jamie Smith and Jennifer Keintz,DEM,106
+Clay,C2,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Clay,C2,Governor,,Kristi Noem and Larry Rhoden,REP,41
+Clay,E1,Governor,,Jamie Smith and Jennifer Keintz,DEM,168
+Clay,E1,Governor,,Tracey Quint and Ashley Strand,LIB,6
+Clay,E1,Governor,,Kristi Noem and Larry Rhoden,REP,118
+Clay,E2,Governor,,Jamie Smith and Jennifer Keintz,DEM,74
+Clay,E2,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Clay,E2,Governor,,Kristi Noem and Larry Rhoden,REP,31
+Clay,S1,Governor,,Jamie Smith and Jennifer Keintz,DEM,441
+Clay,S1,Governor,,Tracey Quint and Ashley Strand,LIB,14
+Clay,S1,Governor,,Kristi Noem and Larry Rhoden,REP,309
+Clay,S2,Governor,,Jamie Smith and Jennifer Keintz,DEM,347
+Clay,S2,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Clay,S2,Governor,,Kristi Noem and Larry Rhoden,REP,179
+Clay,W1,Governor,,Jamie Smith and Jennifer Keintz,DEM,339
+Clay,W1,Governor,,Tracey Quint and Ashley Strand,LIB,18
+Clay,W1,Governor,,Kristi Noem and Larry Rhoden,REP,210
+Clay,W2,Governor,,Jamie Smith and Jennifer Keintz,DEM,220
+Clay,W2,Governor,,Tracey Quint and Ashley Strand,LIB,8
+Clay,W2,Governor,,Kristi Noem and Larry Rhoden,REP,140
+Clay,01,Secretary of State,,Thomas A Cool,DEM,105
+Clay,01,Secretary of State,,Monae Johnson,REP,252
+Clay,02,Secretary of State,,Thomas A Cool,DEM,109
+Clay,02,Secretary of State,,Monae Johnson,REP,180
+Clay,03,Secretary of State,,Thomas A Cool,DEM,370
+Clay,03,Secretary of State,,Monae Johnson,REP,500
+Clay,C1,Secretary of State,,Thomas A Cool,DEM,243
+Clay,C1,Secretary of State,,Monae Johnson,REP,67
+Clay,C2,Secretary of State,,Thomas A Cool,DEM,98
+Clay,C2,Secretary of State,,Monae Johnson,REP,42
+Clay,E1,Secretary of State,,Thomas A Cool,DEM,160
+Clay,E1,Secretary of State,,Monae Johnson,REP,112
+Clay,E2,Secretary of State,,Thomas A Cool,DEM,62
+Clay,E2,Secretary of State,,Monae Johnson,REP,36
+Clay,S1,Secretary of State,,Thomas A Cool,DEM,418
+Clay,S1,Secretary of State,,Monae Johnson,REP,291
+Clay,S2,Secretary of State,,Thomas A Cool,DEM,318
+Clay,S2,Secretary of State,,Monae Johnson,REP,184
+Clay,W1,Secretary of State,,Thomas A Cool,DEM,330
+Clay,W1,Secretary of State,,Monae Johnson,REP,221
+Clay,W2,Secretary of State,,Thomas A Cool,DEM,204
+Clay,W2,Secretary of State,,Monae Johnson,REP,144
+Clay,01,Attorney General,,Marty J. Jackley,REP,300
+Clay,02,Attorney General,,Marty J. Jackley,REP,225
+Clay,03,Attorney General,,Marty J. Jackley,REP,647
+Clay,C1,Attorney General,,Marty J. Jackley,REP,135
+Clay,C2,Attorney General,,Marty J. Jackley,REP,64
+Clay,E1,Attorney General,,Marty J. Jackley,REP,154
+Clay,E2,Attorney General,,Marty J. Jackley,REP,48
+Clay,S1,Attorney General,,Marty J. Jackley,REP,461
+Clay,S2,Attorney General,,Marty J. Jackley,REP,278
+Clay,W1,Attorney General,,Marty J. Jackley,REP,319
+Clay,W2,Attorney General,,Marty J. Jackley,REP,212
+Clay,01,State Auditor,,Stephanie Marty,DEM,83
+Clay,01,State Auditor,,Rene Meyer,LIB,11
+Clay,01,State Auditor,,Richard Sattgast,REP,264
+Clay,02,State Auditor,,Stephanie Marty,DEM,94
+Clay,02,State Auditor,,Rene Meyer,LIB,21
+Clay,02,State Auditor,,Richard Sattgast,REP,173
+Clay,03,State Auditor,,Stephanie Marty,DEM,348
+Clay,03,State Auditor,,Rene Meyer,LIB,37
+Clay,03,State Auditor,,Richard Sattgast,REP,480
+Clay,C1,State Auditor,,Stephanie Marty,DEM,234
+Clay,C1,State Auditor,,Rene Meyer,LIB,9
+Clay,C1,State Auditor,,Richard Sattgast,REP,66
+Clay,C2,State Auditor,,Stephanie Marty,DEM,90
+Clay,C2,State Auditor,,Rene Meyer,LIB,10
+Clay,C2,State Auditor,,Richard Sattgast,REP,37
+Clay,E1,State Auditor,,Stephanie Marty,DEM,146
+Clay,E1,State Auditor,,Rene Meyer,LIB,8
+Clay,E1,State Auditor,,Richard Sattgast,REP,114
+Clay,E2,State Auditor,,Stephanie Marty,DEM,55
+Clay,E2,State Auditor,,Rene Meyer,LIB,11
+Clay,E2,State Auditor,,Richard Sattgast,REP,33
+Clay,S1,State Auditor,,Stephanie Marty,DEM,379
+Clay,S1,State Auditor,,Rene Meyer,LIB,23
+Clay,S1,State Auditor,,Richard Sattgast,REP,311
+Clay,S2,State Auditor,,Stephanie Marty,DEM,304
+Clay,S2,State Auditor,,Rene Meyer,LIB,14
+Clay,S2,State Auditor,,Richard Sattgast,REP,190
+Clay,W1,State Auditor,,Stephanie Marty,DEM,305
+Clay,W1,State Auditor,,Rene Meyer,LIB,28
+Clay,W1,State Auditor,,Richard Sattgast,REP,205
+Clay,W2,State Auditor,,Stephanie Marty,DEM,192
+Clay,W2,State Auditor,,Rene Meyer,LIB,13
+Clay,W2,State Auditor,,Richard Sattgast,REP,144
+Clay,01,State Treasurer,,John Cunningham,DEM,93
+Clay,01,State Treasurer,,Josh Haeder,REP,265
+Clay,02,State Treasurer,,John Cunningham,DEM,101
+Clay,02,State Treasurer,,Josh Haeder,REP,188
+Clay,03,State Treasurer,,John Cunningham,DEM,365
+Clay,03,State Treasurer,,Josh Haeder,REP,497
+Clay,C1,State Treasurer,,John Cunningham,DEM,235
+Clay,C1,State Treasurer,,Josh Haeder,REP,73
+Clay,C2,State Treasurer,,John Cunningham,DEM,96
+Clay,C2,State Treasurer,,Josh Haeder,REP,43
+Clay,E1,State Treasurer,,John Cunningham,DEM,147
+Clay,E1,State Treasurer,,Josh Haeder,REP,124
+Clay,E2,State Treasurer,,John Cunningham,DEM,57
+Clay,E2,State Treasurer,,Josh Haeder,REP,38
+Clay,S1,State Treasurer,,John Cunningham,DEM,374
+Clay,S1,State Treasurer,,Josh Haeder,REP,323
+Clay,S2,State Treasurer,,John Cunningham,DEM,309
+Clay,S2,State Treasurer,,Josh Haeder,REP,197
+Clay,W1,State Treasurer,,John Cunningham,DEM,304
+Clay,W1,State Treasurer,,Josh Haeder,REP,225
+Clay,W2,State Treasurer,,John Cunningham,DEM,201
+Clay,W2,State Treasurer,,Josh Haeder,REP,143
+Clay,01,Commissioner of School and Public Lands,,Timothy Azure,DEM,93
+Clay,01,Commissioner of School and Public Lands,,Brock Greenfield,REP,254
+Clay,02,Commissioner of School and Public Lands,,Timothy Azure,DEM,92
+Clay,02,Commissioner of School and Public Lands,,Brock Greenfield,REP,181
+Clay,03,Commissioner of School and Public Lands,,Timothy Azure,DEM,348
+Clay,03,Commissioner of School and Public Lands,,Brock Greenfield,REP,501
+Clay,C1,Commissioner of School and Public Lands,,Timothy Azure,DEM,234
+Clay,C1,Commissioner of School and Public Lands,,Brock Greenfield,REP,72
+Clay,C2,Commissioner of School and Public Lands,,Timothy Azure,DEM,96
+Clay,C2,Commissioner of School and Public Lands,,Brock Greenfield,REP,40
+Clay,E1,Commissioner of School and Public Lands,,Timothy Azure,DEM,148
+Clay,E1,Commissioner of School and Public Lands,,Brock Greenfield,REP,118
+Clay,E2,Commissioner of School and Public Lands,,Timothy Azure,DEM,53
+Clay,E2,Commissioner of School and Public Lands,,Brock Greenfield,REP,40
+Clay,S1,Commissioner of School and Public Lands,,Timothy Azure,DEM,368
+Clay,S1,Commissioner of School and Public Lands,,Brock Greenfield,REP,325
+Clay,S2,Commissioner of School and Public Lands,,Timothy Azure,DEM,306
+Clay,S2,Commissioner of School and Public Lands,,Brock Greenfield,REP,191
+Clay,W1,Commissioner of School and Public Lands,,Timothy Azure,DEM,306
+Clay,W1,Commissioner of School and Public Lands,,Brock Greenfield,REP,226
+Clay,W2,Commissioner of School and Public Lands,,Timothy Azure,DEM,195
+Clay,W2,Commissioner of School and Public Lands,,Brock Greenfield,REP,137
+Clay,01,Public Utilities Commissioner,,Jeffrey Barth,DEM,86
+Clay,01,Public Utilities Commissioner,,Chris Nelson,REP,271
+Clay,02,Public Utilities Commissioner,,Jeffrey Barth,DEM,71
+Clay,02,Public Utilities Commissioner,,Chris Nelson,REP,223
+Clay,03,Public Utilities Commissioner,,Jeffrey Barth,DEM,324
+Clay,03,Public Utilities Commissioner,,Chris Nelson,REP,560
+Clay,C1,Public Utilities Commissioner,,Jeffrey Barth,DEM,228
+Clay,C1,Public Utilities Commissioner,,Chris Nelson,REP,77
+Clay,C2,Public Utilities Commissioner,,Jeffrey Barth,DEM,92
+Clay,C2,Public Utilities Commissioner,,Chris Nelson,REP,45
+Clay,E1,Public Utilities Commissioner,,Jeffrey Barth,DEM,145
+Clay,E1,Public Utilities Commissioner,,Chris Nelson,REP,128
+Clay,E2,Public Utilities Commissioner,,Jeffrey Barth,DEM,55
+Clay,E2,Public Utilities Commissioner,,Chris Nelson,REP,42
+Clay,S1,Public Utilities Commissioner,,Jeffrey Barth,DEM,352
+Clay,S1,Public Utilities Commissioner,,Chris Nelson,REP,361
+Clay,S2,Public Utilities Commissioner,,Jeffrey Barth,DEM,288
+Clay,S2,Public Utilities Commissioner,,Chris Nelson,REP,215
+Clay,W1,Public Utilities Commissioner,,Jeffrey Barth,DEM,293
+Clay,W1,Public Utilities Commissioner,,Chris Nelson,REP,250
+Clay,W2,Public Utilities Commissioner,,Jeffrey Barth,DEM,183
+Clay,W2,Public Utilities Commissioner,,Chris Nelson,REP,161
+Clay,01,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,161
+Clay,02,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,121
+Clay,03,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,331
+Clay,C1,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,104
+Clay,C2,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,45
+Clay,E1,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,100
+Clay,E2,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,32
+Clay,S1,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,273
+Clay,S2,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,190
+Clay,W1,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,219
+Clay,W2,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,141
+Clay,01,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,157
+Clay,02,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,125
+Clay,03,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,325
+Clay,C1,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,108
+Clay,C2,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,45
+Clay,E1,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,95
+Clay,E2,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,30
+Clay,S1,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,267
+Clay,S2,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,185
+Clay,W1,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,215
+Clay,W2,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,143
+Clay,01,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,155
+Clay,02,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,122
+Clay,03,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,322
+Clay,C1,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,111
+Clay,C2,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,41
+Clay,E1,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,94
+Clay,E2,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,32
+Clay,S1,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,257
+Clay,S2,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,181
+Clay,W1,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,209
+Clay,W2,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,136
+Clay,01,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,160
+Clay,02,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,119
+Clay,03,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,339
+Clay,C1,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,123
+Clay,C2,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,48
+Clay,E1,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,102
+Clay,E2,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,35
+Clay,S1,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,278
+Clay,S2,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,197
+Clay,W1,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,216
+Clay,W2,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,148
+Clay,01,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,150
+Clay,02,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,119
+Clay,03,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,314
+Clay,C1,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,104
+Clay,C2,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,44
+Clay,E1,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,97
+Clay,E2,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,30
+Clay,S1,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,260
+Clay,S2,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,177
+Clay,W1,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,205
+Clay,W2,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,135
+Clay,01,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,190
+Clay,02,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,134
+Clay,03,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,475
+Clay,C1,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,155
+Clay,C2,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,57
+Clay,E1,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,123
+Clay,E2,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,40
+Clay,S1,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,370
+Clay,S2,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,253
+Clay,W1,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,269
+Clay,W2,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,175
+Clay,01,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,260
+Clay,01,Supreme Court Retention,3,Patricia J. DeVaney - No,,52
+Clay,02,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,219
+Clay,02,Supreme Court Retention,3,Patricia J. DeVaney - No,,49
+Clay,03,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,608
+Clay,03,Supreme Court Retention,3,Patricia J. DeVaney - No,,148
+Clay,C1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,184
+Clay,C1,Supreme Court Retention,3,Patricia J. DeVaney - No,,66
+Clay,C2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,75
+Clay,C2,Supreme Court Retention,3,Patricia J. DeVaney - No,,43
+Clay,E1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,161
+Clay,E1,Supreme Court Retention,3,Patricia J. DeVaney - No,,75
+Clay,E2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,56
+Clay,E2,Supreme Court Retention,3,Patricia J. DeVaney - No,,25
+Clay,S1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,490
+Clay,S1,Supreme Court Retention,3,Patricia J. DeVaney - No,,109
+Clay,S2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,346
+Clay,S2,Supreme Court Retention,3,Patricia J. DeVaney - No,,82
+Clay,W1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,348
+Clay,W1,Supreme Court Retention,3,Patricia J. DeVaney - No,,117
+Clay,W2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,241
+Clay,W2,Supreme Court Retention,3,Patricia J. DeVaney - No,,62
+Clay,01,Supreme Court Retention,2,Mark E. Salter - Yes,,252
+Clay,01,Supreme Court Retention,2,Mark E. Salter - No,,51
+Clay,02,Supreme Court Retention,2,Mark E. Salter - Yes,,216
+Clay,02,Supreme Court Retention,2,Mark E. Salter - No,,48
+Clay,03,Supreme Court Retention,2,Mark E. Salter - Yes,,589
+Clay,03,Supreme Court Retention,2,Mark E. Salter - No,,157
+Clay,C1,Supreme Court Retention,2,Mark E. Salter - Yes,,181
+Clay,C1,Supreme Court Retention,2,Mark E. Salter - No,,68
+Clay,C2,Supreme Court Retention,2,Mark E. Salter - Yes,,72
+Clay,C2,Supreme Court Retention,2,Mark E. Salter - No,,45
+Clay,E1,Supreme Court Retention,2,Mark E. Salter - Yes,,162
+Clay,E1,Supreme Court Retention,2,Mark E. Salter - No,,72
+Clay,E2,Supreme Court Retention,2,Mark E. Salter - Yes,,54
+Clay,E2,Supreme Court Retention,2,Mark E. Salter - No,,29
+Clay,S1,Supreme Court Retention,2,Mark E. Salter - Yes,,484
+Clay,S1,Supreme Court Retention,2,Mark E. Salter - No,,107
+Clay,S2,Supreme Court Retention,2,Mark E. Salter - Yes,,332
+Clay,S2,Supreme Court Retention,2,Mark E. Salter - No,,91
+Clay,W1,Supreme Court Retention,2,Mark E. Salter - Yes,,342
+Clay,W1,Supreme Court Retention,2,Mark E. Salter - No,,125
+Clay,W2,Supreme Court Retention,2,Mark E. Salter - Yes,,233
+Clay,W2,Supreme Court Retention,2,Mark E. Salter - No,,69
+Clay,01,Constitutional Amendment D,,Yes,,167
+Clay,01,Constitutional Amendment D,,No,,198
+Clay,02,Constitutional Amendment D,,Yes,,180
+Clay,02,Constitutional Amendment D,,No,,130
+Clay,03,Constitutional Amendment D,,Yes,,535
+Clay,03,Constitutional Amendment D,,No,,354
+Clay,C1,Constitutional Amendment D,,Yes,,275
+Clay,C1,Constitutional Amendment D,,No,,39
+Clay,C2,Constitutional Amendment D,,Yes,,114
+Clay,C2,Constitutional Amendment D,,No,,33
+Clay,E1,Constitutional Amendment D,,Yes,,197
+Clay,E1,Constitutional Amendment D,,No,,88
+Clay,E2,Constitutional Amendment D,,Yes,,80
+Clay,E2,Constitutional Amendment D,,No,,29
+Clay,S1,Constitutional Amendment D,,Yes,,523
+Clay,S1,Constitutional Amendment D,,No,,218
+Clay,S2,Constitutional Amendment D,,Yes,,393
+Clay,S2,Constitutional Amendment D,,No,,137
+Clay,W1,Constitutional Amendment D,,Yes,,410
+Clay,W1,Constitutional Amendment D,,No,,154
+Clay,W2,Constitutional Amendment D,,Yes,,266
+Clay,W2,Constitutional Amendment D,,No,,102
+Clay,01,Initiated Measure 27,,Yes,,141
+Clay,01,Initiated Measure 27,,No,,230
+Clay,02,Initiated Measure 27,,Yes,,163
+Clay,02,Initiated Measure 27,,No,,152
+Clay,03,Initiated Measure 27,,Yes,,510
+Clay,03,Initiated Measure 27,,No,,407
+Clay,C1,Initiated Measure 27,,Yes,,253
+Clay,C1,Initiated Measure 27,,No,,66
+Clay,C2,Initiated Measure 27,,Yes,,124
+Clay,C2,Initiated Measure 27,,No,,21
+Clay,E1,Initiated Measure 27,,Yes,,202
+Clay,E1,Initiated Measure 27,,No,,87
+Clay,E2,Initiated Measure 27,,Yes,,91
+Clay,E2,Initiated Measure 27,,No,,21
+Clay,S1,Initiated Measure 27,,Yes,,469
+Clay,S1,Initiated Measure 27,,No,,280
+Clay,S2,Initiated Measure 27,,Yes,,350
+Clay,S2,Initiated Measure 27,,No,,187
+Clay,W1,Initiated Measure 27,,Yes,,387
+Clay,W1,Initiated Measure 27,,No,,183
+Clay,W2,Initiated Measure 27,,Yes,,230
+Clay,W2,Initiated Measure 27,,No,,137
+Clay,01,State Senate,17,Sydney Davis,REP,281
+Clay,02,State Senate,18,Fredrick Bender,DEM,84
+Clay,02,State Senate,18,Jean M. Hunhoff,REP,213
+Clay,03,State Senate,17,Sydney Davis,REP,610
+Clay,C1,State Senate,17,Sydney Davis,REP,124
+Clay,C2,State Senate,17,Sydney Davis,REP,65
+Clay,E1,State Senate,17,Sydney Davis,REP,141
+Clay,E2,State Senate,17,Sydney Davis,REP,52
+Clay,S1,State Senate,17,Sydney Davis,REP,452
+Clay,S2,State Senate,17,Sydney Davis,REP,266
+Clay,W1,State Senate,17,Sydney Davis,REP,310
+Clay,W2 10 of 23,State Senate,17,Sydney Davis,REP,197
+Clay,DEM Precinct-01,State House,17,"Rebecca ""Bekki"" Engquist-Schroeder",DEM,97
+Clay,DEM Precinct-01,State House,17,"William ""Bill"" Shorma",REP,207
+Clay,DEM Precinct-01,State House,17,Chris Kassin,REP,249
+Clay,02,State House,18,Ryan D. Cwach,DEM,125
+Clay,02,State House,18,Jay Williams,DEM,60
+Clay,02,State House,18,Julie Auch,REP,174
+Clay,02,State House,18,Mike Stevens,REP,160
+Clay,03,State House,17,"Rebecca ""Bekki"" Engquist-Schroeder",DEM,413
+Clay,03,State House,17,"William ""Bill"" Shorma",REP,372
+Clay,03,State House,17,Chris Kassin,REP,551
+Clay,C1,State House,17,"Rebecca ""Bekki"" Engquist-Schroeder",DEM,260
+Clay,C1,State House,17,"William ""Bill"" Shorma",REP,51
+Clay,C1,State House,17,Chris Kassin,REP,82
+Clay,C2,State House,17,"Rebecca ""Bekki"" Engquist-Schroeder",DEM,103
+Clay,C2,State House,17,"William ""Bill"" Shorma",REP,32
+Clay,C2,State House,17,Chris Kassin,REP,48
+Clay,E1,State House,17,"Rebecca ""Bekki"" Engquist-Schroeder",DEM,158
+Clay,E1,State House,17,"William ""Bill"" Shorma",REP,93
+Clay,E1,State House,17,Chris Kassin,REP,135
+Clay,E2,State House,17,"Rebecca ""Bekki"" Engquist-Schroeder",DEM,62
+Clay,E2,State House,17,"William ""Bill"" Shorma",REP,33
+Clay,E2,State House,17,Chris Kassin,REP,44
+Clay,S1,State House,17,"Rebecca ""Bekki"" Engquist-Schroeder",DEM,414
+Clay,S1,State House,17,"William ""Bill"" Shorma",REP,240
+Clay,S1,State House,17,Chris Kassin,REP,399
+Clay,S2,State House,17,"Rebecca ""Bekki"" Engquist-Schroeder",DEM,329
+Clay,S2,State House,17,"William ""Bill"" Shorma",REP,141
+Clay,S2,State House,17,Chris Kassin,REP,228
+Clay,W1,State House,17,"Rebecca ""Bekki"" Engquist-Schroeder",DEM,327
+Clay,W1,State House,17,"William ""Bill"" Shorma",REP,163
+Clay,W1,State House,17,Chris Kassin,REP,266
+Clay,W2 11 of 23,State House,17,"Rebecca ""Bekki"" Engquist-Schroeder",DEM,204
+Clay,W2 11 of 23,State House,17,"William ""Bill"" Shorma",REP,101
+Clay,W2 11 of 23,State House,17,Chris Kassin,REP,172

--- a/2022/counties/20221108__sd__general__codington__precinct.csv
+++ b/2022/counties/20221108__sd__general__codington__precinct.csv
@@ -1,0 +1,889 @@
+county,precinct,office,district,candidate,party,votes
+Codington,DEXTER,U.S. Senate,,Brian L. Bengs,DEM,13
+Codington,DEXTER,U.S. Senate,,Tamara J Lesnar,LIB,1
+Codington,DEXTER,U.S. Senate,,John R. Thune,REP,74
+Codington,"EDEN, PHIPPS, WALLACE",U.S. Senate,,Brian L. Bengs,DEM,21
+Codington,"EDEN, PHIPPS, WALLACE",U.S. Senate,,Tamara J Lesnar,LIB,9
+Codington,"EDEN, PHIPPS, WALLACE",U.S. Senate,,John R. Thune,REP,81
+Codington,"FULLER, FLORENCE",U.S. Senate,,Brian L. Bengs,DEM,46
+Codington,"FULLER, FLORENCE",U.S. Senate,,Tamara J Lesnar,LIB,14
+Codington,"FULLER, FLORENCE",U.S. Senate,,John R. Thune,REP,191
+Codington,GERMANTOWN (RAUVILLE),U.S. Senate,,Brian L. Bengs,DEM,41
+Codington,GERMANTOWN (RAUVILLE),U.S. Senate,,Tamara J Lesnar,LIB,7
+Codington,GERMANTOWN (RAUVILLE),U.S. Senate,,John R. Thune,REP,159
+Codington,?,U.S. Senate,,Brian L. Bengs,DEM,24
+Codington,?,U.S. Senate,,Tamara J Lesnar,LIB,7
+Codington,?,U.S. Senate,,John R. Thune,REP,183
+Codington,KAMPESKA (RICHLAND),U.S. Senate,,Brian L. Bengs,DEM,28
+Codington,KAMPESKA (RICHLAND),U.S. Senate,,Tamara J Lesnar,LIB,17
+Codington,KAMPESKA (RICHLAND),U.S. Senate,,John R. Thune,REP,175
+Codington,"KRANZBURG, KRANZBURG",U.S. Senate,,Brian L. Bengs,DEM,23
+Codington,"KRANZBURG, KRANZBURG",U.S. Senate,,Tamara J Lesnar,LIB,3
+Codington,"KRANZBURG, KRANZBURG",U.S. Senate,,John R. Thune,REP,198
+Codington,"LEOLA, SOUTH SHORE",U.S. Senate,,Brian L. Bengs,DEM,24
+Codington,"LEOLA, SOUTH SHORE",U.S. Senate,,Tamara J Lesnar,LIB,6
+Codington,"LEOLA, SOUTH SHORE",U.S. Senate,,John R. Thune,REP,99
+Codington,A1,U.S. Senate,,Brian L. Bengs,DEM,166
+Codington,A1,U.S. Senate,,Tamara J Lesnar,LIB,25
+Codington,A1,U.S. Senate,,John R. Thune,REP,795
+Codington,A2,U.S. Senate,,Brian L. Bengs,DEM,118
+Codington,A2,U.S. Senate,,Tamara J Lesnar,LIB,9
+Codington,A2,U.S. Senate,,John R. Thune,REP,347
+Codington,A3 (Precinct-A4),U.S. Senate,,Brian L. Bengs,DEM,88
+Codington,A3 (Precinct-A4),U.S. Senate,,Tamara J Lesnar,LIB,16
+Codington,A3 (Precinct-A4),U.S. Senate,,John R. Thune,REP,368
+Codington,?,U.S. Senate,,Brian L. Bengs,DEM,123
+Codington,?,U.S. Senate,,Tamara J Lesnar,LIB,25
+Codington,?,U.S. Senate,,John R. Thune,REP,557
+Codington,B2,U.S. Senate,,Brian L. Bengs,DEM,221
+Codington,B2,U.S. Senate,,Tamara J Lesnar,LIB,51
+Codington,B2,U.S. Senate,,John R. Thune,REP,461
+Codington,B3 (Precinct-C1),U.S. Senate,,Brian L. Bengs,DEM,182
+Codington,B3 (Precinct-C1),U.S. Senate,,Tamara J Lesnar,LIB,37
+Codington,B3 (Precinct-C1),U.S. Senate,,John R. Thune,REP,532
+Codington,?,U.S. Senate,,Brian L. Bengs,DEM,147
+Codington,?,U.S. Senate,,Tamara J Lesnar,LIB,32
+Codington,?,U.S. Senate,,John R. Thune,REP,379
+Codington,?,U.S. Senate,,Brian L. Bengs,DEM,264
+Codington,?,U.S. Senate,,Tamara J Lesnar,LIB,61
+Codington,?,U.S. Senate,,John R. Thune,REP,802
+Codington,D1,U.S. Senate,,Brian L. Bengs,DEM,107
+Codington,D1,U.S. Senate,,Tamara J Lesnar,LIB,18
+Codington,D1,U.S. Senate,,John R. Thune,REP,347
+Codington,D2,U.S. Senate,,Brian L. Bengs,DEM,99
+Codington,D2,U.S. Senate,,Tamara J Lesnar,LIB,15
+Codington,D2,U.S. Senate,,John R. Thune,REP,282
+Codington,D3,U.S. Senate,,Brian L. Bengs,DEM,85
+Codington,D3,U.S. Senate,,Tamara J Lesnar,LIB,16
+Codington,D3,U.S. Senate,,John R. Thune,REP,282
+Codington,?,U.S. Senate,,Brian L. Bengs,DEM,240
+Codington,?,U.S. Senate,,Tamara J Lesnar,LIB,47
+Codington,?,U.S. Senate,,John R. Thune,REP,859
+Codington,E2 (Precinct-E3),U.S. Senate,,Brian L. Bengs,DEM,155
+Codington,E2 (Precinct-E3),U.S. Senate,,Tamara J Lesnar,LIB,35
+Codington,E2 (Precinct-E3),U.S. Senate,,John R. Thune,REP,855
+Codington,SHERIDAN,U.S. Senate,,Brian L. Bengs,DEM,36
+Codington,SHERIDAN,U.S. Senate,,Tamara J Lesnar,LIB,5
+Codington,SHERIDAN,U.S. Senate,,John R. Thune,REP,170
+Codington,WAVERLY,U.S. Senate,,Brian L. Bengs,DEM,14
+Codington,WAVERLY,U.S. Senate,,Tamara J Lesnar,LIB,4
+Codington,WAVERLY,U.S. Senate,,John R. Thune,REP,83
+Codington,DEXTER,U.S. House,1,Collin Duprel,LIB,10
+Codington,DEXTER,U.S. House,1,Dusty Johnson,REP,77
+Codington,"EDEN, PHIPPS, WALLACE",U.S. House,1,Collin Duprel,LIB,18
+Codington,"EDEN, PHIPPS, WALLACE",U.S. House,1,Dusty Johnson,REP,86
+Codington,"FULLER, FLORENCE",U.S. House,1,Collin Duprel,LIB,36
+Codington,"FULLER, FLORENCE",U.S. House,1,Dusty Johnson,REP,212
+Codington,GERMANTOWN (RAUVILLE),U.S. House,1,Collin Duprel,LIB,27
+Codington,GERMANTOWN (RAUVILLE),U.S. House,1,Dusty Johnson,REP,168
+Codington,?,U.S. House,1,Collin Duprel,LIB,35
+Codington,?,U.S. House,1,Dusty Johnson,REP,172
+Codington,KAMPESKA (RICHLAND),U.S. House,1,Collin Duprel,LIB,23
+Codington,KAMPESKA (RICHLAND),U.S. House,1,Dusty Johnson,REP,191
+Codington,"KRANZBURG, KRANZBURG",U.S. House,1,Collin Duprel,LIB,23
+Codington,"KRANZBURG, KRANZBURG",U.S. House,1,Dusty Johnson,REP,202
+Codington,"LEOLA, SOUTH SHORE",U.S. House,1,Collin Duprel,LIB,22
+Codington,"LEOLA, SOUTH SHORE",U.S. House,1,Dusty Johnson,REP,99
+Codington,A1,U.S. House,1,Collin Duprel,LIB,113
+Codington,A1,U.S. House,1,Dusty Johnson,REP,833
+Codington,A2,U.S. House,1,Collin Duprel,LIB,79
+Codington,A2,U.S. House,1,Dusty Johnson,REP,363
+Codington,A3 (Precinct-A4),U.S. House,1,Collin Duprel,LIB,63
+Codington,A3 (Precinct-A4),U.S. House,1,Dusty Johnson,REP,385
+Codington,?,U.S. House,1,Collin Duprel,LIB,90
+Codington,?,U.S. House,1,Dusty Johnson,REP,589
+Codington,B2,U.S. House,1,Collin Duprel,LIB,197
+Codington,B2,U.S. House,1,Dusty Johnson,REP,501
+Codington,B3 (Precinct-C1),U.S. House,1,Collin Duprel,LIB,124
+Codington,B3 (Precinct-C1),U.S. House,1,Dusty Johnson,REP,578
+Codington,?,U.S. House,1,Collin Duprel,LIB,114
+Codington,?,U.S. House,1,Dusty Johnson,REP,416
+Codington,?,U.S. House,1,Collin Duprel,LIB,223
+Codington,?,U.S. House,1,Dusty Johnson,REP,851
+Codington,D1,U.S. House,1,Collin Duprel,LIB,79
+Codington,D1,U.S. House,1,Dusty Johnson,REP,367
+Codington,D2,U.S. House,1,Collin Duprel,LIB,77
+Codington,D2,U.S. House,1,Dusty Johnson,REP,299
+Codington,D3,U.S. House,1,Collin Duprel,LIB,61
+Codington,D3,U.S. House,1,Dusty Johnson,REP,301
+Codington,?,U.S. House,1,Collin Duprel,LIB,207
+Codington,?,U.S. House,1,Dusty Johnson,REP,897
+Codington,E2 (Precinct-E3),U.S. House,1,Collin Duprel,LIB,124
+Codington,E2 (Precinct-E3),U.S. House,1,Dusty Johnson,REP,897
+Codington,SHERIDAN,U.S. House,1,Collin Duprel,LIB,32
+Codington,SHERIDAN,U.S. House,1,Dusty Johnson,REP,164
+Codington,WAVERLY,U.S. House,1,Collin Duprel,LIB,13
+Codington,WAVERLY,U.S. House,1,Dusty Johnson,REP,81
+Codington,DEXTER,Governor,,Jamie Smith and Jennifer Keintz,DEM,20
+Codington,DEXTER,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Codington,DEXTER,Governor,,Kristi Noem and Larry Rhoden,REP,67
+Codington,"EDEN, PHIPPS, WALLACE",Governor,,Jamie Smith and Jennifer Keintz,DEM,30
+Codington,"EDEN, PHIPPS, WALLACE",Governor,,Tracey Quint and Ashley Strand,LIB,4
+Codington,"EDEN, PHIPPS, WALLACE",Governor,,Kristi Noem and Larry Rhoden,REP,78
+Codington,"FULLER, FLORENCE",Governor,,Jamie Smith and Jennifer Keintz,DEM,58
+Codington,"FULLER, FLORENCE",Governor,,Tracey Quint and Ashley Strand,LIB,7
+Codington,"FULLER, FLORENCE",Governor,,Kristi Noem and Larry Rhoden,REP,192
+Codington,GERMANTOWN (RAUVILLE),Governor,,Jamie Smith and Jennifer Keintz,DEM,50
+Codington,GERMANTOWN (RAUVILLE),Governor,,Tracey Quint and Ashley Strand,LIB,10
+Codington,GERMANTOWN (RAUVILLE),Governor,,Kristi Noem and Larry Rhoden,REP,149
+Codington,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,38
+Codington,?,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Codington,?,Governor,,Kristi Noem and Larry Rhoden,REP,173
+Codington,KAMPESKA (RICHLAND),Governor,,Jamie Smith and Jennifer Keintz,DEM,50
+Codington,KAMPESKA (RICHLAND),Governor,,Tracey Quint and Ashley Strand,LIB,3
+Codington,KAMPESKA (RICHLAND),Governor,,Kristi Noem and Larry Rhoden,REP,172
+Codington,"KRANZBURG, KRANZBURG",Governor,,Jamie Smith and Jennifer Keintz,DEM,25
+Codington,"KRANZBURG, KRANZBURG",Governor,,Tracey Quint and Ashley Strand,LIB,6
+Codington,"KRANZBURG, KRANZBURG",Governor,,Kristi Noem and Larry Rhoden,REP,197
+Codington,"LEOLA, SOUTH SHORE",Governor,,Jamie Smith and Jennifer Keintz,DEM,35
+Codington,"LEOLA, SOUTH SHORE",Governor,,Tracey Quint and Ashley Strand,LIB,5
+Codington,"LEOLA, SOUTH SHORE",Governor,,Kristi Noem and Larry Rhoden,REP,88
+Codington,A1,Governor,,Jamie Smith and Jennifer Keintz,DEM,251
+Codington,A1,Governor,,Tracey Quint and Ashley Strand,LIB,13
+Codington,A1,Governor,,Kristi Noem and Larry Rhoden,REP,728
+Codington,A2,Governor,,Jamie Smith and Jennifer Keintz,DEM,158
+Codington,A2,Governor,,Tracey Quint and Ashley Strand,LIB,9
+Codington,A2,Governor,,Kristi Noem and Larry Rhoden,REP,309
+Codington,A3 (Precinct-A4),Governor,,Jamie Smith and Jennifer Keintz,DEM,136
+Codington,A3 (Precinct-A4),Governor,,Tracey Quint and Ashley Strand,LIB,10
+Codington,A3 (Precinct-A4),Governor,,Kristi Noem and Larry Rhoden,REP,330
+Codington,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,191
+Codington,?,Governor,,Tracey Quint and Ashley Strand,LIB,20
+Codington,?,Governor,,Kristi Noem and Larry Rhoden,REP,495
+Codington,B2,Governor,,Jamie Smith and Jennifer Keintz,DEM,310
+Codington,B2,Governor,,Tracey Quint and Ashley Strand,LIB,42
+Codington,B2,Governor,,Kristi Noem and Larry Rhoden,REP,384
+Codington,B3 (Precinct-C1),Governor,,Jamie Smith and Jennifer Keintz,DEM,247
+Codington,B3 (Precinct-C1),Governor,,Tracey Quint and Ashley Strand,LIB,18
+Codington,B3 (Precinct-C1),Governor,,Kristi Noem and Larry Rhoden,REP,491
+Codington,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,210
+Codington,?,Governor,,Tracey Quint and Ashley Strand,LIB,21
+Codington,?,Governor,,Kristi Noem and Larry Rhoden,REP,328
+Codington,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,358
+Codington,?,Governor,,Tracey Quint and Ashley Strand,LIB,40
+Codington,?,Governor,,Kristi Noem and Larry Rhoden,REP,743
+Codington,D1,Governor,,Jamie Smith and Jennifer Keintz,DEM,155
+Codington,D1,Governor,,Tracey Quint and Ashley Strand,LIB,10
+Codington,D1,Governor,,Kristi Noem and Larry Rhoden,REP,308
+Codington,D2,Governor,,Jamie Smith and Jennifer Keintz,DEM,140
+Codington,D2,Governor,,Tracey Quint and Ashley Strand,LIB,9
+Codington,D2,Governor,,Kristi Noem and Larry Rhoden,REP,257
+Codington,D3,Governor,,Jamie Smith and Jennifer Keintz,DEM,118
+Codington,D3,Governor,,Tracey Quint and Ashley Strand,LIB,12
+Codington,D3,Governor,,Kristi Noem and Larry Rhoden,REP,255
+Codington,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,344
+Codington,?,Governor,,Tracey Quint and Ashley Strand,LIB,38
+Codington,?,Governor,,Kristi Noem and Larry Rhoden,REP,769
+Codington,E2 (Precinct-E3),Governor,,Jamie Smith and Jennifer Keintz,DEM,259
+Codington,E2 (Precinct-E3),Governor,,Tracey Quint and Ashley Strand,LIB,17
+Codington,E2 (Precinct-E3),Governor,,Kristi Noem and Larry Rhoden,REP,773
+Codington,SHERIDAN,Governor,,Jamie Smith and Jennifer Keintz,DEM,48
+Codington,SHERIDAN,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Codington,SHERIDAN,Governor,,Kristi Noem and Larry Rhoden,REP,156
+Codington,WAVERLY,Governor,,Jamie Smith and Jennifer Keintz,DEM,22
+Codington,WAVERLY,Governor,,Tracey Quint and Ashley Strand,LIB,0
+Codington,WAVERLY,Governor,,Kristi Noem and Larry Rhoden,REP,78
+Codington,DEXTER,Secretary of State,,Thomas A Cool,DEM,23
+Codington,DEXTER,Secretary of State,,Monae Johnson,REP,60
+Codington,"EDEN, PHIPPS, WALLACE",Secretary of State,,Thomas A Cool,DEM,32
+Codington,"EDEN, PHIPPS, WALLACE",Secretary of State,,Monae Johnson,REP,68
+Codington,"FULLER, FLORENCE",Secretary of State,,Thomas A Cool,DEM,64
+Codington,"FULLER, FLORENCE",Secretary of State,,Monae Johnson,REP,171
+Codington,GERMANTOWN (RAUVILLE),Secretary of State,,Thomas A Cool,DEM,46
+Codington,GERMANTOWN (RAUVILLE),Secretary of State,,Monae Johnson,REP,141
+Codington,?,Secretary of State,,Thomas A Cool,DEM,43
+Codington,?,Secretary of State,,Monae Johnson,REP,156
+Codington,KAMPESKA (RICHLAND),Secretary of State,,Thomas A Cool,DEM,49
+Codington,KAMPESKA (RICHLAND),Secretary of State,,Monae Johnson,REP,155
+Codington,"KRANZBURG, KRANZBURG",Secretary of State,,Thomas A Cool,DEM,41
+Codington,"KRANZBURG, KRANZBURG",Secretary of State,,Monae Johnson,REP,160
+Codington,"LEOLA, SOUTH SHORE",Secretary of State,,Thomas A Cool,DEM,41
+Codington,"LEOLA, SOUTH SHORE",Secretary of State,,Monae Johnson,REP,83
+Codington,A1,Secretary of State,,Thomas A Cool,DEM,241
+Codington,A1,Secretary of State,,Monae Johnson,REP,697
+Codington,A2,Secretary of State,,Thomas A Cool,DEM,153
+Codington,A2,Secretary of State,,Monae Johnson,REP,301
+Codington,A3 (Precinct-A4),Secretary of State,,Thomas A Cool,DEM,126
+Codington,A3 (Precinct-A4),Secretary of State,,Monae Johnson,REP,317
+Codington,?,Secretary of State,,Thomas A Cool,DEM,185
+Codington,?,Secretary of State,,Monae Johnson,REP,480
+Codington,B2,Secretary of State,,Thomas A Cool,DEM,294
+Codington,B2,Secretary of State,,Monae Johnson,REP,394
+Codington,B3 (Precinct-C1),Secretary of State,,Thomas A Cool,DEM,222
+Codington,B3 (Precinct-C1),Secretary of State,,Monae Johnson,REP,479
+Codington,?,Secretary of State,,Thomas A Cool,DEM,214
+Codington,?,Secretary of State,,Monae Johnson,REP,304
+Codington,?,Secretary of State,,Thomas A Cool,DEM,340
+Codington,?,Secretary of State,,Monae Johnson,REP,715
+Codington,D1,Secretary of State,,Thomas A Cool,DEM,140
+Codington,D1,Secretary of State,,Monae Johnson,REP,298
+Codington,D2,Secretary of State,,Thomas A Cool,DEM,134
+Codington,D2,Secretary of State,,Monae Johnson,REP,234
+Codington,D3,Secretary of State,,Thomas A Cool,DEM,115
+Codington,D3,Secretary of State,,Monae Johnson,REP,242
+Codington,?,Secretary of State,,Thomas A Cool,DEM,329
+Codington,?,Secretary of State,,Monae Johnson,REP,753
+Codington,E2 (Precinct-E3),Secretary of State,,Thomas A Cool,DEM,245
+Codington,E2 (Precinct-E3),Secretary of State,,Monae Johnson,REP,749
+Codington,SHERIDAN,Secretary of State,,Thomas A Cool,DEM,48
+Codington,SHERIDAN,Secretary of State,,Monae Johnson,REP,146
+Codington,WAVERLY,Secretary of State,,Thomas A Cool,DEM,32
+Codington,WAVERLY,Secretary of State,,Monae Johnson,REP,59
+Codington,DEXTER,Attorney General,,Marty J. Jackley,REP,74
+Codington,"EDEN, PHIPPS, WALLACE",Attorney General,,Marty J. Jackley,REP,81
+Codington,"FULLER, FLORENCE",Attorney General,,Marty J. Jackley,REP,198
+Codington,GERMANTOWN (RAUVILLE),Attorney General,,Marty J. Jackley,REP,153
+Codington,?,Attorney General,,Marty J. Jackley,REP,177
+Codington,KAMPESKA (RICHLAND),Attorney General,,Marty J. Jackley,REP,193
+Codington,"KRANZBURG, KRANZBURG",Attorney General,,Marty J. Jackley,REP,187
+Codington,"LEOLA, SOUTH SHORE",Attorney General,,Marty J. Jackley,REP,102
+Codington,A1,Attorney General,,Marty J. Jackley,REP,814
+Codington,A2,Attorney General,,Marty J. Jackley,REP,361
+Codington,A3 (Precinct-A4),Attorney General,,Marty J. Jackley,REP,383
+Codington,?,Attorney General,,Marty J. Jackley,REP,578
+Codington,B2,Attorney General,,Marty J. Jackley,REP,528
+Codington,B3 (Precinct-C1),Attorney General,,Marty J. Jackley,REP,588
+Codington,?,Attorney General,,Marty J. Jackley,REP,401
+Codington,?,Attorney General,,Marty J. Jackley,REP,868
+Codington,D1,Attorney General,,Marty J. Jackley,REP,370
+Codington,D2,Attorney General,,Marty J. Jackley,REP,296
+Codington,D3,Attorney General,,Marty J. Jackley,REP,288
+Codington,?,Attorney General,,Marty J. Jackley,REP,863
+Codington,E2 (Precinct-E3),Attorney General,,Marty J. Jackley,REP,857
+Codington,SHERIDAN,Attorney General,,Marty J. Jackley,REP,169
+Codington,WAVERLY,Attorney General,,Marty J. Jackley,REP,80
+Codington,DEXTER,State Auditor,,Stephanie Marty,DEM,24
+Codington,DEXTER,State Auditor,,Rene Meyer,LIB,6
+Codington,DEXTER,State Auditor,,Richard Sattgast,REP,53
+Codington,"EDEN, PHIPPS, WALLACE",State Auditor,,Stephanie Marty,DEM,30
+Codington,"EDEN, PHIPPS, WALLACE",State Auditor,,Rene Meyer,LIB,9
+Codington,"EDEN, PHIPPS, WALLACE",State Auditor,,Richard Sattgast,REP,56
+Codington,"FULLER, FLORENCE",State Auditor,,Stephanie Marty,DEM,61
+Codington,"FULLER, FLORENCE",State Auditor,,Rene Meyer,LIB,9
+Codington,"FULLER, FLORENCE",State Auditor,,Richard Sattgast,REP,164
+Codington,GERMANTOWN (RAUVILLE),State Auditor,,Stephanie Marty,DEM,45
+Codington,GERMANTOWN (RAUVILLE),State Auditor,,Rene Meyer,LIB,15
+Codington,GERMANTOWN (RAUVILLE),State Auditor,,Richard Sattgast,REP,125
+Codington,?,State Auditor,,Stephanie Marty,DEM,32
+Codington,?,State Auditor,,Rene Meyer,LIB,14
+Codington,?,State Auditor,,Richard Sattgast,REP,151
+Codington,KAMPESKA (RICHLAND),State Auditor,,Stephanie Marty,DEM,48
+Codington,KAMPESKA (RICHLAND),State Auditor,,Rene Meyer,LIB,6
+Codington,KAMPESKA (RICHLAND),State Auditor,,Richard Sattgast,REP,149
+Codington,"KRANZBURG, KRANZBURG",State Auditor,,Stephanie Marty,DEM,33
+Codington,"KRANZBURG, KRANZBURG",State Auditor,,Rene Meyer,LIB,9
+Codington,"KRANZBURG, KRANZBURG",State Auditor,,Richard Sattgast,REP,158
+Codington,"LEOLA, SOUTH SHORE",State Auditor,,Stephanie Marty,DEM,34
+Codington,"LEOLA, SOUTH SHORE",State Auditor,,Rene Meyer,LIB,4
+Codington,"LEOLA, SOUTH SHORE",State Auditor,,Richard Sattgast,REP,81
+Codington,A1,State Auditor,,Stephanie Marty,DEM,211
+Codington,A1,State Auditor,,Rene Meyer,LIB,31
+Codington,A1,State Auditor,,Richard Sattgast,REP,687
+Codington,A2,State Auditor,,Stephanie Marty,DEM,135
+Codington,A2,State Auditor,,Rene Meyer,LIB,22
+Codington,A2,State Auditor,,Richard Sattgast,REP,289
+Codington,A3 (Precinct-A4),State Auditor,,Stephanie Marty,DEM,112
+Codington,A3 (Precinct-A4),State Auditor,,Rene Meyer,LIB,22
+Codington,A3 (Precinct-A4),State Auditor,,Richard Sattgast,REP,299
+Codington,?,State Auditor,,Stephanie Marty,DEM,167
+Codington,?,State Auditor,,Rene Meyer,LIB,20
+Codington,?,State Auditor,,Richard Sattgast,REP,474
+Codington,B2,State Auditor,,Stephanie Marty,DEM,267
+Codington,B2,State Auditor,,Rene Meyer,LIB,54
+Codington,B2,State Auditor,,Richard Sattgast,REP,353
+Codington,B3 (Precinct-C1),State Auditor,,Stephanie Marty,DEM,207
+Codington,B3 (Precinct-C1),State Auditor,,Rene Meyer,LIB,40
+Codington,B3 (Precinct-C1),State Auditor,,Richard Sattgast,REP,455
+Codington,?,State Auditor,,Stephanie Marty,DEM,175
+Codington,?,State Auditor,,Rene Meyer,LIB,32
+Codington,?,State Auditor,,Richard Sattgast,REP,301
+Codington,?,State Auditor,,Stephanie Marty,DEM,298
+Codington,?,State Auditor,,Rene Meyer,LIB,79
+Codington,?,State Auditor,,Richard Sattgast,REP,680
+Codington,D1,State Auditor,,Stephanie Marty,DEM,131
+Codington,D1,State Auditor,,Rene Meyer,LIB,24
+Codington,D1,State Auditor,,Richard Sattgast,REP,284
+Codington,D2,State Auditor,,Stephanie Marty,DEM,124
+Codington,D2,State Auditor,,Rene Meyer,LIB,20
+Codington,D2,State Auditor,,Richard Sattgast,REP,221
+Codington,D3,State Auditor,,Stephanie Marty,DEM,108
+Codington,D3,State Auditor,,Rene Meyer,LIB,13
+Codington,D3,State Auditor,,Richard Sattgast,REP,233
+Codington,?,State Auditor,,Stephanie Marty,DEM,310
+Codington,?,State Auditor,,Rene Meyer,LIB,65
+Codington,?,State Auditor,,Richard Sattgast,REP,716
+Codington,E2 (Precinct-E3),State Auditor,,Stephanie Marty,DEM,220
+Codington,E2 (Precinct-E3),State Auditor,,Rene Meyer,LIB,30
+Codington,E2 (Precinct-E3),State Auditor,,Richard Sattgast,REP,727
+Codington,SHERIDAN,State Auditor,,Stephanie Marty,DEM,41
+Codington,SHERIDAN,State Auditor,,Rene Meyer,LIB,11
+Codington,SHERIDAN,State Auditor,,Richard Sattgast,REP,137
+Codington,WAVERLY,State Auditor,,Stephanie Marty,DEM,23
+Codington,WAVERLY,State Auditor,,Rene Meyer,LIB,5
+Codington,WAVERLY,State Auditor,,Richard Sattgast,REP,64
+Codington,DEXTER,State Treasurer,,John Cunningham,DEM,25
+Codington,DEXTER,State Treasurer,,Josh Haeder,REP,56
+Codington,"EDEN, PHIPPS, WALLACE",State Treasurer,,John Cunningham,DEM,31
+Codington,"EDEN, PHIPPS, WALLACE",State Treasurer,,Josh Haeder,REP,63
+Codington,"FULLER, FLORENCE",State Treasurer,,John Cunningham,DEM,60
+Codington,"FULLER, FLORENCE",State Treasurer,,Josh Haeder,REP,173
+Codington,GERMANTOWN (RAUVILLE),State Treasurer,,John Cunningham,DEM,54
+Codington,GERMANTOWN (RAUVILLE),State Treasurer,,Josh Haeder,REP,129
+Codington,?,State Treasurer,,John Cunningham,DEM,39
+Codington,?,State Treasurer,,Josh Haeder,REP,159
+Codington,KAMPESKA (RICHLAND),State Treasurer,,John Cunningham,DEM,51
+Codington,KAMPESKA (RICHLAND),State Treasurer,,Josh Haeder,REP,152
+Codington,"KRANZBURG, KRANZBURG",State Treasurer,,John Cunningham,DEM,44
+Codington,"KRANZBURG, KRANZBURG",State Treasurer,,Josh Haeder,REP,158
+Codington,"LEOLA, SOUTH SHORE",State Treasurer,,John Cunningham,DEM,36
+Codington,"LEOLA, SOUTH SHORE",State Treasurer,,Josh Haeder,REP,86
+Codington,A1,State Treasurer,,John Cunningham,DEM,209
+Codington,A1,State Treasurer,,Josh Haeder,REP,713
+Codington,A2,State Treasurer,,John Cunningham,DEM,140
+Codington,A2,State Treasurer,,Josh Haeder,REP,303
+Codington,A3 (Precinct-A4),State Treasurer,,John Cunningham,DEM,118
+Codington,A3 (Precinct-A4),State Treasurer,,Josh Haeder,REP,324
+Codington,?,State Treasurer,,John Cunningham,DEM,163
+Codington,?,State Treasurer,,Josh Haeder,REP,490
+Codington,B2,State Treasurer,,John Cunningham,DEM,276
+Codington,B2,State Treasurer,,Josh Haeder,REP,401
+Codington,B3 (Precinct-C1),State Treasurer,,John Cunningham,DEM,220
+Codington,B3 (Precinct-C1),State Treasurer,,Josh Haeder,REP,475
+Codington,?,State Treasurer,,John Cunningham,DEM,188
+Codington,?,State Treasurer,,Josh Haeder,REP,317
+Codington,?,State Treasurer,,John Cunningham,DEM,323
+Codington,?,State Treasurer,,Josh Haeder,REP,717
+Codington,D1,State Treasurer,,John Cunningham,DEM,145
+Codington,D1,State Treasurer,,Josh Haeder,REP,296
+Codington,D2,State Treasurer,,John Cunningham,DEM,128
+Codington,D2,State Treasurer,,Josh Haeder,REP,235
+Codington,D3,State Treasurer,,John Cunningham,DEM,119
+Codington,D3,State Treasurer,,Josh Haeder,REP,239
+Codington,?,State Treasurer,,John Cunningham,DEM,317
+Codington,?,State Treasurer,,Josh Haeder,REP,753
+Codington,E2 (Precinct-E3),State Treasurer,,John Cunningham,DEM,217
+Codington,E2 (Precinct-E3),State Treasurer,,Josh Haeder,REP,758
+Codington,SHERIDAN,State Treasurer,,John Cunningham,DEM,45
+Codington,SHERIDAN,State Treasurer,,Josh Haeder,REP,141
+Codington,WAVERLY,State Treasurer,,John Cunningham,DEM,24
+Codington,WAVERLY,State Treasurer,,Josh Haeder,REP,65
+Codington,DEXTER,Commissioner of School and Public Lands,,Timothy Azure,DEM,17
+Codington,DEXTER,Commissioner of School and Public Lands,,Brock Greenfield,REP,66
+Codington,"EDEN, PHIPPS, WALLACE",Commissioner of School and Public Lands,,Timothy Azure,DEM,29
+Codington,"EDEN, PHIPPS, WALLACE",Commissioner of School and Public Lands,,Brock Greenfield,REP,71
+Codington,"FULLER, FLORENCE",Commissioner of School and Public Lands,,Timothy Azure,DEM,57
+Codington,"FULLER, FLORENCE",Commissioner of School and Public Lands,,Brock Greenfield,REP,185
+Codington,GERMANTOWN (RAUVILLE),Commissioner of School and Public Lands,,Timothy Azure,DEM,47
+Codington,GERMANTOWN (RAUVILLE),Commissioner of School and Public Lands,,Brock Greenfield,REP,137
+Codington,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,37
+Codington,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,168
+Codington,KAMPESKA (RICHLAND),Commissioner of School and Public Lands,,Timothy Azure,DEM,44
+Codington,KAMPESKA (RICHLAND),Commissioner of School and Public Lands,,Brock Greenfield,REP,161
+Codington,"KRANZBURG, KRANZBURG",Commissioner of School and Public Lands,,Timothy Azure,DEM,34
+Codington,"KRANZBURG, KRANZBURG",Commissioner of School and Public Lands,,Brock Greenfield,REP,176
+Codington,"LEOLA, SOUTH SHORE",Commissioner of School and Public Lands,,Timothy Azure,DEM,39
+Codington,"LEOLA, SOUTH SHORE",Commissioner of School and Public Lands,,Brock Greenfield,REP,84
+Codington,A1,Commissioner of School and Public Lands,,Timothy Azure,DEM,208
+Codington,A1,Commissioner of School and Public Lands,,Brock Greenfield,REP,721
+Codington,A2,Commissioner of School and Public Lands,,Timothy Azure,DEM,143
+Codington,A2,Commissioner of School and Public Lands,,Brock Greenfield,REP,315
+Codington,A3 (Precinct-A4),Commissioner of School and Public Lands,,Timothy Azure,DEM,101
+Codington,A3 (Precinct-A4),Commissioner of School and Public Lands,,Brock Greenfield,REP,332
+Codington,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,161
+Codington,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,496
+Codington,B2,Commissioner of School and Public Lands,,Timothy Azure,DEM,252
+Codington,B2,Commissioner of School and Public Lands,,Brock Greenfield,REP,421
+Codington,B3 (Precinct-C1),Commissioner of School and Public Lands,,Timothy Azure,DEM,195
+Codington,B3 (Precinct-C1),Commissioner of School and Public Lands,,Brock Greenfield,REP,495
+Codington,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,178
+Codington,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,332
+Codington,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,295
+Codington,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,751
+Codington,D1,Commissioner of School and Public Lands,,Timothy Azure,DEM,133
+Codington,D1,Commissioner of School and Public Lands,,Brock Greenfield,REP,307
+Codington,D2,Commissioner of School and Public Lands,,Timothy Azure,DEM,116
+Codington,D2,Commissioner of School and Public Lands,,Brock Greenfield,REP,252
+Codington,D3,Commissioner of School and Public Lands,,Timothy Azure,DEM,102
+Codington,D3,Commissioner of School and Public Lands,,Brock Greenfield,REP,261
+Codington,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,291
+Codington,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,786
+Codington,E2 (Precinct-E3),Commissioner of School and Public Lands,,Timothy Azure,DEM,204
+Codington,E2 (Precinct-E3),Commissioner of School and Public Lands,,Brock Greenfield,REP,773
+Codington,SHERIDAN,Commissioner of School and Public Lands,,Timothy Azure,DEM,35
+Codington,SHERIDAN,Commissioner of School and Public Lands,,Brock Greenfield,REP,156
+Codington,WAVERLY,Commissioner of School and Public Lands,,Timothy Azure,DEM,22
+Codington,WAVERLY,Commissioner of School and Public Lands,,Brock Greenfield,REP,70
+Codington,DEXTER,Public Utilities Commissioner,,Jeffrey Barth,DEM,23
+Codington,DEXTER,Public Utilities Commissioner,,Chris Nelson,REP,59
+Codington,"EDEN, PHIPPS, WALLACE",Public Utilities Commissioner,,Jeffrey Barth,DEM,23
+Codington,"EDEN, PHIPPS, WALLACE",Public Utilities Commissioner,,Chris Nelson,REP,79
+Codington,"FULLER, FLORENCE",Public Utilities Commissioner,,Jeffrey Barth,DEM,57
+Codington,"FULLER, FLORENCE",Public Utilities Commissioner,,Chris Nelson,REP,182
+Codington,GERMANTOWN (RAUVILLE),Public Utilities Commissioner,,Jeffrey Barth,DEM,45
+Codington,GERMANTOWN (RAUVILLE),Public Utilities Commissioner,,Chris Nelson,REP,141
+Codington,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,28
+Codington,?,Public Utilities Commissioner,,Chris Nelson,REP,176
+Codington,KAMPESKA (RICHLAND),Public Utilities Commissioner,,Jeffrey Barth,DEM,42
+Codington,KAMPESKA (RICHLAND),Public Utilities Commissioner,,Chris Nelson,REP,163
+Codington,"KRANZBURG, KRANZBURG",Public Utilities Commissioner,,Jeffrey Barth,DEM,29
+Codington,"KRANZBURG, KRANZBURG",Public Utilities Commissioner,,Chris Nelson,REP,178
+Codington,"LEOLA, SOUTH SHORE",Public Utilities Commissioner,,Jeffrey Barth,DEM,30
+Codington,"LEOLA, SOUTH SHORE",Public Utilities Commissioner,,Chris Nelson,REP,95
+Codington,A1,Public Utilities Commissioner,,Jeffrey Barth,DEM,186
+Codington,A1,Public Utilities Commissioner,,Chris Nelson,REP,750
+Codington,A2,Public Utilities Commissioner,,Jeffrey Barth,DEM,128
+Codington,A2,Public Utilities Commissioner,,Chris Nelson,REP,327
+Codington,A3 (Precinct-A4),Public Utilities Commissioner,,Jeffrey Barth,DEM,100
+Codington,A3 (Precinct-A4),Public Utilities Commissioner,,Chris Nelson,REP,340
+Codington,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,141
+Codington,?,Public Utilities Commissioner,,Chris Nelson,REP,520
+Codington,B2,Public Utilities Commissioner,,Jeffrey Barth,DEM,241
+Codington,B2,Public Utilities Commissioner,,Chris Nelson,REP,432
+Codington,B3 (Precinct-C1),Public Utilities Commissioner,,Jeffrey Barth,DEM,180
+Codington,B3 (Precinct-C1),Public Utilities Commissioner,,Chris Nelson,REP,520
+Codington,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,175
+Codington,?,Public Utilities Commissioner,,Chris Nelson,REP,331
+Codington,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,309
+Codington,?,Public Utilities Commissioner,,Chris Nelson,REP,740
+Codington,D1,Public Utilities Commissioner,,Jeffrey Barth,DEM,124
+Codington,D1,Public Utilities Commissioner,,Chris Nelson,REP,326
+Codington,D2,Public Utilities Commissioner,,Jeffrey Barth,DEM,116
+Codington,D2,Public Utilities Commissioner,,Chris Nelson,REP,248
+Codington,D3,Public Utilities Commissioner,,Jeffrey Barth,DEM,94
+Codington,D3,Public Utilities Commissioner,,Chris Nelson,REP,265
+Codington,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,272
+Codington,?,Public Utilities Commissioner,,Chris Nelson,REP,810
+Codington,E2 (Precinct-E3),Public Utilities Commissioner,,Jeffrey Barth,DEM,183
+Codington,E2 (Precinct-E3),Public Utilities Commissioner,,Chris Nelson,REP,821
+Codington,SHERIDAN,Public Utilities Commissioner,,Jeffrey Barth,DEM,39
+Codington,SHERIDAN,Public Utilities Commissioner,,Chris Nelson,REP,152
+Codington,WAVERLY,Public Utilities Commissioner,,Jeffrey Barth,DEM,18
+Codington,WAVERLY,Public Utilities Commissioner,,Chris Nelson,REP,74
+Codington,DEXTER,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,50
+Codington,"EDEN, PHIPPS, WALLACE",Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,44
+Codington,"FULLER, FLORENCE",Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,120
+Codington,GERMANTOWN (RAUVILLE),Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,76
+Codington,?,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,97
+Codington,KAMPESKA (RICHLAND),Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,97
+Codington,"KRANZBURG, KRANZBURG",Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,105
+Codington,"LEOLA, SOUTH SHORE",Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,78
+Codington,A1,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,536
+Codington,A2,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,246
+Codington,A3 (Precinct-A4),Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,227
+Codington,?,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,372
+Codington,B2,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,391
+Codington,B3 (Precinct-C1),Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,354
+Codington,?,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,264
+Codington,?,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,567
+Codington,D1,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,223
+Codington,D2,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,212
+Codington,D3,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,203
+Codington,?,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,582
+Codington,E2 (Precinct-E3),Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,534
+Codington,SHERIDAN,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,110
+Codington,WAVERLY,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,47
+Codington,DEXTER,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,50
+Codington,"EDEN, PHIPPS, WALLACE",Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,46
+Codington,"FULLER, FLORENCE",Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,119
+Codington,GERMANTOWN (RAUVILLE),Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,85
+Codington,?,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,100
+Codington,KAMPESKA (RICHLAND),Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,105
+Codington,"KRANZBURG, KRANZBURG",Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,109
+Codington,"LEOLA, SOUTH SHORE",Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,83
+Codington,A1,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,543
+Codington,A2,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,254
+Codington,A3 (Precinct-A4),Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,235
+Codington,?,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,386
+Codington,B2,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,380
+Codington,B3 (Precinct-C1),Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,370
+Codington,?,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,270
+Codington,?,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,563
+Codington,D1,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,224
+Codington,D2,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,195
+Codington,D3,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,193
+Codington,?,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,578
+Codington,E2 (Precinct-E3),Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,570
+Codington,SHERIDAN,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,112
+Codington,WAVERLY,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,50
+Codington,DEXTER,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,48
+Codington,"EDEN, PHIPPS, WALLACE",Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,36
+Codington,"FULLER, FLORENCE",Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,109
+Codington,GERMANTOWN (RAUVILLE),Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,74
+Codington,?,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,90
+Codington,KAMPESKA (RICHLAND),Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,90
+Codington,"KRANZBURG, KRANZBURG",Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,98
+Codington,"LEOLA, SOUTH SHORE",Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,73
+Codington,A1,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,488
+Codington,A2,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,222
+Codington,A3 (Precinct-A4),Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,200
+Codington,?,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,333
+Codington,B2,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,330
+Codington,B3 (Precinct-C1),Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,305
+Codington,?,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,230
+Codington,?,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,491
+Codington,D1,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,194
+Codington,D2,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,177
+Codington,D3,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,176
+Codington,?,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,495
+Codington,E2 (Precinct-E3),Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,484
+Codington,SHERIDAN,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,97
+Codington,WAVERLY,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,42
+Codington,DEXTER,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,49
+Codington,"EDEN, PHIPPS, WALLACE",Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,37
+Codington,"FULLER, FLORENCE",Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,115
+Codington,GERMANTOWN (RAUVILLE),Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,78
+Codington,?,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,93
+Codington,KAMPESKA (RICHLAND),Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,92
+Codington,"KRANZBURG, KRANZBURG",Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,120
+Codington,"LEOLA, SOUTH SHORE",Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,76
+Codington,A1,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,515
+Codington,A2,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,232
+Codington,A3 (Precinct-A4),Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,215
+Codington,?,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,341
+Codington,B2,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,343
+Codington,B3 (Precinct-C1),Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,325
+Codington,?,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,250
+Codington,?,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,525
+Codington,D1,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,206
+Codington,D2,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,188
+Codington,D3,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,185
+Codington,?,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,523
+Codington,E2 (Precinct-E3),Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,493
+Codington,SHERIDAN,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,104
+Codington,WAVERLY,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,49
+Codington,DEXTER,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,39
+Codington,DEXTER,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,23
+Codington,"EDEN, PHIPPS, WALLACE",Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,35
+Codington,"EDEN, PHIPPS, WALLACE",Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,30
+Codington,"FULLER, FLORENCE",Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,97
+Codington,"FULLER, FLORENCE",Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,59
+Codington,GERMANTOWN (RAUVILLE),Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,69
+Codington,GERMANTOWN (RAUVILLE),Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,39
+Codington,?,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,105
+Codington,?,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,37
+Codington,KAMPESKA (RICHLAND),Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,105
+Codington,KAMPESKA (RICHLAND),Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,44
+Codington,"KRANZBURG, KRANZBURG",Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,106
+Codington,"KRANZBURG, KRANZBURG",Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,32
+Codington,"LEOLA, SOUTH SHORE",Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,65
+Codington,"LEOLA, SOUTH SHORE",Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,27
+Codington,A1,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,408
+Codington,A1,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,235
+Codington,A2,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,200
+Codington,A2,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,108
+Codington,A3 (Precinct-A4),Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,193
+Codington,A3 (Precinct-A4),Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,94
+Codington,?,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,314
+Codington,?,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,160
+Codington,B2,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,304
+Codington,B2,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,176
+Codington,B3 (Precinct-C1),Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,300
+Codington,B3 (Precinct-C1),Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,150
+Codington,?,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,247
+Codington,?,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,118
+Codington,?,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,491
+Codington,?,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,253
+Codington,D1,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,177
+Codington,D1,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,109
+Codington,D2,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,189
+Codington,D2,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,76
+Codington,D3,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,148
+Codington,D3,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,90
+Codington,?,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,526
+Codington,?,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,244
+Codington,E2 (Precinct-E3),Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,479
+Codington,E2 (Precinct-E3),Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,214
+Codington,SHERIDAN,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,101
+Codington,SHERIDAN,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,43
+Codington,WAVERLY,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,43
+Codington,WAVERLY,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,26
+Codington,DEXTER,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,46
+Codington,"EDEN, PHIPPS, WALLACE",Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,39
+Codington,"FULLER, FLORENCE",Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,111
+Codington,GERMANTOWN (RAUVILLE),Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,72
+Codington,?,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,86
+Codington,KAMPESKA (RICHLAND),Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,86
+Codington,"KRANZBURG, KRANZBURG",Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,95
+Codington,"LEOLA, SOUTH SHORE",Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,67
+Codington,A1,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,477
+Codington,A2,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,224
+Codington,A3 (Precinct-A4),Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,200
+Codington,?,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,323
+Codington,B2,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,332
+Codington,B3 (Precinct-C1),Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,298
+Codington,?,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,220
+Codington,?,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,483
+Codington,D1,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,190
+Codington,D2,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,179
+Codington,D3,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,175
+Codington,?,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,492
+Codington,E2 (Precinct-E3),Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,471
+Codington,SHERIDAN,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,99
+Codington,WAVERLY,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,39
+Codington,DEXTER,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,66
+Codington,DEXTER,Supreme Court Retention,3,Patricia J. DeVaney - No,,7
+Codington,"EDEN, PHIPPS, WALLACE",Supreme Court Retention,3,Patricia J. DeVaney - Yes,,71
+Codington,"EDEN, PHIPPS, WALLACE",Supreme Court Retention,3,Patricia J. DeVaney - No,,10
+Codington,"FULLER, FLORENCE",Supreme Court Retention,3,Patricia J. DeVaney - Yes,,171
+Codington,"FULLER, FLORENCE",Supreme Court Retention,3,Patricia J. DeVaney - No,,37
+Codington,GERMANTOWN (RAUVILLE),Supreme Court Retention,3,Patricia J. DeVaney - Yes,,124
+Codington,GERMANTOWN (RAUVILLE),Supreme Court Retention,3,Patricia J. DeVaney - No,,33
+Codington,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,140
+Codington,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,35
+Codington,KAMPESKA (RICHLAND),Supreme Court Retention,3,Patricia J. DeVaney - Yes,,141
+Codington,KAMPESKA (RICHLAND),Supreme Court Retention,3,Patricia J. DeVaney - No,,31
+Codington,"KRANZBURG, KRANZBURG",Supreme Court Retention,3,Patricia J. DeVaney - Yes,,146
+Codington,"KRANZBURG, KRANZBURG",Supreme Court Retention,3,Patricia J. DeVaney - No,,29
+Codington,"LEOLA, SOUTH SHORE",Supreme Court Retention,3,Patricia J. DeVaney - Yes,,97
+Codington,"LEOLA, SOUTH SHORE",Supreme Court Retention,3,Patricia J. DeVaney - No,,19
+Codington,A1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,667
+Codington,A1,Supreme Court Retention,3,Patricia J. DeVaney - No,,105
+Codington,A2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,334
+Codington,A2,Supreme Court Retention,3,Patricia J. DeVaney - No,,62
+Codington,A3 (Precinct-A4),Supreme Court Retention,3,Patricia J. DeVaney - Yes,,324
+Codington,A3 (Precinct-A4),Supreme Court Retention,3,Patricia J. DeVaney - No,,47
+Codington,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,486
+Codington,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,83
+Codington,B2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,458
+Codington,B2,Supreme Court Retention,3,Patricia J. DeVaney - No,,126
+Codington,B3 (Precinct-C1),Supreme Court Retention,3,Patricia J. DeVaney - Yes,,468
+Codington,B3 (Precinct-C1),Supreme Court Retention,3,Patricia J. DeVaney - No,,118
+Codington,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,360
+Codington,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,85
+Codington,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,725
+Codington,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,176
+Codington,D1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,316
+Codington,D1,Supreme Court Retention,3,Patricia J. DeVaney - No,,66
+Codington,D2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,270
+Codington,D2,Supreme Court Retention,3,Patricia J. DeVaney - No,,67
+Codington,D3,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,242
+Codington,D3,Supreme Court Retention,3,Patricia J. DeVaney - No,,71
+Codington,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,745
+Codington,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,190
+Codington,E2 (Precinct-E3),Supreme Court Retention,3,Patricia J. DeVaney - Yes,,753
+Codington,E2 (Precinct-E3),Supreme Court Retention,3,Patricia J. DeVaney - No,,102
+Codington,SHERIDAN,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,147
+Codington,SHERIDAN,Supreme Court Retention,3,Patricia J. DeVaney - No,,32
+Codington,WAVERLY,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,58
+Codington,WAVERLY,Supreme Court Retention,3,Patricia J. DeVaney - No,,20
+Codington,DEXTER,Supreme Court Retention,2,Mark E. Salter - Yes,,66
+Codington,DEXTER,Supreme Court Retention,2,Mark E. Salter - No,,8
+Codington,"EDEN, PHIPPS, WALLACE",Supreme Court Retention,2,Mark E. Salter - Yes,,65
+Codington,"EDEN, PHIPPS, WALLACE",Supreme Court Retention,2,Mark E. Salter - No,,13
+Codington,"FULLER, FLORENCE",Supreme Court Retention,2,Mark E. Salter - Yes,,171
+Codington,"FULLER, FLORENCE",Supreme Court Retention,2,Mark E. Salter - No,,35
+Codington,GERMANTOWN (RAUVILLE),Supreme Court Retention,2,Mark E. Salter - Yes,,127
+Codington,GERMANTOWN (RAUVILLE),Supreme Court Retention,2,Mark E. Salter - No,,31
+Codington,?,Supreme Court Retention,2,Mark E. Salter - Yes,,142
+Codington,?,Supreme Court Retention,2,Mark E. Salter - No,,30
+Codington,KAMPESKA (RICHLAND),Supreme Court Retention,2,Mark E. Salter - Yes,,139
+Codington,KAMPESKA (RICHLAND),Supreme Court Retention,2,Mark E. Salter - No,,31
+Codington,"KRANZBURG, KRANZBURG",Supreme Court Retention,2,Mark E. Salter - Yes,,152
+Codington,"KRANZBURG, KRANZBURG",Supreme Court Retention,2,Mark E. Salter - No,,28
+Codington,"LEOLA, SOUTH SHORE",Supreme Court Retention,2,Mark E. Salter - Yes,,96
+Codington,"LEOLA, SOUTH SHORE",Supreme Court Retention,2,Mark E. Salter - No,,18
+Codington,A1,Supreme Court Retention,2,Mark E. Salter - Yes,,671
+Codington,A1,Supreme Court Retention,2,Mark E. Salter - No,,102
+Codington,A2,Supreme Court Retention,2,Mark E. Salter - Yes,,334
+Codington,A2,Supreme Court Retention,2,Mark E. Salter - No,,56
+Codington,A3 (Precinct-A4),Supreme Court Retention,2,Mark E. Salter - Yes,,315
+Codington,A3 (Precinct-A4),Supreme Court Retention,2,Mark E. Salter - No,,54
+Codington,?,Supreme Court Retention,2,Mark E. Salter - Yes,,493
+Codington,?,Supreme Court Retention,2,Mark E. Salter - No,,75
+Codington,B2,Supreme Court Retention,2,Mark E. Salter - Yes,,456
+Codington,B2,Supreme Court Retention,2,Mark E. Salter - No,,122
+Codington,B3 (Precinct-C1),Supreme Court Retention,2,Mark E. Salter - Yes,,468
+Codington,B3 (Precinct-C1),Supreme Court Retention,2,Mark E. Salter - No,,106
+Codington,?,Supreme Court Retention,2,Mark E. Salter - Yes,,358
+Codington,?,Supreme Court Retention,2,Mark E. Salter - No,,86
+Codington,?,Supreme Court Retention,2,Mark E. Salter - Yes,,716
+Codington,?,Supreme Court Retention,2,Mark E. Salter - No,,175
+Codington,D1,Supreme Court Retention,2,Mark E. Salter - Yes,,315
+Codington,D1,Supreme Court Retention,2,Mark E. Salter - No,,67
+Codington,D2,Supreme Court Retention,2,Mark E. Salter - Yes,,257
+Codington,D2,Supreme Court Retention,2,Mark E. Salter - No,,74
+Codington,D3,Supreme Court Retention,2,Mark E. Salter - Yes,,244
+Codington,D3,Supreme Court Retention,2,Mark E. Salter - No,,69
+Codington,?,Supreme Court Retention,2,Mark E. Salter - Yes,,749
+Codington,?,Supreme Court Retention,2,Mark E. Salter - No,,180
+Codington,E2 (Precinct-E3),Supreme Court Retention,2,Mark E. Salter - Yes,,752
+Codington,E2 (Precinct-E3),Supreme Court Retention,2,Mark E. Salter - No,,99
+Codington,SHERIDAN,Supreme Court Retention,2,Mark E. Salter - Yes,,146
+Codington,SHERIDAN,Supreme Court Retention,2,Mark E. Salter - No,,32
+Codington,WAVERLY,Supreme Court Retention,2,Mark E. Salter - Yes,,60
+Codington,WAVERLY,Supreme Court Retention,2,Mark E. Salter - No,,18
+Codington,DEXTER,Constitutional Amendment D,,Yes,,29
+Codington,DEXTER,Constitutional Amendment D,,No,,56
+Codington,"EDEN, PHIPPS, WALLACE",Constitutional Amendment D,,Yes,,48
+Codington,"EDEN, PHIPPS, WALLACE",Constitutional Amendment D,,No,,56
+Codington,"FULLER, FLORENCE",Constitutional Amendment D,,Yes,,106
+Codington,"FULLER, FLORENCE",Constitutional Amendment D,,No,,144
+Codington,GERMANTOWN (RAUVILLE),Constitutional Amendment D,,Yes,,78
+Codington,GERMANTOWN (RAUVILLE),Constitutional Amendment D,,No,,121
+Codington,?,Constitutional Amendment D,,Yes,,101
+Codington,?,Constitutional Amendment D,,No,,111
+Codington,KAMPESKA (RICHLAND),Constitutional Amendment D,,Yes,,70
+Codington,KAMPESKA (RICHLAND),Constitutional Amendment D,,No,,142
+Codington,"KRANZBURG, KRANZBURG",Constitutional Amendment D,,Yes,,75
+Codington,"KRANZBURG, KRANZBURG",Constitutional Amendment D,,No,,141
+Codington,"LEOLA, SOUTH SHORE",Constitutional Amendment D,,Yes,,62
+Codington,"LEOLA, SOUTH SHORE",Constitutional Amendment D,,No,,64
+Codington,A1,Constitutional Amendment D,,Yes,,443
+Codington,A1,Constitutional Amendment D,,No,,517
+Codington,A2,Constitutional Amendment D,,Yes,,237
+Codington,A2,Constitutional Amendment D,,No,,233
+Codington,A3 (Precinct-A4),Constitutional Amendment D,,Yes,,218
+Codington,A3 (Precinct-A4),Constitutional Amendment D,,No,,240
+Codington,?,Constitutional Amendment D,,Yes,,334
+Codington,?,Constitutional Amendment D,,No,,364
+Codington,B2,Constitutional Amendment D,,Yes,,453
+Codington,B2,Constitutional Amendment D,,No,,273
+Codington,B3 (Precinct-C1),Constitutional Amendment D,,Yes,,388
+Codington,B3 (Precinct-C1),Constitutional Amendment D,,No,,342
+Codington,?,Constitutional Amendment D,,Yes,,301
+Codington,?,Constitutional Amendment D,,No,,246
+Codington,?,Constitutional Amendment D,,Yes,,663
+Codington,?,Constitutional Amendment D,,No,,456
+Codington,D1,Constitutional Amendment D,,Yes,,255
+Codington,D1,Constitutional Amendment D,,No,,206
+Codington,D2,Constitutional Amendment D,,Yes,,230
+Codington,D2,Constitutional Amendment D,,No,,161
+Codington,D3,Constitutional Amendment D,,Yes,,216
+Codington,D3,Constitutional Amendment D,,No,,165
+Codington,?,Constitutional Amendment D,,Yes,,603
+Codington,?,Constitutional Amendment D,,No,,523
+Codington,E2 (Precinct-E3),Constitutional Amendment D,,Yes,,461
+Codington,E2 (Precinct-E3),Constitutional Amendment D,,No,,571
+Codington,SHERIDAN,Constitutional Amendment D,,Yes,,96
+Codington,SHERIDAN,Constitutional Amendment D,,No,,103
+Codington,WAVERLY,Constitutional Amendment D,,Yes,,39
+Codington,WAVERLY,Constitutional Amendment D,,No,,57
+Codington,DEXTER,Initiated Measure 27,,Yes,,23
+Codington,DEXTER,Initiated Measure 27,,No,,64
+Codington,"EDEN, PHIPPS, WALLACE",Initiated Measure 27,,Yes,,35
+Codington,"EDEN, PHIPPS, WALLACE",Initiated Measure 27,,No,,74
+Codington,"FULLER, FLORENCE",Initiated Measure 27,,Yes,,83
+Codington,"FULLER, FLORENCE",Initiated Measure 27,,No,,174
+Codington,GERMANTOWN (RAUVILLE),Initiated Measure 27,,Yes,,78
+Codington,GERMANTOWN (RAUVILLE),Initiated Measure 27,,No,,128
+Codington,?,Initiated Measure 27,,Yes,,103
+Codington,?,Initiated Measure 27,,No,,117
+Codington,KAMPESKA (RICHLAND),Initiated Measure 27,,Yes,,78
+Codington,KAMPESKA (RICHLAND),Initiated Measure 27,,No,,149
+Codington,"KRANZBURG, KRANZBURG",Initiated Measure 27,,Yes,,60
+Codington,"KRANZBURG, KRANZBURG",Initiated Measure 27,,No,,167
+Codington,"LEOLA, SOUTH SHORE",Initiated Measure 27,,Yes,,47
+Codington,"LEOLA, SOUTH SHORE",Initiated Measure 27,,No,,80
+Codington,A1,Initiated Measure 27,,Yes,,363
+Codington,A1,Initiated Measure 27,,No,,616
+Codington,A2,Initiated Measure 27,,Yes,,195
+Codington,A2,Initiated Measure 27,,No,,281
+Codington,A3 (Precinct-A4),Initiated Measure 27,,Yes,,207
+Codington,A3 (Precinct-A4),Initiated Measure 27,,No,,261
+Codington,?,Initiated Measure 27,,Yes,,296
+Codington,?,Initiated Measure 27,,No,,413
+Codington,B2,Initiated Measure 27,,Yes,,440
+Codington,B2,Initiated Measure 27,,No,,302
+Codington,B3 (Precinct-C1),Initiated Measure 27,,Yes,,330
+Codington,B3 (Precinct-C1),Initiated Measure 27,,No,,419
+Codington,?,Initiated Measure 27,,Yes,,260
+Codington,?,Initiated Measure 27,,No,,294
+Codington,?,Initiated Measure 27,,Yes,,607
+Codington,?,Initiated Measure 27,,No,,538
+Codington,D1,Initiated Measure 27,,Yes,,200
+Codington,D1,Initiated Measure 27,,No,,274
+Codington,D2,Initiated Measure 27,,Yes,,225
+Codington,D2,Initiated Measure 27,,No,,177
+Codington,D3,Initiated Measure 27,,Yes,,157
+Codington,D3,Initiated Measure 27,,No,,224
+Codington,?,Initiated Measure 27,,Yes,,540
+Codington,?,Initiated Measure 27,,No,,603
+Codington,E2 (Precinct-E3),Initiated Measure 27,,Yes,,421
+Codington,E2 (Precinct-E3),Initiated Measure 27,,No,,631
+Codington,SHERIDAN,Initiated Measure 27,,Yes,,64
+Codington,SHERIDAN,Initiated Measure 27,,No,,140
+Codington,WAVERLY,Initiated Measure 27,,Yes,,31
+Codington,WAVERLY,Initiated Measure 27,,No,,67
+Codington,DEXTER,State Senate,04,John Wiik,REP,69
+Codington,"EDEN, PHIPPS, WALLACE",State Senate,04,John Wiik,REP,75
+Codington,"FULLER, FLORENCE",State Senate,04,John Wiik,REP,186
+Codington,GERMANTOWN (RAUVILLE),State Senate,04,John Wiik,REP,144
+Codington,"GRACELAND, HENRY, HENRY",State Senate,04,John Wiik,REP,172
+Codington,KAMPESKA (RICHLAND),State Senate,04,John Wiik,REP,176
+Codington,"KRANZBURG, KRANZBURG",State Senate,04,John Wiik,REP,180
+Codington,"LEOLA, SOUTH SHORE",State Senate,04,John Wiik,REP,95
+Codington,A1,State Senate,05,Lee Schoenbeck,REP,751
+Codington,A2,State Senate,05,Lee Schoenbeck,REP,338
+Codington,A3 (Precinct-A4),State Senate,05,Lee Schoenbeck,REP,350
+Codington,"B1 (Precinct-B4, Precinct-E5)",State Senate,05,Lee Schoenbeck,REP,534
+Codington,B2,State Senate,05,Lee Schoenbeck,REP,473
+Codington,B3 (Precinct-C1),State Senate,05,Lee Schoenbeck,REP,531
+Codington,"C2 (ELMIRA, Precinct-D4)",State Senate,05,Lee Schoenbeck,REP,358
+Codington,"C3 (PELICAN, Precinct-C4)",State Senate,05,Lee Schoenbeck,REP,787
+Codington,D1,State Senate,05,Lee Schoenbeck,REP,336
+Codington,D2,State Senate,05,Lee Schoenbeck,REP,266
+Codington,D3,State Senate,05,Lee Schoenbeck,REP,258
+Codington,"E1 (LAKE, Precinct -E4)",State Senate,05,Lee Schoenbeck,REP,806
+Codington,E2 (Precinct-E3),State Senate,05,Lee Schoenbeck,REP,800
+Codington,SHERIDAN,State Senate,05,Lee Schoenbeck,REP,155
+Codington,WAVERLY 10 of 22,State Senate,04,John Wiik,REP,62
+Codington,DEXTER,State House,04,Stephanie Sauder,REP,41
+Codington,DEXTER,State House,04,Fred Deutsch,REP,55
+Codington,"EDEN, PHIPPS, WALLACE",State House,04,Stephanie Sauder,REP,41
+Codington,"EDEN, PHIPPS, WALLACE",State House,04,Fred Deutsch,REP,65
+Codington,"FULLER, FLORENCE",State House,04,Stephanie Sauder,REP,120
+Codington,"FULLER, FLORENCE",State House,04,Fred Deutsch,REP,156
+Codington,GERMANTOWN (RAUVILLE),State House,04,Stephanie Sauder,REP,95
+Codington,GERMANTOWN (RAUVILLE),State House,04,Fred Deutsch,REP,118
+Codington,"GRACELAND, HENRY, HENRY",State House,04,Stephanie Sauder,REP,123
+Codington,"GRACELAND, HENRY, HENRY",State House,04,Fred Deutsch,REP,129
+Codington,KAMPESKA (RICHLAND),State House,04,Stephanie Sauder,REP,120
+Codington,KAMPESKA (RICHLAND),State House,04,Fred Deutsch,REP,138
+Codington,"KRANZBURG, KRANZBURG",State House,04,Stephanie Sauder,REP,106
+Codington,"KRANZBURG, KRANZBURG",State House,04,Fred Deutsch,REP,147
+Codington,"LEOLA, SOUTH SHORE",State House,04,Stephanie Sauder,REP,63
+Codington,"LEOLA, SOUTH SHORE",State House,04,Fred Deutsch,REP,76
+Codington,A1,State House,05,Kahden Mooney,DEM,266
+Codington,A1,State House,05,Byron I. Callies,REP,515
+Codington,A1,State House,05,Hugh M. Bartels,REP,658
+Codington,A2,State House,05,Kahden Mooney,DEM,166
+Codington,A2,State House,05,Byron I. Callies,REP,235
+Codington,A2,State House,05,Hugh M. Bartels,REP,304
+Codington,A3 (Precinct-A4),State House,05,Kahden Mooney,DEM,147
+Codington,A3 (Precinct-A4),State House,05,Byron I. Callies,REP,224
+Codington,A3 (Precinct-A4),State House,05,Hugh M. Bartels,REP,303
+Codington,"B1 (Precinct-B4, Precinct-E5)",State House,05,Kahden Mooney,DEM,186
+Codington,"B1 (Precinct-B4, Precinct-E5)",State House,05,Byron I. Callies,REP,374
+Codington,"B1 (Precinct-B4, Precinct-E5)",State House,05,Hugh M. Bartels,REP,475
+Codington,B2,State House,05,Kahden Mooney,DEM,320
+Codington,B2,State House,05,Byron I. Callies,REP,276
+Codington,B2,State House,05,Hugh M. Bartels,REP,398
+Codington,B3 (Precinct-C1),State House,05,Kahden Mooney,DEM,235
+Codington,B3 (Precinct-C1),State House,05,Byron I. Callies,REP,323
+Codington,B3 (Precinct-C1),State House,05,Hugh M. Bartels,REP,492
+Codington,"C2 (ELMIRA, Precinct-D4)",State House,05,Kahden Mooney,DEM,206
+Codington,"C2 (ELMIRA, Precinct-D4)",State House,05,Byron I. Callies,REP,242
+Codington,"C2 (ELMIRA, Precinct-D4)",State House,05,Hugh M. Bartels,REP,329
+Codington,"C3 (PELICAN, Precinct-C4)",State House,05,Kahden Mooney,DEM,364
+Codington,"C3 (PELICAN, Precinct-C4)",State House,05,Byron I. Callies,REP,468
+Codington,"C3 (PELICAN, Precinct-C4)",State House,05,Hugh M. Bartels,REP,671
+Codington,D1,State House,05,Kahden Mooney,DEM,141
+Codington,D1,State House,05,Byron I. Callies,REP,207
+Codington,D1,State House,05,Hugh M. Bartels,REP,308
+Codington,D2,State House,05,Kahden Mooney,DEM,136
+Codington,D2,State House,05,Byron I. Callies,REP,165
+Codington,D2,State House,05,Hugh M. Bartels,REP,238
+Codington,D3,State House,05,Kahden Mooney,DEM,123
+Codington,D3,State House,05,Byron I. Callies,REP,160
+Codington,D3,State House,05,Hugh M. Bartels,REP,220
+Codington,"E1 (LAKE, Precinct -E4)",State House,05,Kahden Mooney,DEM,337
+Codington,"E1 (LAKE, Precinct -E4)",State House,05,Byron I. Callies,REP,525
+Codington,"E1 (LAKE, Precinct -E4)",State House,05,Hugh M. Bartels,REP,739
+Codington,E2 (Precinct-E3),State House,05,Kahden Mooney,DEM,240
+Codington,E2 (Precinct-E3),State House,05,Byron I. Callies,REP,550
+Codington,E2 (Precinct-E3),State House,05,Hugh M. Bartels,REP,770
+Codington,SHERIDAN,State House,05,Kahden Mooney,DEM,50
+Codington,SHERIDAN,State House,05,Byron I. Callies,REP,87
+Codington,SHERIDAN,State House,05,Hugh M. Bartels,REP,153
+Codington,WAVERLY 11 of 22,State House,04,Stephanie Sauder,REP,40
+Codington,WAVERLY 11 of 22,State House,04,Fred Deutsch,REP,63

--- a/2022/counties/20221108__sd__general__corson__precinct.csv
+++ b/2022/counties/20221108__sd__general__corson__precinct.csv
@@ -1,0 +1,352 @@
+county,precinct,office,district,candidate,party,votes
+Corson,Bullhead Precinct,U.S. Senate,,Brian L. Bengs,DEM,34
+Corson,Bullhead Precinct,U.S. Senate,,Tamara J Lesnar,LIB,0
+Corson,Bullhead Precinct,U.S. Senate,,John R. Thune,REP,4
+Corson,Kenel Precinct,U.S. Senate,,Brian L. Bengs,DEM,31
+Corson,Kenel Precinct,U.S. Senate,,Tamara J Lesnar,LIB,6
+Corson,Kenel Precinct,U.S. Senate,,John R. Thune,REP,7
+Corson,Lincoln Precinct,U.S. Senate,,Brian L. Bengs,DEM,63
+Corson,Lincoln Precinct,U.S. Senate,,Tamara J Lesnar,LIB,9
+Corson,Lincoln Precinct,U.S. Senate,,John R. Thune,REP,66
+Corson,Little Eagle Precinct,U.S. Senate,,Brian L. Bengs,DEM,35
+Corson,Little Eagle Precinct,U.S. Senate,,Tamara J Lesnar,LIB,5
+Corson,Little Eagle Precinct,U.S. Senate,,John R. Thune,REP,25
+Corson,McIntosh Precinct,U.S. Senate,,Brian L. Bengs,DEM,15
+Corson,McIntosh Precinct,U.S. Senate,,Tamara J Lesnar,LIB,10
+Corson,McIntosh Precinct,U.S. Senate,,John R. Thune,REP,152
+Corson,McLaughlin Precinct,U.S. Senate,,Brian L. Bengs,DEM,66
+Corson,McLaughlin Precinct,U.S. Senate,,Tamara J Lesnar,LIB,10
+Corson,McLaughlin Precinct,U.S. Senate,,John R. Thune,REP,65
+Corson,Morristown Precinct,U.S. Senate,,Brian L. Bengs,DEM,17
+Corson,Morristown Precinct,U.S. Senate,,Tamara J Lesnar,LIB,6
+Corson,Morristown Precinct,U.S. Senate,,John R. Thune,REP,140
+Corson,Ridgeland Precinct,U.S. Senate,,Brian L. Bengs,DEM,14
+Corson,Ridgeland Precinct,U.S. Senate,,Tamara J Lesnar,LIB,7
+Corson,Ridgeland Precinct,U.S. Senate,,John R. Thune,REP,63
+Corson,Wakpala Precinct,U.S. Senate,,Brian L. Bengs,DEM,59
+Corson,Wakpala Precinct,U.S. Senate,,Tamara J Lesnar,LIB,4
+Corson,Wakpala Precinct,U.S. Senate,,John R. Thune,REP,12
+Corson,Bullhead Precinct,U.S. House,1,Collin Duprel,LIB,17
+Corson,Bullhead Precinct,U.S. House,1,Dusty Johnson,REP,5
+Corson,Kenel Precinct,U.S. House,1,Collin Duprel,LIB,23
+Corson,Kenel Precinct,U.S. House,1,Dusty Johnson,REP,12
+Corson,Lincoln Precinct,U.S. House,1,Collin Duprel,LIB,39
+Corson,Lincoln Precinct,U.S. House,1,Dusty Johnson,REP,77
+Corson,Little Eagle Precinct,U.S. House,1,Collin Duprel,LIB,22
+Corson,Little Eagle Precinct,U.S. House,1,Dusty Johnson,REP,31
+Corson,McIntosh Precinct,U.S. House,1,Collin Duprel,LIB,27
+Corson,McIntosh Precinct,U.S. House,1,Dusty Johnson,REP,149
+Corson,McLaughlin Precinct,U.S. House,1,Collin Duprel,LIB,50
+Corson,McLaughlin Precinct,U.S. House,1,Dusty Johnson,REP,71
+Corson,Morristown Precinct,U.S. House,1,Collin Duprel,LIB,31
+Corson,Morristown Precinct,U.S. House,1,Dusty Johnson,REP,126
+Corson,Ridgeland Precinct,U.S. House,1,Collin Duprel,LIB,20
+Corson,Ridgeland Precinct,U.S. House,1,Dusty Johnson,REP,61
+Corson,Wakpala Precinct,U.S. House,1,Collin Duprel,LIB,40
+Corson,Wakpala Precinct,U.S. House,1,Dusty Johnson,REP,18
+Corson,Bullhead Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,34
+Corson,Bullhead Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,0
+Corson,Bullhead Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,2
+Corson,Kenel Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,35
+Corson,Kenel Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Corson,Kenel Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,6
+Corson,Lincoln Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,70
+Corson,Lincoln Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Corson,Lincoln Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,66
+Corson,Little Eagle Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,42
+Corson,Little Eagle Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Corson,Little Eagle Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,18
+Corson,McIntosh Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,18
+Corson,McIntosh Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Corson,McIntosh Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,156
+Corson,McLaughlin Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,83
+Corson,McLaughlin Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Corson,McLaughlin Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,55
+Corson,Morristown Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,19
+Corson,Morristown Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Corson,Morristown Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,145
+Corson,Ridgeland Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,17
+Corson,Ridgeland Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Corson,Ridgeland Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,64
+Corson,Wakpala Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,61
+Corson,Wakpala Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Corson,Wakpala Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,10
+Corson,Bullhead Precinct,Secretary of State,,Thomas A Cool,DEM,35
+Corson,Bullhead Precinct,Secretary of State,,Monae Johnson,REP,2
+Corson,Kenel Precinct,Secretary of State,,Thomas A Cool,DEM,34
+Corson,Kenel Precinct,Secretary of State,,Monae Johnson,REP,9
+Corson,Lincoln Precinct,Secretary of State,,Thomas A Cool,DEM,68
+Corson,Lincoln Precinct,Secretary of State,,Monae Johnson,REP,66
+Corson,Little Eagle Precinct,Secretary of State,,Thomas A Cool,DEM,39
+Corson,Little Eagle Precinct,Secretary of State,,Monae Johnson,REP,24
+Corson,McIntosh Precinct,Secretary of State,,Thomas A Cool,DEM,24
+Corson,McIntosh Precinct,Secretary of State,,Monae Johnson,REP,148
+Corson,McLaughlin Precinct,Secretary of State,,Thomas A Cool,DEM,82
+Corson,McLaughlin Precinct,Secretary of State,,Monae Johnson,REP,56
+Corson,Morristown Precinct,Secretary of State,,Thomas A Cool,DEM,23
+Corson,Morristown Precinct,Secretary of State,,Monae Johnson,REP,138
+Corson,Ridgeland Precinct,Secretary of State,,Thomas A Cool,DEM,17
+Corson,Ridgeland Precinct,Secretary of State,,Monae Johnson,REP,61
+Corson,Wakpala Precinct,Secretary of State,,Thomas A Cool,DEM,63
+Corson,Wakpala Precinct,Secretary of State,,Monae Johnson,REP,9
+Corson,Bullhead Precinct,Attorney General,,Marty J. Jackley,REP,6
+Corson,Kenel Precinct,Attorney General,,Marty J. Jackley,REP,11
+Corson,Lincoln Precinct,Attorney General,,Marty J. Jackley,REP,79
+Corson,Little Eagle Precinct,Attorney General,,Marty J. Jackley,REP,30
+Corson,McIntosh Precinct,Attorney General,,Marty J. Jackley,REP,156
+Corson,McLaughlin Precinct,Attorney General,,Marty J. Jackley,REP,65
+Corson,Morristown Precinct,Attorney General,,Marty J. Jackley,REP,136
+Corson,Ridgeland Precinct,Attorney General,,Marty J. Jackley,REP,67
+Corson,Wakpala Precinct,Attorney General,,Marty J. Jackley,REP,20
+Corson,Bullhead Precinct,State Auditor,,Stephanie Marty,DEM,34
+Corson,Bullhead Precinct,State Auditor,,Rene Meyer,LIB,2
+Corson,Bullhead Precinct,State Auditor,,Richard Sattgast,REP,1
+Corson,Kenel Precinct,State Auditor,,Stephanie Marty,DEM,34
+Corson,Kenel Precinct,State Auditor,,Rene Meyer,LIB,3
+Corson,Kenel Precinct,State Auditor,,Richard Sattgast,REP,6
+Corson,Lincoln Precinct,State Auditor,,Stephanie Marty,DEM,71
+Corson,Lincoln Precinct,State Auditor,,Rene Meyer,LIB,5
+Corson,Lincoln Precinct,State Auditor,,Richard Sattgast,REP,60
+Corson,Little Eagle Precinct,State Auditor,,Stephanie Marty,DEM,42
+Corson,Little Eagle Precinct,State Auditor,,Rene Meyer,LIB,7
+Corson,Little Eagle Precinct,State Auditor,,Richard Sattgast,REP,13
+Corson,McIntosh Precinct,State Auditor,,Stephanie Marty,DEM,24
+Corson,McIntosh Precinct,State Auditor,,Rene Meyer,LIB,10
+Corson,McIntosh Precinct,State Auditor,,Richard Sattgast,REP,136
+Corson,McLaughlin Precinct,State Auditor,,Stephanie Marty,DEM,77
+Corson,McLaughlin Precinct,State Auditor,,Rene Meyer,LIB,7
+Corson,McLaughlin Precinct,State Auditor,,Richard Sattgast,REP,53
+Corson,Morristown Precinct,State Auditor,,Stephanie Marty,DEM,21
+Corson,Morristown Precinct,State Auditor,,Rene Meyer,LIB,12
+Corson,Morristown Precinct,State Auditor,,Richard Sattgast,REP,125
+Corson,Ridgeland Precinct,State Auditor,,Stephanie Marty,DEM,16
+Corson,Ridgeland Precinct,State Auditor,,Rene Meyer,LIB,5
+Corson,Ridgeland Precinct,State Auditor,,Richard Sattgast,REP,59
+Corson,Wakpala Precinct,State Auditor,,Stephanie Marty,DEM,58
+Corson,Wakpala Precinct,State Auditor,,Rene Meyer,LIB,4
+Corson,Wakpala Precinct,State Auditor,,Richard Sattgast,REP,8
+Corson,Bullhead Precinct,State Treasurer,,John Cunningham,DEM,35
+Corson,Bullhead Precinct,State Treasurer,,Josh Haeder,REP,2
+Corson,Kenel Precinct,State Treasurer,,John Cunningham,DEM,35
+Corson,Kenel Precinct,State Treasurer,,Josh Haeder,REP,7
+Corson,Lincoln Precinct,State Treasurer,,John Cunningham,DEM,70
+Corson,Lincoln Precinct,State Treasurer,,Josh Haeder,REP,66
+Corson,Little Eagle Precinct,State Treasurer,,John Cunningham,DEM,45
+Corson,Little Eagle Precinct,State Treasurer,,Josh Haeder,REP,17
+Corson,McIntosh Precinct,State Treasurer,,John Cunningham,DEM,23
+Corson,McIntosh Precinct,State Treasurer,,Josh Haeder,REP,147
+Corson,McLaughlin Precinct,State Treasurer,,John Cunningham,DEM,80
+Corson,McLaughlin Precinct,State Treasurer,,Josh Haeder,REP,56
+Corson,Morristown Precinct,State Treasurer,,John Cunningham,DEM,23
+Corson,Morristown Precinct,State Treasurer,,Josh Haeder,REP,133
+Corson,Ridgeland Precinct,State Treasurer,,John Cunningham,DEM,15
+Corson,Ridgeland Precinct,State Treasurer,,Josh Haeder,REP,60
+Corson,Wakpala Precinct,State Treasurer,,John Cunningham,DEM,61
+Corson,Wakpala Precinct,State Treasurer,,Josh Haeder,REP,11
+Corson,Bullhead Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,37
+Corson,Bullhead Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,1
+Corson,Kenel Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,36
+Corson,Kenel Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,7
+Corson,Lincoln Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,71
+Corson,Lincoln Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,64
+Corson,Little Eagle Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,44
+Corson,Little Eagle Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,20
+Corson,McIntosh Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,26
+Corson,McIntosh Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,146
+Corson,McLaughlin Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,83
+Corson,McLaughlin Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,55
+Corson,Morristown Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,20
+Corson,Morristown Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,138
+Corson,Ridgeland Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,20
+Corson,Ridgeland Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,59
+Corson,Wakpala Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,59
+Corson,Wakpala Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,10
+Corson,Bullhead Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,35
+Corson,Bullhead Precinct,Public Utilities Commissioner,,Chris Nelson,REP,2
+Corson,Kenel Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,35
+Corson,Kenel Precinct,Public Utilities Commissioner,,Chris Nelson,REP,8
+Corson,Lincoln Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,70
+Corson,Lincoln Precinct,Public Utilities Commissioner,,Chris Nelson,REP,63
+Corson,Little Eagle Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,42
+Corson,Little Eagle Precinct,Public Utilities Commissioner,,Chris Nelson,REP,21
+Corson,McIntosh Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,24
+Corson,McIntosh Precinct,Public Utilities Commissioner,,Chris Nelson,REP,147
+Corson,McLaughlin Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,75
+Corson,McLaughlin Precinct,Public Utilities Commissioner,,Chris Nelson,REP,58
+Corson,Morristown Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,18
+Corson,Morristown Precinct,Public Utilities Commissioner,,Chris Nelson,REP,138
+Corson,Ridgeland Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,15
+Corson,Ridgeland Precinct,Public Utilities Commissioner,,Chris Nelson,REP,66
+Corson,Wakpala Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,60
+Corson,Wakpala Precinct,Public Utilities Commissioner,,Chris Nelson,REP,11
+Corson,Bullhead Precinct,State Senate,28,Ryan M. Maher,REP,9
+Corson,Kenel Precinct,State Senate,28,Ryan M. Maher,REP,13
+Corson,Lincoln Precinct,State Senate,28,Ryan M. Maher,REP,75
+Corson,Little Eagle Precinct,State Senate,28,Ryan M. Maher,REP,34
+Corson,McIntosh Precinct,State Senate,28,Ryan M. Maher,REP,160
+Corson,McLaughlin Precinct,State Senate,28,Ryan M. Maher,REP,73
+Corson,Morristown Precinct,State Senate,28,Ryan M. Maher,REP,142
+Corson,Ridgeland Precinct,State Senate,28,Ryan M. Maher,REP,68
+Corson,Wakpala Precinct,State Senate,28,Ryan M. Maher,REP,17
+Corson,Bullhead Precinct,State House,28A,Oren L Lesmeister,DEM,35
+Corson,Bullhead Precinct,State House,28A,Ralph Lyon,REP,2
+Corson,Kenel Precinct,State House,28A,Oren L Lesmeister,DEM,37
+Corson,Kenel Precinct,State House,28A,Ralph Lyon,REP,6
+Corson,Lincoln Precinct,State House,28A,Oren L Lesmeister,DEM,68
+Corson,Lincoln Precinct,State House,28A,Ralph Lyon,REP,67
+Corson,Little Eagle Precinct,State House,28A,Oren L Lesmeister,DEM,43
+Corson,Little Eagle Precinct,State House,28A,Ralph Lyon,REP,17
+Corson,McIntosh Precinct,State House,28A,Oren L Lesmeister,DEM,30
+Corson,McIntosh Precinct,State House,28A,Ralph Lyon,REP,146
+Corson,McLaughlin Precinct,State House,28A,Oren L Lesmeister,DEM,82
+Corson,McLaughlin Precinct,State House,28A,Ralph Lyon,REP,54
+Corson,Morristown Precinct,State House,28A,Oren L Lesmeister,DEM,27
+Corson,Morristown Precinct,State House,28A,Ralph Lyon,REP,134
+Corson,Ridgeland Precinct,State House,28A,Oren L Lesmeister,DEM,23
+Corson,Ridgeland Precinct,State House,28A,Ralph Lyon,REP,61
+Corson,Wakpala Precinct,State House,28A,Oren L Lesmeister,DEM,62
+Corson,Wakpala Precinct,State House,28A,Ralph Lyon,REP,11
+Corson,Bullhead Precinct,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,4
+Corson,Kenel Precinct,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,16
+Corson,Lincoln Precinct,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,46
+Corson,Little Eagle Precinct,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,23
+Corson,McIntosh Precinct,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,107
+Corson,McLaughlin Precinct,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,51
+Corson,Morristown Precinct,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,71
+Corson,Ridgeland Precinct,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,31
+Corson,Wakpala Precinct,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,20
+Corson,Bullhead Precinct,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,7
+Corson,Kenel Precinct,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,17
+Corson,Lincoln Precinct,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,46
+Corson,Little Eagle Precinct,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,23
+Corson,McIntosh Precinct,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,106
+Corson,McLaughlin Precinct,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,49
+Corson,Morristown Precinct,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,72
+Corson,Ridgeland Precinct,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,34
+Corson,Wakpala Precinct,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,19
+Corson,Bullhead Precinct,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,4
+Corson,Kenel Precinct,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,15
+Corson,Lincoln Precinct,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,41
+Corson,Little Eagle Precinct,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,22
+Corson,McIntosh Precinct,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,107
+Corson,McLaughlin Precinct,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,55
+Corson,Morristown Precinct,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,68
+Corson,Ridgeland Precinct,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,35
+Corson,Wakpala Precinct,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,22
+Corson,Bullhead Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,0
+Corson,Bullhead Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,0
+Corson,Bullhead Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,14
+Corson,Bullhead Precinct,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,1
+Corson,Bullhead Precinct,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,0
+Corson,Kenel Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,5
+Corson,Kenel Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,1
+Corson,Kenel Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,10
+Corson,Kenel Precinct,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,3
+Corson,Kenel Precinct,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,1
+Corson,Lincoln Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,7
+Corson,Lincoln Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,11
+Corson,Lincoln Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,41
+Corson,Lincoln Precinct,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,11
+Corson,Lincoln Precinct,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,8
+Corson,Little Eagle Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,5
+Corson,Little Eagle Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,8
+Corson,Little Eagle Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,10
+Corson,Little Eagle Precinct,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,4
+Corson,Little Eagle Precinct,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,4
+Corson,McIntosh Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,4
+Corson,McIntosh Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,35
+Corson,McIntosh Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,50
+Corson,McIntosh Precinct,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,8
+Corson,McIntosh Precinct,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,31
+Corson,McLaughlin Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,3
+Corson,McLaughlin Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,12
+Corson,McLaughlin Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,37
+Corson,McLaughlin Precinct,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,10
+Corson,McLaughlin Precinct,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,10
+Corson,Morristown Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,5
+Corson,Morristown Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,15
+Corson,Morristown Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,51
+Corson,Morristown Precinct,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,13
+Corson,Morristown Precinct,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,17
+Corson,Ridgeland Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,5
+Corson,Ridgeland Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,8
+Corson,Ridgeland Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,22
+Corson,Ridgeland Precinct,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,3
+Corson,Ridgeland Precinct,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,7
+Corson,Wakpala Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,7
+Corson,Wakpala Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,7
+Corson,Wakpala Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,20
+Corson,Wakpala Precinct,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,5
+Corson,Wakpala Precinct,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,2
+Corson,Bullhead Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,19
+Corson,Bullhead Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,9
+Corson,Kenel Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,24
+Corson,Kenel Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,13
+Corson,Lincoln Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,74
+Corson,Lincoln Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,39
+Corson,Little Eagle Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,30
+Corson,Little Eagle Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,25
+Corson,McIntosh Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,118
+Corson,McIntosh Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,37
+Corson,McLaughlin Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,90
+Corson,McLaughlin Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,37
+Corson,Morristown Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,108
+Corson,Morristown Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,35
+Corson,Ridgeland Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,52
+Corson,Ridgeland Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,22
+Corson,Wakpala Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,39
+Corson,Wakpala Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,31
+Corson,Bullhead Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,15
+Corson,Bullhead Precinct,Supreme Court Retention,2,Mark E. Salter - No,,13
+Corson,Kenel Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,23
+Corson,Kenel Precinct,Supreme Court Retention,2,Mark E. Salter - No,,14
+Corson,Lincoln Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,70
+Corson,Lincoln Precinct,Supreme Court Retention,2,Mark E. Salter - No,,42
+Corson,Little Eagle Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,31
+Corson,Little Eagle Precinct,Supreme Court Retention,2,Mark E. Salter - No,,24
+Corson,McIntosh Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,116
+Corson,McIntosh Precinct,Supreme Court Retention,2,Mark E. Salter - No,,37
+Corson,McLaughlin Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,83
+Corson,McLaughlin Precinct,Supreme Court Retention,2,Mark E. Salter - No,,43
+Corson,Morristown Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,106
+Corson,Morristown Precinct,Supreme Court Retention,2,Mark E. Salter - No,,37
+Corson,Ridgeland Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,49
+Corson,Ridgeland Precinct,Supreme Court Retention,2,Mark E. Salter - No,,25
+Corson,Wakpala Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,33
+Corson,Wakpala Precinct,Supreme Court Retention,2,Mark E. Salter - No,,37
+Corson,Bullhead Precinct,Constitutional Amendment D,,Yes,,34
+Corson,Bullhead Precinct,Constitutional Amendment D,,No,,1
+Corson,Kenel Precinct,Constitutional Amendment D,,Yes,,39
+Corson,Kenel Precinct,Constitutional Amendment D,,No,,6
+Corson,Lincoln Precinct,Constitutional Amendment D,,Yes,,78
+Corson,Lincoln Precinct,Constitutional Amendment D,,No,,56
+Corson,Little Eagle Precinct,Constitutional Amendment D,,Yes,,48
+Corson,Little Eagle Precinct,Constitutional Amendment D,,No,,14
+Corson,McIntosh Precinct,Constitutional Amendment D,,Yes,,67
+Corson,McIntosh Precinct,Constitutional Amendment D,,No,,109
+Corson,McLaughlin Precinct,Constitutional Amendment D,,Yes,,111
+Corson,McLaughlin Precinct,Constitutional Amendment D,,No,,31
+Corson,Morristown Precinct,Constitutional Amendment D,,Yes,,60
+Corson,Morristown Precinct,Constitutional Amendment D,,No,,97
+Corson,Ridgeland Precinct,Constitutional Amendment D,,Yes,,28
+Corson,Ridgeland Precinct,Constitutional Amendment D,,No,,56
+Corson,Wakpala Precinct,Constitutional Amendment D,,Yes,,60
+Corson,Wakpala Precinct,Constitutional Amendment D,,No,,14
+Corson,Bullhead Precinct,Initiated Measure 27,,Yes,,36
+Corson,Bullhead Precinct,Initiated Measure 27,,No,,1
+Corson,Kenel Precinct,Initiated Measure 27,,Yes,,41
+Corson,Kenel Precinct,Initiated Measure 27,,No,,4
+Corson,Lincoln Precinct,Initiated Measure 27,,Yes,,68
+Corson,Lincoln Precinct,Initiated Measure 27,,No,,68
+Corson,Little Eagle Precinct,Initiated Measure 27,,Yes,,42
+Corson,Little Eagle Precinct,Initiated Measure 27,,No,,21
+Corson,McIntosh Precinct,Initiated Measure 27,,Yes,,43
+Corson,McIntosh Precinct,Initiated Measure 27,,No,,134
+Corson,McLaughlin Precinct,Initiated Measure 27,,Yes,,98
+Corson,McLaughlin Precinct,Initiated Measure 27,,No,,44
+Corson,Morristown Precinct,Initiated Measure 27,,Yes,,24
+Corson,Morristown Precinct,Initiated Measure 27,,No,,138
+Corson,Ridgeland Precinct,Initiated Measure 27,,Yes,,24
+Corson,Ridgeland Precinct,Initiated Measure 27,,No,,60
+Corson,Wakpala Precinct,Initiated Measure 27,,Yes,,62
+Corson,Wakpala Precinct,Initiated Measure 27,,No,,12

--- a/2022/counties/20221108__sd__general__custer__precinct.csv
+++ b/2022/counties/20221108__sd__general__custer__precinct.csv
@@ -1,0 +1,401 @@
+county,precinct,office,district,candidate,party,votes
+Custer,01,U.S. Senate,,Brian L. Bengs,DEM,152
+Custer,01,U.S. Senate,,Tamara J Lesnar,LIB,67
+Custer,01,U.S. Senate,,John R. Thune,REP,815
+Custer,02,U.S. Senate,,Brian L. Bengs,DEM,24
+Custer,02,U.S. Senate,,Tamara J Lesnar,LIB,21
+Custer,02,U.S. Senate,,John R. Thune,REP,123
+Custer,03,U.S. Senate,,Brian L. Bengs,DEM,48
+Custer,03,U.S. Senate,,Tamara J Lesnar,LIB,8
+Custer,03,U.S. Senate,,John R. Thune,REP,133
+Custer,04,U.S. Senate,,Brian L. Bengs,DEM,94
+Custer,04,U.S. Senate,,Tamara J Lesnar,LIB,23
+Custer,04,U.S. Senate,,John R. Thune,REP,380
+Custer,05,U.S. Senate,,Brian L. Bengs,DEM,142
+Custer,05,U.S. Senate,,Tamara J Lesnar,LIB,27
+Custer,05,U.S. Senate,,John R. Thune,REP,516
+Custer,06,U.S. Senate,,Brian L. Bengs,DEM,100
+Custer,06,U.S. Senate,,Tamara J Lesnar,LIB,14
+Custer,06,U.S. Senate,,John R. Thune,REP,243
+Custer,07,U.S. Senate,,Brian L. Bengs,DEM,51
+Custer,07,U.S. Senate,,Tamara J Lesnar,LIB,14
+Custer,07,U.S. Senate,,John R. Thune,REP,155
+Custer,08,U.S. Senate,,Brian L. Bengs,DEM,123
+Custer,08,U.S. Senate,,Tamara J Lesnar,LIB,11
+Custer,08,U.S. Senate,,John R. Thune,REP,279
+Custer,09,U.S. Senate,,Brian L. Bengs,DEM,256
+Custer,09,U.S. Senate,,Tamara J Lesnar,LIB,72
+Custer,09,U.S. Senate,,John R. Thune,REP,965
+Custer,10,U.S. Senate,,Brian L. Bengs,DEM,27
+Custer,10,U.S. Senate,,Tamara J Lesnar,LIB,10
+Custer,10,U.S. Senate,,John R. Thune,REP,147
+Custer,01,U.S. House,1,Collin Duprel,LIB,194
+Custer,01,U.S. House,1,Dusty Johnson,REP,789
+Custer,02,U.S. House,1,Collin Duprel,LIB,57
+Custer,02,U.S. House,1,Dusty Johnson,REP,107
+Custer,03,U.S. House,1,Collin Duprel,LIB,39
+Custer,03,U.S. House,1,Dusty Johnson,REP,139
+Custer,04,U.S. House,1,Collin Duprel,LIB,101
+Custer,04,U.S. House,1,Dusty Johnson,REP,378
+Custer,05,U.S. House,1,Collin Duprel,LIB,112
+Custer,05,U.S. House,1,Dusty Johnson,REP,524
+Custer,06,U.S. House,1,Collin Duprel,LIB,76
+Custer,06,U.S. House,1,Dusty Johnson,REP,256
+Custer,07,U.S. House,1,Collin Duprel,LIB,57
+Custer,07,U.S. House,1,Dusty Johnson,REP,154
+Custer,08,U.S. House,1,Collin Duprel,LIB,94
+Custer,08,U.S. House,1,Dusty Johnson,REP,292
+Custer,09,U.S. House,1,Collin Duprel,LIB,253
+Custer,09,U.S. House,1,Dusty Johnson,REP,974
+Custer,10,U.S. House,1,Collin Duprel,LIB,40
+Custer,10,U.S. House,1,Dusty Johnson,REP,140
+Custer,01,Governor,,Jamie Smith and Jennifer Keintz,DEM,226
+Custer,01,Governor,,Tracey Quint and Ashley Strand,LIB,40
+Custer,01,Governor,,Kristi Noem and Larry Rhoden,REP,777
+Custer,02,Governor,,Jamie Smith and Jennifer Keintz,DEM,29
+Custer,02,Governor,,Tracey Quint and Ashley Strand,LIB,8
+Custer,02,Governor,,Kristi Noem and Larry Rhoden,REP,133
+Custer,03,Governor,,Jamie Smith and Jennifer Keintz,DEM,52
+Custer,03,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Custer,03,Governor,,Kristi Noem and Larry Rhoden,REP,133
+Custer,04,Governor,,Jamie Smith and Jennifer Keintz,DEM,110
+Custer,04,Governor,,Tracey Quint and Ashley Strand,LIB,14
+Custer,04,Governor,,Kristi Noem and Larry Rhoden,REP,379
+Custer,05,Governor,,Jamie Smith and Jennifer Keintz,DEM,183
+Custer,05,Governor,,Tracey Quint and Ashley Strand,LIB,15
+Custer,05,Governor,,Kristi Noem and Larry Rhoden,REP,490
+Custer,06,Governor,,Jamie Smith and Jennifer Keintz,DEM,126
+Custer,06,Governor,,Tracey Quint and Ashley Strand,LIB,9
+Custer,06,Governor,,Kristi Noem and Larry Rhoden,REP,220
+Custer,07,Governor,,Jamie Smith and Jennifer Keintz,DEM,60
+Custer,07,Governor,,Tracey Quint and Ashley Strand,LIB,12
+Custer,07,Governor,,Kristi Noem and Larry Rhoden,REP,149
+Custer,08,Governor,,Jamie Smith and Jennifer Keintz,DEM,146
+Custer,08,Governor,,Tracey Quint and Ashley Strand,LIB,9
+Custer,08,Governor,,Kristi Noem and Larry Rhoden,REP,264
+Custer,09,Governor,,Jamie Smith and Jennifer Keintz,DEM,333
+Custer,09,Governor,,Tracey Quint and Ashley Strand,LIB,36
+Custer,09,Governor,,Kristi Noem and Larry Rhoden,REP,933
+Custer,10,Governor,,Jamie Smith and Jennifer Keintz,DEM,28
+Custer,10,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Custer,10,Governor,,Kristi Noem and Larry Rhoden,REP,155
+Custer,01,Secretary of State,,Thomas A Cool,DEM,211
+Custer,01,Secretary of State,,Monae Johnson,REP,787
+Custer,02,Secretary of State,,Thomas A Cool,DEM,30
+Custer,02,Secretary of State,,Monae Johnson,REP,136
+Custer,03,Secretary of State,,Thomas A Cool,DEM,51
+Custer,03,Secretary of State,,Monae Johnson,REP,132
+Custer,04,Secretary of State,,Thomas A Cool,DEM,107
+Custer,04,Secretary of State,,Monae Johnson,REP,377
+Custer,05,Secretary of State,,Thomas A Cool,DEM,174
+Custer,05,Secretary of State,,Monae Johnson,REP,501
+Custer,06,Secretary of State,,Thomas A Cool,DEM,116
+Custer,06,Secretary of State,,Monae Johnson,REP,227
+Custer,07,Secretary of State,,Thomas A Cool,DEM,66
+Custer,07,Secretary of State,,Monae Johnson,REP,146
+Custer,08,Secretary of State,,Thomas A Cool,DEM,143
+Custer,08,Secretary of State,,Monae Johnson,REP,260
+Custer,09,Secretary of State,,Thomas A Cool,DEM,313
+Custer,09,Secretary of State,,Monae Johnson,REP,945
+Custer,10,Secretary of State,,Thomas A Cool,DEM,32
+Custer,10,Secretary of State,,Monae Johnson,REP,149
+Custer,01,Attorney General,,Marty J. Jackley,REP,819
+Custer,02,Attorney General,,Marty J. Jackley,REP,136
+Custer,03,Attorney General,,Marty J. Jackley,REP,141
+Custer,04,Attorney General,,Marty J. Jackley,REP,397
+Custer,05,Attorney General,,Marty J. Jackley,REP,525
+Custer,06,Attorney General,,Marty J. Jackley,REP,262
+Custer,07,Attorney General,,Marty J. Jackley,REP,163
+Custer,08,Attorney General,,Marty J. Jackley,REP,310
+Custer,09,Attorney General,,Marty J. Jackley,REP,1016
+Custer,10,Attorney General,,Marty J. Jackley,REP,151
+Custer,01,State Auditor,,Stephanie Marty,DEM,185
+Custer,01,State Auditor,,Rene Meyer,LIB,69
+Custer,01,State Auditor,,Richard Sattgast,REP,733
+Custer,02,State Auditor,,Stephanie Marty,DEM,33
+Custer,02,State Auditor,,Rene Meyer,LIB,18
+Custer,02,State Auditor,,Richard Sattgast,REP,115
+Custer,03,State Auditor,,Stephanie Marty,DEM,49
+Custer,03,State Auditor,,Rene Meyer,LIB,9
+Custer,03,State Auditor,,Richard Sattgast,REP,128
+Custer,04,State Auditor,,Stephanie Marty,DEM,104
+Custer,04,State Auditor,,Rene Meyer,LIB,30
+Custer,04,State Auditor,,Richard Sattgast,REP,350
+Custer,05,State Auditor,,Stephanie Marty,DEM,166
+Custer,05,State Auditor,,Rene Meyer,LIB,44
+Custer,05,State Auditor,,Richard Sattgast,REP,465
+Custer,06,State Auditor,,Stephanie Marty,DEM,108
+Custer,06,State Auditor,,Rene Meyer,LIB,22
+Custer,06,State Auditor,,Richard Sattgast,REP,209
+Custer,07,State Auditor,,Stephanie Marty,DEM,66
+Custer,07,State Auditor,,Rene Meyer,LIB,11
+Custer,07,State Auditor,,Richard Sattgast,REP,132
+Custer,08,State Auditor,,Stephanie Marty,DEM,136
+Custer,08,State Auditor,,Rene Meyer,LIB,21
+Custer,08,State Auditor,,Richard Sattgast,REP,247
+Custer,09,State Auditor,,Stephanie Marty,DEM,285
+Custer,09,State Auditor,,Rene Meyer,LIB,65
+Custer,09,State Auditor,,Richard Sattgast,REP,908
+Custer,10,State Auditor,,Stephanie Marty,DEM,27
+Custer,10,State Auditor,,Rene Meyer,LIB,9
+Custer,10,State Auditor,,Richard Sattgast,REP,148
+Custer,01,State Treasurer,,John Cunningham,DEM,192
+Custer,01,State Treasurer,,Josh Haeder,REP,789
+Custer,02,State Treasurer,,John Cunningham,DEM,28
+Custer,02,State Treasurer,,Josh Haeder,REP,137
+Custer,03,State Treasurer,,John Cunningham,DEM,49
+Custer,03,State Treasurer,,Josh Haeder,REP,132
+Custer,04,State Treasurer,,John Cunningham,DEM,105
+Custer,04,State Treasurer,,Josh Haeder,REP,373
+Custer,05,State Treasurer,,John Cunningham,DEM,166
+Custer,05,State Treasurer,,Josh Haeder,REP,508
+Custer,06,State Treasurer,,John Cunningham,DEM,113
+Custer,06,State Treasurer,,Josh Haeder,REP,229
+Custer,07,State Treasurer,,John Cunningham,DEM,65
+Custer,07,State Treasurer,,Josh Haeder,REP,144
+Custer,08,State Treasurer,,John Cunningham,DEM,135
+Custer,08,State Treasurer,,Josh Haeder,REP,261
+Custer,09,State Treasurer,,John Cunningham,DEM,291
+Custer,09,State Treasurer,,Josh Haeder,REP,954
+Custer,10,State Treasurer,,John Cunningham,DEM,28
+Custer,10,State Treasurer,,Josh Haeder,REP,153
+Custer,01,Commissioner of School and Public Lands,,Timothy Azure,DEM,198
+Custer,01,Commissioner of School and Public Lands,,Brock Greenfield,REP,782
+Custer,02,Commissioner of School and Public Lands,,Timothy Azure,DEM,29
+Custer,02,Commissioner of School and Public Lands,,Brock Greenfield,REP,135
+Custer,03,Commissioner of School and Public Lands,,Timothy Azure,DEM,45
+Custer,03,Commissioner of School and Public Lands,,Brock Greenfield,REP,133
+Custer,04,Commissioner of School and Public Lands,,Timothy Azure,DEM,105
+Custer,04,Commissioner of School and Public Lands,,Brock Greenfield,REP,375
+Custer,05,Commissioner of School and Public Lands,,Timothy Azure,DEM,173
+Custer,05,Commissioner of School and Public Lands,,Brock Greenfield,REP,489
+Custer,06,Commissioner of School and Public Lands,,Timothy Azure,DEM,115
+Custer,06,Commissioner of School and Public Lands,,Brock Greenfield,REP,226
+Custer,07,Commissioner of School and Public Lands,,Timothy Azure,DEM,67
+Custer,07,Commissioner of School and Public Lands,,Brock Greenfield,REP,141
+Custer,08,Commissioner of School and Public Lands,,Timothy Azure,DEM,135
+Custer,08,Commissioner of School and Public Lands,,Brock Greenfield,REP,259
+Custer,09,Commissioner of School and Public Lands,,Timothy Azure,DEM,283
+Custer,09,Commissioner of School and Public Lands,,Brock Greenfield,REP,943
+Custer,10,Commissioner of School and Public Lands,,Timothy Azure,DEM,31
+Custer,10,Commissioner of School and Public Lands,,Brock Greenfield,REP,151
+Custer,01,Public Utilities Commissioner,,Jeffrey Barth,DEM,183
+Custer,01,Public Utilities Commissioner,,Chris Nelson,REP,807
+Custer,02,Public Utilities Commissioner,,Jeffrey Barth,DEM,26
+Custer,02,Public Utilities Commissioner,,Chris Nelson,REP,140
+Custer,03,Public Utilities Commissioner,,Jeffrey Barth,DEM,42
+Custer,03,Public Utilities Commissioner,,Chris Nelson,REP,138
+Custer,04,Public Utilities Commissioner,,Jeffrey Barth,DEM,98
+Custer,04,Public Utilities Commissioner,,Chris Nelson,REP,385
+Custer,05,Public Utilities Commissioner,,Jeffrey Barth,DEM,161
+Custer,05,Public Utilities Commissioner,,Chris Nelson,REP,501
+Custer,06,Public Utilities Commissioner,,Jeffrey Barth,DEM,106
+Custer,06,Public Utilities Commissioner,,Chris Nelson,REP,238
+Custer,07,Public Utilities Commissioner,,Jeffrey Barth,DEM,62
+Custer,07,Public Utilities Commissioner,,Chris Nelson,REP,150
+Custer,08,Public Utilities Commissioner,,Jeffrey Barth,DEM,135
+Custer,08,Public Utilities Commissioner,,Chris Nelson,REP,264
+Custer,09,Public Utilities Commissioner,,Jeffrey Barth,DEM,283
+Custer,09,Public Utilities Commissioner,,Chris Nelson,REP,956
+Custer,10,Public Utilities Commissioner,,Jeffrey Barth,DEM,28
+Custer,10,Public Utilities Commissioner,,Chris Nelson,REP,154
+Custer,01,State Senate,30,Julie Frye-Mueller,REP,759
+Custer,02,State Senate,30,Julie Frye-Mueller,REP,126
+Custer,03,State Senate,30,Julie Frye-Mueller,REP,132
+Custer,04,State Senate,30,Julie Frye-Mueller,REP,381
+Custer,05,State Senate,30,Julie Frye-Mueller,REP,477
+Custer,06,State Senate,30,Julie Frye-Mueller,REP,232
+Custer,07,State Senate,30,Julie Frye-Mueller,REP,140
+Custer,08,State Senate,30,Julie Frye-Mueller,REP,264
+Custer,09,State Senate,30,Julie Frye-Mueller,REP,941
+Custer,10,State Senate,30,Julie Frye-Mueller,REP,148
+Custer,01,State House,30,Bret Swanson,DEM,207
+Custer,01,State House,30,Dennis Krull,REP,572
+Custer,01,State House,30,Trish Ladner,REP,707
+Custer,02,State House,30,Bret Swanson,DEM,28
+Custer,02,State House,30,Dennis Krull,REP,100
+Custer,02,State House,30,Trish Ladner,REP,127
+Custer,03,State House,30,Bret Swanson,DEM,50
+Custer,03,State House,30,Dennis Krull,REP,92
+Custer,03,State House,30,Trish Ladner,REP,123
+Custer,04,State House,30,Bret Swanson,DEM,110
+Custer,04,State House,30,Dennis Krull,REP,296
+Custer,04,State House,30,Trish Ladner,REP,316
+Custer,05,State House,30,Bret Swanson,DEM,170
+Custer,05,State House,30,Dennis Krull,REP,426
+Custer,05,State House,30,Trish Ladner,REP,429
+Custer,06,State House,30,Bret Swanson,DEM,109
+Custer,06,State House,30,Dennis Krull,REP,210
+Custer,06,State House,30,Trish Ladner,REP,200
+Custer,07,State House,30,Bret Swanson,DEM,59
+Custer,07,State House,30,Dennis Krull,REP,134
+Custer,07,State House,30,Trish Ladner,REP,111
+Custer,08,State House,30,Bret Swanson,DEM,135
+Custer,08,State House,30,Dennis Krull,REP,250
+Custer,08,State House,30,Trish Ladner,REP,224
+Custer,09,State House,30,Bret Swanson,DEM,300
+Custer,09,State House,30,Dennis Krull,REP,842
+Custer,09,State House,30,Trish Ladner,REP,802
+Custer,10,State House,30,Bret Swanson,DEM,33
+Custer,10,State House,30,Dennis Krull,REP,126
+Custer,10,State House,30,Trish Ladner,REP,126
+Custer,01,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,384
+Custer,02,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,68
+Custer,03,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,71
+Custer,04,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,207
+Custer,05,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,262
+Custer,06,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,139
+Custer,07,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,81
+Custer,08,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,161
+Custer,09,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,475
+Custer,10,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,80
+Custer,01,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,376
+Custer,02,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,70
+Custer,03,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,69
+Custer,04,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,204
+Custer,05,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,244
+Custer,06,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,136
+Custer,07,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,87
+Custer,08,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,164
+Custer,09,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,476
+Custer,10,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,77
+Custer,01,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,385
+Custer,02,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,71
+Custer,03,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,70
+Custer,04,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,206
+Custer,05,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,266
+Custer,06,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,139
+Custer,07,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,95
+Custer,08,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,166
+Custer,09,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,480
+Custer,10,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,79
+Custer,01,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,369
+Custer,02,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,60
+Custer,03,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,68
+Custer,04,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,204
+Custer,05,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,244
+Custer,06,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,130
+Custer,07,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,80
+Custer,08,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,155
+Custer,09,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,460
+Custer,10,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,75
+Custer,01,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,391
+Custer,02,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,59
+Custer,03,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,70
+Custer,04,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,204
+Custer,05,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,250
+Custer,06,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,135
+Custer,07,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,89
+Custer,08,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,163
+Custer,09,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,477
+Custer,10,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,76
+Custer,01,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,377
+Custer,02,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,58
+Custer,03,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,66
+Custer,04,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,200
+Custer,05,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,244
+Custer,06,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,138
+Custer,07,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,89
+Custer,08,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,156
+Custer,09,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,466
+Custer,10,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,77
+Custer,01,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,361
+Custer,02,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,59
+Custer,03,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,69
+Custer,04,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,193
+Custer,05,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,242
+Custer,06,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,131
+Custer,07,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,86
+Custer,08,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,154
+Custer,09,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,458
+Custer,10,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,76
+Custer,01,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,381
+Custer,02,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,71
+Custer,03,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,72
+Custer,04,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,233
+Custer,05,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,364
+Custer,06,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,186
+Custer,07,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,129
+Custer,08,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,228
+Custer,09,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,639
+Custer,10,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,83
+Custer,01,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,664
+Custer,01,Supreme Court Retention,3,Patricia J. DeVaney - No,,149
+Custer,02,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,104
+Custer,02,Supreme Court Retention,3,Patricia J. DeVaney - No,,27
+Custer,03,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,127
+Custer,03,Supreme Court Retention,3,Patricia J. DeVaney - No,,28
+Custer,04,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,331
+Custer,04,Supreme Court Retention,3,Patricia J. DeVaney - No,,82
+Custer,05,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,486
+Custer,05,Supreme Court Retention,3,Patricia J. DeVaney - No,,91
+Custer,06,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,224
+Custer,06,Supreme Court Retention,3,Patricia J. DeVaney - No,,68
+Custer,07,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,146
+Custer,07,Supreme Court Retention,3,Patricia J. DeVaney - No,,44
+Custer,08,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,275
+Custer,08,Supreme Court Retention,3,Patricia J. DeVaney - No,,65
+Custer,09,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,849
+Custer,09,Supreme Court Retention,3,Patricia J. DeVaney - No,,204
+Custer,10,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,127
+Custer,10,Supreme Court Retention,3,Patricia J. DeVaney - No,,26
+Custer,01,Supreme Court Retention,2,Mark E. Salter - Yes,,665
+Custer,01,Supreme Court Retention,2,Mark E. Salter - No,,142
+Custer,02,Supreme Court Retention,2,Mark E. Salter - Yes,,98
+Custer,02,Supreme Court Retention,2,Mark E. Salter - No,,29
+Custer,03,Supreme Court Retention,2,Mark E. Salter - Yes,,124
+Custer,03,Supreme Court Retention,2,Mark E. Salter - No,,31
+Custer,04,Supreme Court Retention,2,Mark E. Salter - Yes,,322
+Custer,04,Supreme Court Retention,2,Mark E. Salter - No,,88
+Custer,05,Supreme Court Retention,2,Mark E. Salter - Yes,,466
+Custer,05,Supreme Court Retention,2,Mark E. Salter - No,,103
+Custer,06,Supreme Court Retention,2,Mark E. Salter - Yes,,230
+Custer,06,Supreme Court Retention,2,Mark E. Salter - No,,59
+Custer,07,Supreme Court Retention,2,Mark E. Salter - Yes,,148
+Custer,07,Supreme Court Retention,2,Mark E. Salter - No,,43
+Custer,08,Supreme Court Retention,2,Mark E. Salter - Yes,,270
+Custer,08,Supreme Court Retention,2,Mark E. Salter - No,,64
+Custer,09,Supreme Court Retention,2,Mark E. Salter - Yes,,836
+Custer,09,Supreme Court Retention,2,Mark E. Salter - No,,210
+Custer,10,Supreme Court Retention,2,Mark E. Salter - Yes,,128
+Custer,10,Supreme Court Retention,2,Mark E. Salter - No,,26
+Custer,01,Constitutional Amendment D,,Yes,,463
+Custer,01,Constitutional Amendment D,,No,,560
+Custer,02,Constitutional Amendment D,,Yes,,69
+Custer,02,Constitutional Amendment D,,No,,100
+Custer,03,Constitutional Amendment D,,Yes,,95
+Custer,03,Constitutional Amendment D,,No,,94
+Custer,04,Constitutional Amendment D,,Yes,,240
+Custer,04,Constitutional Amendment D,,No,,247
+Custer,05,Constitutional Amendment D,,Yes,,329
+Custer,05,Constitutional Amendment D,,No,,351
+Custer,06,Constitutional Amendment D,,Yes,,184
+Custer,06,Constitutional Amendment D,,No,,164
+Custer,07,Constitutional Amendment D,,Yes,,131
+Custer,07,Constitutional Amendment D,,No,,90
+Custer,08,Constitutional Amendment D,,Yes,,220
+Custer,08,Constitutional Amendment D,,No,,190
+Custer,09,Constitutional Amendment D,,Yes,,613
+Custer,09,Constitutional Amendment D,,No,,665
+Custer,10,Constitutional Amendment D,,Yes,,76
+Custer,10,Constitutional Amendment D,,No,,110
+Custer,01,Initiated Measure 27,,Yes,,401
+Custer,01,Initiated Measure 27,,No,,636
+Custer,02,Initiated Measure 27,,Yes,,46
+Custer,02,Initiated Measure 27,,No,,123
+Custer,03,Initiated Measure 27,,Yes,,82
+Custer,03,Initiated Measure 27,,No,,107
+Custer,04,Initiated Measure 27,,Yes,,203
+Custer,04,Initiated Measure 27,,No,,291
+Custer,05,Initiated Measure 27,,Yes,,310
+Custer,05,Initiated Measure 27,,No,,380
+Custer,06,Initiated Measure 27,,Yes,,169
+Custer,06,Initiated Measure 27,,No,,183
+Custer,07,Initiated Measure 27,,Yes,,104
+Custer,07,Initiated Measure 27,,No,,120
+Custer,08,Initiated Measure 27,,Yes,,173
+Custer,08,Initiated Measure 27,,No,,243
+Custer,09,Initiated Measure 27,,Yes,,563
+Custer,09,Initiated Measure 27,,No,,729
+Custer,10,Initiated Measure 27,,Yes,,73
+Custer,10,Initiated Measure 27,,No,,114

--- a/2022/counties/20221108__sd__general__davison__precinct.csv
+++ b/2022/counties/20221108__sd__general__davison__precinct.csv
@@ -1,0 +1,408 @@
+county,precinct,office,district,candidate,party,votes
+Davison,01,U.S. Senate,,Brian L. Bengs,DEM,31
+Davison,01,U.S. Senate,,Tamara J Lesnar,LIB,7
+Davison,01,U.S. Senate,,John R. Thune,REP,226
+Davison,02,U.S. Senate,,Brian L. Bengs,DEM,41
+Davison,02,U.S. Senate,,Tamara J Lesnar,LIB,17
+Davison,02,U.S. Senate,,John R. Thune,REP,294
+Davison,03,U.S. Senate,,Brian L. Bengs,DEM,94
+Davison,03,U.S. Senate,,Tamara J Lesnar,LIB,21
+Davison,03,U.S. Senate,,John R. Thune,REP,534
+Davison,04,U.S. Senate,,Brian L. Bengs,DEM,87
+Davison,04,U.S. Senate,,Tamara J Lesnar,LIB,15
+Davison,04,U.S. Senate,,John R. Thune,REP,449
+Davison,?,U.S. Senate,,Brian L. Bengs,DEM,174
+Davison,?,U.S. Senate,,Tamara J Lesnar,LIB,29
+Davison,?,U.S. Senate,,John R. Thune,REP,557
+Davison,06 (Precinct-07),U.S. Senate,,Brian L. Bengs,DEM,181
+Davison,06 (Precinct-07),U.S. Senate,,Tamara J Lesnar,LIB,11
+Davison,06 (Precinct-07),U.S. Senate,,John R. Thune,REP,649
+Davison,08 (Precinct-09),U.S. Senate,,Brian L. Bengs,DEM,173
+Davison,08 (Precinct-09),U.S. Senate,,Tamara J Lesnar,LIB,38
+Davison,08 (Precinct-09),U.S. Senate,,John R. Thune,REP,505
+Davison,10 (Precinct-11),U.S. Senate,,Brian L. Bengs,DEM,177
+Davison,10 (Precinct-11),U.S. Senate,,Tamara J Lesnar,LIB,30
+Davison,10 (Precinct-11),U.S. Senate,,John R. Thune,REP,523
+Davison,12 (Precinct-13),U.S. Senate,,Brian L. Bengs,DEM,131
+Davison,12 (Precinct-13),U.S. Senate,,Tamara J Lesnar,LIB,20
+Davison,12 (Precinct-13),U.S. Senate,,John R. Thune,REP,414
+Davison,?,U.S. Senate,,Brian L. Bengs,DEM,293
+Davison,?,U.S. Senate,,Tamara J Lesnar,LIB,56
+Davison,?,U.S. Senate,,John R. Thune,REP,824
+Davison,20,U.S. Senate,,Brian L. Bengs,DEM,142
+Davison,20,U.S. Senate,,Tamara J Lesnar,LIB,22
+Davison,20,U.S. Senate,,John R. Thune,REP,445
+Davison,01,U.S. House,1,Collin Duprel,LIB,32
+Davison,01,U.S. House,1,Dusty Johnson,REP,232
+Davison,02,U.S. House,1,Collin Duprel,LIB,54
+Davison,02,U.S. House,1,Dusty Johnson,REP,292
+Davison,03,U.S. House,1,Collin Duprel,LIB,80
+Davison,03,U.S. House,1,Dusty Johnson,REP,558
+Davison,04,U.S. House,1,Collin Duprel,LIB,77
+Davison,04,U.S. House,1,Dusty Johnson,REP,460
+Davison,?,U.S. House,1,Collin Duprel,LIB,128
+Davison,?,U.S. House,1,Dusty Johnson,REP,590
+Davison,06 (Precinct-07),U.S. House,1,Collin Duprel,LIB,106
+Davison,06 (Precinct-07),U.S. House,1,Dusty Johnson,REP,695
+Davison,08 (Precinct-09),U.S. House,1,Collin Duprel,LIB,140
+Davison,08 (Precinct-09),U.S. House,1,Dusty Johnson,REP,543
+Davison,10 (Precinct-11),U.S. House,1,Collin Duprel,LIB,125
+Davison,10 (Precinct-11),U.S. House,1,Dusty Johnson,REP,568
+Davison,12 (Precinct-13),U.S. House,1,Collin Duprel,LIB,97
+Davison,12 (Precinct-13),U.S. House,1,Dusty Johnson,REP,440
+Davison,?,U.S. House,1,Collin Duprel,LIB,222
+Davison,?,U.S. House,1,Dusty Johnson,REP,885
+Davison,20,U.S. House,1,Collin Duprel,LIB,82
+Davison,20,U.S. House,1,Dusty Johnson,REP,506
+Davison,01,Governor,,Jamie Smith and Jennifer Keintz,DEM,42
+Davison,01,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Davison,01,Governor,,Kristi Noem and Larry Rhoden,REP,221
+Davison,02,Governor,,Jamie Smith and Jennifer Keintz,DEM,64
+Davison,02,Governor,,Tracey Quint and Ashley Strand,LIB,11
+Davison,02,Governor,,Kristi Noem and Larry Rhoden,REP,277
+Davison,03,Governor,,Jamie Smith and Jennifer Keintz,DEM,133
+Davison,03,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Davison,03,Governor,,Kristi Noem and Larry Rhoden,REP,516
+Davison,04,Governor,,Jamie Smith and Jennifer Keintz,DEM,124
+Davison,04,Governor,,Tracey Quint and Ashley Strand,LIB,20
+Davison,04,Governor,,Kristi Noem and Larry Rhoden,REP,412
+Davison,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,239
+Davison,?,Governor,,Tracey Quint and Ashley Strand,LIB,19
+Davison,?,Governor,,Kristi Noem and Larry Rhoden,REP,500
+Davison,06 (Precinct-07),Governor,,Jamie Smith and Jennifer Keintz,DEM,272
+Davison,06 (Precinct-07),Governor,,Tracey Quint and Ashley Strand,LIB,15
+Davison,06 (Precinct-07),Governor,,Kristi Noem and Larry Rhoden,REP,555
+Davison,08 (Precinct-09),Governor,,Jamie Smith and Jennifer Keintz,DEM,232
+Davison,08 (Precinct-09),Governor,,Tracey Quint and Ashley Strand,LIB,25
+Davison,08 (Precinct-09),Governor,,Kristi Noem and Larry Rhoden,REP,457
+Davison,10 (Precinct-11),Governor,,Jamie Smith and Jennifer Keintz,DEM,257
+Davison,10 (Precinct-11),Governor,,Tracey Quint and Ashley Strand,LIB,14
+Davison,10 (Precinct-11),Governor,,Kristi Noem and Larry Rhoden,REP,462
+Davison,12 (Precinct-13),Governor,,Jamie Smith and Jennifer Keintz,DEM,188
+Davison,12 (Precinct-13),Governor,,Tracey Quint and Ashley Strand,LIB,8
+Davison,12 (Precinct-13),Governor,,Kristi Noem and Larry Rhoden,REP,373
+Davison,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,416
+Davison,?,Governor,,Tracey Quint and Ashley Strand,LIB,37
+Davison,?,Governor,,Kristi Noem and Larry Rhoden,REP,726
+Davison,20,Governor,,Jamie Smith and Jennifer Keintz,DEM,212
+Davison,20,Governor,,Tracey Quint and Ashley Strand,LIB,12
+Davison,20,Governor,,Kristi Noem and Larry Rhoden,REP,388
+Davison,01,Secretary of State,,Thomas A Cool,DEM,53
+Davison,01,Secretary of State,,Monae Johnson,REP,191
+Davison,02,Secretary of State,,Thomas A Cool,DEM,66
+Davison,02,Secretary of State,,Monae Johnson,REP,269
+Davison,03,Secretary of State,,Thomas A Cool,DEM,155
+Davison,03,Secretary of State,,Monae Johnson,REP,473
+Davison,04,Secretary of State,,Thomas A Cool,DEM,124
+Davison,04,Secretary of State,,Monae Johnson,REP,400
+Davison,?,Secretary of State,,Thomas A Cool,DEM,256
+Davison,?,Secretary of State,,Monae Johnson,REP,473
+Davison,06 (Precinct-07),Secretary of State,,Thomas A Cool,DEM,266
+Davison,06 (Precinct-07),Secretary of State,,Monae Johnson,REP,554
+Davison,08 (Precinct-09),Secretary of State,,Thomas A Cool,DEM,250
+Davison,08 (Precinct-09),Secretary of State,,Monae Johnson,REP,435
+Davison,10 (Precinct-11),Secretary of State,,Thomas A Cool,DEM,261
+Davison,10 (Precinct-11),Secretary of State,,Monae Johnson,REP,439
+Davison,12 (Precinct-13),Secretary of State,,Thomas A Cool,DEM,183
+Davison,12 (Precinct-13),Secretary of State,,Monae Johnson,REP,352
+Davison,?,Secretary of State,,Thomas A Cool,DEM,407
+Davison,?,Secretary of State,,Monae Johnson,REP,710
+Davison,20,Secretary of State,,Thomas A Cool,DEM,209
+Davison,20,Secretary of State,,Monae Johnson,REP,384
+Davison,01,Attorney General,,Marty J. Jackley,REP,208
+Davison,02,Attorney General,,Marty J. Jackley,REP,290
+Davison,03,Attorney General,,Marty J. Jackley,REP,544
+Davison,04,Attorney General,,Marty J. Jackley,REP,464
+Davison,?,Attorney General,,Marty J. Jackley,REP,607
+Davison,06 (Precinct-07),Attorney General,,Marty J. Jackley,REP,676
+Davison,08 (Precinct-09),Attorney General,,Marty J. Jackley,REP,540
+Davison,10 (Precinct-11),Attorney General,,Marty J. Jackley,REP,552
+Davison,12 (Precinct-13),Attorney General,,Marty J. Jackley,REP,431
+Davison,?,Attorney General,,Marty J. Jackley,REP,897
+Davison,20,Attorney General,,Marty J. Jackley,REP,477
+Davison,01,State Auditor,,Stephanie Marty,DEM,47
+Davison,01,State Auditor,,Rene Meyer,LIB,11
+Davison,01,State Auditor,,Richard Sattgast,REP,188
+Davison,02,State Auditor,,Stephanie Marty,DEM,57
+Davison,02,State Auditor,,Rene Meyer,LIB,19
+Davison,02,State Auditor,,Richard Sattgast,REP,257
+Davison,03,State Auditor,,Stephanie Marty,DEM,118
+Davison,03,State Auditor,,Rene Meyer,LIB,22
+Davison,03,State Auditor,,Richard Sattgast,REP,484
+Davison,04,State Auditor,,Stephanie Marty,DEM,105
+Davison,04,State Auditor,,Rene Meyer,LIB,27
+Davison,04,State Auditor,,Richard Sattgast,REP,392
+Davison,?,State Auditor,,Stephanie Marty,DEM,206
+Davison,?,State Auditor,,Rene Meyer,LIB,33
+Davison,?,State Auditor,,Richard Sattgast,REP,478
+Davison,06 (Precinct-07),State Auditor,,Stephanie Marty,DEM,224
+Davison,06 (Precinct-07),State Auditor,,Rene Meyer,LIB,17
+Davison,06 (Precinct-07),State Auditor,,Richard Sattgast,REP,561
+Davison,08 (Precinct-09),State Auditor,,Stephanie Marty,DEM,220
+Davison,08 (Precinct-09),State Auditor,,Rene Meyer,LIB,43
+Davison,08 (Precinct-09),State Auditor,,Richard Sattgast,REP,420
+Davison,10 (Precinct-11),State Auditor,,Stephanie Marty,DEM,223
+Davison,10 (Precinct-11),State Auditor,,Rene Meyer,LIB,38
+Davison,10 (Precinct-11),State Auditor,,Richard Sattgast,REP,429
+Davison,12 (Precinct-13),State Auditor,,Stephanie Marty,DEM,163
+Davison,12 (Precinct-13),State Auditor,,Rene Meyer,LIB,17
+Davison,12 (Precinct-13),State Auditor,,Richard Sattgast,REP,362
+Davison,?,State Auditor,,Stephanie Marty,DEM,333
+Davison,?,State Auditor,,Rene Meyer,LIB,70
+Davison,?,State Auditor,,Richard Sattgast,REP,702
+Davison,20,State Auditor,,Stephanie Marty,DEM,178
+Davison,20,State Auditor,,Rene Meyer,LIB,21
+Davison,20,State Auditor,,Richard Sattgast,REP,390
+Davison,01,State Treasurer,,John Cunningham,DEM,54
+Davison,01,State Treasurer,,Josh Haeder,REP,190
+Davison,02,State Treasurer,,John Cunningham,DEM,62
+Davison,02,State Treasurer,,Josh Haeder,REP,267
+Davison,03,State Treasurer,,John Cunningham,DEM,127
+Davison,03,State Treasurer,,Josh Haeder,REP,492
+Davison,04,State Treasurer,,John Cunningham,DEM,117
+Davison,04,State Treasurer,,Josh Haeder,REP,397
+Davison,?,State Treasurer,,John Cunningham,DEM,223
+Davison,?,State Treasurer,,Josh Haeder,REP,486
+Davison,06 (Precinct-07),State Treasurer,,John Cunningham,DEM,227
+Davison,06 (Precinct-07),State Treasurer,,Josh Haeder,REP,570
+Davison,08 (Precinct-09),State Treasurer,,John Cunningham,DEM,245
+Davison,08 (Precinct-09),State Treasurer,,Josh Haeder,REP,431
+Davison,10 (Precinct-11),State Treasurer,,John Cunningham,DEM,237
+Davison,10 (Precinct-11),State Treasurer,,Josh Haeder,REP,447
+Davison,12 (Precinct-13),State Treasurer,,John Cunningham,DEM,171
+Davison,12 (Precinct-13),State Treasurer,,Josh Haeder,REP,364
+Davison,?,State Treasurer,,John Cunningham,DEM,357
+Davison,?,State Treasurer,,Josh Haeder,REP,734
+Davison,20,State Treasurer,,John Cunningham,DEM,195
+Davison,20,State Treasurer,,Josh Haeder,REP,383
+Davison,01,Commissioner of School and Public Lands,,Timothy Azure,DEM,46
+Davison,01,Commissioner of School and Public Lands,,Brock Greenfield,REP,192
+Davison,02,Commissioner of School and Public Lands,,Timothy Azure,DEM,53
+Davison,02,Commissioner of School and Public Lands,,Brock Greenfield,REP,264
+Davison,03,Commissioner of School and Public Lands,,Timothy Azure,DEM,116
+Davison,03,Commissioner of School and Public Lands,,Brock Greenfield,REP,482
+Davison,04,Commissioner of School and Public Lands,,Timothy Azure,DEM,112
+Davison,04,Commissioner of School and Public Lands,,Brock Greenfield,REP,395
+Davison,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,206
+Davison,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,488
+Davison,06 (Precinct-07),Commissioner of School and Public Lands,,Timothy Azure,DEM,215
+Davison,06 (Precinct-07),Commissioner of School and Public Lands,,Brock Greenfield,REP,567
+Davison,08 (Precinct-09),Commissioner of School and Public Lands,,Timothy Azure,DEM,222
+Davison,08 (Precinct-09),Commissioner of School and Public Lands,,Brock Greenfield,REP,444
+Davison,10 (Precinct-11),Commissioner of School and Public Lands,,Timothy Azure,DEM,218
+Davison,10 (Precinct-11),Commissioner of School and Public Lands,,Brock Greenfield,REP,446
+Davison,12 (Precinct-13),Commissioner of School and Public Lands,,Timothy Azure,DEM,161
+Davison,12 (Precinct-13),Commissioner of School and Public Lands,,Brock Greenfield,REP,364
+Davison,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,341
+Davison,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,737
+Davison,20,Commissioner of School and Public Lands,,Timothy Azure,DEM,173
+Davison,20,Commissioner of School and Public Lands,,Brock Greenfield,REP,397
+Davison,01,Public Utilities Commissioner,,Jeffrey Barth,DEM,37
+Davison,01,Public Utilities Commissioner,,Chris Nelson,REP,215
+Davison,02,Public Utilities Commissioner,,Jeffrey Barth,DEM,50
+Davison,02,Public Utilities Commissioner,,Chris Nelson,REP,289
+Davison,03,Public Utilities Commissioner,,Jeffrey Barth,DEM,102
+Davison,03,Public Utilities Commissioner,,Chris Nelson,REP,526
+Davison,04,Public Utilities Commissioner,,Jeffrey Barth,DEM,108
+Davison,04,Public Utilities Commissioner,,Chris Nelson,REP,417
+Davison,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,191
+Davison,?,Public Utilities Commissioner,,Chris Nelson,REP,530
+Davison,06 (Precinct-07),Public Utilities Commissioner,,Jeffrey Barth,DEM,198
+Davison,06 (Precinct-07),Public Utilities Commissioner,,Chris Nelson,REP,613
+Davison,08 (Precinct-09),Public Utilities Commissioner,,Jeffrey Barth,DEM,212
+Davison,08 (Precinct-09),Public Utilities Commissioner,,Chris Nelson,REP,474
+Davison,10 (Precinct-11),Public Utilities Commissioner,,Jeffrey Barth,DEM,208
+Davison,10 (Precinct-11),Public Utilities Commissioner,,Chris Nelson,REP,487
+Davison,12 (Precinct-13),Public Utilities Commissioner,,Jeffrey Barth,DEM,155
+Davison,12 (Precinct-13),Public Utilities Commissioner,,Chris Nelson,REP,393
+Davison,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,306
+Davison,?,Public Utilities Commissioner,,Chris Nelson,REP,793
+Davison,20,Public Utilities Commissioner,,Jeffrey Barth,DEM,164
+Davison,20,Public Utilities Commissioner,,Chris Nelson,REP,422
+Davison,01,State Senate,20,Joshua Klumb,REP,224
+Davison,02,State Senate,20,Joshua Klumb,REP,299
+Davison,03,State Senate,20,Joshua Klumb,REP,540
+Davison,04,State Senate,20,Joshua Klumb,REP,450
+Davison,?,State Senate,20,Joshua Klumb,REP,567
+Davison,06 (Precinct-07),State Senate,20,Joshua Klumb,REP,650
+Davison,08 (Precinct-09),State Senate,20,Joshua Klumb,REP,534
+Davison,10 (Precinct-11),State Senate,20,Joshua Klumb,REP,532
+Davison,12 (Precinct-13),State Senate,20,Joshua Klumb,REP,416
+Davison,?,State Senate,20,Joshua Klumb,REP,854
+Davison,20,State Senate,20,Joshua Klumb,REP,446
+Davison,01,State House,20,Ben Krohmer,REP,121
+Davison,01,State House,20,Lance Koth,REP,182
+Davison,02,State House,20,Ben Krohmer,REP,189
+Davison,02,State House,20,Lance Koth,REP,233
+Davison,03,State House,20,Ben Krohmer,REP,376
+Davison,03,State House,20,Lance Koth,REP,449
+Davison,04,State House,20,Ben Krohmer,REP,320
+Davison,04,State House,20,Lance Koth,REP,385
+Davison,?,State House,20,Ben Krohmer,REP,412
+Davison,?,State House,20,Lance Koth,REP,461
+Davison,06 (Precinct-07),State House,20,Ben Krohmer,REP,482
+Davison,06 (Precinct-07),State House,20,Lance Koth,REP,576
+Davison,08 (Precinct-09),State House,20,Ben Krohmer,REP,400
+Davison,08 (Precinct-09),State House,20,Lance Koth,REP,404
+Davison,10 (Precinct-11),State House,20,Ben Krohmer,REP,402
+Davison,10 (Precinct-11),State House,20,Lance Koth,REP,404
+Davison,12 (Precinct-13),State House,20,Ben Krohmer,REP,316
+Davison,12 (Precinct-13),State House,20,Lance Koth,REP,335
+Davison,?,State House,20,Ben Krohmer,REP,644
+Davison,?,State House,20,Lance Koth,REP,694
+Davison,20,State House,20,Ben Krohmer,REP,370
+Davison,20,State House,20,Lance Koth,REP,367
+Davison,01,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,117
+Davison,02,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,181
+Davison,03,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,324
+Davison,04,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,271
+Davison,?,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,366
+Davison,06 (Precinct-07),Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,433
+Davison,08 (Precinct-09),Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,336
+Davison,10 (Precinct-11),Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,365
+Davison,12 (Precinct-13),Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,284
+Davison,?,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,588
+Davison,20,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,292
+Davison,01,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,110
+Davison,02,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,166
+Davison,03,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,294
+Davison,04,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,254
+Davison,?,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,331
+Davison,06 (Precinct-07),Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,407
+Davison,08 (Precinct-09),Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,298
+Davison,10 (Precinct-11),Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,328
+Davison,12 (Precinct-13),Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,255
+Davison,?,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,540
+Davison,20,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,255
+Davison,01,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,110
+Davison,02,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,172
+Davison,03,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,294
+Davison,04,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,253
+Davison,?,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,336
+Davison,06 (Precinct-07),Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,416
+Davison,08 (Precinct-09),Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,301
+Davison,10 (Precinct-11),Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,335
+Davison,12 (Precinct-13),Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,267
+Davison,?,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,545
+Davison,20,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,264
+Davison,01,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,114
+Davison,02,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,166
+Davison,03,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,294
+Davison,04,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,257
+Davison,?,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,328
+Davison,06 (Precinct-07),Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,410
+Davison,08 (Precinct-09),Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,301
+Davison,10 (Precinct-11),Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,324
+Davison,12 (Precinct-13),Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,256
+Davison,?,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,539
+Davison,20,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,264
+Davison,01,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,115
+Davison,02,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,178
+Davison,03,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,325
+Davison,04,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,289
+Davison,?,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,376
+Davison,06 (Precinct-07),Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,467
+Davison,08 (Precinct-09),Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,351
+Davison,10 (Precinct-11),Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,370
+Davison,12 (Precinct-13),Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,288
+Davison,?,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,617
+Davison,20,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,303
+Davison,01,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,108
+Davison,02,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,166
+Davison,03,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,296
+Davison,04,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,256
+Davison,?,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,331
+Davison,06 (Precinct-07),Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,404
+Davison,08 (Precinct-09),Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,301
+Davison,10 (Precinct-11),Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,324
+Davison,12 (Precinct-13),Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,256
+Davison,?,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,538
+Davison,20,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,250
+Davison,01,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,184
+Davison,01,Supreme Court Retention,3,Patricia J. DeVaney - No,,41
+Davison,02,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,269
+Davison,02,Supreme Court Retention,3,Patricia J. DeVaney - No,,42
+Davison,03,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,468
+Davison,03,Supreme Court Retention,3,Patricia J. DeVaney - No,,97
+Davison,04,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,393
+Davison,04,Supreme Court Retention,3,Patricia J. DeVaney - No,,78
+Davison,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,529
+Davison,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,117
+Davison,06 (Precinct-07),Supreme Court Retention,3,Patricia J. DeVaney - Yes,,636
+Davison,06 (Precinct-07),Supreme Court Retention,3,Patricia J. DeVaney - No,,99
+Davison,08 (Precinct-09),Supreme Court Retention,3,Patricia J. DeVaney - Yes,,502
+Davison,08 (Precinct-09),Supreme Court Retention,3,Patricia J. DeVaney - No,,121
+Davison,10 (Precinct-11),Supreme Court Retention,3,Patricia J. DeVaney - Yes,,500
+Davison,10 (Precinct-11),Supreme Court Retention,3,Patricia J. DeVaney - No,,129
+Davison,12 (Precinct-13),Supreme Court Retention,3,Patricia J. DeVaney - Yes,,379
+Davison,12 (Precinct-13),Supreme Court Retention,3,Patricia J. DeVaney - No,,89
+Davison,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,796
+Davison,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,213
+Davison,20,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,413
+Davison,20,Supreme Court Retention,3,Patricia J. DeVaney - No,,103
+Davison,01,Supreme Court Retention,2,Mark E. Salter - Yes,,181
+Davison,01,Supreme Court Retention,2,Mark E. Salter - No,,41
+Davison,02,Supreme Court Retention,2,Mark E. Salter - Yes,,264
+Davison,02,Supreme Court Retention,2,Mark E. Salter - No,,45
+Davison,03,Supreme Court Retention,2,Mark E. Salter - Yes,,473
+Davison,03,Supreme Court Retention,2,Mark E. Salter - No,,85
+Davison,04,Supreme Court Retention,2,Mark E. Salter - Yes,,396
+Davison,04,Supreme Court Retention,2,Mark E. Salter - No,,71
+Davison,?,Supreme Court Retention,2,Mark E. Salter - Yes,,539
+Davison,?,Supreme Court Retention,2,Mark E. Salter - No,,103
+Davison,06 (Precinct-07),Supreme Court Retention,2,Mark E. Salter - Yes,,639
+Davison,06 (Precinct-07),Supreme Court Retention,2,Mark E. Salter - No,,91
+Davison,08 (Precinct-09),Supreme Court Retention,2,Mark E. Salter - Yes,,505
+Davison,08 (Precinct-09),Supreme Court Retention,2,Mark E. Salter - No,,117
+Davison,10 (Precinct-11),Supreme Court Retention,2,Mark E. Salter - Yes,,502
+Davison,10 (Precinct-11),Supreme Court Retention,2,Mark E. Salter - No,,124
+Davison,12 (Precinct-13),Supreme Court Retention,2,Mark E. Salter - Yes,,382
+Davison,12 (Precinct-13),Supreme Court Retention,2,Mark E. Salter - No,,85
+Davison,?,Supreme Court Retention,2,Mark E. Salter - Yes,,798
+Davison,?,Supreme Court Retention,2,Mark E. Salter - No,,203
+Davison,20,Supreme Court Retention,2,Mark E. Salter - Yes,,417
+Davison,20,Supreme Court Retention,2,Mark E. Salter - No,,98
+Davison,01,Constitutional Amendment D,,Yes,,117
+Davison,01,Constitutional Amendment D,,No,,147
+Davison,02,Constitutional Amendment D,,Yes,,137
+Davison,02,Constitutional Amendment D,,No,,198
+Davison,03,Constitutional Amendment D,,Yes,,260
+Davison,03,Constitutional Amendment D,,No,,371
+Davison,04,Constitutional Amendment D,,Yes,,262
+Davison,04,Constitutional Amendment D,,No,,284
+Davison,?,Constitutional Amendment D,,Yes,,378
+Davison,?,Constitutional Amendment D,,No,,362
+Davison,06 (Precinct-07),Constitutional Amendment D,,Yes,,406
+Davison,06 (Precinct-07),Constitutional Amendment D,,No,,425
+Davison,08 (Precinct-09),Constitutional Amendment D,,Yes,,400
+Davison,08 (Precinct-09),Constitutional Amendment D,,No,,291
+Davison,10 (Precinct-11),Constitutional Amendment D,,Yes,,415
+Davison,10 (Precinct-11),Constitutional Amendment D,,No,,305
+Davison,12 (Precinct-13),Constitutional Amendment D,,Yes,,279
+Davison,12 (Precinct-13),Constitutional Amendment D,,No,,270
+Davison,?,Constitutional Amendment D,,Yes,,646
+Davison,?,Constitutional Amendment D,,No,,507
+Davison,20,Constitutional Amendment D,,Yes,,320
+Davison,20,Constitutional Amendment D,,No,,281
+Davison,01,Initiated Measure 27,,Yes,,92
+Davison,01,Initiated Measure 27,,No,,178
+Davison,02,Initiated Measure 27,,Yes,,102
+Davison,02,Initiated Measure 27,,No,,240
+Davison,03,Initiated Measure 27,,Yes,,205
+Davison,03,Initiated Measure 27,,No,,437
+Davison,04,Initiated Measure 27,,Yes,,192
+Davison,04,Initiated Measure 27,,No,,362
+Davison,?,Initiated Measure 27,,Yes,,330
+Davison,?,Initiated Measure 27,,No,,425
+Davison,06 (Precinct-07),Initiated Measure 27,,Yes,,308
+Davison,06 (Precinct-07),Initiated Measure 27,,No,,532
+Davison,08 (Precinct-09),Initiated Measure 27,,Yes,,339
+Davison,08 (Precinct-09),Initiated Measure 27,,No,,362
+Davison,10 (Precinct-11),Initiated Measure 27,,Yes,,343
+Davison,10 (Precinct-11),Initiated Measure 27,,No,,390
+Davison,12 (Precinct-13),Initiated Measure 27,,Yes,,213
+Davison,12 (Precinct-13),Initiated Measure 27,,No,,346
+Davison,?,Initiated Measure 27,,Yes,,547
+Davison,?,Initiated Measure 27,,No,,614
+Davison,20,Initiated Measure 27,,Yes,,256
+Davison,20,Initiated Measure 27,,No,,356

--- a/2022/counties/20221108__sd__general__day__precinct.csv
+++ b/2022/counties/20221108__sd__general__day__precinct.csv
@@ -1,0 +1,419 @@
+county,precinct,office,district,candidate,party,votes
+Day,01,U.S. Senate,,Brian L. Bengs,DEM,54
+Day,01,U.S. Senate,,Tamara J Lesnar,LIB,7
+Day,01,U.S. Senate,,John R. Thune,REP,171
+Day,02,U.S. Senate,,Brian L. Bengs,DEM,48
+Day,02,U.S. Senate,,Tamara J Lesnar,LIB,10
+Day,02,U.S. Senate,,John R. Thune,REP,171
+Day,03,U.S. Senate,,Brian L. Bengs,DEM,51
+Day,03,U.S. Senate,,Tamara J Lesnar,LIB,12
+Day,03,U.S. Senate,,John R. Thune,REP,207
+Day,04,U.S. Senate,,Brian L. Bengs,DEM,79
+Day,04,U.S. Senate,,Tamara J Lesnar,LIB,20
+Day,04,U.S. Senate,,John R. Thune,REP,263
+Day,05,U.S. Senate,,Brian L. Bengs,DEM,72
+Day,05,U.S. Senate,,Tamara J Lesnar,LIB,18
+Day,05,U.S. Senate,,John R. Thune,REP,241
+Day,06,U.S. Senate,,Brian L. Bengs,DEM,23
+Day,06,U.S. Senate,,Tamara J Lesnar,LIB,2
+Day,06,U.S. Senate,,John R. Thune,REP,63
+Day,07,U.S. Senate,,Brian L. Bengs,DEM,51
+Day,07,U.S. Senate,,Tamara J Lesnar,LIB,6
+Day,07,U.S. Senate,,John R. Thune,REP,145
+Day,08,U.S. Senate,,Brian L. Bengs,DEM,54
+Day,08,U.S. Senate,,Tamara J Lesnar,LIB,10
+Day,08,U.S. Senate,,John R. Thune,REP,124
+Day,09,U.S. Senate,,Brian L. Bengs,DEM,42
+Day,09,U.S. Senate,,Tamara J Lesnar,LIB,13
+Day,09,U.S. Senate,,John R. Thune,REP,132
+Day,10,U.S. Senate,,Brian L. Bengs,DEM,10
+Day,10,U.S. Senate,,Tamara J Lesnar,LIB,3
+Day,10,U.S. Senate,,John R. Thune,REP,70
+Day,11,U.S. Senate,,Brian L. Bengs,DEM,118
+Day,11,U.S. Senate,,Tamara J Lesnar,LIB,15
+Day,11,U.S. Senate,,John R. Thune,REP,209
+Day,01,U.S. House,1,Collin Duprel,LIB,33
+Day,01,U.S. House,1,Dusty Johnson,REP,181
+Day,02,U.S. House,1,Collin Duprel,LIB,43
+Day,02,U.S. House,1,Dusty Johnson,REP,171
+Day,03,U.S. House,1,Collin Duprel,LIB,40
+Day,03,U.S. House,1,Dusty Johnson,REP,213
+Day,04,U.S. House,1,Collin Duprel,LIB,72
+Day,04,U.S. House,1,Dusty Johnson,REP,270
+Day,05,U.S. House,1,Collin Duprel,LIB,60
+Day,05,U.S. House,1,Dusty Johnson,REP,259
+Day,06,U.S. House,1,Collin Duprel,LIB,19
+Day,06,U.S. House,1,Dusty Johnson,REP,65
+Day,07,U.S. House,1,Collin Duprel,LIB,36
+Day,07,U.S. House,1,Dusty Johnson,REP,158
+Day,08,U.S. House,1,Collin Duprel,LIB,47
+Day,08,U.S. House,1,Dusty Johnson,REP,126
+Day,09,U.S. House,1,Collin Duprel,LIB,35
+Day,09,U.S. House,1,Dusty Johnson,REP,145
+Day,10,U.S. House,1,Collin Duprel,LIB,10
+Day,10,U.S. House,1,Dusty Johnson,REP,72
+Day,11,U.S. House,1,Collin Duprel,LIB,85
+Day,11,U.S. House,1,Dusty Johnson,REP,238
+Day,01,Governor,,Jamie Smith and Jennifer Keintz,DEM,97
+Day,01,Governor,,Tracey Quint and Ashley Strand,LIB,6
+Day,01,Governor,,Kristi Noem and Larry Rhoden,REP,132
+Day,02,Governor,,Jamie Smith and Jennifer Keintz,DEM,71
+Day,02,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Day,02,Governor,,Kristi Noem and Larry Rhoden,REP,157
+Day,03,Governor,,Jamie Smith and Jennifer Keintz,DEM,79
+Day,03,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Day,03,Governor,,Kristi Noem and Larry Rhoden,REP,188
+Day,04,Governor,,Jamie Smith and Jennifer Keintz,DEM,112
+Day,04,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Day,04,Governor,,Kristi Noem and Larry Rhoden,REP,244
+Day,05,Governor,,Jamie Smith and Jennifer Keintz,DEM,105
+Day,05,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Day,05,Governor,,Kristi Noem and Larry Rhoden,REP,223
+Day,06,Governor,,Jamie Smith and Jennifer Keintz,DEM,27
+Day,06,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Day,06,Governor,,Kristi Noem and Larry Rhoden,REP,60
+Day,07,Governor,,Jamie Smith and Jennifer Keintz,DEM,68
+Day,07,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Day,07,Governor,,Kristi Noem and Larry Rhoden,REP,131
+Day,08,Governor,,Jamie Smith and Jennifer Keintz,DEM,82
+Day,08,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Day,08,Governor,,Kristi Noem and Larry Rhoden,REP,105
+Day,09,Governor,,Jamie Smith and Jennifer Keintz,DEM,66
+Day,09,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Day,09,Governor,,Kristi Noem and Larry Rhoden,REP,116
+Day,10,Governor,,Jamie Smith and Jennifer Keintz,DEM,11
+Day,10,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Day,10,Governor,,Kristi Noem and Larry Rhoden,REP,69
+Day,11,Governor,,Jamie Smith and Jennifer Keintz,DEM,158
+Day,11,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Day,11,Governor,,Kristi Noem and Larry Rhoden,REP,174
+Day,01,Secretary of State,,Thomas A Cool,DEM,95
+Day,01,Secretary of State,,Monae Johnson,REP,117
+Day,02,Secretary of State,,Thomas A Cool,DEM,71
+Day,02,Secretary of State,,Monae Johnson,REP,153
+Day,03,Secretary of State,,Thomas A Cool,DEM,85
+Day,03,Secretary of State,,Monae Johnson,REP,173
+Day,04,Secretary of State,,Thomas A Cool,DEM,119
+Day,04,Secretary of State,,Monae Johnson,REP,221
+Day,05,Secretary of State,,Thomas A Cool,DEM,121
+Day,05,Secretary of State,,Monae Johnson,REP,188
+Day,06,Secretary of State,,Thomas A Cool,DEM,30
+Day,06,Secretary of State,,Monae Johnson,REP,56
+Day,07,Secretary of State,,Thomas A Cool,DEM,70
+Day,07,Secretary of State,,Monae Johnson,REP,117
+Day,08,Secretary of State,,Thomas A Cool,DEM,80
+Day,08,Secretary of State,,Monae Johnson,REP,97
+Day,09,Secretary of State,,Thomas A Cool,DEM,72
+Day,09,Secretary of State,,Monae Johnson,REP,105
+Day,10,Secretary of State,,Thomas A Cool,DEM,19
+Day,10,Secretary of State,,Monae Johnson,REP,55
+Day,11,Secretary of State,,Thomas A Cool,DEM,157
+Day,11,Secretary of State,,Monae Johnson,REP,174
+Day,01,Attorney General,,Marty J. Jackley,REP,178
+Day,02,Attorney General,,Marty J. Jackley,REP,172
+Day,03,Attorney General,,Marty J. Jackley,REP,221
+Day,04,Attorney General,,Marty J. Jackley,REP,272
+Day,05,Attorney General,,Marty J. Jackley,REP,264
+Day,06,Attorney General,,Marty J. Jackley,REP,66
+Day,07,Attorney General,,Marty J. Jackley,REP,156
+Day,08,Attorney General,,Marty J. Jackley,REP,131
+Day,09,Attorney General,,Marty J. Jackley,REP,140
+Day,10,Attorney General,,Marty J. Jackley,REP,71
+Day,11,Attorney General,,Marty J. Jackley,REP,236
+Day,01,State Auditor,,Stephanie Marty,DEM,76
+Day,01,State Auditor,,Rene Meyer,LIB,16
+Day,01,State Auditor,,Richard Sattgast,REP,123
+Day,02,State Auditor,,Stephanie Marty,DEM,64
+Day,02,State Auditor,,Rene Meyer,LIB,13
+Day,02,State Auditor,,Richard Sattgast,REP,145
+Day,03,State Auditor,,Stephanie Marty,DEM,79
+Day,03,State Auditor,,Rene Meyer,LIB,14
+Day,03,State Auditor,,Richard Sattgast,REP,164
+Day,04,State Auditor,,Stephanie Marty,DEM,97
+Day,04,State Auditor,,Rene Meyer,LIB,15
+Day,04,State Auditor,,Richard Sattgast,REP,218
+Day,05,State Auditor,,Stephanie Marty,DEM,115
+Day,05,State Auditor,,Rene Meyer,LIB,15
+Day,05,State Auditor,,Richard Sattgast,REP,183
+Day,06,State Auditor,,Stephanie Marty,DEM,25
+Day,06,State Auditor,,Rene Meyer,LIB,7
+Day,06,State Auditor,,Richard Sattgast,REP,53
+Day,07,State Auditor,,Stephanie Marty,DEM,62
+Day,07,State Auditor,,Rene Meyer,LIB,8
+Day,07,State Auditor,,Richard Sattgast,REP,118
+Day,08,State Auditor,,Stephanie Marty,DEM,73
+Day,08,State Auditor,,Rene Meyer,LIB,8
+Day,08,State Auditor,,Richard Sattgast,REP,97
+Day,09,State Auditor,,Stephanie Marty,DEM,70
+Day,09,State Auditor,,Rene Meyer,LIB,8
+Day,09,State Auditor,,Richard Sattgast,REP,99
+Day,10,State Auditor,,Stephanie Marty,DEM,17
+Day,10,State Auditor,,Rene Meyer,LIB,3
+Day,10,State Auditor,,Richard Sattgast,REP,58
+Day,11,State Auditor,,Stephanie Marty,DEM,148
+Day,11,State Auditor,,Rene Meyer,LIB,18
+Day,11,State Auditor,,Richard Sattgast,REP,165
+Day,01,State Treasurer,,John Cunningham,DEM,82
+Day,01,State Treasurer,,Josh Haeder,REP,130
+Day,02,State Treasurer,,John Cunningham,DEM,64
+Day,02,State Treasurer,,Josh Haeder,REP,156
+Day,03,State Treasurer,,John Cunningham,DEM,82
+Day,03,State Treasurer,,Josh Haeder,REP,171
+Day,04,State Treasurer,,John Cunningham,DEM,109
+Day,04,State Treasurer,,Josh Haeder,REP,218
+Day,05,State Treasurer,,John Cunningham,DEM,110
+Day,05,State Treasurer,,Josh Haeder,REP,206
+Day,06,State Treasurer,,John Cunningham,DEM,27
+Day,06,State Treasurer,,Josh Haeder,REP,57
+Day,07,State Treasurer,,John Cunningham,DEM,61
+Day,07,State Treasurer,,Josh Haeder,REP,120
+Day,08,State Treasurer,,John Cunningham,DEM,75
+Day,08,State Treasurer,,Josh Haeder,REP,100
+Day,09,State Treasurer,,John Cunningham,DEM,64
+Day,09,State Treasurer,,Josh Haeder,REP,108
+Day,10,State Treasurer,,John Cunningham,DEM,18
+Day,10,State Treasurer,,Josh Haeder,REP,59
+Day,11,State Treasurer,,John Cunningham,DEM,151
+Day,11,State Treasurer,,Josh Haeder,REP,177
+Day,01,Commissioner of School and Public Lands,,Timothy Azure,DEM,77
+Day,01,Commissioner of School and Public Lands,,Brock Greenfield,REP,135
+Day,02,Commissioner of School and Public Lands,,Timothy Azure,DEM,64
+Day,02,Commissioner of School and Public Lands,,Brock Greenfield,REP,151
+Day,03,Commissioner of School and Public Lands,,Timothy Azure,DEM,72
+Day,03,Commissioner of School and Public Lands,,Brock Greenfield,REP,179
+Day,04,Commissioner of School and Public Lands,,Timothy Azure,DEM,101
+Day,04,Commissioner of School and Public Lands,,Brock Greenfield,REP,229
+Day,05,Commissioner of School and Public Lands,,Timothy Azure,DEM,109
+Day,05,Commissioner of School and Public Lands,,Brock Greenfield,REP,202
+Day,06,Commissioner of School and Public Lands,,Timothy Azure,DEM,28
+Day,06,Commissioner of School and Public Lands,,Brock Greenfield,REP,57
+Day,07,Commissioner of School and Public Lands,,Timothy Azure,DEM,57
+Day,07,Commissioner of School and Public Lands,,Brock Greenfield,REP,127
+Day,08,Commissioner of School and Public Lands,,Timothy Azure,DEM,74
+Day,08,Commissioner of School and Public Lands,,Brock Greenfield,REP,102
+Day,09,Commissioner of School and Public Lands,,Timothy Azure,DEM,65
+Day,09,Commissioner of School and Public Lands,,Brock Greenfield,REP,106
+Day,10,Commissioner of School and Public Lands,,Timothy Azure,DEM,17
+Day,10,Commissioner of School and Public Lands,,Brock Greenfield,REP,60
+Day,11,Commissioner of School and Public Lands,,Timothy Azure,DEM,142
+Day,11,Commissioner of School and Public Lands,,Brock Greenfield,REP,175
+Day,01,Public Utilities Commissioner,,Jeffrey Barth,DEM,69
+Day,01,Public Utilities Commissioner,,Chris Nelson,REP,145
+Day,02,Public Utilities Commissioner,,Jeffrey Barth,DEM,60
+Day,02,Public Utilities Commissioner,,Chris Nelson,REP,159
+Day,03,Public Utilities Commissioner,,Jeffrey Barth,DEM,70
+Day,03,Public Utilities Commissioner,,Chris Nelson,REP,190
+Day,04,Public Utilities Commissioner,,Jeffrey Barth,DEM,101
+Day,04,Public Utilities Commissioner,,Chris Nelson,REP,238
+Day,05,Public Utilities Commissioner,,Jeffrey Barth,DEM,94
+Day,05,Public Utilities Commissioner,,Chris Nelson,REP,227
+Day,06,Public Utilities Commissioner,,Jeffrey Barth,DEM,24
+Day,06,Public Utilities Commissioner,,Chris Nelson,REP,61
+Day,07,Public Utilities Commissioner,,Jeffrey Barth,DEM,51
+Day,07,Public Utilities Commissioner,,Chris Nelson,REP,136
+Day,08,Public Utilities Commissioner,,Jeffrey Barth,DEM,64
+Day,08,Public Utilities Commissioner,,Chris Nelson,REP,109
+Day,09,Public Utilities Commissioner,,Jeffrey Barth,DEM,61
+Day,09,Public Utilities Commissioner,,Chris Nelson,REP,115
+Day,10,Public Utilities Commissioner,,Jeffrey Barth,DEM,12
+Day,10,Public Utilities Commissioner,,Chris Nelson,REP,64
+Day,11,Public Utilities Commissioner,,Jeffrey Barth,DEM,133
+Day,11,Public Utilities Commissioner,,Chris Nelson,REP,194
+Day,01,State Senate,01,Michael H. Rohl,REP,126
+Day,01,State Senate,01,Susan Wismer,IND,98
+Day,02,State Senate,01,Michael H. Rohl,REP,143
+Day,02,State Senate,01,Susan Wismer,IND,79
+Day,03,State Senate,01,Michael H. Rohl,REP,162
+Day,03,State Senate,01,Susan Wismer,IND,96
+Day,04,State Senate,01,Michael H. Rohl,REP,227
+Day,04,State Senate,01,Susan Wismer,IND,119
+Day,05,State Senate,01,Michael H. Rohl,REP,193
+Day,05,State Senate,01,Susan Wismer,IND,125
+Day,06,State Senate,01,Michael H. Rohl,REP,48
+Day,06,State Senate,01,Susan Wismer,IND,35
+Day,07,State Senate,01,Michael H. Rohl,REP,111
+Day,07,State Senate,01,Susan Wismer,IND,83
+Day,08,State Senate,01,Michael H. Rohl,REP,93
+Day,08,State Senate,01,Susan Wismer,IND,95
+Day,09,State Senate,01,Michael H. Rohl,REP,108
+Day,09,State Senate,01,Susan Wismer,IND,70
+Day,10,State Senate,01,Michael H. Rohl,REP,43
+Day,10,State Senate,01,Susan Wismer,IND,25
+Day,11,State Senate,01,Michael H. Rohl,REP,175
+Day,11,State Senate,01,Susan Wismer,IND,146
+Day,01,State House,01,Steven D. McCleerey,DEM,93
+Day,01,State House,01,Kay F. Nikolas,DEM,71
+Day,01,State House,01,Joe Donnell,REP,91
+Day,01,State House,01,Tamara St John,REP,119
+Day,02,State House,01,Steven D. McCleerey,DEM,66
+Day,02,State House,01,Kay F. Nikolas,DEM,50
+Day,02,State House,01,Joe Donnell,REP,109
+Day,02,State House,01,Tamara St John,REP,129
+Day,03,State House,01,Steven D. McCleerey,DEM,88
+Day,03,State House,01,Kay F. Nikolas,DEM,76
+Day,03,State House,01,Joe Donnell,REP,113
+Day,03,State House,01,Tamara St John,REP,141
+Day,04,State House,01,Steven D. McCleerey,DEM,122
+Day,04,State House,01,Kay F. Nikolas,DEM,94
+Day,04,State House,01,Joe Donnell,REP,175
+Day,04,State House,01,Tamara St John,REP,206
+Day,05,State House,01,Steven D. McCleerey,DEM,127
+Day,05,State House,01,Kay F. Nikolas,DEM,85
+Day,05,State House,01,Joe Donnell,REP,139
+Day,05,State House,01,Tamara St John,REP,185
+Day,06,State House,01,Steven D. McCleerey,DEM,30
+Day,06,State House,01,Kay F. Nikolas,DEM,26
+Day,06,State House,01,Joe Donnell,REP,39
+Day,06,State House,01,Tamara St John,REP,52
+Day,07,State House,01,Steven D. McCleerey,DEM,77
+Day,07,State House,01,Kay F. Nikolas,DEM,55
+Day,07,State House,01,Joe Donnell,REP,90
+Day,07,State House,01,Tamara St John,REP,100
+Day,08,State House,01,Steven D. McCleerey,DEM,80
+Day,08,State House,01,Kay F. Nikolas,DEM,62
+Day,08,State House,01,Joe Donnell,REP,70
+Day,08,State House,01,Tamara St John,REP,85
+Day,09,State House,01,Steven D. McCleerey,DEM,72
+Day,09,State House,01,Kay F. Nikolas,DEM,55
+Day,09,State House,01,Joe Donnell,REP,83
+Day,09,State House,01,Tamara St John,REP,99
+Day,10,State House,01,Steven D. McCleerey,DEM,17
+Day,10,State House,01,Kay F. Nikolas,DEM,16
+Day,10,State House,01,Joe Donnell,REP,46
+Day,10,State House,01,Tamara St John,REP,45
+Day,11,State House,01,Steven D. McCleerey,DEM,135
+Day,11,State House,01,Kay F. Nikolas,DEM,86
+Day,11,State House,01,Joe Donnell,REP,145
+Day,11,State House,01,Tamara St John,REP,187
+Day,01,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,120
+Day,02,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,106
+Day,03,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,134
+Day,04,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,163
+Day,05,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,178
+Day,06,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,53
+Day,07,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,96
+Day,08,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,95
+Day,09,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,84
+Day,10,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,35
+Day,11,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,138
+Day,01,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,108
+Day,02,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,102
+Day,03,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,121
+Day,04,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,149
+Day,05,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,163
+Day,06,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,49
+Day,07,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,94
+Day,08,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,91
+Day,09,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,82
+Day,10,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,35
+Day,11,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,140
+Day,01,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,109
+Day,02,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,97
+Day,03,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,120
+Day,04,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,140
+Day,05,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,158
+Day,06,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,48
+Day,07,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,84
+Day,08,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,80
+Day,09,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,79
+Day,10,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,34
+Day,11,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,130
+Day,01,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,122
+Day,02,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,105
+Day,03,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,133
+Day,04,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,161
+Day,05,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,167
+Day,06,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,51
+Day,07,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,116
+Day,08,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,114
+Day,09,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,110
+Day,10,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,35
+Day,11,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,141
+Day,01,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,157
+Day,01,Supreme Court Retention,3,Patricia J. DeVaney - No,,29
+Day,02,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,151
+Day,02,Supreme Court Retention,3,Patricia J. DeVaney - No,,30
+Day,03,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,186
+Day,03,Supreme Court Retention,3,Patricia J. DeVaney - No,,33
+Day,04,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,245
+Day,04,Supreme Court Retention,3,Patricia J. DeVaney - No,,43
+Day,05,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,236
+Day,05,Supreme Court Retention,3,Patricia J. DeVaney - No,,45
+Day,06,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,56
+Day,06,Supreme Court Retention,3,Patricia J. DeVaney - No,,21
+Day,07,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,137
+Day,07,Supreme Court Retention,3,Patricia J. DeVaney - No,,28
+Day,08,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,130
+Day,08,Supreme Court Retention,3,Patricia J. DeVaney - No,,26
+Day,09,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,123
+Day,09,Supreme Court Retention,3,Patricia J. DeVaney - No,,27
+Day,10,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,42
+Day,10,Supreme Court Retention,3,Patricia J. DeVaney - No,,18
+Day,11,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,221
+Day,11,Supreme Court Retention,3,Patricia J. DeVaney - No,,67
+Day,01,Supreme Court Retention,2,Mark E. Salter - Yes,,152
+Day,01,Supreme Court Retention,2,Mark E. Salter - No,,31
+Day,02,Supreme Court Retention,2,Mark E. Salter - Yes,,152
+Day,02,Supreme Court Retention,2,Mark E. Salter - No,,29
+Day,03,Supreme Court Retention,2,Mark E. Salter - Yes,,184
+Day,03,Supreme Court Retention,2,Mark E. Salter - No,,39
+Day,04,Supreme Court Retention,2,Mark E. Salter - Yes,,243
+Day,04,Supreme Court Retention,2,Mark E. Salter - No,,43
+Day,05,Supreme Court Retention,2,Mark E. Salter - Yes,,230
+Day,05,Supreme Court Retention,2,Mark E. Salter - No,,45
+Day,06,Supreme Court Retention,2,Mark E. Salter - Yes,,51
+Day,06,Supreme Court Retention,2,Mark E. Salter - No,,21
+Day,07,Supreme Court Retention,2,Mark E. Salter - Yes,,133
+Day,07,Supreme Court Retention,2,Mark E. Salter - No,,29
+Day,08,Supreme Court Retention,2,Mark E. Salter - Yes,,123
+Day,08,Supreme Court Retention,2,Mark E. Salter - No,,26
+Day,09,Supreme Court Retention,2,Mark E. Salter - Yes,,125
+Day,09,Supreme Court Retention,2,Mark E. Salter - No,,25
+Day,10,Supreme Court Retention,2,Mark E. Salter - Yes,,41
+Day,10,Supreme Court Retention,2,Mark E. Salter - No,,19
+Day,11,Supreme Court Retention,2,Mark E. Salter - Yes,,216
+Day,11,Supreme Court Retention,2,Mark E. Salter - No,,72
+Day,01,Constitutional Amendment D,,Yes,,121
+Day,01,Constitutional Amendment D,,No,,104
+Day,02,Constitutional Amendment D,,Yes,,118
+Day,02,Constitutional Amendment D,,No,,105
+Day,03,Constitutional Amendment D,,Yes,,148
+Day,03,Constitutional Amendment D,,No,,114
+Day,04,Constitutional Amendment D,,Yes,,179
+Day,04,Constitutional Amendment D,,No,,173
+Day,05,Constitutional Amendment D,,Yes,,182
+Day,05,Constitutional Amendment D,,No,,149
+Day,06,Constitutional Amendment D,,Yes,,48
+Day,06,Constitutional Amendment D,,No,,36
+Day,07,Constitutional Amendment D,,Yes,,91
+Day,07,Constitutional Amendment D,,No,,103
+Day,08,Constitutional Amendment D,,Yes,,104
+Day,08,Constitutional Amendment D,,No,,82
+Day,09,Constitutional Amendment D,,Yes,,102
+Day,09,Constitutional Amendment D,,No,,84
+Day,10,Constitutional Amendment D,,Yes,,30
+Day,10,Constitutional Amendment D,,No,,51
+Day,11,Constitutional Amendment D,,Yes,,202
+Day,11,Constitutional Amendment D,,No,,134
+Day,01,Initiated Measure 27,,Yes,,98
+Day,01,Initiated Measure 27,,No,,129
+Day,02,Initiated Measure 27,,Yes,,100
+Day,02,Initiated Measure 27,,No,,124
+Day,03,Initiated Measure 27,,Yes,,117
+Day,03,Initiated Measure 27,,No,,149
+Day,04,Initiated Measure 27,,Yes,,120
+Day,04,Initiated Measure 27,,No,,237
+Day,05,Initiated Measure 27,,Yes,,145
+Day,05,Initiated Measure 27,,No,,191
+Day,06,Initiated Measure 27,,Yes,,30
+Day,06,Initiated Measure 27,,No,,58
+Day,07,Initiated Measure 27,,Yes,,76
+Day,07,Initiated Measure 27,,No,,120
+Day,08,Initiated Measure 27,,Yes,,81
+Day,08,Initiated Measure 27,,No,,106
+Day,09,Initiated Measure 27,,Yes,,87
+Day,09,Initiated Measure 27,,No,,98
+Day,10,Initiated Measure 27,,Yes,,20
+Day,10,Initiated Measure 27,,No,,63
+Day,11,Initiated Measure 27,,Yes,,195
+Day,11,Initiated Measure 27,,No,,143

--- a/2022/counties/20221108__sd__general__deuel__precinct.csv
+++ b/2022/counties/20221108__sd__general__deuel__precinct.csv
@@ -1,0 +1,381 @@
+county,precinct,office,district,candidate,party,votes
+Deuel,01,U.S. Senate,,Brian L. Bengs,DEM,26
+Deuel,01,U.S. Senate,,Tamara J Lesnar,LIB,2
+Deuel,01,U.S. Senate,,John R. Thune,REP,110
+Deuel,03,U.S. Senate,,Brian L. Bengs,DEM,35
+Deuel,03,U.S. Senate,,Tamara J Lesnar,LIB,8
+Deuel,03,U.S. Senate,,John R. Thune,REP,234
+Deuel,04,U.S. Senate,,Brian L. Bengs,DEM,22
+Deuel,04,U.S. Senate,,Tamara J Lesnar,LIB,10
+Deuel,04,U.S. Senate,,John R. Thune,REP,122
+Deuel,05,U.S. Senate,,Brian L. Bengs,DEM,45
+Deuel,05,U.S. Senate,,Tamara J Lesnar,LIB,3
+Deuel,05,U.S. Senate,,John R. Thune,REP,119
+Deuel,06,U.S. Senate,,Brian L. Bengs,DEM,41
+Deuel,06,U.S. Senate,,Tamara J Lesnar,LIB,9
+Deuel,06,U.S. Senate,,John R. Thune,REP,130
+Deuel,07,U.S. Senate,,Brian L. Bengs,DEM,29
+Deuel,07,U.S. Senate,,Tamara J Lesnar,LIB,11
+Deuel,07,U.S. Senate,,John R. Thune,REP,139
+Deuel,08,U.S. Senate,,Brian L. Bengs,DEM,43
+Deuel,08,U.S. Senate,,Tamara J Lesnar,LIB,18
+Deuel,08,U.S. Senate,,John R. Thune,REP,202
+Deuel,09,U.S. Senate,,Brian L. Bengs,DEM,40
+Deuel,09,U.S. Senate,,Tamara J Lesnar,LIB,16
+Deuel,09,U.S. Senate,,John R. Thune,REP,222
+Deuel,10,U.S. Senate,,Brian L. Bengs,DEM,22
+Deuel,10,U.S. Senate,,Tamara J Lesnar,LIB,8
+Deuel,10,U.S. Senate,,John R. Thune,REP,132
+Deuel,11,U.S. Senate,,Brian L. Bengs,DEM,43
+Deuel,11,U.S. Senate,,Tamara J Lesnar,LIB,7
+Deuel,11,U.S. Senate,,John R. Thune,REP,138
+Deuel,01,U.S. House,1,Collin Duprel,LIB,15
+Deuel,01,U.S. House,1,Dusty Johnson,REP,116
+Deuel,03,U.S. House,1,Collin Duprel,LIB,26
+Deuel,03,U.S. House,1,Dusty Johnson,REP,241
+Deuel,04,U.S. House,1,Collin Duprel,LIB,25
+Deuel,04,U.S. House,1,Dusty Johnson,REP,127
+Deuel,05,U.S. House,1,Collin Duprel,LIB,27
+Deuel,05,U.S. House,1,Dusty Johnson,REP,129
+Deuel,06,U.S. House,1,Collin Duprel,LIB,29
+Deuel,06,U.S. House,1,Dusty Johnson,REP,144
+Deuel,07,U.S. House,1,Collin Duprel,LIB,30
+Deuel,07,U.S. House,1,Dusty Johnson,REP,145
+Deuel,08,U.S. House,1,Collin Duprel,LIB,41
+Deuel,08,U.S. House,1,Dusty Johnson,REP,218
+Deuel,09,U.S. House,1,Collin Duprel,LIB,32
+Deuel,09,U.S. House,1,Dusty Johnson,REP,238
+Deuel,10,U.S. House,1,Collin Duprel,LIB,21
+Deuel,10,U.S. House,1,Dusty Johnson,REP,139
+Deuel,11,U.S. House,1,Collin Duprel,LIB,33
+Deuel,11,U.S. House,1,Dusty Johnson,REP,146
+Deuel,01,Governor,,Jamie Smith and Jennifer Keintz,DEM,36
+Deuel,01,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Deuel,01,Governor,,Kristi Noem and Larry Rhoden,REP,99
+Deuel,03,Governor,,Jamie Smith and Jennifer Keintz,DEM,50
+Deuel,03,Governor,,Tracey Quint and Ashley Strand,LIB,9
+Deuel,03,Governor,,Kristi Noem and Larry Rhoden,REP,220
+Deuel,04,Governor,,Jamie Smith and Jennifer Keintz,DEM,29
+Deuel,04,Governor,,Tracey Quint and Ashley Strand,LIB,9
+Deuel,04,Governor,,Kristi Noem and Larry Rhoden,REP,114
+Deuel,05,Governor,,Jamie Smith and Jennifer Keintz,DEM,53
+Deuel,05,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Deuel,05,Governor,,Kristi Noem and Larry Rhoden,REP,111
+Deuel,06,Governor,,Jamie Smith and Jennifer Keintz,DEM,56
+Deuel,06,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Deuel,06,Governor,,Kristi Noem and Larry Rhoden,REP,117
+Deuel,07,Governor,,Jamie Smith and Jennifer Keintz,DEM,32
+Deuel,07,Governor,,Tracey Quint and Ashley Strand,LIB,8
+Deuel,07,Governor,,Kristi Noem and Larry Rhoden,REP,137
+Deuel,08,Governor,,Jamie Smith and Jennifer Keintz,DEM,53
+Deuel,08,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Deuel,08,Governor,,Kristi Noem and Larry Rhoden,REP,210
+Deuel,09,Governor,,Jamie Smith and Jennifer Keintz,DEM,53
+Deuel,09,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Deuel,09,Governor,,Kristi Noem and Larry Rhoden,REP,222
+Deuel,10,Governor,,Jamie Smith and Jennifer Keintz,DEM,35
+Deuel,10,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Deuel,10,Governor,,Kristi Noem and Larry Rhoden,REP,125
+Deuel,11,Governor,,Jamie Smith and Jennifer Keintz,DEM,61
+Deuel,11,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Deuel,11,Governor,,Kristi Noem and Larry Rhoden,REP,124
+Deuel,01,Secretary of State,,Thomas A Cool,DEM,38
+Deuel,01,Secretary of State,,Monae Johnson,REP,90
+Deuel,03,Secretary of State,,Thomas A Cool,DEM,58
+Deuel,03,Secretary of State,,Monae Johnson,REP,205
+Deuel,04,Secretary of State,,Thomas A Cool,DEM,41
+Deuel,04,Secretary of State,,Monae Johnson,REP,102
+Deuel,05,Secretary of State,,Thomas A Cool,DEM,60
+Deuel,05,Secretary of State,,Monae Johnson,REP,98
+Deuel,06,Secretary of State,,Thomas A Cool,DEM,62
+Deuel,06,Secretary of State,,Monae Johnson,REP,109
+Deuel,07,Secretary of State,,Thomas A Cool,DEM,43
+Deuel,07,Secretary of State,,Monae Johnson,REP,125
+Deuel,08,Secretary of State,,Thomas A Cool,DEM,66
+Deuel,08,Secretary of State,,Monae Johnson,REP,196
+Deuel,09,Secretary of State,,Thomas A Cool,DEM,56
+Deuel,09,Secretary of State,,Monae Johnson,REP,209
+Deuel,10,Secretary of State,,Thomas A Cool,DEM,45
+Deuel,10,Secretary of State,,Monae Johnson,REP,113
+Deuel,11,Secretary of State,,Thomas A Cool,DEM,71
+Deuel,11,Secretary of State,,Monae Johnson,REP,112
+Deuel,01,Attorney General,,Marty J. Jackley,REP,110
+Deuel,03,Attorney General,,Marty J. Jackley,REP,243
+Deuel,04,Attorney General,,Marty J. Jackley,REP,128
+Deuel,05,Attorney General,,Marty J. Jackley,REP,135
+Deuel,06,Attorney General,,Marty J. Jackley,REP,145
+Deuel,07,Attorney General,,Marty J. Jackley,REP,144
+Deuel,08,Attorney General,,Marty J. Jackley,REP,219
+Deuel,09,Attorney General,,Marty J. Jackley,REP,237
+Deuel,10,Attorney General,,Marty J. Jackley,REP,136
+Deuel,11,Attorney General,,Marty J. Jackley,REP,149
+Deuel,01,State Auditor,,Stephanie Marty,DEM,37
+Deuel,01,State Auditor,,Rene Meyer,LIB,3
+Deuel,01,State Auditor,,Richard Sattgast,REP,87
+Deuel,03,State Auditor,,Stephanie Marty,DEM,50
+Deuel,03,State Auditor,,Rene Meyer,LIB,13
+Deuel,03,State Auditor,,Richard Sattgast,REP,194
+Deuel,04,State Auditor,,Stephanie Marty,DEM,32
+Deuel,04,State Auditor,,Rene Meyer,LIB,13
+Deuel,04,State Auditor,,Richard Sattgast,REP,94
+Deuel,05,State Auditor,,Stephanie Marty,DEM,52
+Deuel,05,State Auditor,,Rene Meyer,LIB,4
+Deuel,05,State Auditor,,Richard Sattgast,REP,105
+Deuel,06,State Auditor,,Stephanie Marty,DEM,50
+Deuel,06,State Auditor,,Rene Meyer,LIB,6
+Deuel,06,State Auditor,,Richard Sattgast,REP,116
+Deuel,07,State Auditor,,Stephanie Marty,DEM,34
+Deuel,07,State Auditor,,Rene Meyer,LIB,13
+Deuel,07,State Auditor,,Richard Sattgast,REP,117
+Deuel,08,State Auditor,,Stephanie Marty,DEM,60
+Deuel,08,State Auditor,,Rene Meyer,LIB,17
+Deuel,08,State Auditor,,Richard Sattgast,REP,184
+Deuel,09,State Auditor,,Stephanie Marty,DEM,50
+Deuel,09,State Auditor,,Rene Meyer,LIB,14
+Deuel,09,State Auditor,,Richard Sattgast,REP,202
+Deuel,10,State Auditor,,Stephanie Marty,DEM,34
+Deuel,10,State Auditor,,Rene Meyer,LIB,6
+Deuel,10,State Auditor,,Richard Sattgast,REP,117
+Deuel,11,State Auditor,,Stephanie Marty,DEM,64
+Deuel,11,State Auditor,,Rene Meyer,LIB,10
+Deuel,11,State Auditor,,Richard Sattgast,REP,109
+Deuel,01,State Treasurer,,John Cunningham,DEM,37
+Deuel,01,State Treasurer,,Josh Haeder,REP,89
+Deuel,03,State Treasurer,,John Cunningham,DEM,50
+Deuel,03,State Treasurer,,Josh Haeder,REP,207
+Deuel,04,State Treasurer,,John Cunningham,DEM,30
+Deuel,04,State Treasurer,,Josh Haeder,REP,107
+Deuel,05,State Treasurer,,John Cunningham,DEM,53
+Deuel,05,State Treasurer,,Josh Haeder,REP,108
+Deuel,06,State Treasurer,,John Cunningham,DEM,54
+Deuel,06,State Treasurer,,Josh Haeder,REP,117
+Deuel,07,State Treasurer,,John Cunningham,DEM,38
+Deuel,07,State Treasurer,,Josh Haeder,REP,127
+Deuel,08,State Treasurer,,John Cunningham,DEM,62
+Deuel,08,State Treasurer,,Josh Haeder,REP,196
+Deuel,09,State Treasurer,,John Cunningham,DEM,49
+Deuel,09,State Treasurer,,Josh Haeder,REP,216
+Deuel,10,State Treasurer,,John Cunningham,DEM,35
+Deuel,10,State Treasurer,,Josh Haeder,REP,124
+Deuel,11,State Treasurer,,John Cunningham,DEM,62
+Deuel,11,State Treasurer,,Josh Haeder,REP,121
+Deuel,01,Commissioner of School and Public Lands,,Timothy Azure,DEM,32
+Deuel,01,Commissioner of School and Public Lands,,Brock Greenfield,REP,93
+Deuel,03,Commissioner of School and Public Lands,,Timothy Azure,DEM,35
+Deuel,03,Commissioner of School and Public Lands,,Brock Greenfield,REP,222
+Deuel,04,Commissioner of School and Public Lands,,Timothy Azure,DEM,29
+Deuel,04,Commissioner of School and Public Lands,,Brock Greenfield,REP,115
+Deuel,05,Commissioner of School and Public Lands,,Timothy Azure,DEM,45
+Deuel,05,Commissioner of School and Public Lands,,Brock Greenfield,REP,113
+Deuel,06,Commissioner of School and Public Lands,,Timothy Azure,DEM,48
+Deuel,06,Commissioner of School and Public Lands,,Brock Greenfield,REP,122
+Deuel,07,Commissioner of School and Public Lands,,Timothy Azure,DEM,34
+Deuel,07,Commissioner of School and Public Lands,,Brock Greenfield,REP,131
+Deuel,08,Commissioner of School and Public Lands,,Timothy Azure,DEM,58
+Deuel,08,Commissioner of School and Public Lands,,Brock Greenfield,REP,208
+Deuel,09,Commissioner of School and Public Lands,,Timothy Azure,DEM,52
+Deuel,09,Commissioner of School and Public Lands,,Brock Greenfield,REP,214
+Deuel,10,Commissioner of School and Public Lands,,Timothy Azure,DEM,31
+Deuel,10,Commissioner of School and Public Lands,,Brock Greenfield,REP,129
+Deuel,11,Commissioner of School and Public Lands,,Timothy Azure,DEM,62
+Deuel,11,Commissioner of School and Public Lands,,Brock Greenfield,REP,120
+Deuel,01,Public Utilities Commissioner,,Jeffrey Barth,DEM,36
+Deuel,01,Public Utilities Commissioner,,Chris Nelson,REP,93
+Deuel,03,Public Utilities Commissioner,,Jeffrey Barth,DEM,41
+Deuel,03,Public Utilities Commissioner,,Chris Nelson,REP,216
+Deuel,04,Public Utilities Commissioner,,Jeffrey Barth,DEM,29
+Deuel,04,Public Utilities Commissioner,,Chris Nelson,REP,118
+Deuel,05,Public Utilities Commissioner,,Jeffrey Barth,DEM,43
+Deuel,05,Public Utilities Commissioner,,Chris Nelson,REP,121
+Deuel,06,Public Utilities Commissioner,,Jeffrey Barth,DEM,42
+Deuel,06,Public Utilities Commissioner,,Chris Nelson,REP,129
+Deuel,07,Public Utilities Commissioner,,Jeffrey Barth,DEM,39
+Deuel,07,Public Utilities Commissioner,,Chris Nelson,REP,131
+Deuel,08,Public Utilities Commissioner,,Jeffrey Barth,DEM,61
+Deuel,08,Public Utilities Commissioner,,Chris Nelson,REP,200
+Deuel,09,Public Utilities Commissioner,,Jeffrey Barth,DEM,47
+Deuel,09,Public Utilities Commissioner,,Chris Nelson,REP,224
+Deuel,10,Public Utilities Commissioner,,Jeffrey Barth,DEM,29
+Deuel,10,Public Utilities Commissioner,,Chris Nelson,REP,131
+Deuel,11,Public Utilities Commissioner,,Jeffrey Barth,DEM,54
+Deuel,11,Public Utilities Commissioner,,Chris Nelson,REP,128
+Deuel,01,State Senate,04,John Wiik,REP,107
+Deuel,03,State Senate,04,John Wiik,REP,237
+Deuel,04,State Senate,04,John Wiik,REP,121
+Deuel,05,State Senate,04,John Wiik,REP,126
+Deuel,06,State Senate,04,John Wiik,REP,138
+Deuel,07,State Senate,04,John Wiik,REP,137
+Deuel,08,State Senate,04,John Wiik,REP,211
+Deuel,09,State Senate,04,John Wiik,REP,229
+Deuel,10,State Senate,04,John Wiik,REP,129
+Deuel,11,State Senate,04,John Wiik,REP,137
+Deuel,01,State House,04,Stephanie Sauder,REP,73
+Deuel,01,State House,04,Fred Deutsch,REP,86
+Deuel,03,State House,04,Stephanie Sauder,REP,157
+Deuel,03,State House,04,Fred Deutsch,REP,182
+Deuel,04,State House,04,Stephanie Sauder,REP,72
+Deuel,04,State House,04,Fred Deutsch,REP,99
+Deuel,05,State House,04,Stephanie Sauder,REP,81
+Deuel,05,State House,04,Fred Deutsch,REP,105
+Deuel,06,State House,04,Stephanie Sauder,REP,93
+Deuel,06,State House,04,Fred Deutsch,REP,110
+Deuel,07,State House,04,Stephanie Sauder,REP,98
+Deuel,07,State House,04,Fred Deutsch,REP,109
+Deuel,08,State House,04,Stephanie Sauder,REP,123
+Deuel,08,State House,04,Fred Deutsch,REP,180
+Deuel,09,State House,04,Stephanie Sauder,REP,156
+Deuel,09,State House,04,Fred Deutsch,REP,171
+Deuel,10,State House,04,Stephanie Sauder,REP,83
+Deuel,10,State House,04,Fred Deutsch,REP,108
+Deuel,11,State House,04,Stephanie Sauder,REP,90
+Deuel,11,State House,04,Fred Deutsch,REP,115
+Deuel,01,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,65
+Deuel,03,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,163
+Deuel,04,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,76
+Deuel,05,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,100
+Deuel,06,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,96
+Deuel,07,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,100
+Deuel,08,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,144
+Deuel,09,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,129
+Deuel,10,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,70
+Deuel,11,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,94
+Deuel,01,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,71
+Deuel,03,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,161
+Deuel,04,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,79
+Deuel,05,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,103
+Deuel,06,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,97
+Deuel,07,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,101
+Deuel,08,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,141
+Deuel,09,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,131
+Deuel,10,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,71
+Deuel,11,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,98
+Deuel,01,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,61
+Deuel,03,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,159
+Deuel,04,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,76
+Deuel,05,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,93
+Deuel,06,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,89
+Deuel,07,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,99
+Deuel,08,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,133
+Deuel,09,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,121
+Deuel,10,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,65
+Deuel,11,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,92
+Deuel,01,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,90
+Deuel,03,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,195
+Deuel,04,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,108
+Deuel,05,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,125
+Deuel,06,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,122
+Deuel,07,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,119
+Deuel,08,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,170
+Deuel,09,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,189
+Deuel,10,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,86
+Deuel,11,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,116
+Deuel,01,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,57
+Deuel,01,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,29
+Deuel,03,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,119
+Deuel,03,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,67
+Deuel,04,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,57
+Deuel,04,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,37
+Deuel,05,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,92
+Deuel,05,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,33
+Deuel,06,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,82
+Deuel,06,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,39
+Deuel,07,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,75
+Deuel,07,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,50
+Deuel,08,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,125
+Deuel,08,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,65
+Deuel,09,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,127
+Deuel,09,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,43
+Deuel,10,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,40
+Deuel,10,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,55
+Deuel,11,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,56
+Deuel,11,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,77
+Deuel,01,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,54
+Deuel,03,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,155
+Deuel,04,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,71
+Deuel,05,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,94
+Deuel,06,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,87
+Deuel,07,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,100
+Deuel,08,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,129
+Deuel,09,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,118
+Deuel,10,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,61
+Deuel,11,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,95
+Deuel,01,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,96
+Deuel,01,Supreme Court Retention,3,Patricia J. DeVaney - No,,19
+Deuel,03,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,198
+Deuel,03,Supreme Court Retention,3,Patricia J. DeVaney - No,,32
+Deuel,04,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,105
+Deuel,04,Supreme Court Retention,3,Patricia J. DeVaney - No,,22
+Deuel,05,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,122
+Deuel,05,Supreme Court Retention,3,Patricia J. DeVaney - No,,14
+Deuel,06,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,136
+Deuel,06,Supreme Court Retention,3,Patricia J. DeVaney - No,,19
+Deuel,07,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,112
+Deuel,07,Supreme Court Retention,3,Patricia J. DeVaney - No,,34
+Deuel,08,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,206
+Deuel,08,Supreme Court Retention,3,Patricia J. DeVaney - No,,30
+Deuel,09,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,188
+Deuel,09,Supreme Court Retention,3,Patricia J. DeVaney - No,,31
+Deuel,10,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,113
+Deuel,10,Supreme Court Retention,3,Patricia J. DeVaney - No,,14
+Deuel,11,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,135
+Deuel,11,Supreme Court Retention,3,Patricia J. DeVaney - No,,23
+Deuel,01,Supreme Court Retention,2,Mark E. Salter - Yes,,93
+Deuel,01,Supreme Court Retention,2,Mark E. Salter - No,,16
+Deuel,03,Supreme Court Retention,2,Mark E. Salter - Yes,,195
+Deuel,03,Supreme Court Retention,2,Mark E. Salter - No,,32
+Deuel,04,Supreme Court Retention,2,Mark E. Salter - Yes,,105
+Deuel,04,Supreme Court Retention,2,Mark E. Salter - No,,18
+Deuel,05,Supreme Court Retention,2,Mark E. Salter - Yes,,124
+Deuel,05,Supreme Court Retention,2,Mark E. Salter - No,,14
+Deuel,06,Supreme Court Retention,2,Mark E. Salter - Yes,,127
+Deuel,06,Supreme Court Retention,2,Mark E. Salter - No,,23
+Deuel,07,Supreme Court Retention,2,Mark E. Salter - Yes,,114
+Deuel,07,Supreme Court Retention,2,Mark E. Salter - No,,32
+Deuel,08,Supreme Court Retention,2,Mark E. Salter - Yes,,201
+Deuel,08,Supreme Court Retention,2,Mark E. Salter - No,,34
+Deuel,09,Supreme Court Retention,2,Mark E. Salter - Yes,,188
+Deuel,09,Supreme Court Retention,2,Mark E. Salter - No,,30
+Deuel,10,Supreme Court Retention,2,Mark E. Salter - Yes,,110
+Deuel,10,Supreme Court Retention,2,Mark E. Salter - No,,15
+Deuel,11,Supreme Court Retention,2,Mark E. Salter - Yes,,129
+Deuel,11,Supreme Court Retention,2,Mark E. Salter - No,,24
+Deuel,01,Constitutional Amendment D,,Yes,,79
+Deuel,01,Constitutional Amendment D,,No,,55
+Deuel,03,Constitutional Amendment D,,Yes,,115
+Deuel,03,Constitutional Amendment D,,No,,155
+Deuel,04,Constitutional Amendment D,,Yes,,77
+Deuel,04,Constitutional Amendment D,,No,,73
+Deuel,05,Constitutional Amendment D,,Yes,,98
+Deuel,05,Constitutional Amendment D,,No,,64
+Deuel,06,Constitutional Amendment D,,Yes,,92
+Deuel,06,Constitutional Amendment D,,No,,80
+Deuel,07,Constitutional Amendment D,,Yes,,80
+Deuel,07,Constitutional Amendment D,,No,,98
+Deuel,08,Constitutional Amendment D,,Yes,,118
+Deuel,08,Constitutional Amendment D,,No,,152
+Deuel,09,Constitutional Amendment D,,Yes,,122
+Deuel,09,Constitutional Amendment D,,No,,152
+Deuel,10,Constitutional Amendment D,,Yes,,80
+Deuel,10,Constitutional Amendment D,,No,,78
+Deuel,11,Constitutional Amendment D,,Yes,,84
+Deuel,11,Constitutional Amendment D,,No,,105
+Deuel,01,Initiated Measure 27,,Yes,,49
+Deuel,01,Initiated Measure 27,,No,,88
+Deuel,03,Initiated Measure 27,,Yes,,86
+Deuel,03,Initiated Measure 27,,No,,191
+Deuel,04,Initiated Measure 27,,Yes,,52
+Deuel,04,Initiated Measure 27,,No,,99
+Deuel,05,Initiated Measure 27,,Yes,,77
+Deuel,05,Initiated Measure 27,,No,,88
+Deuel,06,Initiated Measure 27,,Yes,,63
+Deuel,06,Initiated Measure 27,,No,,116
+Deuel,07,Initiated Measure 27,,Yes,,65
+Deuel,07,Initiated Measure 27,,No,,113
+Deuel,08,Initiated Measure 27,,Yes,,66
+Deuel,08,Initiated Measure 27,,No,,206
+Deuel,09,Initiated Measure 27,,Yes,,74
+Deuel,09,Initiated Measure 27,,No,,204
+Deuel,10,Initiated Measure 27,,Yes,,41
+Deuel,10,Initiated Measure 27,,No,,123
+Deuel,11,Initiated Measure 27,,Yes,,57
+Deuel,11,Initiated Measure 27,,No,,135

--- a/2022/counties/20221108__sd__general__dewey__precinct.csv
+++ b/2022/counties/20221108__sd__general__dewey__precinct.csv
@@ -1,0 +1,430 @@
+county,precinct,office,district,candidate,party,votes
+Dewey,02 Trail City,U.S. Senate,,Brian L. Bengs,DEM,2
+Dewey,02 Trail City,U.S. Senate,,Tamara J Lesnar,LIB,3
+Dewey,02 Trail City,U.S. Senate,,John R. Thune,REP,27
+Dewey,04 Timber Lake,U.S. Senate,,Brian L. Bengs,DEM,62
+Dewey,04 Timber Lake,U.S. Senate,,Tamara J Lesnar,LIB,16
+Dewey,04 Timber Lake,U.S. Senate,,John R. Thune,REP,246
+Dewey,05 Firesteel,U.S. Senate,,Brian L. Bengs,DEM,12
+Dewey,05 Firesteel,U.S. Senate,,Tamara J Lesnar,LIB,4
+Dewey,05 Firesteel,U.S. Senate,,John R. Thune,REP,37
+Dewey,06 Isabel,U.S. Senate,,Brian L. Bengs,DEM,10
+Dewey,06 Isabel,U.S. Senate,,Tamara J Lesnar,LIB,2
+Dewey,06 Isabel,U.S. Senate,,John R. Thune,REP,96
+Dewey,?,U.S. Senate,,Brian L. Bengs,DEM,163
+Dewey,?,U.S. Senate,,Tamara J Lesnar,LIB,14
+Dewey,?,U.S. Senate,,John R. Thune,REP,47
+Dewey,08 White Horse,U.S. Senate,,Brian L. Bengs,DEM,33
+Dewey,08 White Horse,U.S. Senate,,Tamara J Lesnar,LIB,3
+Dewey,08 White Horse,U.S. Senate,,John R. Thune,REP,16
+Dewey,09 Promise,U.S. Senate,,Brian L. Bengs,DEM,32
+Dewey,09 Promise,U.S. Senate,,Tamara J Lesnar,LIB,2
+Dewey,09 Promise,U.S. Senate,,John R. Thune,REP,26
+Dewey,?,U.S. Senate,,Brian L. Bengs,DEM,56
+Dewey,?,U.S. Senate,,Tamara J Lesnar,LIB,4
+Dewey,?,U.S. Senate,,John R. Thune,REP,18
+Dewey,North (Precinct-13 Eagle,U.S. Senate,,Brian L. Bengs,DEM,112
+Dewey,North (Precinct-13 Eagle,U.S. Senate,,Tamara J Lesnar,LIB,7
+Dewey,North (Precinct-13 Eagle,U.S. Senate,,John R. Thune,REP,92
+Dewey,?,U.S. Senate,,Brian L. Bengs,DEM,152
+Dewey,?,U.S. Senate,,Tamara J Lesnar,LIB,13
+Dewey,?,U.S. Senate,,John R. Thune,REP,79
+Dewey,?,U.S. Senate,,Brian L. Bengs,DEM,86
+Dewey,?,U.S. Senate,,Tamara J Lesnar,LIB,2
+Dewey,?,U.S. Senate,,John R. Thune,REP,86
+Dewey,02 Trail City,U.S. House,1,Collin Duprel,LIB,4
+Dewey,02 Trail City,U.S. House,1,Dusty Johnson,REP,28
+Dewey,04 Timber Lake,U.S. House,1,Collin Duprel,LIB,60
+Dewey,04 Timber Lake,U.S. House,1,Dusty Johnson,REP,252
+Dewey,05 Firesteel,U.S. House,1,Collin Duprel,LIB,8
+Dewey,05 Firesteel,U.S. House,1,Dusty Johnson,REP,38
+Dewey,06 Isabel,U.S. House,1,Collin Duprel,LIB,9
+Dewey,06 Isabel,U.S. House,1,Dusty Johnson,REP,94
+Dewey,?,U.S. House,1,Collin Duprel,LIB,119
+Dewey,?,U.S. House,1,Dusty Johnson,REP,68
+Dewey,08 White Horse,U.S. House,1,Collin Duprel,LIB,22
+Dewey,08 White Horse,U.S. House,1,Dusty Johnson,REP,21
+Dewey,09 Promise,U.S. House,1,Collin Duprel,LIB,25
+Dewey,09 Promise,U.S. House,1,Dusty Johnson,REP,25
+Dewey,?,U.S. House,1,Collin Duprel,LIB,35
+Dewey,?,U.S. House,1,Dusty Johnson,REP,33
+Dewey,North (Precinct-13 Eagle,U.S. House,1,Collin Duprel,LIB,74
+Dewey,North (Precinct-13 Eagle,U.S. House,1,Dusty Johnson,REP,108
+Dewey,?,U.S. House,1,Collin Duprel,LIB,104
+Dewey,?,U.S. House,1,Dusty Johnson,REP,107
+Dewey,?,U.S. House,1,Collin Duprel,LIB,59
+Dewey,?,U.S. House,1,Dusty Johnson,REP,96
+Dewey,02 Trail City,Governor,,Jamie Smith and Jennifer Keintz,DEM,2
+Dewey,02 Trail City,Governor,,Tracey Quint and Ashley Strand,LIB,0
+Dewey,02 Trail City,Governor,,Kristi Noem and Larry Rhoden,REP,33
+Dewey,04 Timber Lake,Governor,,Jamie Smith and Jennifer Keintz,DEM,82
+Dewey,04 Timber Lake,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Dewey,04 Timber Lake,Governor,,Kristi Noem and Larry Rhoden,REP,238
+Dewey,05 Firesteel,Governor,,Jamie Smith and Jennifer Keintz,DEM,16
+Dewey,05 Firesteel,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Dewey,05 Firesteel,Governor,,Kristi Noem and Larry Rhoden,REP,36
+Dewey,06 Isabel,Governor,,Jamie Smith and Jennifer Keintz,DEM,15
+Dewey,06 Isabel,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Dewey,06 Isabel,Governor,,Kristi Noem and Larry Rhoden,REP,92
+Dewey,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,184
+Dewey,?,Governor,,Tracey Quint and Ashley Strand,LIB,14
+Dewey,?,Governor,,Kristi Noem and Larry Rhoden,REP,25
+Dewey,08 White Horse,Governor,,Jamie Smith and Jennifer Keintz,DEM,37
+Dewey,08 White Horse,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Dewey,08 White Horse,Governor,,Kristi Noem and Larry Rhoden,REP,14
+Dewey,09 Promise,Governor,,Jamie Smith and Jennifer Keintz,DEM,37
+Dewey,09 Promise,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Dewey,09 Promise,Governor,,Kristi Noem and Larry Rhoden,REP,21
+Dewey,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,69
+Dewey,?,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Dewey,?,Governor,,Kristi Noem and Larry Rhoden,REP,12
+Dewey,North (Precinct-13 Eagle,Governor,,Jamie Smith and Jennifer Keintz,DEM,130
+Dewey,North (Precinct-13 Eagle,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Dewey,North (Precinct-13 Eagle,Governor,,Kristi Noem and Larry Rhoden,REP,71
+Dewey,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,187
+Dewey,?,Governor,,Tracey Quint and Ashley Strand,LIB,9
+Dewey,?,Governor,,Kristi Noem and Larry Rhoden,REP,50
+Dewey,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,103
+Dewey,?,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Dewey,?,Governor,,Kristi Noem and Larry Rhoden,REP,70
+Dewey,02 Trail City,Secretary of State,,Thomas A Cool,DEM,2
+Dewey,02 Trail City,Secretary of State,,Monae Johnson,REP,31
+Dewey,04 Timber Lake,Secretary of State,,Thomas A Cool,DEM,93
+Dewey,04 Timber Lake,Secretary of State,,Monae Johnson,REP,217
+Dewey,05 Firesteel,Secretary of State,,Thomas A Cool,DEM,21
+Dewey,05 Firesteel,Secretary of State,,Monae Johnson,REP,28
+Dewey,06 Isabel,Secretary of State,,Thomas A Cool,DEM,17
+Dewey,06 Isabel,Secretary of State,,Monae Johnson,REP,87
+Dewey,?,Secretary of State,,Thomas A Cool,DEM,183
+Dewey,?,Secretary of State,,Monae Johnson,REP,37
+Dewey,08 White Horse,Secretary of State,,Thomas A Cool,DEM,49
+Dewey,08 White Horse,Secretary of State,,Monae Johnson,REP,4
+Dewey,09 Promise,Secretary of State,,Thomas A Cool,DEM,38
+Dewey,09 Promise,Secretary of State,,Monae Johnson,REP,19
+Dewey,?,Secretary of State,,Thomas A Cool,DEM,64
+Dewey,?,Secretary of State,,Monae Johnson,REP,14
+Dewey,North (Precinct-13 Eagle,Secretary of State,,Thomas A Cool,DEM,127
+Dewey,North (Precinct-13 Eagle,Secretary of State,,Monae Johnson,REP,74
+Dewey,?,Secretary of State,,Thomas A Cool,DEM,190
+Dewey,?,Secretary of State,,Monae Johnson,REP,48
+Dewey,?,Secretary of State,,Thomas A Cool,DEM,100
+Dewey,?,Secretary of State,,Monae Johnson,REP,69
+Dewey,02 Trail City,Attorney General,,Marty J. Jackley,REP,32
+Dewey,04 Timber Lake,Attorney General,,Marty J. Jackley,REP,254
+Dewey,05 Firesteel,Attorney General,,Marty J. Jackley,REP,33
+Dewey,06 Isabel,Attorney General,,Marty J. Jackley,REP,97
+Dewey,?,Attorney General,,Marty J. Jackley,REP,87
+Dewey,08 White Horse,Attorney General,,Marty J. Jackley,REP,21
+Dewey,09 Promise,Attorney General,,Marty J. Jackley,REP,29
+Dewey,?,Attorney General,,Marty J. Jackley,REP,29
+Dewey,North (Precinct-13 Eagle,Attorney General,,Marty J. Jackley,REP,115
+Dewey,?,Attorney General,,Marty J. Jackley,REP,103
+Dewey,?,Attorney General,,Marty J. Jackley,REP,93
+Dewey,02 Trail City,State Auditor,,Stephanie Marty,DEM,2
+Dewey,02 Trail City,State Auditor,,Rene Meyer,LIB,2
+Dewey,02 Trail City,State Auditor,,Richard Sattgast,REP,29
+Dewey,04 Timber Lake,State Auditor,,Stephanie Marty,DEM,82
+Dewey,04 Timber Lake,State Auditor,,Rene Meyer,LIB,13
+Dewey,04 Timber Lake,State Auditor,,Richard Sattgast,REP,205
+Dewey,05 Firesteel,State Auditor,,Stephanie Marty,DEM,17
+Dewey,05 Firesteel,State Auditor,,Rene Meyer,LIB,2
+Dewey,05 Firesteel,State Auditor,,Richard Sattgast,REP,32
+Dewey,06 Isabel,State Auditor,,Stephanie Marty,DEM,14
+Dewey,06 Isabel,State Auditor,,Rene Meyer,LIB,3
+Dewey,06 Isabel,State Auditor,,Richard Sattgast,REP,85
+Dewey,?,State Auditor,,Stephanie Marty,DEM,174
+Dewey,?,State Auditor,,Rene Meyer,LIB,17
+Dewey,?,State Auditor,,Richard Sattgast,REP,27
+Dewey,08 White Horse,State Auditor,,Stephanie Marty,DEM,46
+Dewey,08 White Horse,State Auditor,,Rene Meyer,LIB,3
+Dewey,08 White Horse,State Auditor,,Richard Sattgast,REP,2
+Dewey,09 Promise,State Auditor,,Stephanie Marty,DEM,38
+Dewey,09 Promise,State Auditor,,Rene Meyer,LIB,4
+Dewey,09 Promise,State Auditor,,Richard Sattgast,REP,16
+Dewey,?,State Auditor,,Stephanie Marty,DEM,61
+Dewey,?,State Auditor,,Rene Meyer,LIB,7
+Dewey,?,State Auditor,,Richard Sattgast,REP,11
+Dewey,North (Precinct-13 Eagle,State Auditor,,Stephanie Marty,DEM,124
+Dewey,North (Precinct-13 Eagle,State Auditor,,Rene Meyer,LIB,11
+Dewey,North (Precinct-13 Eagle,State Auditor,,Richard Sattgast,REP,70
+Dewey,?,State Auditor,,Stephanie Marty,DEM,182
+Dewey,?,State Auditor,,Rene Meyer,LIB,16
+Dewey,?,State Auditor,,Richard Sattgast,REP,38
+Dewey,?,State Auditor,,Stephanie Marty,DEM,101
+Dewey,?,State Auditor,,Rene Meyer,LIB,12
+Dewey,?,State Auditor,,Richard Sattgast,REP,55
+Dewey,02 Trail City,State Treasurer,,John Cunningham,DEM,2
+Dewey,02 Trail City,State Treasurer,,Josh Haeder,REP,31
+Dewey,04 Timber Lake,State Treasurer,,John Cunningham,DEM,92
+Dewey,04 Timber Lake,State Treasurer,,Josh Haeder,REP,205
+Dewey,05 Firesteel,State Treasurer,,John Cunningham,DEM,17
+Dewey,05 Firesteel,State Treasurer,,Josh Haeder,REP,31
+Dewey,06 Isabel,State Treasurer,,John Cunningham,DEM,12
+Dewey,06 Isabel,State Treasurer,,Josh Haeder,REP,91
+Dewey,?,State Treasurer,,John Cunningham,DEM,177
+Dewey,?,State Treasurer,,Josh Haeder,REP,38
+Dewey,08 White Horse,State Treasurer,,John Cunningham,DEM,49
+Dewey,08 White Horse,State Treasurer,,Josh Haeder,REP,5
+Dewey,09 Promise,State Treasurer,,John Cunningham,DEM,38
+Dewey,09 Promise,State Treasurer,,Josh Haeder,REP,20
+Dewey,?,State Treasurer,,John Cunningham,DEM,65
+Dewey,?,State Treasurer,,Josh Haeder,REP,12
+Dewey,North (Precinct-13 Eagle,State Treasurer,,John Cunningham,DEM,130
+Dewey,North (Precinct-13 Eagle,State Treasurer,,Josh Haeder,REP,73
+Dewey,?,State Treasurer,,John Cunningham,DEM,197
+Dewey,?,State Treasurer,,Josh Haeder,REP,39
+Dewey,?,State Treasurer,,John Cunningham,DEM,103
+Dewey,?,State Treasurer,,Josh Haeder,REP,66
+Dewey,02 Trail City,Commissioner of School and Public Lands,,Timothy Azure,DEM,2
+Dewey,02 Trail City,Commissioner of School and Public Lands,,Brock Greenfield,REP,31
+Dewey,04 Timber Lake,Commissioner of School and Public Lands,,Timothy Azure,DEM,86
+Dewey,04 Timber Lake,Commissioner of School and Public Lands,,Brock Greenfield,REP,214
+Dewey,05 Firesteel,Commissioner of School and Public Lands,,Timothy Azure,DEM,17
+Dewey,05 Firesteel,Commissioner of School and Public Lands,,Brock Greenfield,REP,33
+Dewey,06 Isabel,Commissioner of School and Public Lands,,Timothy Azure,DEM,13
+Dewey,06 Isabel,Commissioner of School and Public Lands,,Brock Greenfield,REP,90
+Dewey,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,183
+Dewey,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,30
+Dewey,08 White Horse,Commissioner of School and Public Lands,,Timothy Azure,DEM,45
+Dewey,08 White Horse,Commissioner of School and Public Lands,,Brock Greenfield,REP,7
+Dewey,09 Promise,Commissioner of School and Public Lands,,Timothy Azure,DEM,40
+Dewey,09 Promise,Commissioner of School and Public Lands,,Brock Greenfield,REP,17
+Dewey,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,67
+Dewey,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,12
+Dewey,North (Precinct-13 Eagle,Commissioner of School and Public Lands,,Timothy Azure,DEM,124
+Dewey,North (Precinct-13 Eagle,Commissioner of School and Public Lands,,Brock Greenfield,REP,77
+Dewey,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,191
+Dewey,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,41
+Dewey,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,104
+Dewey,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,62
+Dewey,02 Trail City,Public Utilities Commissioner,,Jeffrey Barth,DEM,2
+Dewey,02 Trail City,Public Utilities Commissioner,,Chris Nelson,REP,32
+Dewey,04 Timber Lake,Public Utilities Commissioner,,Jeffrey Barth,DEM,72
+Dewey,04 Timber Lake,Public Utilities Commissioner,,Chris Nelson,REP,231
+Dewey,05 Firesteel,Public Utilities Commissioner,,Jeffrey Barth,DEM,16
+Dewey,05 Firesteel,Public Utilities Commissioner,,Chris Nelson,REP,37
+Dewey,06 Isabel,Public Utilities Commissioner,,Jeffrey Barth,DEM,14
+Dewey,06 Isabel,Public Utilities Commissioner,,Chris Nelson,REP,92
+Dewey,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,174
+Dewey,?,Public Utilities Commissioner,,Chris Nelson,REP,38
+Dewey,08 White Horse,Public Utilities Commissioner,,Jeffrey Barth,DEM,46
+Dewey,08 White Horse,Public Utilities Commissioner,,Chris Nelson,REP,7
+Dewey,09 Promise,Public Utilities Commissioner,,Jeffrey Barth,DEM,37
+Dewey,09 Promise,Public Utilities Commissioner,,Chris Nelson,REP,22
+Dewey,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,68
+Dewey,?,Public Utilities Commissioner,,Chris Nelson,REP,11
+Dewey,North (Precinct-13 Eagle,Public Utilities Commissioner,,Jeffrey Barth,DEM,121
+Dewey,North (Precinct-13 Eagle,Public Utilities Commissioner,,Chris Nelson,REP,84
+Dewey,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,177
+Dewey,?,Public Utilities Commissioner,,Chris Nelson,REP,51
+Dewey,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,97
+Dewey,?,Public Utilities Commissioner,,Chris Nelson,REP,72
+Dewey,02 Trail City,State Senate,28,Ryan M. Maher,REP,32
+Dewey,04 Timber Lake,State Senate,28,Ryan M. Maher,REP,272
+Dewey,05 Firesteel,State Senate,28,Ryan M. Maher,REP,38
+Dewey,06 Isabel,State Senate,28,Ryan M. Maher,REP,98
+Dewey,?,State Senate,28,Ryan M. Maher,REP,86
+Dewey,08 White Horse,State Senate,28,Ryan M. Maher,REP,27
+Dewey,09 Promise,State Senate,28,Ryan M. Maher,REP,31
+Dewey,?,State Senate,28,Ryan M. Maher,REP,25
+Dewey,North (Precinct-13 Eagle,State Senate,28,Ryan M. Maher,REP,117
+Dewey,?,State Senate,28,Ryan M. Maher,REP,104
+Dewey,?,State Senate,28,Ryan M. Maher,REP,105
+Dewey,02 Trail City,State House,28A,Oren L Lesmeister,DEM,3
+Dewey,02 Trail City,State House,28A,Ralph Lyon,REP,32
+Dewey,04 Timber Lake,State House,28A,Oren L Lesmeister,DEM,127
+Dewey,04 Timber Lake,State House,28A,Ralph Lyon,REP,189
+Dewey,05 Firesteel,State House,28A,Oren L Lesmeister,DEM,21
+Dewey,05 Firesteel,State House,28A,Ralph Lyon,REP,32
+Dewey,06 Isabel,State House,28A,Oren L Lesmeister,DEM,22
+Dewey,06 Isabel,State House,28A,Ralph Lyon,REP,86
+Dewey,?,State House,28A,Oren L Lesmeister,DEM,196
+Dewey,?,State House,28A,Ralph Lyon,REP,23
+Dewey,08 White Horse,State House,28A,Oren L Lesmeister,DEM,52
+Dewey,08 White Horse,State House,28A,Ralph Lyon,REP,2
+Dewey,09 Promise,State House,28A,Oren L Lesmeister,DEM,45
+Dewey,09 Promise,State House,28A,Ralph Lyon,REP,14
+Dewey,?,State House,28A,Oren L Lesmeister,DEM,78
+Dewey,?,State House,28A,Ralph Lyon,REP,5
+Dewey,North (Precinct-13 Eagle,State House,28A,Oren L Lesmeister,DEM,154
+Dewey,North (Precinct-13 Eagle,State House,28A,Ralph Lyon,REP,58
+Dewey,?,State House,28A,Oren L Lesmeister,DEM,215
+Dewey,?,State House,28A,Ralph Lyon,REP,23
+Dewey,?,State House,28A,Oren L Lesmeister,DEM,124
+Dewey,?,State House,28A,Ralph Lyon,REP,50
+Dewey,02 Trail City,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,14
+Dewey,04 Timber Lake,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,146
+Dewey,05 Firesteel,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,19
+Dewey,06 Isabel,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,40
+Dewey,?,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,70
+Dewey,08 White Horse,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,19
+Dewey,09 Promise,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,14
+Dewey,?,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,14
+Dewey,North (Precinct-13 Eagle,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,77
+Dewey,?,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,83
+Dewey,?,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,58
+Dewey,02 Trail City,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,14
+Dewey,04 Timber Lake,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,151
+Dewey,05 Firesteel,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,21
+Dewey,06 Isabel,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,42
+Dewey,?,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,70
+Dewey,08 White Horse,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,19
+Dewey,09 Promise,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,16
+Dewey,?,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,15
+Dewey,North (Precinct-13 Eagle,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,77
+Dewey,?,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,84
+Dewey,?,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,65
+Dewey,02 Trail City,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,12
+Dewey,04 Timber Lake,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,143
+Dewey,05 Firesteel,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,21
+Dewey,06 Isabel,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,38
+Dewey,?,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,72
+Dewey,08 White Horse,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,19
+Dewey,09 Promise,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,14
+Dewey,?,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,17
+Dewey,North (Precinct-13 Eagle,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,82
+Dewey,?,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,85
+Dewey,?,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,55
+Dewey,02 Trail City,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,1
+Dewey,02 Trail City,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,2
+Dewey,02 Trail City,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,5
+Dewey,02 Trail City,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,5
+Dewey,02 Trail City,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,1
+Dewey,04 Timber Lake,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,24
+Dewey,04 Timber Lake,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,29
+Dewey,04 Timber Lake,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,49
+Dewey,04 Timber Lake,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,40
+Dewey,04 Timber Lake,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,36
+Dewey,05 Firesteel,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,4
+Dewey,05 Firesteel,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,8
+Dewey,05 Firesteel,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,16
+Dewey,05 Firesteel,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,2
+Dewey,05 Firesteel,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,5
+Dewey,06 Isabel,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,5
+Dewey,06 Isabel,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,3
+Dewey,06 Isabel,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,24
+Dewey,06 Isabel,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,9
+Dewey,06 Isabel,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,11
+Dewey,?,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,23
+Dewey,?,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,23
+Dewey,?,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,42
+Dewey,?,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,10
+Dewey,?,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,14
+Dewey,08 White Horse,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,5
+Dewey,08 White Horse,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,8
+Dewey,08 White Horse,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,12
+Dewey,08 White Horse,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,5
+Dewey,08 White Horse,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,2
+Dewey,09 Promise,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,5
+Dewey,09 Promise,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,3
+Dewey,09 Promise,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,15
+Dewey,09 Promise,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,1
+Dewey,09 Promise,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,2
+Dewey,?,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,9
+Dewey,?,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,3
+Dewey,?,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,15
+Dewey,?,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,2
+Dewey,?,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,5
+Dewey,North (Precinct-13 Eagle,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,24
+Dewey,North (Precinct-13 Eagle,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,19
+Dewey,North (Precinct-13 Eagle,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,28
+Dewey,North (Precinct-13 Eagle,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,28
+Dewey,North (Precinct-13 Eagle,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,10
+Dewey,?,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,24
+Dewey,?,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,18
+Dewey,?,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,50
+Dewey,?,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,21
+Dewey,?,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,11
+Dewey,?,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,11
+Dewey,?,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,22
+Dewey,?,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,32
+Dewey,?,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,16
+Dewey,?,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,6
+Dewey,02 Trail City,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,22
+Dewey,02 Trail City,Supreme Court Retention,3,Patricia J. DeVaney - No,,4
+Dewey,04 Timber Lake,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,212
+Dewey,04 Timber Lake,Supreme Court Retention,3,Patricia J. DeVaney - No,,63
+Dewey,05 Firesteel,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,35
+Dewey,05 Firesteel,Supreme Court Retention,3,Patricia J. DeVaney - No,,10
+Dewey,06 Isabel,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,77
+Dewey,06 Isabel,Supreme Court Retention,3,Patricia J. DeVaney - No,,13
+Dewey,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,106
+Dewey,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,88
+Dewey,08 White Horse,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,29
+Dewey,08 White Horse,Supreme Court Retention,3,Patricia J. DeVaney - No,,20
+Dewey,09 Promise,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,24
+Dewey,09 Promise,Supreme Court Retention,3,Patricia J. DeVaney - No,,16
+Dewey,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,36
+Dewey,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,32
+Dewey,North (Precinct-13 Eagle,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,122
+Dewey,North (Precinct-13 Eagle,Supreme Court Retention,3,Patricia J. DeVaney - No,,66
+Dewey,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,129
+Dewey,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,83
+Dewey,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,103
+Dewey,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,43
+Dewey,02 Trail City,Supreme Court Retention,2,Mark E. Salter - Yes,,22
+Dewey,02 Trail City,Supreme Court Retention,2,Mark E. Salter - No,,4
+Dewey,04 Timber Lake,Supreme Court Retention,2,Mark E. Salter - Yes,,214
+Dewey,04 Timber Lake,Supreme Court Retention,2,Mark E. Salter - No,,61
+Dewey,05 Firesteel,Supreme Court Retention,2,Mark E. Salter - Yes,,34
+Dewey,05 Firesteel,Supreme Court Retention,2,Mark E. Salter - No,,11
+Dewey,06 Isabel,Supreme Court Retention,2,Mark E. Salter - Yes,,73
+Dewey,06 Isabel,Supreme Court Retention,2,Mark E. Salter - No,,17
+Dewey,?,Supreme Court Retention,2,Mark E. Salter - Yes,,99
+Dewey,?,Supreme Court Retention,2,Mark E. Salter - No,,94
+Dewey,08 White Horse,Supreme Court Retention,2,Mark E. Salter - Yes,,30
+Dewey,08 White Horse,Supreme Court Retention,2,Mark E. Salter - No,,19
+Dewey,09 Promise,Supreme Court Retention,2,Mark E. Salter - Yes,,23
+Dewey,09 Promise,Supreme Court Retention,2,Mark E. Salter - No,,17
+Dewey,?,Supreme Court Retention,2,Mark E. Salter - Yes,,29
+Dewey,?,Supreme Court Retention,2,Mark E. Salter - No,,41
+Dewey,North (Precinct-13 Eagle,Supreme Court Retention,2,Mark E. Salter - Yes,,116
+Dewey,North (Precinct-13 Eagle,Supreme Court Retention,2,Mark E. Salter - No,,67
+Dewey,?,Supreme Court Retention,2,Mark E. Salter - Yes,,125
+Dewey,?,Supreme Court Retention,2,Mark E. Salter - No,,88
+Dewey,?,Supreme Court Retention,2,Mark E. Salter - Yes,,97
+Dewey,?,Supreme Court Retention,2,Mark E. Salter - No,,48
+Dewey,02 Trail City,Constitutional Amendment D,,Yes,,10
+Dewey,02 Trail City,Constitutional Amendment D,,No,,25
+Dewey,04 Timber Lake,Constitutional Amendment D,,Yes,,150
+Dewey,04 Timber Lake,Constitutional Amendment D,,No,,161
+Dewey,05 Firesteel,Constitutional Amendment D,,Yes,,24
+Dewey,05 Firesteel,Constitutional Amendment D,,No,,28
+Dewey,06 Isabel,Constitutional Amendment D,,Yes,,49
+Dewey,06 Isabel,Constitutional Amendment D,,No,,58
+Dewey,?,Constitutional Amendment D,,Yes,,195
+Dewey,?,Constitutional Amendment D,,No,,25
+Dewey,08 White Horse,Constitutional Amendment D,,Yes,,42
+Dewey,08 White Horse,Constitutional Amendment D,,No,,10
+Dewey,09 Promise,Constitutional Amendment D,,Yes,,41
+Dewey,09 Promise,Constitutional Amendment D,,No,,12
+Dewey,?,Constitutional Amendment D,,Yes,,69
+Dewey,?,Constitutional Amendment D,,No,,10
+Dewey,North (Precinct-13 Eagle,Constitutional Amendment D,,Yes,,157
+Dewey,North (Precinct-13 Eagle,Constitutional Amendment D,,No,,48
+Dewey,?,Constitutional Amendment D,,Yes,,208
+Dewey,?,Constitutional Amendment D,,No,,31
+Dewey,?,Constitutional Amendment D,,Yes,,127
+Dewey,?,Constitutional Amendment D,,No,,45
+Dewey,02 Trail City,Initiated Measure 27,,Yes,,9
+Dewey,02 Trail City,Initiated Measure 27,,No,,26
+Dewey,04 Timber Lake,Initiated Measure 27,,Yes,,127
+Dewey,04 Timber Lake,Initiated Measure 27,,No,,191
+Dewey,05 Firesteel,Initiated Measure 27,,Yes,,20
+Dewey,05 Firesteel,Initiated Measure 27,,No,,33
+Dewey,06 Isabel,Initiated Measure 27,,Yes,,30
+Dewey,06 Isabel,Initiated Measure 27,,No,,79
+Dewey,?,Initiated Measure 27,,Yes,,166
+Dewey,?,Initiated Measure 27,,No,,53
+Dewey,08 White Horse,Initiated Measure 27,,Yes,,39
+Dewey,08 White Horse,Initiated Measure 27,,No,,11
+Dewey,09 Promise,Initiated Measure 27,,Yes,,32
+Dewey,09 Promise,Initiated Measure 27,,No,,21
+Dewey,?,Initiated Measure 27,,Yes,,66
+Dewey,?,Initiated Measure 27,,No,,14
+Dewey,North (Precinct-13 Eagle,Initiated Measure 27,,Yes,,136
+Dewey,North (Precinct-13 Eagle,Initiated Measure 27,,No,,70
+Dewey,?,Initiated Measure 27,,Yes,,194
+Dewey,?,Initiated Measure 27,,No,,47
+Dewey,?,Initiated Measure 27,,Yes,,105
+Dewey,?,Initiated Measure 27,,No,,71

--- a/2022/counties/20221108__sd__general__douglas__precinct.csv
+++ b/2022/counties/20221108__sd__general__douglas__precinct.csv
@@ -1,0 +1,229 @@
+county,precinct,office,district,candidate,party,votes
+Douglas,Absentee Precinct,U.S. Senate,,Brian L. Bengs,DEM,41
+Douglas,Absentee Precinct,U.S. Senate,,Tamara J Lesnar,LIB,8
+Douglas,Absentee Precinct,U.S. Senate,,John R. Thune,REP,198
+Douglas,1,U.S. Senate,,Brian L. Bengs,DEM,11
+Douglas,1,U.S. Senate,,Tamara J Lesnar,LIB,4
+Douglas,1,U.S. Senate,,John R. Thune,REP,265
+Douglas,2,U.S. Senate,,Brian L. Bengs,DEM,19
+Douglas,2,U.S. Senate,,Tamara J Lesnar,LIB,5
+Douglas,2,U.S. Senate,,John R. Thune,REP,249
+Douglas,3,U.S. Senate,,Brian L. Bengs,DEM,16
+Douglas,3,U.S. Senate,,Tamara J Lesnar,LIB,6
+Douglas,3,U.S. Senate,,John R. Thune,REP,185
+Douglas,4,U.S. Senate,,Brian L. Bengs,DEM,25
+Douglas,4,U.S. Senate,,Tamara J Lesnar,LIB,13
+Douglas,4,U.S. Senate,,John R. Thune,REP,181
+Douglas,5,U.S. Senate,,Brian L. Bengs,DEM,5
+Douglas,5,U.S. Senate,,Tamara J Lesnar,LIB,6
+Douglas,5,U.S. Senate,,John R. Thune,REP,230
+Douglas,Absentee Precinct,U.S. House,1,Collin Duprel,LIB,41
+Douglas,Absentee Precinct,U.S. House,1,Dusty Johnson,REP,197
+Douglas,1,U.S. House,1,Collin Duprel,LIB,21
+Douglas,1,U.S. House,1,Dusty Johnson,REP,251
+Douglas,2,U.S. House,1,Collin Duprel,LIB,19
+Douglas,2,U.S. House,1,Dusty Johnson,REP,247
+Douglas,3,U.S. House,1,Collin Duprel,LIB,25
+Douglas,3,U.S. House,1,Dusty Johnson,REP,180
+Douglas,4,U.S. House,1,Collin Duprel,LIB,29
+Douglas,4,U.S. House,1,Dusty Johnson,REP,184
+Douglas,5,U.S. House,1,Collin Duprel,LIB,11
+Douglas,5,U.S. House,1,Dusty Johnson,REP,220
+Douglas,Absentee Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,60
+Douglas,Absentee Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,8
+Douglas,Absentee Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,179
+Douglas,1,Governor,,Jamie Smith and Jennifer Keintz,DEM,20
+Douglas,1,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Douglas,1,Governor,,Kristi Noem and Larry Rhoden,REP,261
+Douglas,2,Governor,,Jamie Smith and Jennifer Keintz,DEM,40
+Douglas,2,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Douglas,2,Governor,,Kristi Noem and Larry Rhoden,REP,229
+Douglas,3,Governor,,Jamie Smith and Jennifer Keintz,DEM,23
+Douglas,3,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Douglas,3,Governor,,Kristi Noem and Larry Rhoden,REP,184
+Douglas,4,Governor,,Jamie Smith and Jennifer Keintz,DEM,38
+Douglas,4,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Douglas,4,Governor,,Kristi Noem and Larry Rhoden,REP,184
+Douglas,5,Governor,,Jamie Smith and Jennifer Keintz,DEM,7
+Douglas,5,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Douglas,5,Governor,,Kristi Noem and Larry Rhoden,REP,235
+Douglas,Absentee Precinct,Secretary of State,,Thomas A Cool,DEM,55
+Douglas,Absentee Precinct,Secretary of State,,Monae Johnson,REP,178
+Douglas,1,Secretary of State,,Thomas A Cool,DEM,16
+Douglas,1,Secretary of State,,Monae Johnson,REP,249
+Douglas,2,Secretary of State,,Thomas A Cool,DEM,52
+Douglas,2,Secretary of State,,Monae Johnson,REP,208
+Douglas,3,Secretary of State,,Thomas A Cool,DEM,28
+Douglas,3,Secretary of State,,Monae Johnson,REP,174
+Douglas,4,Secretary of State,,Thomas A Cool,DEM,45
+Douglas,4,Secretary of State,,Monae Johnson,REP,162
+Douglas,5,Secretary of State,,Thomas A Cool,DEM,11
+Douglas,5,Secretary of State,,Monae Johnson,REP,218
+Douglas,Absentee Precinct,Attorney General,,Marty J. Jackley,REP,196
+Douglas,1,Attorney General,,Marty J. Jackley,REP,237
+Douglas,2,Attorney General,,Marty J. Jackley,REP,230
+Douglas,3,Attorney General,,Marty J. Jackley,REP,164
+Douglas,4,Attorney General,,Marty J. Jackley,REP,176
+Douglas,5,Attorney General,,Marty J. Jackley,REP,197
+Douglas,Absentee Precinct,State Auditor,,Stephanie Marty,DEM,44
+Douglas,Absentee Precinct,State Auditor,,Rene Meyer,LIB,11
+Douglas,Absentee Precinct,State Auditor,,Richard Sattgast,REP,174
+Douglas,1,State Auditor,,Stephanie Marty,DEM,12
+Douglas,1,State Auditor,,Rene Meyer,LIB,1
+Douglas,1,State Auditor,,Richard Sattgast,REP,249
+Douglas,2,State Auditor,,Stephanie Marty,DEM,38
+Douglas,2,State Auditor,,Rene Meyer,LIB,6
+Douglas,2,State Auditor,,Richard Sattgast,REP,209
+Douglas,3,State Auditor,,Stephanie Marty,DEM,21
+Douglas,3,State Auditor,,Rene Meyer,LIB,1
+Douglas,3,State Auditor,,Richard Sattgast,REP,176
+Douglas,4,State Auditor,,Stephanie Marty,DEM,38
+Douglas,4,State Auditor,,Rene Meyer,LIB,4
+Douglas,4,State Auditor,,Richard Sattgast,REP,168
+Douglas,5,State Auditor,,Stephanie Marty,DEM,12
+Douglas,5,State Auditor,,Rene Meyer,LIB,2
+Douglas,5,State Auditor,,Richard Sattgast,REP,209
+Douglas,Absentee Precinct,State Treasurer,,John Cunningham,DEM,46
+Douglas,Absentee Precinct,State Treasurer,,Josh Haeder,REP,186
+Douglas,1,State Treasurer,,John Cunningham,DEM,14
+Douglas,1,State Treasurer,,Josh Haeder,REP,248
+Douglas,2,State Treasurer,,John Cunningham,DEM,35
+Douglas,2,State Treasurer,,Josh Haeder,REP,219
+Douglas,3,State Treasurer,,John Cunningham,DEM,19
+Douglas,3,State Treasurer,,Josh Haeder,REP,177
+Douglas,4,State Treasurer,,John Cunningham,DEM,37
+Douglas,4,State Treasurer,,Josh Haeder,REP,167
+Douglas,5,State Treasurer,,John Cunningham,DEM,12
+Douglas,5,State Treasurer,,Josh Haeder,REP,213
+Douglas,Absentee Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,44
+Douglas,Absentee Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,182
+Douglas,1,Commissioner of School and Public Lands,,Timothy Azure,DEM,12
+Douglas,1,Commissioner of School and Public Lands,,Brock Greenfield,REP,246
+Douglas,2,Commissioner of School and Public Lands,,Timothy Azure,DEM,29
+Douglas,2,Commissioner of School and Public Lands,,Brock Greenfield,REP,218
+Douglas,3,Commissioner of School and Public Lands,,Timothy Azure,DEM,22
+Douglas,3,Commissioner of School and Public Lands,,Brock Greenfield,REP,169
+Douglas,4,Commissioner of School and Public Lands,,Timothy Azure,DEM,33
+Douglas,4,Commissioner of School and Public Lands,,Brock Greenfield,REP,172
+Douglas,5,Commissioner of School and Public Lands,,Timothy Azure,DEM,8
+Douglas,5,Commissioner of School and Public Lands,,Brock Greenfield,REP,217
+Douglas,Absentee Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,43
+Douglas,Absentee Precinct,Public Utilities Commissioner,,Chris Nelson,REP,192
+Douglas,1,Public Utilities Commissioner,,Jeffrey Barth,DEM,10
+Douglas,1,Public Utilities Commissioner,,Chris Nelson,REP,260
+Douglas,2,Public Utilities Commissioner,,Jeffrey Barth,DEM,22
+Douglas,2,Public Utilities Commissioner,,Chris Nelson,REP,240
+Douglas,3,Public Utilities Commissioner,,Jeffrey Barth,DEM,16
+Douglas,3,Public Utilities Commissioner,,Chris Nelson,REP,185
+Douglas,4,Public Utilities Commissioner,,Jeffrey Barth,DEM,24
+Douglas,4,Public Utilities Commissioner,,Chris Nelson,REP,187
+Douglas,5,Public Utilities Commissioner,,Jeffrey Barth,DEM,8
+Douglas,5,Public Utilities Commissioner,,Chris Nelson,REP,216
+Douglas,Absentee Precinct,State Senate,21,Dan Andersson,DEM,48
+Douglas,Absentee Precinct,State Senate,21,Erin Tobin,REP,179
+Douglas,1,State Senate,21,Dan Andersson,DEM,10
+Douglas,1,State Senate,21,Erin Tobin,REP,261
+Douglas,2,State Senate,21,Dan Andersson,DEM,32
+Douglas,2,State Senate,21,Erin Tobin,REP,227
+Douglas,3,State Senate,21,Dan Andersson,DEM,21
+Douglas,3,State Senate,21,Erin Tobin,REP,179
+Douglas,4,State Senate,21,Dan Andersson,DEM,30
+Douglas,4,State Senate,21,Erin Tobin,REP,176
+Douglas,5,State Senate,21,Dan Andersson,DEM,7
+Douglas,5,State Senate,21,Erin Tobin,REP,217
+Douglas,Absentee Precinct,State House,21,Rocky Blare,REP,104
+Douglas,Absentee Precinct,State House,21,Marty Overweg,REP,187
+Douglas,1,State House,21,Rocky Blare,REP,131
+Douglas,1,State House,21,Marty Overweg,REP,256
+Douglas,2,State House,21,Rocky Blare,REP,103
+Douglas,2,State House,21,Marty Overweg,REP,245
+Douglas,3,State House,21,Rocky Blare,REP,80
+Douglas,3,State House,21,Marty Overweg,REP,165
+Douglas,4,State House,21,Rocky Blare,REP,76
+Douglas,4,State House,21,Marty Overweg,REP,165
+Douglas,5,State House,21,Rocky Blare,REP,92
+Douglas,5,State House,21,Marty Overweg,REP,213
+Douglas,Absentee Precinct,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,109
+Douglas,1,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,130
+Douglas,2,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,121
+Douglas,3,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,77
+Douglas,4,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,99
+Douglas,5,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,109
+Douglas,Absentee Precinct,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,108
+Douglas,1,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,128
+Douglas,2,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,111
+Douglas,3,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,74
+Douglas,4,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,92
+Douglas,5,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,105
+Douglas,Absentee Precinct,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,130
+Douglas,1,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,140
+Douglas,2,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,120
+Douglas,3,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,92
+Douglas,4,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,118
+Douglas,5,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,115
+Douglas,Absentee Precinct,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,113
+Douglas,1,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,126
+Douglas,2,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,112
+Douglas,3,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,73
+Douglas,4,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,95
+Douglas,5,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,103
+Douglas,Absentee Precinct,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,112
+Douglas,1,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,127
+Douglas,2,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,111
+Douglas,3,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,72
+Douglas,4,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,96
+Douglas,5,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,105
+Douglas,Absentee Precinct,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,107
+Douglas,1,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,128
+Douglas,2,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,112
+Douglas,3,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,70
+Douglas,4,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,93
+Douglas,5,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,103
+Douglas,Absentee Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,181
+Douglas,Absentee Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,36
+Douglas,1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,191
+Douglas,1,Supreme Court Retention,3,Patricia J. DeVaney - No,,40
+Douglas,2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,185
+Douglas,2,Supreme Court Retention,3,Patricia J. DeVaney - No,,46
+Douglas,3,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,145
+Douglas,3,Supreme Court Retention,3,Patricia J. DeVaney - No,,29
+Douglas,4,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,162
+Douglas,4,Supreme Court Retention,3,Patricia J. DeVaney - No,,32
+Douglas,5,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,167
+Douglas,5,Supreme Court Retention,3,Patricia J. DeVaney - No,,30
+Douglas,Absentee Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,178
+Douglas,Absentee Precinct,Supreme Court Retention,2,Mark E. Salter - No,,38
+Douglas,1,Supreme Court Retention,2,Mark E. Salter - Yes,,191
+Douglas,1,Supreme Court Retention,2,Mark E. Salter - No,,39
+Douglas,2,Supreme Court Retention,2,Mark E. Salter - Yes,,184
+Douglas,2,Supreme Court Retention,2,Mark E. Salter - No,,45
+Douglas,3,Supreme Court Retention,2,Mark E. Salter - Yes,,145
+Douglas,3,Supreme Court Retention,2,Mark E. Salter - No,,30
+Douglas,4,Supreme Court Retention,2,Mark E. Salter - Yes,,164
+Douglas,4,Supreme Court Retention,2,Mark E. Salter - No,,29
+Douglas,5,Supreme Court Retention,2,Mark E. Salter - Yes,,168
+Douglas,5,Supreme Court Retention,2,Mark E. Salter - No,,29
+Douglas,Absentee Precinct,Constitutional Amendment D,,Yes,,100
+Douglas,Absentee Precinct,Constitutional Amendment D,,No,,139
+Douglas,1,Constitutional Amendment D,,Yes,,61
+Douglas,1,Constitutional Amendment D,,No,,209
+Douglas,2,Constitutional Amendment D,,Yes,,95
+Douglas,2,Constitutional Amendment D,,No,,161
+Douglas,3,Constitutional Amendment D,,Yes,,69
+Douglas,3,Constitutional Amendment D,,No,,130
+Douglas,4,Constitutional Amendment D,,Yes,,83
+Douglas,4,Constitutional Amendment D,,No,,131
+Douglas,5,Constitutional Amendment D,,Yes,,41
+Douglas,5,Constitutional Amendment D,,No,,186
+Douglas,Absentee Precinct,Initiated Measure 27,,Yes,,58
+Douglas,Absentee Precinct,Initiated Measure 27,,No,,183
+Douglas,1,Initiated Measure 27,,Yes,,40
+Douglas,1,Initiated Measure 27,,No,,236
+Douglas,2,Initiated Measure 27,,Yes,,62
+Douglas,2,Initiated Measure 27,,No,,199
+Douglas,3,Initiated Measure 27,,Yes,,50
+Douglas,3,Initiated Measure 27,,No,,154
+Douglas,4,Initiated Measure 27,,Yes,,50
+Douglas,4,Initiated Measure 27,,No,,164
+Douglas,5,Initiated Measure 27,,Yes,,19
+Douglas,5,Initiated Measure 27,,No,,217

--- a/2022/counties/20221108__sd__general__edmunds__precinct.csv
+++ b/2022/counties/20221108__sd__general__edmunds__precinct.csv
@@ -1,0 +1,211 @@
+county,precinct,office,district,candidate,party,votes
+Edmunds,1,U.S. Senate,,Brian L. Bengs,DEM,65
+Edmunds,1,U.S. Senate,,Tamara J Lesnar,LIB,7
+Edmunds,1,U.S. Senate,,John R. Thune,REP,312
+Edmunds,2,U.S. Senate,,Brian L. Bengs,DEM,45
+Edmunds,2,U.S. Senate,,Tamara J Lesnar,LIB,12
+Edmunds,2,U.S. Senate,,John R. Thune,REP,281
+Edmunds,3,U.S. Senate,,Brian L. Bengs,DEM,36
+Edmunds,3,U.S. Senate,,Tamara J Lesnar,LIB,12
+Edmunds,3,U.S. Senate,,John R. Thune,REP,237
+Edmunds,4,U.S. Senate,,Brian L. Bengs,DEM,45
+Edmunds,4,U.S. Senate,,Tamara J Lesnar,LIB,6
+Edmunds,4,U.S. Senate,,John R. Thune,REP,190
+Edmunds,5,U.S. Senate,,Brian L. Bengs,DEM,45
+Edmunds,5,U.S. Senate,,Tamara J Lesnar,LIB,7
+Edmunds,5,U.S. Senate,,John R. Thune,REP,257
+Edmunds,6,U.S. Senate,,Brian L. Bengs,DEM,17
+Edmunds,6,U.S. Senate,,Tamara J Lesnar,LIB,5
+Edmunds,6,U.S. Senate,,John R. Thune,REP,108
+Edmunds,1,U.S. House,1,Collin Duprel,LIB,46
+Edmunds,1,U.S. House,1,Dusty Johnson,REP,327
+Edmunds,2,U.S. House,1,Collin Duprel,LIB,42
+Edmunds,2,U.S. House,1,Dusty Johnson,REP,286
+Edmunds,3,U.S. House,1,Collin Duprel,LIB,29
+Edmunds,3,U.S. House,1,Dusty Johnson,REP,246
+Edmunds,4,U.S. House,1,Collin Duprel,LIB,28
+Edmunds,4,U.S. House,1,Dusty Johnson,REP,206
+Edmunds,5,U.S. House,1,Collin Duprel,LIB,39
+Edmunds,5,U.S. House,1,Dusty Johnson,REP,264
+Edmunds,6,U.S. House,1,Collin Duprel,LIB,16
+Edmunds,6,U.S. House,1,Dusty Johnson,REP,111
+Edmunds,1,Governor,,Jamie Smith and Jennifer Keintz,DEM,85
+Edmunds,1,Governor,,Tracey Quint and Ashley Strand,LIB,12
+Edmunds,1,Governor,,Kristi Noem and Larry Rhoden,REP,293
+Edmunds,2,Governor,,Jamie Smith and Jennifer Keintz,DEM,67
+Edmunds,2,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Edmunds,2,Governor,,Kristi Noem and Larry Rhoden,REP,263
+Edmunds,3,Governor,,Jamie Smith and Jennifer Keintz,DEM,48
+Edmunds,3,Governor,,Tracey Quint and Ashley Strand,LIB,6
+Edmunds,3,Governor,,Kristi Noem and Larry Rhoden,REP,237
+Edmunds,4,Governor,,Jamie Smith and Jennifer Keintz,DEM,52
+Edmunds,4,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Edmunds,4,Governor,,Kristi Noem and Larry Rhoden,REP,187
+Edmunds,5,Governor,,Jamie Smith and Jennifer Keintz,DEM,64
+Edmunds,5,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Edmunds,5,Governor,,Kristi Noem and Larry Rhoden,REP,246
+Edmunds,6,Governor,,Jamie Smith and Jennifer Keintz,DEM,30
+Edmunds,6,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Edmunds,6,Governor,,Kristi Noem and Larry Rhoden,REP,95
+Edmunds,1,Secretary of State,,Thomas A Cool,DEM,92
+Edmunds,1,Secretary of State,,Monae Johnson,REP,280
+Edmunds,2,Secretary of State,,Thomas A Cool,DEM,76
+Edmunds,2,Secretary of State,,Monae Johnson,REP,239
+Edmunds,3,Secretary of State,,Thomas A Cool,DEM,53
+Edmunds,3,Secretary of State,,Monae Johnson,REP,206
+Edmunds,4,Secretary of State,,Thomas A Cool,DEM,68
+Edmunds,4,Secretary of State,,Monae Johnson,REP,164
+Edmunds,5,Secretary of State,,Thomas A Cool,DEM,58
+Edmunds,5,Secretary of State,,Monae Johnson,REP,236
+Edmunds,6,Secretary of State,,Thomas A Cool,DEM,32
+Edmunds,6,Secretary of State,,Monae Johnson,REP,90
+Edmunds,1,Attorney General,,Marty J. Jackley,REP,318
+Edmunds,2,Attorney General,,Marty J. Jackley,REP,269
+Edmunds,3,Attorney General,,Marty J. Jackley,REP,238
+Edmunds,4,Attorney General,,Marty J. Jackley,REP,193
+Edmunds,5,Attorney General,,Marty J. Jackley,REP,268
+Edmunds,6,Attorney General,,Marty J. Jackley,REP,112
+Edmunds,1,State Auditor,,Stephanie Marty,DEM,80
+Edmunds,1,State Auditor,,Rene Meyer,LIB,12
+Edmunds,1,State Auditor,,Richard Sattgast,REP,277
+Edmunds,2,State Auditor,,Stephanie Marty,DEM,58
+Edmunds,2,State Auditor,,Rene Meyer,LIB,17
+Edmunds,2,State Auditor,,Richard Sattgast,REP,240
+Edmunds,3,State Auditor,,Stephanie Marty,DEM,42
+Edmunds,3,State Auditor,,Rene Meyer,LIB,3
+Edmunds,3,State Auditor,,Richard Sattgast,REP,216
+Edmunds,4,State Auditor,,Stephanie Marty,DEM,62
+Edmunds,4,State Auditor,,Rene Meyer,LIB,7
+Edmunds,4,State Auditor,,Richard Sattgast,REP,152
+Edmunds,5,State Auditor,,Stephanie Marty,DEM,54
+Edmunds,5,State Auditor,,Rene Meyer,LIB,9
+Edmunds,5,State Auditor,,Richard Sattgast,REP,231
+Edmunds,6,State Auditor,,Stephanie Marty,DEM,31
+Edmunds,6,State Auditor,,Rene Meyer,LIB,3
+Edmunds,6,State Auditor,,Richard Sattgast,REP,89
+Edmunds,1,State Treasurer,,John Cunningham,DEM,81
+Edmunds,1,State Treasurer,,Josh Haeder,REP,289
+Edmunds,2,State Treasurer,,John Cunningham,DEM,71
+Edmunds,2,State Treasurer,,Josh Haeder,REP,241
+Edmunds,3,State Treasurer,,John Cunningham,DEM,45
+Edmunds,3,State Treasurer,,Josh Haeder,REP,217
+Edmunds,4,State Treasurer,,John Cunningham,DEM,68
+Edmunds,4,State Treasurer,,Josh Haeder,REP,151
+Edmunds,5,State Treasurer,,John Cunningham,DEM,56
+Edmunds,5,State Treasurer,,Josh Haeder,REP,235
+Edmunds,6,State Treasurer,,John Cunningham,DEM,25
+Edmunds,6,State Treasurer,,Josh Haeder,REP,97
+Edmunds,1,Commissioner of School and Public Lands,,Timothy Azure,DEM,75
+Edmunds,1,Commissioner of School and Public Lands,,Brock Greenfield,REP,294
+Edmunds,2,Commissioner of School and Public Lands,,Timothy Azure,DEM,59
+Edmunds,2,Commissioner of School and Public Lands,,Brock Greenfield,REP,242
+Edmunds,3,Commissioner of School and Public Lands,,Timothy Azure,DEM,41
+Edmunds,3,Commissioner of School and Public Lands,,Brock Greenfield,REP,222
+Edmunds,4,Commissioner of School and Public Lands,,Timothy Azure,DEM,53
+Edmunds,4,Commissioner of School and Public Lands,,Brock Greenfield,REP,162
+Edmunds,5,Commissioner of School and Public Lands,,Timothy Azure,DEM,48
+Edmunds,5,Commissioner of School and Public Lands,,Brock Greenfield,REP,241
+Edmunds,6,Commissioner of School and Public Lands,,Timothy Azure,DEM,27
+Edmunds,6,Commissioner of School and Public Lands,,Brock Greenfield,REP,96
+Edmunds,1,Public Utilities Commissioner,,Jeffrey Barth,DEM,72
+Edmunds,1,Public Utilities Commissioner,,Chris Nelson,REP,301
+Edmunds,2,Public Utilities Commissioner,,Jeffrey Barth,DEM,58
+Edmunds,2,Public Utilities Commissioner,,Chris Nelson,REP,252
+Edmunds,3,Public Utilities Commissioner,,Jeffrey Barth,DEM,47
+Edmunds,3,Public Utilities Commissioner,,Chris Nelson,REP,228
+Edmunds,4,Public Utilities Commissioner,,Jeffrey Barth,DEM,42
+Edmunds,4,Public Utilities Commissioner,,Chris Nelson,REP,181
+Edmunds,5,Public Utilities Commissioner,,Jeffrey Barth,DEM,46
+Edmunds,5,Public Utilities Commissioner,,Chris Nelson,REP,252
+Edmunds,6,Public Utilities Commissioner,,Jeffrey Barth,DEM,25
+Edmunds,6,Public Utilities Commissioner,,Chris Nelson,REP,102
+Edmunds,1,State Senate,23,Bryan J. Breitling,REP,301
+Edmunds,2,State Senate,23,Bryan J. Breitling,REP,277
+Edmunds,3,State Senate,23,Bryan J. Breitling,REP,233
+Edmunds,4,State Senate,23,Bryan J. Breitling,REP,207
+Edmunds,5,State Senate,23,Bryan J. Breitling,REP,266
+Edmunds,6,State Senate,23,Bryan J. Breitling,REP,111
+Edmunds,1,State House,23,James D. Wangsness,REP,170
+Edmunds,1,State House,23,Scott Moore,REP,287
+Edmunds,2,State House,23,James D. Wangsness,REP,159
+Edmunds,2,State House,23,Scott Moore,REP,232
+Edmunds,3,State House,23,James D. Wangsness,REP,126
+Edmunds,3,State House,23,Scott Moore,REP,203
+Edmunds,4,State House,23,James D. Wangsness,REP,104
+Edmunds,4,State House,23,Scott Moore,REP,180
+Edmunds,5,State House,23,James D. Wangsness,REP,118
+Edmunds,5,State House,23,Scott Moore,REP,230
+Edmunds,6,State House,23,James D. Wangsness,REP,46
+Edmunds,6,State House,23,Scott Moore,REP,100
+Edmunds,1,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,223
+Edmunds,2,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,200
+Edmunds,3,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,141
+Edmunds,4,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,127
+Edmunds,5,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,153
+Edmunds,6,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,75
+Edmunds,1,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,224
+Edmunds,2,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,183
+Edmunds,3,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,131
+Edmunds,4,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,116
+Edmunds,5,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,150
+Edmunds,6,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,71
+Edmunds,1,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,202
+Edmunds,2,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,177
+Edmunds,3,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,125
+Edmunds,4,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,121
+Edmunds,5,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,147
+Edmunds,6,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,67
+Edmunds,1,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,222
+Edmunds,2,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,184
+Edmunds,3,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,132
+Edmunds,4,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,122
+Edmunds,5,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,149
+Edmunds,6,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,66
+Edmunds,1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,266
+Edmunds,1,Supreme Court Retention,3,Patricia J. DeVaney - No,,61
+Edmunds,2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,252
+Edmunds,2,Supreme Court Retention,3,Patricia J. DeVaney - No,,48
+Edmunds,3,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,195
+Edmunds,3,Supreme Court Retention,3,Patricia J. DeVaney - No,,41
+Edmunds,4,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,162
+Edmunds,4,Supreme Court Retention,3,Patricia J. DeVaney - No,,41
+Edmunds,5,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,217
+Edmunds,5,Supreme Court Retention,3,Patricia J. DeVaney - No,,53
+Edmunds,6,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,88
+Edmunds,6,Supreme Court Retention,3,Patricia J. DeVaney - No,,26
+Edmunds,1,Supreme Court Retention,2,Mark E. Salter - Yes,,273
+Edmunds,1,Supreme Court Retention,2,Mark E. Salter - No,,54
+Edmunds,2,Supreme Court Retention,2,Mark E. Salter - Yes,,254
+Edmunds,2,Supreme Court Retention,2,Mark E. Salter - No,,45
+Edmunds,3,Supreme Court Retention,2,Mark E. Salter - Yes,,198
+Edmunds,3,Supreme Court Retention,2,Mark E. Salter - No,,37
+Edmunds,4,Supreme Court Retention,2,Mark E. Salter - Yes,,162
+Edmunds,4,Supreme Court Retention,2,Mark E. Salter - No,,41
+Edmunds,5,Supreme Court Retention,2,Mark E. Salter - Yes,,219
+Edmunds,5,Supreme Court Retention,2,Mark E. Salter - No,,51
+Edmunds,6,Supreme Court Retention,2,Mark E. Salter - Yes,,89
+Edmunds,6,Supreme Court Retention,2,Mark E. Salter - No,,25
+Edmunds,1,Constitutional Amendment D,,Yes,,164
+Edmunds,1,Constitutional Amendment D,,No,,215
+Edmunds,2,Constitutional Amendment D,,Yes,,150
+Edmunds,2,Constitutional Amendment D,,No,,175
+Edmunds,3,Constitutional Amendment D,,Yes,,95
+Edmunds,3,Constitutional Amendment D,,No,,173
+Edmunds,4,Constitutional Amendment D,,Yes,,111
+Edmunds,4,Constitutional Amendment D,,No,,122
+Edmunds,5,Constitutional Amendment D,,Yes,,108
+Edmunds,5,Constitutional Amendment D,,No,,195
+Edmunds,6,Constitutional Amendment D,,Yes,,50
+Edmunds,6,Constitutional Amendment D,,No,,72
+Edmunds,1,Initiated Measure 27,,Yes,,161
+Edmunds,1,Initiated Measure 27,,No,,223
+Edmunds,2,Initiated Measure 27,,Yes,,124
+Edmunds,2,Initiated Measure 27,,No,,210
+Edmunds,3,Initiated Measure 27,,Yes,,79
+Edmunds,3,Initiated Measure 27,,No,,199
+Edmunds,4,Initiated Measure 27,,Yes,,86
+Edmunds,4,Initiated Measure 27,,No,,153
+Edmunds,5,Initiated Measure 27,,Yes,,85
+Edmunds,5,Initiated Measure 27,,No,,221
+Edmunds,6,Initiated Measure 27,,Yes,,54
+Edmunds,6,Initiated Measure 27,,No,,69

--- a/2022/counties/20221108__sd__general__fall_river__precinct.csv
+++ b/2022/counties/20221108__sd__general__fall_river__precinct.csv
@@ -1,0 +1,361 @@
+county,precinct,office,district,candidate,party,votes
+Fall River,BEA,U.S. Senate,,Brian L. Bengs,DEM,8
+Fall River,BEA,U.S. Senate,,Tamara J Lesnar,LIB,15
+Fall River,BEA,U.S. Senate,,John R. Thune,REP,114
+Fall River,CAS,U.S. Senate,,Brian L. Bengs,DEM,25
+Fall River,CAS,U.S. Senate,,Tamara J Lesnar,LIB,20
+Fall River,CAS,U.S. Senate,,John R. Thune,REP,130
+Fall River,EDA,U.S. Senate,,Brian L. Bengs,DEM,70
+Fall River,EDA,U.S. Senate,,Tamara J Lesnar,LIB,33
+Fall River,EDA,U.S. Senate,,John R. Thune,REP,437
+Fall River,HS 1,U.S. Senate,,Brian L. Bengs,DEM,105
+Fall River,HS 1,U.S. Senate,,Tamara J Lesnar,LIB,29
+Fall River,HS 1,U.S. Senate,,John R. Thune,REP,303
+Fall River,HS 2,U.S. Senate,,Brian L. Bengs,DEM,95
+Fall River,HS 2,U.S. Senate,,Tamara J Lesnar,LIB,22
+Fall River,HS 2,U.S. Senate,,John R. Thune,REP,319
+Fall River,HS 3,U.S. Senate,,Brian L. Bengs,DEM,88
+Fall River,HS 3,U.S. Senate,,Tamara J Lesnar,LIB,20
+Fall River,HS 3,U.S. Senate,,John R. Thune,REP,229
+Fall River,HS 4,U.S. Senate,,Brian L. Bengs,DEM,101
+Fall River,HS 4,U.S. Senate,,Tamara J Lesnar,LIB,16
+Fall River,HS 4,U.S. Senate,,John R. Thune,REP,248
+Fall River,JAC,U.S. Senate,,Brian L. Bengs,DEM,162
+Fall River,JAC,U.S. Senate,,Tamara J Lesnar,LIB,50
+Fall River,JAC,U.S. Senate,,John R. Thune,REP,818
+Fall River,Oelrichs Area,U.S. Senate,,Brian L. Bengs,DEM,11
+Fall River,Oelrichs Area,U.S. Senate,,Tamara J Lesnar,LIB,17
+Fall River,Oelrichs Area,U.S. Senate,,John R. Thune,REP,156
+Fall River,BEA,U.S. House,1,Collin Duprel,LIB,26
+Fall River,BEA,U.S. House,1,Dusty Johnson,REP,110
+Fall River,CAS,U.S. House,1,Collin Duprel,LIB,35
+Fall River,CAS,U.S. House,1,Dusty Johnson,REP,132
+Fall River,EDA,U.S. House,1,Collin Duprel,LIB,100
+Fall River,EDA,U.S. House,1,Dusty Johnson,REP,421
+Fall River,HS 1,U.S. House,1,Collin Duprel,LIB,102
+Fall River,HS 1,U.S. House,1,Dusty Johnson,REP,312
+Fall River,HS 2,U.S. House,1,Collin Duprel,LIB,91
+Fall River,HS 2,U.S. House,1,Dusty Johnson,REP,319
+Fall River,HS 3,U.S. House,1,Collin Duprel,LIB,86
+Fall River,HS 3,U.S. House,1,Dusty Johnson,REP,228
+Fall River,HS 4,U.S. House,1,Collin Duprel,LIB,87
+Fall River,HS 4,U.S. House,1,Dusty Johnson,REP,248
+Fall River,JAC,U.S. House,1,Collin Duprel,LIB,196
+Fall River,JAC,U.S. House,1,Dusty Johnson,REP,786
+Fall River,Oelrichs Area,U.S. House,1,Collin Duprel,LIB,36
+Fall River,Oelrichs Area,U.S. House,1,Dusty Johnson,REP,144
+Fall River,BEA,Governor,,Jamie Smith and Jennifer Keintz,DEM,11
+Fall River,BEA,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Fall River,BEA,Governor,,Kristi Noem and Larry Rhoden,REP,130
+Fall River,CAS,Governor,,Jamie Smith and Jennifer Keintz,DEM,37
+Fall River,CAS,Governor,,Tracey Quint and Ashley Strand,LIB,8
+Fall River,CAS,Governor,,Kristi Noem and Larry Rhoden,REP,131
+Fall River,EDA,Governor,,Jamie Smith and Jennifer Keintz,DEM,88
+Fall River,EDA,Governor,,Tracey Quint and Ashley Strand,LIB,18
+Fall River,EDA,Governor,,Kristi Noem and Larry Rhoden,REP,440
+Fall River,HS 1,Governor,,Jamie Smith and Jennifer Keintz,DEM,130
+Fall River,HS 1,Governor,,Tracey Quint and Ashley Strand,LIB,16
+Fall River,HS 1,Governor,,Kristi Noem and Larry Rhoden,REP,298
+Fall River,HS 2,Governor,,Jamie Smith and Jennifer Keintz,DEM,126
+Fall River,HS 2,Governor,,Tracey Quint and Ashley Strand,LIB,15
+Fall River,HS 2,Governor,,Kristi Noem and Larry Rhoden,REP,293
+Fall River,HS 3,Governor,,Jamie Smith and Jennifer Keintz,DEM,110
+Fall River,HS 3,Governor,,Tracey Quint and Ashley Strand,LIB,18
+Fall River,HS 3,Governor,,Kristi Noem and Larry Rhoden,REP,212
+Fall River,HS 4,Governor,,Jamie Smith and Jennifer Keintz,DEM,127
+Fall River,HS 4,Governor,,Tracey Quint and Ashley Strand,LIB,13
+Fall River,HS 4,Governor,,Kristi Noem and Larry Rhoden,REP,224
+Fall River,JAC,Governor,,Jamie Smith and Jennifer Keintz,DEM,214
+Fall River,JAC,Governor,,Tracey Quint and Ashley Strand,LIB,31
+Fall River,JAC,Governor,,Kristi Noem and Larry Rhoden,REP,790
+Fall River,Oelrichs Area,Governor,,Jamie Smith and Jennifer Keintz,DEM,16
+Fall River,Oelrichs Area,Governor,,Tracey Quint and Ashley Strand,LIB,8
+Fall River,Oelrichs Area,Governor,,Kristi Noem and Larry Rhoden,REP,161
+Fall River,BEA,Secretary of State,,Thomas A Cool,DEM,13
+Fall River,BEA,Secretary of State,,Monae Johnson,REP,123
+Fall River,CAS,Secretary of State,,Thomas A Cool,DEM,37
+Fall River,CAS,Secretary of State,,Monae Johnson,REP,134
+Fall River,EDA,Secretary of State,,Thomas A Cool,DEM,107
+Fall River,EDA,Secretary of State,,Monae Johnson,REP,427
+Fall River,HS 1,Secretary of State,,Thomas A Cool,DEM,132
+Fall River,HS 1,Secretary of State,,Monae Johnson,REP,300
+Fall River,HS 2,Secretary of State,,Thomas A Cool,DEM,121
+Fall River,HS 2,Secretary of State,,Monae Johnson,REP,293
+Fall River,HS 3,Secretary of State,,Thomas A Cool,DEM,107
+Fall River,HS 3,Secretary of State,,Monae Johnson,REP,218
+Fall River,HS 4,Secretary of State,,Thomas A Cool,DEM,129
+Fall River,HS 4,Secretary of State,,Monae Johnson,REP,220
+Fall River,JAC,Secretary of State,,Thomas A Cool,DEM,236
+Fall River,JAC,Secretary of State,,Monae Johnson,REP,774
+Fall River,Oelrichs Area,Secretary of State,,Thomas A Cool,DEM,16
+Fall River,Oelrichs Area,Secretary of State,,Monae Johnson,REP,157
+Fall River,BEA,Attorney General,,Marty J. Jackley,REP,122
+Fall River,CAS,Attorney General,,Marty J. Jackley,REP,134
+Fall River,EDA,Attorney General,,Marty J. Jackley,REP,457
+Fall River,HS 1,Attorney General,,Marty J. Jackley,REP,310
+Fall River,HS 2,Attorney General,,Marty J. Jackley,REP,333
+Fall River,HS 3,Attorney General,,Marty J. Jackley,REP,252
+Fall River,HS 4,Attorney General,,Marty J. Jackley,REP,264
+Fall River,JAC,Attorney General,,Marty J. Jackley,REP,835
+Fall River,Oelrichs Area,Attorney General,,Marty J. Jackley,REP,157
+Fall River,BEA,State Auditor,,Stephanie Marty,DEM,9
+Fall River,BEA,State Auditor,,Rene Meyer,LIB,17
+Fall River,BEA,State Auditor,,Richard Sattgast,REP,111
+Fall River,CAS,State Auditor,,Stephanie Marty,DEM,29
+Fall River,CAS,State Auditor,,Rene Meyer,LIB,14
+Fall River,CAS,State Auditor,,Richard Sattgast,REP,131
+Fall River,EDA,State Auditor,,Stephanie Marty,DEM,95
+Fall River,EDA,State Auditor,,Rene Meyer,LIB,36
+Fall River,EDA,State Auditor,,Richard Sattgast,REP,402
+Fall River,HS 1,State Auditor,,Stephanie Marty,DEM,118
+Fall River,HS 1,State Auditor,,Rene Meyer,LIB,33
+Fall River,HS 1,State Auditor,,Richard Sattgast,REP,276
+Fall River,HS 2,State Auditor,,Stephanie Marty,DEM,121
+Fall River,HS 2,State Auditor,,Rene Meyer,LIB,21
+Fall River,HS 2,State Auditor,,Richard Sattgast,REP,275
+Fall River,HS 3,State Auditor,,Stephanie Marty,DEM,98
+Fall River,HS 3,State Auditor,,Rene Meyer,LIB,37
+Fall River,HS 3,State Auditor,,Richard Sattgast,REP,199
+Fall River,HS 4,State Auditor,,Stephanie Marty,DEM,123
+Fall River,HS 4,State Auditor,,Rene Meyer,LIB,15
+Fall River,HS 4,State Auditor,,Richard Sattgast,REP,213
+Fall River,JAC,State Auditor,,Stephanie Marty,DEM,196
+Fall River,JAC,State Auditor,,Rene Meyer,LIB,58
+Fall River,JAC,State Auditor,,Richard Sattgast,REP,743
+Fall River,Oelrichs Area,State Auditor,,Stephanie Marty,DEM,11
+Fall River,Oelrichs Area,State Auditor,,Rene Meyer,LIB,11
+Fall River,Oelrichs Area,State Auditor,,Richard Sattgast,REP,149
+Fall River,BEA,State Treasurer,,John Cunningham,DEM,10
+Fall River,BEA,State Treasurer,,Josh Haeder,REP,121
+Fall River,CAS,State Treasurer,,John Cunningham,DEM,35
+Fall River,CAS,State Treasurer,,Josh Haeder,REP,136
+Fall River,EDA,State Treasurer,,John Cunningham,DEM,98
+Fall River,EDA,State Treasurer,,Josh Haeder,REP,431
+Fall River,HS 1,State Treasurer,,John Cunningham,DEM,127
+Fall River,HS 1,State Treasurer,,Josh Haeder,REP,298
+Fall River,HS 2,State Treasurer,,John Cunningham,DEM,114
+Fall River,HS 2,State Treasurer,,Josh Haeder,REP,302
+Fall River,HS 3,State Treasurer,,John Cunningham,DEM,102
+Fall River,HS 3,State Treasurer,,Josh Haeder,REP,226
+Fall River,HS 4,State Treasurer,,John Cunningham,DEM,117
+Fall River,HS 4,State Treasurer,,Josh Haeder,REP,230
+Fall River,JAC,State Treasurer,,John Cunningham,DEM,213
+Fall River,JAC,State Treasurer,,Josh Haeder,REP,780
+Fall River,Oelrichs Area,State Treasurer,,John Cunningham,DEM,11
+Fall River,Oelrichs Area,State Treasurer,,Josh Haeder,REP,161
+Fall River,BEA,Commissioner of School and Public Lands,,Timothy Azure,DEM,11
+Fall River,BEA,Commissioner of School and Public Lands,,Brock Greenfield,REP,127
+Fall River,CAS,Commissioner of School and Public Lands,,Timothy Azure,DEM,36
+Fall River,CAS,Commissioner of School and Public Lands,,Brock Greenfield,REP,132
+Fall River,EDA,Commissioner of School and Public Lands,,Timothy Azure,DEM,87
+Fall River,EDA,Commissioner of School and Public Lands,,Brock Greenfield,REP,434
+Fall River,HS 1,Commissioner of School and Public Lands,,Timothy Azure,DEM,124
+Fall River,HS 1,Commissioner of School and Public Lands,,Brock Greenfield,REP,299
+Fall River,HS 2,Commissioner of School and Public Lands,,Timothy Azure,DEM,116
+Fall River,HS 2,Commissioner of School and Public Lands,,Brock Greenfield,REP,287
+Fall River,HS 3,Commissioner of School and Public Lands,,Timothy Azure,DEM,106
+Fall River,HS 3,Commissioner of School and Public Lands,,Brock Greenfield,REP,214
+Fall River,HS 4,Commissioner of School and Public Lands,,Timothy Azure,DEM,117
+Fall River,HS 4,Commissioner of School and Public Lands,,Brock Greenfield,REP,228
+Fall River,JAC,Commissioner of School and Public Lands,,Timothy Azure,DEM,203
+Fall River,JAC,Commissioner of School and Public Lands,,Brock Greenfield,REP,776
+Fall River,Oelrichs Area,Commissioner of School and Public Lands,,Timothy Azure,DEM,11
+Fall River,Oelrichs Area,Commissioner of School and Public Lands,,Brock Greenfield,REP,159
+Fall River,BEA,Public Utilities Commissioner,,Jeffrey Barth,DEM,12
+Fall River,BEA,Public Utilities Commissioner,,Chris Nelson,REP,125
+Fall River,CAS,Public Utilities Commissioner,,Jeffrey Barth,DEM,32
+Fall River,CAS,Public Utilities Commissioner,,Chris Nelson,REP,138
+Fall River,EDA,Public Utilities Commissioner,,Jeffrey Barth,DEM,84
+Fall River,EDA,Public Utilities Commissioner,,Chris Nelson,REP,439
+Fall River,HS 1,Public Utilities Commissioner,,Jeffrey Barth,DEM,125
+Fall River,HS 1,Public Utilities Commissioner,,Chris Nelson,REP,299
+Fall River,HS 2,Public Utilities Commissioner,,Jeffrey Barth,DEM,110
+Fall River,HS 2,Public Utilities Commissioner,,Chris Nelson,REP,299
+Fall River,HS 3,Public Utilities Commissioner,,Jeffrey Barth,DEM,94
+Fall River,HS 3,Public Utilities Commissioner,,Chris Nelson,REP,233
+Fall River,HS 4,Public Utilities Commissioner,,Jeffrey Barth,DEM,114
+Fall River,HS 4,Public Utilities Commissioner,,Chris Nelson,REP,233
+Fall River,JAC,Public Utilities Commissioner,,Jeffrey Barth,DEM,202
+Fall River,JAC,Public Utilities Commissioner,,Chris Nelson,REP,794
+Fall River,Oelrichs Area,Public Utilities Commissioner,,Jeffrey Barth,DEM,16
+Fall River,Oelrichs Area,Public Utilities Commissioner,,Chris Nelson,REP,159
+Fall River,BEA,State Senate,30,Julie Frye-Mueller,REP,116
+Fall River,CAS,State Senate,30,Julie Frye-Mueller,REP,132
+Fall River,EDA,State Senate,30,Julie Frye-Mueller,REP,437
+Fall River,HS 1,State Senate,30,Julie Frye-Mueller,REP,304
+Fall River,HS 2,State Senate,30,Julie Frye-Mueller,REP,314
+Fall River,HS 3,State Senate,30,Julie Frye-Mueller,REP,238
+Fall River,HS 4,State Senate,30,Julie Frye-Mueller,REP,249
+Fall River,JAC,State Senate,30,Julie Frye-Mueller,REP,788
+Fall River,Oelrichs Area,State Senate,30,Julie Frye-Mueller,REP,151
+Fall River,BEA,State House,30,Bret Swanson,DEM,13
+Fall River,BEA,State House,30,Dennis Krull,REP,84
+Fall River,BEA,State House,30,Trish Ladner,REP,104
+Fall River,CAS,State House,30,Bret Swanson,DEM,37
+Fall River,CAS,State House,30,Dennis Krull,REP,96
+Fall River,CAS,State House,30,Trish Ladner,REP,119
+Fall River,EDA,State House,30,Bret Swanson,DEM,98
+Fall River,EDA,State House,30,Dennis Krull,REP,291
+Fall River,EDA,State House,30,Trish Ladner,REP,386
+Fall River,HS 1,State House,30,Bret Swanson,DEM,127
+Fall River,HS 1,State House,30,Dennis Krull,REP,192
+Fall River,HS 1,State House,30,Trish Ladner,REP,277
+Fall River,HS 2,State House,30,Bret Swanson,DEM,120
+Fall River,HS 2,State House,30,Dennis Krull,REP,199
+Fall River,HS 2,State House,30,Trish Ladner,REP,278
+Fall River,HS 3,State House,30,Bret Swanson,DEM,98
+Fall River,HS 3,State House,30,Dennis Krull,REP,153
+Fall River,HS 3,State House,30,Trish Ladner,REP,209
+Fall River,HS 4,State House,30,Bret Swanson,DEM,121
+Fall River,HS 4,State House,30,Dennis Krull,REP,143
+Fall River,HS 4,State House,30,Trish Ladner,REP,210
+Fall River,JAC,State House,30,Bret Swanson,DEM,219
+Fall River,JAC,State House,30,Dennis Krull,REP,508
+Fall River,JAC,State House,30,Trish Ladner,REP,719
+Fall River,Oelrichs Area,State House,30,Bret Swanson,DEM,12
+Fall River,Oelrichs Area,State House,30,Dennis Krull,REP,107
+Fall River,Oelrichs Area,State House,30,Trish Ladner,REP,150
+Fall River,BEA,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,55
+Fall River,CAS,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,65
+Fall River,EDA,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,226
+Fall River,HS 1,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,165
+Fall River,HS 2,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,180
+Fall River,HS 3,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,133
+Fall River,HS 4,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,150
+Fall River,JAC,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,412
+Fall River,Oelrichs Area,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,65
+Fall River,BEA,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,56
+Fall River,CAS,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,62
+Fall River,EDA,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,225
+Fall River,HS 1,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,160
+Fall River,HS 2,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,173
+Fall River,HS 3,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,131
+Fall River,HS 4,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,137
+Fall River,JAC,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,384
+Fall River,Oelrichs Area,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,62
+Fall River,BEA,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,59
+Fall River,CAS,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,68
+Fall River,EDA,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,231
+Fall River,HS 1,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,168
+Fall River,HS 2,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,177
+Fall River,HS 3,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,140
+Fall River,HS 4,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,149
+Fall River,JAC,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,409
+Fall River,Oelrichs Area,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,64
+Fall River,BEA,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,56
+Fall River,CAS,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,59
+Fall River,EDA,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,215
+Fall River,HS 1,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,150
+Fall River,HS 2,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,172
+Fall River,HS 3,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,132
+Fall River,HS 4,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,136
+Fall River,JAC,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,382
+Fall River,Oelrichs Area,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,67
+Fall River,BEA,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,54
+Fall River,CAS,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,61
+Fall River,EDA,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,220
+Fall River,HS 1,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,159
+Fall River,HS 2,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,170
+Fall River,HS 3,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,129
+Fall River,HS 4,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,135
+Fall River,JAC,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,384
+Fall River,Oelrichs Area,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,58
+Fall River,BEA,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,56
+Fall River,CAS,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,60
+Fall River,EDA,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,217
+Fall River,HS 1,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,147
+Fall River,HS 2,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,165
+Fall River,HS 3,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,130
+Fall River,HS 4,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,130
+Fall River,JAC,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,384
+Fall River,Oelrichs Area,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,57
+Fall River,BEA,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,53
+Fall River,CAS,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,61
+Fall River,EDA,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,215
+Fall River,HS 1,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,148
+Fall River,HS 2,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,164
+Fall River,HS 3,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,130
+Fall River,HS 4,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,133
+Fall River,JAC,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,374
+Fall River,Oelrichs Area,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,58
+Fall River,BEA,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,54
+Fall River,CAS,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,59
+Fall River,EDA,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,241
+Fall River,HS 1,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,154
+Fall River,HS 2,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,167
+Fall River,HS 3,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,132
+Fall River,HS 4,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,140
+Fall River,JAC,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,389
+Fall River,Oelrichs Area,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,62
+Fall River,BEA,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,89
+Fall River,BEA,Supreme Court Retention,3,Patricia J. DeVaney - No,,25
+Fall River,CAS,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,112
+Fall River,CAS,Supreme Court Retention,3,Patricia J. DeVaney - No,,30
+Fall River,EDA,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,365
+Fall River,EDA,Supreme Court Retention,3,Patricia J. DeVaney - No,,102
+Fall River,HS 1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,252
+Fall River,HS 1,Supreme Court Retention,3,Patricia J. DeVaney - No,,91
+Fall River,HS 2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,299
+Fall River,HS 2,Supreme Court Retention,3,Patricia J. DeVaney - No,,71
+Fall River,HS 3,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,218
+Fall River,HS 3,Supreme Court Retention,3,Patricia J. DeVaney - No,,56
+Fall River,HS 4,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,236
+Fall River,HS 4,Supreme Court Retention,3,Patricia J. DeVaney - No,,77
+Fall River,JAC,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,679
+Fall River,JAC,Supreme Court Retention,3,Patricia J. DeVaney - No,,155
+Fall River,Oelrichs Area,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,109
+Fall River,Oelrichs Area,Supreme Court Retention,3,Patricia J. DeVaney - No,,38
+Fall River,BEA,Supreme Court Retention,2,Mark E. Salter - Yes,,88
+Fall River,BEA,Supreme Court Retention,2,Mark E. Salter - No,,24
+Fall River,CAS,Supreme Court Retention,2,Mark E. Salter - Yes,,111
+Fall River,CAS,Supreme Court Retention,2,Mark E. Salter - No,,29
+Fall River,EDA,Supreme Court Retention,2,Mark E. Salter - Yes,,367
+Fall River,EDA,Supreme Court Retention,2,Mark E. Salter - No,,99
+Fall River,HS 1,Supreme Court Retention,2,Mark E. Salter - Yes,,244
+Fall River,HS 1,Supreme Court Retention,2,Mark E. Salter - No,,96
+Fall River,HS 2,Supreme Court Retention,2,Mark E. Salter - Yes,,296
+Fall River,HS 2,Supreme Court Retention,2,Mark E. Salter - No,,71
+Fall River,HS 3,Supreme Court Retention,2,Mark E. Salter - Yes,,213
+Fall River,HS 3,Supreme Court Retention,2,Mark E. Salter - No,,59
+Fall River,HS 4,Supreme Court Retention,2,Mark E. Salter - Yes,,246
+Fall River,HS 4,Supreme Court Retention,2,Mark E. Salter - No,,69
+Fall River,JAC,Supreme Court Retention,2,Mark E. Salter - Yes,,663
+Fall River,JAC,Supreme Court Retention,2,Mark E. Salter - No,,164
+Fall River,Oelrichs Area,Supreme Court Retention,2,Mark E. Salter - Yes,,110
+Fall River,Oelrichs Area,Supreme Court Retention,2,Mark E. Salter - No,,38
+Fall River,BEA,Constitutional Amendment D,,Yes,,39
+Fall River,BEA,Constitutional Amendment D,,No,,95
+Fall River,CAS,Constitutional Amendment D,,Yes,,80
+Fall River,CAS,Constitutional Amendment D,,No,,85
+Fall River,EDA,Constitutional Amendment D,,Yes,,240
+Fall River,EDA,Constitutional Amendment D,,No,,273
+Fall River,HS 1,Constitutional Amendment D,,Yes,,249
+Fall River,HS 1,Constitutional Amendment D,,No,,177
+Fall River,HS 2,Constitutional Amendment D,,Yes,,246
+Fall River,HS 2,Constitutional Amendment D,,No,,176
+Fall River,HS 3,Constitutional Amendment D,,Yes,,184
+Fall River,HS 3,Constitutional Amendment D,,No,,153
+Fall River,HS 4,Constitutional Amendment D,,Yes,,218
+Fall River,HS 4,Constitutional Amendment D,,No,,139
+Fall River,JAC,Constitutional Amendment D,,Yes,,473
+Fall River,JAC,Constitutional Amendment D,,No,,533
+Fall River,Oelrichs Area,Constitutional Amendment D,,Yes,,61
+Fall River,Oelrichs Area,Constitutional Amendment D,,No,,116
+Fall River,BEA,Initiated Measure 27,,Yes,,45
+Fall River,BEA,Initiated Measure 27,,No,,91
+Fall River,CAS,Initiated Measure 27,,Yes,,83
+Fall River,CAS,Initiated Measure 27,,No,,87
+Fall River,EDA,Initiated Measure 27,,Yes,,227
+Fall River,EDA,Initiated Measure 27,,No,,296
+Fall River,HS 1,Initiated Measure 27,,Yes,,222
+Fall River,HS 1,Initiated Measure 27,,No,,210
+Fall River,HS 2,Initiated Measure 27,,Yes,,214
+Fall River,HS 2,Initiated Measure 27,,No,,217
+Fall River,HS 3,Initiated Measure 27,,Yes,,176
+Fall River,HS 3,Initiated Measure 27,,No,,164
+Fall River,HS 4,Initiated Measure 27,,Yes,,199
+Fall River,HS 4,Initiated Measure 27,,No,,163
+Fall River,JAC,Initiated Measure 27,,Yes,,423
+Fall River,JAC,Initiated Measure 27,,No,,599
+Fall River,Oelrichs Area,Initiated Measure 27,,Yes,,40
+Fall River,Oelrichs Area,Initiated Measure 27,,No,,138

--- a/2022/counties/20221108__sd__general__faulk__precinct.csv
+++ b/2022/counties/20221108__sd__general__faulk__precinct.csv
@@ -1,0 +1,246 @@
+county,precinct,office,district,candidate,party,votes
+Faulk,1,U.S. Senate,,Brian L. Bengs,DEM,29
+Faulk,1,U.S. Senate,,Tamara J Lesnar,LIB,6
+Faulk,1,U.S. Senate,,John R. Thune,REP,111
+Faulk,2,U.S. Senate,,Brian L. Bengs,DEM,4
+Faulk,2,U.S. Senate,,Tamara J Lesnar,LIB,3
+Faulk,2,U.S. Senate,,John R. Thune,REP,98
+Faulk,3,U.S. Senate,,Brian L. Bengs,DEM,9
+Faulk,3,U.S. Senate,,Tamara J Lesnar,LIB,6
+Faulk,3,U.S. Senate,,John R. Thune,REP,91
+Faulk,4,U.S. Senate,,Brian L. Bengs,DEM,8
+Faulk,4,U.S. Senate,,Tamara J Lesnar,LIB,6
+Faulk,4,U.S. Senate,,John R. Thune,REP,71
+Faulk,5,U.S. Senate,,Brian L. Bengs,DEM,13
+Faulk,5,U.S. Senate,,Tamara J Lesnar,LIB,6
+Faulk,5,U.S. Senate,,John R. Thune,REP,72
+Faulk,6,U.S. Senate,,Brian L. Bengs,DEM,22
+Faulk,6,U.S. Senate,,Tamara J Lesnar,LIB,9
+Faulk,6,U.S. Senate,,John R. Thune,REP,163
+Faulk,7,U.S. Senate,,Brian L. Bengs,DEM,35
+Faulk,7,U.S. Senate,,Tamara J Lesnar,LIB,11
+Faulk,7,U.S. Senate,,John R. Thune,REP,174
+Faulk,1,U.S. House,1,Collin Duprel,LIB,29
+Faulk,1,U.S. House,1,Dusty Johnson,REP,109
+Faulk,2,U.S. House,1,Collin Duprel,LIB,13
+Faulk,2,U.S. House,1,Dusty Johnson,REP,90
+Faulk,3,U.S. House,1,Collin Duprel,LIB,15
+Faulk,3,U.S. House,1,Dusty Johnson,REP,92
+Faulk,4,U.S. House,1,Collin Duprel,LIB,9
+Faulk,4,U.S. House,1,Dusty Johnson,REP,73
+Faulk,5,U.S. House,1,Collin Duprel,LIB,13
+Faulk,5,U.S. House,1,Dusty Johnson,REP,76
+Faulk,6,U.S. House,1,Collin Duprel,LIB,24
+Faulk,6,U.S. House,1,Dusty Johnson,REP,167
+Faulk,7,U.S. House,1,Collin Duprel,LIB,37
+Faulk,7,U.S. House,1,Dusty Johnson,REP,172
+Faulk,1,Governor,,Jamie Smith and Jennifer Keintz,DEM,37
+Faulk,1,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Faulk,1,Governor,,Kristi Noem and Larry Rhoden,REP,109
+Faulk,2,Governor,,Jamie Smith and Jennifer Keintz,DEM,7
+Faulk,2,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Faulk,2,Governor,,Kristi Noem and Larry Rhoden,REP,98
+Faulk,3,Governor,,Jamie Smith and Jennifer Keintz,DEM,17
+Faulk,3,Governor,,Tracey Quint and Ashley Strand,LIB,0
+Faulk,3,Governor,,Kristi Noem and Larry Rhoden,REP,92
+Faulk,4,Governor,,Jamie Smith and Jennifer Keintz,DEM,13
+Faulk,4,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Faulk,4,Governor,,Kristi Noem and Larry Rhoden,REP,72
+Faulk,5,Governor,,Jamie Smith and Jennifer Keintz,DEM,14
+Faulk,5,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Faulk,5,Governor,,Kristi Noem and Larry Rhoden,REP,77
+Faulk,6,Governor,,Jamie Smith and Jennifer Keintz,DEM,35
+Faulk,6,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Faulk,6,Governor,,Kristi Noem and Larry Rhoden,REP,155
+Faulk,7,Governor,,Jamie Smith and Jennifer Keintz,DEM,44
+Faulk,7,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Faulk,7,Governor,,Kristi Noem and Larry Rhoden,REP,168
+Faulk,1,Secretary of State,,Thomas A Cool,DEM,38
+Faulk,1,Secretary of State,,Monae Johnson,REP,104
+Faulk,2,Secretary of State,,Thomas A Cool,DEM,9
+Faulk,2,Secretary of State,,Monae Johnson,REP,90
+Faulk,3,Secretary of State,,Thomas A Cool,DEM,17
+Faulk,3,Secretary of State,,Monae Johnson,REP,84
+Faulk,4,Secretary of State,,Thomas A Cool,DEM,19
+Faulk,4,Secretary of State,,Monae Johnson,REP,63
+Faulk,5,Secretary of State,,Thomas A Cool,DEM,16
+Faulk,5,Secretary of State,,Monae Johnson,REP,72
+Faulk,6,Secretary of State,,Thomas A Cool,DEM,41
+Faulk,6,Secretary of State,,Monae Johnson,REP,143
+Faulk,7,Secretary of State,,Thomas A Cool,DEM,53
+Faulk,7,Secretary of State,,Monae Johnson,REP,156
+Faulk,1,Attorney General,,Marty J. Jackley,REP,115
+Faulk,2,Attorney General,,Marty J. Jackley,REP,91
+Faulk,3,Attorney General,,Marty J. Jackley,REP,86
+Faulk,4,Attorney General,,Marty J. Jackley,REP,73
+Faulk,5,Attorney General,,Marty J. Jackley,REP,79
+Faulk,6,Attorney General,,Marty J. Jackley,REP,168
+Faulk,7,Attorney General,,Marty J. Jackley,REP,185
+Faulk,1,State Auditor,,Stephanie Marty,DEM,33
+Faulk,1,State Auditor,,Rene Meyer,LIB,2
+Faulk,1,State Auditor,,Richard Sattgast,REP,107
+Faulk,2,State Auditor,,Stephanie Marty,DEM,9
+Faulk,2,State Auditor,,Rene Meyer,LIB,2
+Faulk,2,State Auditor,,Richard Sattgast,REP,84
+Faulk,3,State Auditor,,Stephanie Marty,DEM,11
+Faulk,3,State Auditor,,Rene Meyer,LIB,2
+Faulk,3,State Auditor,,Richard Sattgast,REP,88
+Faulk,4,State Auditor,,Stephanie Marty,DEM,15
+Faulk,4,State Auditor,,Rene Meyer,LIB,6
+Faulk,4,State Auditor,,Richard Sattgast,REP,64
+Faulk,5,State Auditor,,Stephanie Marty,DEM,16
+Faulk,5,State Auditor,,Rene Meyer,LIB,4
+Faulk,5,State Auditor,,Richard Sattgast,REP,67
+Faulk,6,State Auditor,,Stephanie Marty,DEM,29
+Faulk,6,State Auditor,,Rene Meyer,LIB,10
+Faulk,6,State Auditor,,Richard Sattgast,REP,148
+Faulk,7,State Auditor,,Stephanie Marty,DEM,40
+Faulk,7,State Auditor,,Rene Meyer,LIB,5
+Faulk,7,State Auditor,,Richard Sattgast,REP,165
+Faulk,1,State Treasurer,,John Cunningham,DEM,36
+Faulk,1,State Treasurer,,Josh Haeder,REP,104
+Faulk,2,State Treasurer,,John Cunningham,DEM,8
+Faulk,2,State Treasurer,,Josh Haeder,REP,89
+Faulk,3,State Treasurer,,John Cunningham,DEM,13
+Faulk,3,State Treasurer,,Josh Haeder,REP,89
+Faulk,4,State Treasurer,,John Cunningham,DEM,17
+Faulk,4,State Treasurer,,Josh Haeder,REP,67
+Faulk,5,State Treasurer,,John Cunningham,DEM,15
+Faulk,5,State Treasurer,,Josh Haeder,REP,71
+Faulk,6,State Treasurer,,John Cunningham,DEM,38
+Faulk,6,State Treasurer,,Josh Haeder,REP,144
+Faulk,7,State Treasurer,,John Cunningham,DEM,40
+Faulk,7,State Treasurer,,Josh Haeder,REP,166
+Faulk,1,Commissioner of School and Public Lands,,Timothy Azure,DEM,33
+Faulk,1,Commissioner of School and Public Lands,,Brock Greenfield,REP,107
+Faulk,2,Commissioner of School and Public Lands,,Timothy Azure,DEM,10
+Faulk,2,Commissioner of School and Public Lands,,Brock Greenfield,REP,89
+Faulk,3,Commissioner of School and Public Lands,,Timothy Azure,DEM,13
+Faulk,3,Commissioner of School and Public Lands,,Brock Greenfield,REP,87
+Faulk,4,Commissioner of School and Public Lands,,Timothy Azure,DEM,14
+Faulk,4,Commissioner of School and Public Lands,,Brock Greenfield,REP,68
+Faulk,5,Commissioner of School and Public Lands,,Timothy Azure,DEM,14
+Faulk,5,Commissioner of School and Public Lands,,Brock Greenfield,REP,74
+Faulk,6,Commissioner of School and Public Lands,,Timothy Azure,DEM,21
+Faulk,6,Commissioner of School and Public Lands,,Brock Greenfield,REP,163
+Faulk,7,Commissioner of School and Public Lands,,Timothy Azure,DEM,43
+Faulk,7,Commissioner of School and Public Lands,,Brock Greenfield,REP,158
+Faulk,1,Public Utilities Commissioner,,Jeffrey Barth,DEM,27
+Faulk,1,Public Utilities Commissioner,,Chris Nelson,REP,114
+Faulk,2,Public Utilities Commissioner,,Jeffrey Barth,DEM,11
+Faulk,2,Public Utilities Commissioner,,Chris Nelson,REP,87
+Faulk,3,Public Utilities Commissioner,,Jeffrey Barth,DEM,13
+Faulk,3,Public Utilities Commissioner,,Chris Nelson,REP,89
+Faulk,4,Public Utilities Commissioner,,Jeffrey Barth,DEM,10
+Faulk,4,Public Utilities Commissioner,,Chris Nelson,REP,75
+Faulk,5,Public Utilities Commissioner,,Jeffrey Barth,DEM,13
+Faulk,5,Public Utilities Commissioner,,Chris Nelson,REP,76
+Faulk,6,Public Utilities Commissioner,,Jeffrey Barth,DEM,23
+Faulk,6,Public Utilities Commissioner,,Chris Nelson,REP,165
+Faulk,7,Public Utilities Commissioner,,Jeffrey Barth,DEM,34
+Faulk,7,Public Utilities Commissioner,,Chris Nelson,REP,174
+Faulk,1,State Senate,23,Bryan J. Breitling,REP,110
+Faulk,2,State Senate,23,Bryan J. Breitling,REP,84
+Faulk,3,State Senate,23,Bryan J. Breitling,REP,80
+Faulk,4,State Senate,23,Bryan J. Breitling,REP,69
+Faulk,5,State Senate,23,Bryan J. Breitling,REP,72
+Faulk,6,State Senate,23,Bryan J. Breitling,REP,149
+Faulk,7,State Senate,23,Bryan J. Breitling,REP,166
+Faulk,1,State House,23,James D. Wangsness,REP,58
+Faulk,1,State House,23,Scott Moore,REP,95
+Faulk,2,State House,23,James D. Wangsness,REP,45
+Faulk,2,State House,23,Scott Moore,REP,79
+Faulk,3,State House,23,James D. Wangsness,REP,51
+Faulk,3,State House,23,Scott Moore,REP,78
+Faulk,4,State House,23,James D. Wangsness,REP,49
+Faulk,4,State House,23,Scott Moore,REP,66
+Faulk,5,State House,23,James D. Wangsness,REP,44
+Faulk,5,State House,23,Scott Moore,REP,72
+Faulk,6,State House,23,James D. Wangsness,REP,96
+Faulk,6,State House,23,Scott Moore,REP,137
+Faulk,7,State House,23,James D. Wangsness,REP,117
+Faulk,7,State House,23,Scott Moore,REP,154
+Faulk,1,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,81
+Faulk,2,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,57
+Faulk,3,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,59
+Faulk,4,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,45
+Faulk,5,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,46
+Faulk,6,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,99
+Faulk,7,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,138
+Faulk,1,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,77
+Faulk,2,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,52
+Faulk,3,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,54
+Faulk,4,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,48
+Faulk,5,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,45
+Faulk,6,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,103
+Faulk,7,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,135
+Faulk,1,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,70
+Faulk,2,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,43
+Faulk,3,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,41
+Faulk,4,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,44
+Faulk,5,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,42
+Faulk,6,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,89
+Faulk,7,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,122
+Faulk,1,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,76
+Faulk,2,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,45
+Faulk,3,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,46
+Faulk,4,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,45
+Faulk,5,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,40
+Faulk,6,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,94
+Faulk,7,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,129
+Faulk,1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,103
+Faulk,1,Supreme Court Retention,3,Patricia J. DeVaney - No,,22
+Faulk,2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,70
+Faulk,2,Supreme Court Retention,3,Patricia J. DeVaney - No,,15
+Faulk,3,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,70
+Faulk,3,Supreme Court Retention,3,Patricia J. DeVaney - No,,11
+Faulk,4,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,65
+Faulk,4,Supreme Court Retention,3,Patricia J. DeVaney - No,,13
+Faulk,5,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,62
+Faulk,5,Supreme Court Retention,3,Patricia J. DeVaney - No,,9
+Faulk,6,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,140
+Faulk,6,Supreme Court Retention,3,Patricia J. DeVaney - No,,33
+Faulk,7,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,151
+Faulk,7,Supreme Court Retention,3,Patricia J. DeVaney - No,,35
+Faulk,1,Supreme Court Retention,2,Mark E. Salter - Yes,,103
+Faulk,1,Supreme Court Retention,2,Mark E. Salter - No,,22
+Faulk,2,Supreme Court Retention,2,Mark E. Salter - Yes,,68
+Faulk,2,Supreme Court Retention,2,Mark E. Salter - No,,17
+Faulk,3,Supreme Court Retention,2,Mark E. Salter - Yes,,72
+Faulk,3,Supreme Court Retention,2,Mark E. Salter - No,,9
+Faulk,4,Supreme Court Retention,2,Mark E. Salter - Yes,,64
+Faulk,4,Supreme Court Retention,2,Mark E. Salter - No,,14
+Faulk,5,Supreme Court Retention,2,Mark E. Salter - Yes,,63
+Faulk,5,Supreme Court Retention,2,Mark E. Salter - No,,8
+Faulk,6,Supreme Court Retention,2,Mark E. Salter - Yes,,138
+Faulk,6,Supreme Court Retention,2,Mark E. Salter - No,,34
+Faulk,7,Supreme Court Retention,2,Mark E. Salter - Yes,,153
+Faulk,7,Supreme Court Retention,2,Mark E. Salter - No,,33
+Faulk,1,Constitutional Amendment D,,Yes,,72
+Faulk,1,Constitutional Amendment D,,No,,76
+Faulk,2,Constitutional Amendment D,,Yes,,38
+Faulk,2,Constitutional Amendment D,,No,,60
+Faulk,3,Constitutional Amendment D,,Yes,,27
+Faulk,3,Constitutional Amendment D,,No,,79
+Faulk,4,Constitutional Amendment D,,Yes,,28
+Faulk,4,Constitutional Amendment D,,No,,53
+Faulk,5,Constitutional Amendment D,,Yes,,32
+Faulk,5,Constitutional Amendment D,,No,,55
+Faulk,6,Constitutional Amendment D,,Yes,,74
+Faulk,6,Constitutional Amendment D,,No,,110
+Faulk,7,Constitutional Amendment D,,Yes,,91
+Faulk,7,Constitutional Amendment D,,No,,117
+Faulk,1,Initiated Measure 27,,Yes,,41
+Faulk,1,Initiated Measure 27,,No,,107
+Faulk,2,Initiated Measure 27,,Yes,,22
+Faulk,2,Initiated Measure 27,,No,,79
+Faulk,3,Initiated Measure 27,,Yes,,24
+Faulk,3,Initiated Measure 27,,No,,81
+Faulk,4,Initiated Measure 27,,Yes,,23
+Faulk,4,Initiated Measure 27,,No,,62
+Faulk,5,Initiated Measure 27,,Yes,,27
+Faulk,5,Initiated Measure 27,,No,,62
+Faulk,6,Initiated Measure 27,,Yes,,58
+Faulk,6,Initiated Measure 27,,No,,131
+Faulk,7,Initiated Measure 27,,Yes,,67
+Faulk,7,Initiated Measure 27,,No,,144

--- a/2022/counties/20221108__sd__general__grant__precinct.csv
+++ b/2022/counties/20221108__sd__general__grant__precinct.csv
@@ -1,0 +1,685 @@
+county,precinct,office,district,candidate,party,votes
+Grant,11,U.S. Senate,,Brian L. Bengs,DEM,59
+Grant,11,U.S. Senate,,Tamara J Lesnar,LIB,9
+Grant,11,U.S. Senate,,John R. Thune,REP,236
+Grant,12,U.S. Senate,,Brian L. Bengs,DEM,20
+Grant,12,U.S. Senate,,Tamara J Lesnar,LIB,3
+Grant,12,U.S. Senate,,John R. Thune,REP,55
+Grant,21,U.S. Senate,,Brian L. Bengs,DEM,26
+Grant,21,U.S. Senate,,Tamara J Lesnar,LIB,6
+Grant,21,U.S. Senate,,John R. Thune,REP,102
+Grant,22,U.S. Senate,,Brian L. Bengs,DEM,71
+Grant,22,U.S. Senate,,Tamara J Lesnar,LIB,5
+Grant,22,U.S. Senate,,John R. Thune,REP,239
+Grant,31,U.S. Senate,,Brian L. Bengs,DEM,12
+Grant,31,U.S. Senate,,Tamara J Lesnar,LIB,0
+Grant,31,U.S. Senate,,John R. Thune,REP,44
+Grant,32,U.S. Senate,,Brian L. Bengs,DEM,21
+Grant,32,U.S. Senate,,Tamara J Lesnar,LIB,3
+Grant,32,U.S. Senate,,John R. Thune,REP,60
+Grant,33,U.S. Senate,,Brian L. Bengs,DEM,72
+Grant,33,U.S. Senate,,Tamara J Lesnar,LIB,10
+Grant,33,U.S. Senate,,John R. Thune,REP,281
+Grant,41,U.S. Senate,,Brian L. Bengs,DEM,53
+Grant,41,U.S. Senate,,Tamara J Lesnar,LIB,7
+Grant,41,U.S. Senate,,John R. Thune,REP,150
+Grant,42,U.S. Senate,,Brian L. Bengs,DEM,42
+Grant,42,U.S. Senate,,Tamara J Lesnar,LIB,10
+Grant,42,U.S. Senate,,John R. Thune,REP,216
+Grant,43,U.S. Senate,,Brian L. Bengs,DEM,68
+Grant,43,U.S. Senate,,Tamara J Lesnar,LIB,11
+Grant,43,U.S. Senate,,John R. Thune,REP,283
+Grant,44,U.S. Senate,,Brian L. Bengs,DEM,15
+Grant,44,U.S. Senate,,Tamara J Lesnar,LIB,7
+Grant,44,U.S. Senate,,John R. Thune,REP,90
+Grant,45,U.S. Senate,,Brian L. Bengs,DEM,27
+Grant,45,U.S. Senate,,Tamara J Lesnar,LIB,4
+Grant,45,U.S. Senate,,John R. Thune,REP,113
+Grant,46,U.S. Senate,,Brian L. Bengs,DEM,39
+Grant,46,U.S. Senate,,Tamara J Lesnar,LIB,6
+Grant,46,U.S. Senate,,John R. Thune,REP,156
+Grant,47,U.S. Senate,,Brian L. Bengs,DEM,15
+Grant,47,U.S. Senate,,Tamara J Lesnar,LIB,11
+Grant,47,U.S. Senate,,John R. Thune,REP,165
+Grant,49,U.S. Senate,,Brian L. Bengs,DEM,16
+Grant,49,U.S. Senate,,Tamara J Lesnar,LIB,4
+Grant,49,U.S. Senate,,John R. Thune,REP,77
+Grant,52,U.S. Senate,,Brian L. Bengs,DEM,8
+Grant,52,U.S. Senate,,Tamara J Lesnar,LIB,3
+Grant,52,U.S. Senate,,John R. Thune,REP,63
+Grant,53,U.S. Senate,,Brian L. Bengs,DEM,11
+Grant,53,U.S. Senate,,Tamara J Lesnar,LIB,1
+Grant,53,U.S. Senate,,John R. Thune,REP,44
+Grant,54,U.S. Senate,,Brian L. Bengs,DEM,26
+Grant,54,U.S. Senate,,Tamara J Lesnar,LIB,5
+Grant,54,U.S. Senate,,John R. Thune,REP,118
+Grant,11,U.S. House,1,Collin Duprel,LIB,44
+Grant,11,U.S. House,1,Dusty Johnson,REP,243
+Grant,12,U.S. House,1,Collin Duprel,LIB,16
+Grant,12,U.S. House,1,Dusty Johnson,REP,57
+Grant,21,U.S. House,1,Collin Duprel,LIB,17
+Grant,21,U.S. House,1,Dusty Johnson,REP,105
+Grant,22,U.S. House,1,Collin Duprel,LIB,45
+Grant,22,U.S. House,1,Dusty Johnson,REP,256
+Grant,31,U.S. House,1,Collin Duprel,LIB,6
+Grant,31,U.S. House,1,Dusty Johnson,REP,48
+Grant,32,U.S. House,1,Collin Duprel,LIB,15
+Grant,32,U.S. House,1,Dusty Johnson,REP,64
+Grant,33,U.S. House,1,Collin Duprel,LIB,50
+Grant,33,U.S. House,1,Dusty Johnson,REP,298
+Grant,41,U.S. House,1,Collin Duprel,LIB,38
+Grant,41,U.S. House,1,Dusty Johnson,REP,157
+Grant,42,U.S. House,1,Collin Duprel,LIB,30
+Grant,42,U.S. House,1,Dusty Johnson,REP,228
+Grant,43,U.S. House,1,Collin Duprel,LIB,60
+Grant,43,U.S. House,1,Dusty Johnson,REP,288
+Grant,44,U.S. House,1,Collin Duprel,LIB,14
+Grant,44,U.S. House,1,Dusty Johnson,REP,94
+Grant,45,U.S. House,1,Collin Duprel,LIB,25
+Grant,45,U.S. House,1,Dusty Johnson,REP,117
+Grant,46,U.S. House,1,Collin Duprel,LIB,27
+Grant,46,U.S. House,1,Dusty Johnson,REP,166
+Grant,47,U.S. House,1,Collin Duprel,LIB,21
+Grant,47,U.S. House,1,Dusty Johnson,REP,166
+Grant,49,U.S. House,1,Collin Duprel,LIB,16
+Grant,49,U.S. House,1,Dusty Johnson,REP,76
+Grant,52,U.S. House,1,Collin Duprel,LIB,10
+Grant,52,U.S. House,1,Dusty Johnson,REP,61
+Grant,53,U.S. House,1,Collin Duprel,LIB,10
+Grant,53,U.S. House,1,Dusty Johnson,REP,43
+Grant,54,U.S. House,1,Collin Duprel,LIB,24
+Grant,54,U.S. House,1,Dusty Johnson,REP,120
+Grant,11,Governor,,Jamie Smith and Jennifer Keintz,DEM,69
+Grant,11,Governor,,Tracey Quint and Ashley Strand,LIB,6
+Grant,11,Governor,,Kristi Noem and Larry Rhoden,REP,229
+Grant,12,Governor,,Jamie Smith and Jennifer Keintz,DEM,21
+Grant,12,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Grant,12,Governor,,Kristi Noem and Larry Rhoden,REP,54
+Grant,21,Governor,,Jamie Smith and Jennifer Keintz,DEM,39
+Grant,21,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Grant,21,Governor,,Kristi Noem and Larry Rhoden,REP,92
+Grant,22,Governor,,Jamie Smith and Jennifer Keintz,DEM,85
+Grant,22,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Grant,22,Governor,,Kristi Noem and Larry Rhoden,REP,221
+Grant,31,Governor,,Jamie Smith and Jennifer Keintz,DEM,21
+Grant,31,Governor,,Tracey Quint and Ashley Strand,LIB,0
+Grant,31,Governor,,Kristi Noem and Larry Rhoden,REP,35
+Grant,32,Governor,,Jamie Smith and Jennifer Keintz,DEM,25
+Grant,32,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Grant,32,Governor,,Kristi Noem and Larry Rhoden,REP,59
+Grant,33,Governor,,Jamie Smith and Jennifer Keintz,DEM,104
+Grant,33,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Grant,33,Governor,,Kristi Noem and Larry Rhoden,REP,257
+Grant,41,Governor,,Jamie Smith and Jennifer Keintz,DEM,69
+Grant,41,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Grant,41,Governor,,Kristi Noem and Larry Rhoden,REP,138
+Grant,42,Governor,,Jamie Smith and Jennifer Keintz,DEM,67
+Grant,42,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Grant,42,Governor,,Kristi Noem and Larry Rhoden,REP,197
+Grant,43,Governor,,Jamie Smith and Jennifer Keintz,DEM,92
+Grant,43,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Grant,43,Governor,,Kristi Noem and Larry Rhoden,REP,269
+Grant,44,Governor,,Jamie Smith and Jennifer Keintz,DEM,26
+Grant,44,Governor,,Tracey Quint and Ashley Strand,LIB,0
+Grant,44,Governor,,Kristi Noem and Larry Rhoden,REP,87
+Grant,45,Governor,,Jamie Smith and Jennifer Keintz,DEM,41
+Grant,45,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Grant,45,Governor,,Kristi Noem and Larry Rhoden,REP,99
+Grant,46,Governor,,Jamie Smith and Jennifer Keintz,DEM,46
+Grant,46,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Grant,46,Governor,,Kristi Noem and Larry Rhoden,REP,154
+Grant,47,Governor,,Jamie Smith and Jennifer Keintz,DEM,29
+Grant,47,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Grant,47,Governor,,Kristi Noem and Larry Rhoden,REP,160
+Grant,49,Governor,,Jamie Smith and Jennifer Keintz,DEM,23
+Grant,49,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Grant,49,Governor,,Kristi Noem and Larry Rhoden,REP,74
+Grant,52,Governor,,Jamie Smith and Jennifer Keintz,DEM,15
+Grant,52,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Grant,52,Governor,,Kristi Noem and Larry Rhoden,REP,58
+Grant,53,Governor,,Jamie Smith and Jennifer Keintz,DEM,18
+Grant,53,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Grant,53,Governor,,Kristi Noem and Larry Rhoden,REP,39
+Grant,54,Governor,,Jamie Smith and Jennifer Keintz,DEM,40
+Grant,54,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Grant,54,Governor,,Kristi Noem and Larry Rhoden,REP,106
+Grant,11,Secretary of State,,Thomas A Cool,DEM,80
+Grant,11,Secretary of State,,Monae Johnson,REP,196
+Grant,12,Secretary of State,,Thomas A Cool,DEM,26
+Grant,12,Secretary of State,,Monae Johnson,REP,50
+Grant,21,Secretary of State,,Thomas A Cool,DEM,39
+Grant,21,Secretary of State,,Monae Johnson,REP,92
+Grant,22,Secretary of State,,Thomas A Cool,DEM,93
+Grant,22,Secretary of State,,Monae Johnson,REP,209
+Grant,31,Secretary of State,,Thomas A Cool,DEM,17
+Grant,31,Secretary of State,,Monae Johnson,REP,37
+Grant,32,Secretary of State,,Thomas A Cool,DEM,25
+Grant,32,Secretary of State,,Monae Johnson,REP,56
+Grant,33,Secretary of State,,Thomas A Cool,DEM,113
+Grant,33,Secretary of State,,Monae Johnson,REP,234
+Grant,41,Secretary of State,,Thomas A Cool,DEM,66
+Grant,41,Secretary of State,,Monae Johnson,REP,134
+Grant,42,Secretary of State,,Thomas A Cool,DEM,66
+Grant,42,Secretary of State,,Monae Johnson,REP,185
+Grant,43,Secretary of State,,Thomas A Cool,DEM,95
+Grant,43,Secretary of State,,Monae Johnson,REP,252
+Grant,44,Secretary of State,,Thomas A Cool,DEM,27
+Grant,44,Secretary of State,,Monae Johnson,REP,75
+Grant,45,Secretary of State,,Thomas A Cool,DEM,41
+Grant,45,Secretary of State,,Monae Johnson,REP,96
+Grant,46,Secretary of State,,Thomas A Cool,DEM,45
+Grant,46,Secretary of State,,Monae Johnson,REP,148
+Grant,47,Secretary of State,,Thomas A Cool,DEM,36
+Grant,47,Secretary of State,,Monae Johnson,REP,148
+Grant,49,Secretary of State,,Thomas A Cool,DEM,21
+Grant,49,Secretary of State,,Monae Johnson,REP,71
+Grant,52,Secretary of State,,Thomas A Cool,DEM,11
+Grant,52,Secretary of State,,Monae Johnson,REP,57
+Grant,53,Secretary of State,,Thomas A Cool,DEM,12
+Grant,53,Secretary of State,,Monae Johnson,REP,39
+Grant,54,Secretary of State,,Thomas A Cool,DEM,40
+Grant,54,Secretary of State,,Monae Johnson,REP,98
+Grant,11,Attorney General,,Marty J. Jackley,REP,230
+Grant,12,Attorney General,,Marty J. Jackley,REP,54
+Grant,21,Attorney General,,Marty J. Jackley,REP,107
+Grant,22,Attorney General,,Marty J. Jackley,REP,253
+Grant,31,Attorney General,,Marty J. Jackley,REP,42
+Grant,32,Attorney General,,Marty J. Jackley,REP,68
+Grant,33,Attorney General,,Marty J. Jackley,REP,290
+Grant,41,Attorney General,,Marty J. Jackley,REP,143
+Grant,42,Attorney General,,Marty J. Jackley,REP,220
+Grant,43,Attorney General,,Marty J. Jackley,REP,283
+Grant,44,Attorney General,,Marty J. Jackley,REP,89
+Grant,45,Attorney General,,Marty J. Jackley,REP,115
+Grant,46,Attorney General,,Marty J. Jackley,REP,170
+Grant,47,Attorney General,,Marty J. Jackley,REP,166
+Grant,49,Attorney General,,Marty J. Jackley,REP,76
+Grant,52,Attorney General,,Marty J. Jackley,REP,55
+Grant,53,Attorney General,,Marty J. Jackley,REP,44
+Grant,54,Attorney General,,Marty J. Jackley,REP,124
+Grant,11,State Auditor,,Stephanie Marty,DEM,76
+Grant,11,State Auditor,,Rene Meyer,LIB,13
+Grant,11,State Auditor,,Richard Sattgast,REP,194
+Grant,12,State Auditor,,Stephanie Marty,DEM,24
+Grant,12,State Auditor,,Rene Meyer,LIB,2
+Grant,12,State Auditor,,Richard Sattgast,REP,50
+Grant,21,State Auditor,,Stephanie Marty,DEM,38
+Grant,21,State Auditor,,Rene Meyer,LIB,9
+Grant,21,State Auditor,,Richard Sattgast,REP,79
+Grant,22,State Auditor,,Stephanie Marty,DEM,84
+Grant,22,State Auditor,,Rene Meyer,LIB,12
+Grant,22,State Auditor,,Richard Sattgast,REP,199
+Grant,31,State Auditor,,Stephanie Marty,DEM,17
+Grant,31,State Auditor,,Rene Meyer,LIB,1
+Grant,31,State Auditor,,Richard Sattgast,REP,36
+Grant,32,State Auditor,,Stephanie Marty,DEM,19
+Grant,32,State Auditor,,Rene Meyer,LIB,3
+Grant,32,State Auditor,,Richard Sattgast,REP,57
+Grant,33,State Auditor,,Stephanie Marty,DEM,95
+Grant,33,State Auditor,,Rene Meyer,LIB,15
+Grant,33,State Auditor,,Richard Sattgast,REP,235
+Grant,41,State Auditor,,Stephanie Marty,DEM,65
+Grant,41,State Auditor,,Rene Meyer,LIB,15
+Grant,41,State Auditor,,Richard Sattgast,REP,118
+Grant,42,State Auditor,,Stephanie Marty,DEM,57
+Grant,42,State Auditor,,Rene Meyer,LIB,5
+Grant,42,State Auditor,,Richard Sattgast,REP,186
+Grant,43,State Auditor,,Stephanie Marty,DEM,79
+Grant,43,State Auditor,,Rene Meyer,LIB,21
+Grant,43,State Auditor,,Richard Sattgast,REP,236
+Grant,44,State Auditor,,Stephanie Marty,DEM,24
+Grant,44,State Auditor,,Rene Meyer,LIB,3
+Grant,44,State Auditor,,Richard Sattgast,REP,74
+Grant,45,State Auditor,,Stephanie Marty,DEM,40
+Grant,45,State Auditor,,Rene Meyer,LIB,7
+Grant,45,State Auditor,,Richard Sattgast,REP,88
+Grant,46,State Auditor,,Stephanie Marty,DEM,41
+Grant,46,State Auditor,,Rene Meyer,LIB,9
+Grant,46,State Auditor,,Richard Sattgast,REP,141
+Grant,47,State Auditor,,Stephanie Marty,DEM,27
+Grant,47,State Auditor,,Rene Meyer,LIB,14
+Grant,47,State Auditor,,Richard Sattgast,REP,145
+Grant,49,State Auditor,,Stephanie Marty,DEM,19
+Grant,49,State Auditor,,Rene Meyer,LIB,4
+Grant,49,State Auditor,,Richard Sattgast,REP,68
+Grant,52,State Auditor,,Stephanie Marty,DEM,12
+Grant,52,State Auditor,,Rene Meyer,LIB,6
+Grant,52,State Auditor,,Richard Sattgast,REP,50
+Grant,53,State Auditor,,Stephanie Marty,DEM,13
+Grant,53,State Auditor,,Rene Meyer,LIB,2
+Grant,53,State Auditor,,Richard Sattgast,REP,33
+Grant,54,State Auditor,,Stephanie Marty,DEM,37
+Grant,54,State Auditor,,Rene Meyer,LIB,6
+Grant,54,State Auditor,,Richard Sattgast,REP,95
+Grant,11,State Treasurer,,John Cunningham,DEM,74
+Grant,11,State Treasurer,,Josh Haeder,REP,196
+Grant,12,State Treasurer,,John Cunningham,DEM,23
+Grant,12,State Treasurer,,Josh Haeder,REP,49
+Grant,21,State Treasurer,,John Cunningham,DEM,38
+Grant,21,State Treasurer,,Josh Haeder,REP,92
+Grant,22,State Treasurer,,John Cunningham,DEM,87
+Grant,22,State Treasurer,,Josh Haeder,REP,208
+Grant,31,State Treasurer,,John Cunningham,DEM,15
+Grant,31,State Treasurer,,Josh Haeder,REP,39
+Grant,32,State Treasurer,,John Cunningham,DEM,21
+Grant,32,State Treasurer,,Josh Haeder,REP,59
+Grant,33,State Treasurer,,John Cunningham,DEM,93
+Grant,33,State Treasurer,,Josh Haeder,REP,243
+Grant,41,State Treasurer,,John Cunningham,DEM,65
+Grant,41,State Treasurer,,Josh Haeder,REP,133
+Grant,42,State Treasurer,,John Cunningham,DEM,53
+Grant,42,State Treasurer,,Josh Haeder,REP,191
+Grant,43,State Treasurer,,John Cunningham,DEM,91
+Grant,43,State Treasurer,,Josh Haeder,REP,253
+Grant,44,State Treasurer,,John Cunningham,DEM,23
+Grant,44,State Treasurer,,Josh Haeder,REP,77
+Grant,45,State Treasurer,,John Cunningham,DEM,36
+Grant,45,State Treasurer,,Josh Haeder,REP,100
+Grant,46,State Treasurer,,John Cunningham,DEM,42
+Grant,46,State Treasurer,,Josh Haeder,REP,148
+Grant,47,State Treasurer,,John Cunningham,DEM,26
+Grant,47,State Treasurer,,Josh Haeder,REP,154
+Grant,49,State Treasurer,,John Cunningham,DEM,20
+Grant,49,State Treasurer,,Josh Haeder,REP,73
+Grant,52,State Treasurer,,John Cunningham,DEM,14
+Grant,52,State Treasurer,,Josh Haeder,REP,53
+Grant,53,State Treasurer,,John Cunningham,DEM,12
+Grant,53,State Treasurer,,Josh Haeder,REP,37
+Grant,54,State Treasurer,,John Cunningham,DEM,43
+Grant,54,State Treasurer,,Josh Haeder,REP,96
+Grant,11,Commissioner of School and Public Lands,,Timothy Azure,DEM,69
+Grant,11,Commissioner of School and Public Lands,,Brock Greenfield,REP,202
+Grant,12,Commissioner of School and Public Lands,,Timothy Azure,DEM,22
+Grant,12,Commissioner of School and Public Lands,,Brock Greenfield,REP,51
+Grant,21,Commissioner of School and Public Lands,,Timothy Azure,DEM,29
+Grant,21,Commissioner of School and Public Lands,,Brock Greenfield,REP,96
+Grant,22,Commissioner of School and Public Lands,,Timothy Azure,DEM,74
+Grant,22,Commissioner of School and Public Lands,,Brock Greenfield,REP,222
+Grant,31,Commissioner of School and Public Lands,,Timothy Azure,DEM,13
+Grant,31,Commissioner of School and Public Lands,,Brock Greenfield,REP,39
+Grant,32,Commissioner of School and Public Lands,,Timothy Azure,DEM,22
+Grant,32,Commissioner of School and Public Lands,,Brock Greenfield,REP,57
+Grant,33,Commissioner of School and Public Lands,,Timothy Azure,DEM,91
+Grant,33,Commissioner of School and Public Lands,,Brock Greenfield,REP,246
+Grant,41,Commissioner of School and Public Lands,,Timothy Azure,DEM,61
+Grant,41,Commissioner of School and Public Lands,,Brock Greenfield,REP,137
+Grant,42,Commissioner of School and Public Lands,,Timothy Azure,DEM,52
+Grant,42,Commissioner of School and Public Lands,,Brock Greenfield,REP,189
+Grant,43,Commissioner of School and Public Lands,,Timothy Azure,DEM,87
+Grant,43,Commissioner of School and Public Lands,,Brock Greenfield,REP,244
+Grant,44,Commissioner of School and Public Lands,,Timothy Azure,DEM,24
+Grant,44,Commissioner of School and Public Lands,,Brock Greenfield,REP,76
+Grant,45,Commissioner of School and Public Lands,,Timothy Azure,DEM,37
+Grant,45,Commissioner of School and Public Lands,,Brock Greenfield,REP,95
+Grant,46,Commissioner of School and Public Lands,,Timothy Azure,DEM,39
+Grant,46,Commissioner of School and Public Lands,,Brock Greenfield,REP,146
+Grant,47,Commissioner of School and Public Lands,,Timothy Azure,DEM,32
+Grant,47,Commissioner of School and Public Lands,,Brock Greenfield,REP,150
+Grant,49,Commissioner of School and Public Lands,,Timothy Azure,DEM,21
+Grant,49,Commissioner of School and Public Lands,,Brock Greenfield,REP,72
+Grant,52,Commissioner of School and Public Lands,,Timothy Azure,DEM,10
+Grant,52,Commissioner of School and Public Lands,,Brock Greenfield,REP,54
+Grant,53,Commissioner of School and Public Lands,,Timothy Azure,DEM,12
+Grant,53,Commissioner of School and Public Lands,,Brock Greenfield,REP,38
+Grant,54,Commissioner of School and Public Lands,,Timothy Azure,DEM,34
+Grant,54,Commissioner of School and Public Lands,,Brock Greenfield,REP,99
+Grant,11,Public Utilities Commissioner,,Jeffrey Barth,DEM,66
+Grant,11,Public Utilities Commissioner,,Chris Nelson,REP,221
+Grant,12,Public Utilities Commissioner,,Jeffrey Barth,DEM,19
+Grant,12,Public Utilities Commissioner,,Chris Nelson,REP,55
+Grant,21,Public Utilities Commissioner,,Jeffrey Barth,DEM,27
+Grant,21,Public Utilities Commissioner,,Chris Nelson,REP,102
+Grant,22,Public Utilities Commissioner,,Jeffrey Barth,DEM,69
+Grant,22,Public Utilities Commissioner,,Chris Nelson,REP,231
+Grant,31,Public Utilities Commissioner,,Jeffrey Barth,DEM,15
+Grant,31,Public Utilities Commissioner,,Chris Nelson,REP,39
+Grant,32,Public Utilities Commissioner,,Jeffrey Barth,DEM,17
+Grant,32,Public Utilities Commissioner,,Chris Nelson,REP,62
+Grant,33,Public Utilities Commissioner,,Jeffrey Barth,DEM,79
+Grant,33,Public Utilities Commissioner,,Chris Nelson,REP,263
+Grant,41,Public Utilities Commissioner,,Jeffrey Barth,DEM,61
+Grant,41,Public Utilities Commissioner,,Chris Nelson,REP,142
+Grant,42,Public Utilities Commissioner,,Jeffrey Barth,DEM,47
+Grant,42,Public Utilities Commissioner,,Chris Nelson,REP,198
+Grant,43,Public Utilities Commissioner,,Jeffrey Barth,DEM,76
+Grant,43,Public Utilities Commissioner,,Chris Nelson,REP,265
+Grant,44,Public Utilities Commissioner,,Jeffrey Barth,DEM,24
+Grant,44,Public Utilities Commissioner,,Chris Nelson,REP,79
+Grant,45,Public Utilities Commissioner,,Jeffrey Barth,DEM,39
+Grant,45,Public Utilities Commissioner,,Chris Nelson,REP,99
+Grant,46,Public Utilities Commissioner,,Jeffrey Barth,DEM,37
+Grant,46,Public Utilities Commissioner,,Chris Nelson,REP,157
+Grant,47,Public Utilities Commissioner,,Jeffrey Barth,DEM,24
+Grant,47,Public Utilities Commissioner,,Chris Nelson,REP,162
+Grant,49,Public Utilities Commissioner,,Jeffrey Barth,DEM,21
+Grant,49,Public Utilities Commissioner,,Chris Nelson,REP,73
+Grant,52,Public Utilities Commissioner,,Jeffrey Barth,DEM,13
+Grant,52,Public Utilities Commissioner,,Chris Nelson,REP,53
+Grant,53,Public Utilities Commissioner,,Jeffrey Barth,DEM,11
+Grant,53,Public Utilities Commissioner,,Chris Nelson,REP,42
+Grant,54,Public Utilities Commissioner,,Jeffrey Barth,DEM,33
+Grant,54,Public Utilities Commissioner,,Chris Nelson,REP,107
+Grant,11,State Senate,04,John Wiik,REP,241
+Grant,12,State Senate,04,John Wiik,REP,53
+Grant,21,State Senate,04,John Wiik,REP,99
+Grant,22,State Senate,04,John Wiik,REP,234
+Grant,31,State Senate,04,John Wiik,REP,41
+Grant,32,State Senate,04,John Wiik,REP,65
+Grant,33,State Senate,04,John Wiik,REP,273
+Grant,41,State Senate,04,John Wiik,REP,141
+Grant,42,State Senate,04,John Wiik,REP,208
+Grant,43,State Senate,04,John Wiik,REP,268
+Grant,44,State Senate,04,John Wiik,REP,84
+Grant,45,State Senate,04,John Wiik,REP,103
+Grant,46,State Senate,04,John Wiik,REP,160
+Grant,47,State Senate,04,John Wiik,REP,160
+Grant,49,State Senate,04,John Wiik,REP,77
+Grant,52,State Senate,04,John Wiik,REP,57
+Grant,53,State Senate,04,John Wiik,REP,39
+Grant,54,State Senate,04,John Wiik,REP,109
+Grant,11,State House,04,Stephanie Sauder,REP,148
+Grant,11,State House,04,Fred Deutsch,REP,192
+Grant,12,State House,04,Stephanie Sauder,REP,35
+Grant,12,State House,04,Fred Deutsch,REP,47
+Grant,21,State House,04,Stephanie Sauder,REP,56
+Grant,21,State House,04,Fred Deutsch,REP,86
+Grant,22,State House,04,Stephanie Sauder,REP,162
+Grant,22,State House,04,Fred Deutsch,REP,187
+Grant,31,State House,04,Stephanie Sauder,REP,27
+Grant,31,State House,04,Fred Deutsch,REP,33
+Grant,32,State House,04,Stephanie Sauder,REP,37
+Grant,32,State House,04,Fred Deutsch,REP,55
+Grant,33,State House,04,Stephanie Sauder,REP,190
+Grant,33,State House,04,Fred Deutsch,REP,229
+Grant,41,State House,04,Stephanie Sauder,REP,105
+Grant,41,State House,04,Fred Deutsch,REP,120
+Grant,42,State House,04,Stephanie Sauder,REP,128
+Grant,42,State House,04,Fred Deutsch,REP,177
+Grant,43,State House,04,Stephanie Sauder,REP,160
+Grant,43,State House,04,Fred Deutsch,REP,242
+Grant,44,State House,04,Stephanie Sauder,REP,45
+Grant,44,State House,04,Fred Deutsch,REP,66
+Grant,45,State House,04,Stephanie Sauder,REP,58
+Grant,45,State House,04,Fred Deutsch,REP,91
+Grant,46,State House,04,Stephanie Sauder,REP,88
+Grant,46,State House,04,Fred Deutsch,REP,133
+Grant,47,State House,04,Stephanie Sauder,REP,103
+Grant,47,State House,04,Fred Deutsch,REP,152
+Grant,49,State House,04,Stephanie Sauder,REP,48
+Grant,49,State House,04,Fred Deutsch,REP,54
+Grant,52,State House,04,Stephanie Sauder,REP,25
+Grant,52,State House,04,Fred Deutsch,REP,49
+Grant,53,State House,04,Stephanie Sauder,REP,23
+Grant,53,State House,04,Fred Deutsch,REP,29
+Grant,54,State House,04,Stephanie Sauder,REP,70
+Grant,54,State House,04,Fred Deutsch,REP,98
+Grant,11,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,120
+Grant,12,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,33
+Grant,21,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,59
+Grant,22,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,154
+Grant,31,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,30
+Grant,32,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,37
+Grant,33,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,179
+Grant,41,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,100
+Grant,42,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,114
+Grant,43,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,168
+Grant,44,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,52
+Grant,45,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,66
+Grant,46,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,95
+Grant,47,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,103
+Grant,49,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,47
+Grant,52,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,28
+Grant,53,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,22
+Grant,54,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,72
+Grant,11,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,147
+Grant,12,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,38
+Grant,21,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,64
+Grant,22,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,162
+Grant,31,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,34
+Grant,32,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,41
+Grant,33,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,187
+Grant,41,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,107
+Grant,42,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,126
+Grant,43,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,178
+Grant,44,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,49
+Grant,45,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,72
+Grant,46,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,101
+Grant,47,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,114
+Grant,49,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,43
+Grant,52,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,35
+Grant,53,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,24
+Grant,54,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,77
+Grant,11,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,116
+Grant,12,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,33
+Grant,21,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,60
+Grant,22,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,147
+Grant,31,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,28
+Grant,32,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,37
+Grant,33,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,170
+Grant,41,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,91
+Grant,42,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,104
+Grant,43,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,162
+Grant,44,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,44
+Grant,45,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,63
+Grant,46,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,89
+Grant,47,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,100
+Grant,49,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,44
+Grant,52,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,27
+Grant,53,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,23
+Grant,54,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,69
+Grant,11,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,116
+Grant,12,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,31
+Grant,21,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,60
+Grant,22,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,148
+Grant,31,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,26
+Grant,32,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,36
+Grant,33,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,174
+Grant,41,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,102
+Grant,42,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,111
+Grant,43,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,158
+Grant,44,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,50
+Grant,45,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,66
+Grant,46,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,92
+Grant,47,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,102
+Grant,49,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,41
+Grant,52,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,27
+Grant,53,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,22
+Grant,54,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,66
+Grant,11,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,90
+Grant,11,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,80
+Grant,12,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,25
+Grant,12,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,22
+Grant,21,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,38
+Grant,21,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,44
+Grant,22,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,97
+Grant,22,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,112
+Grant,31,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,14
+Grant,31,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,21
+Grant,32,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,21
+Grant,32,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,27
+Grant,33,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,117
+Grant,33,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,111
+Grant,41,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,54
+Grant,41,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,66
+Grant,42,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,62
+Grant,42,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,81
+Grant,43,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,104
+Grant,43,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,107
+Grant,44,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,38
+Grant,44,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,19
+Grant,45,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,37
+Grant,45,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,47
+Grant,46,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,46
+Grant,46,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,71
+Grant,47,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,63
+Grant,47,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,71
+Grant,49,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,22
+Grant,49,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,28
+Grant,52,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,20
+Grant,52,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,21
+Grant,53,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,12
+Grant,53,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,16
+Grant,54,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,49
+Grant,54,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,42
+Grant,11,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,107
+Grant,12,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,33
+Grant,21,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,56
+Grant,22,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,143
+Grant,31,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,27
+Grant,32,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,36
+Grant,33,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,172
+Grant,41,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,93
+Grant,42,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,106
+Grant,43,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,155
+Grant,44,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,47
+Grant,45,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,67
+Grant,46,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,88
+Grant,47,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,100
+Grant,49,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,39
+Grant,52,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,27
+Grant,53,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,20
+Grant,54,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,64
+Grant,11,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,190
+Grant,11,Supreme Court Retention,3,Patricia J. DeVaney - No,,55
+Grant,12,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,52
+Grant,12,Supreme Court Retention,3,Patricia J. DeVaney - No,,14
+Grant,21,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,99
+Grant,21,Supreme Court Retention,3,Patricia J. DeVaney - No,,22
+Grant,22,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,223
+Grant,22,Supreme Court Retention,3,Patricia J. DeVaney - No,,42
+Grant,31,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,40
+Grant,31,Supreme Court Retention,3,Patricia J. DeVaney - No,,10
+Grant,32,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,54
+Grant,32,Supreme Court Retention,3,Patricia J. DeVaney - No,,13
+Grant,33,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,273
+Grant,33,Supreme Court Retention,3,Patricia J. DeVaney - No,,42
+Grant,41,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,136
+Grant,41,Supreme Court Retention,3,Patricia J. DeVaney - No,,37
+Grant,42,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,187
+Grant,42,Supreme Court Retention,3,Patricia J. DeVaney - No,,39
+Grant,43,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,268
+Grant,43,Supreme Court Retention,3,Patricia J. DeVaney - No,,48
+Grant,44,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,76
+Grant,44,Supreme Court Retention,3,Patricia J. DeVaney - No,,16
+Grant,45,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,104
+Grant,45,Supreme Court Retention,3,Patricia J. DeVaney - No,,14
+Grant,46,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,142
+Grant,46,Supreme Court Retention,3,Patricia J. DeVaney - No,,32
+Grant,47,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,143
+Grant,47,Supreme Court Retention,3,Patricia J. DeVaney - No,,21
+Grant,49,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,62
+Grant,49,Supreme Court Retention,3,Patricia J. DeVaney - No,,21
+Grant,52,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,47
+Grant,52,Supreme Court Retention,3,Patricia J. DeVaney - No,,12
+Grant,53,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,31
+Grant,53,Supreme Court Retention,3,Patricia J. DeVaney - No,,12
+Grant,54,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,106
+Grant,54,Supreme Court Retention,3,Patricia J. DeVaney - No,,25
+Grant,11,Supreme Court Retention,2,Mark E. Salter - Yes,,197
+Grant,11,Supreme Court Retention,2,Mark E. Salter - No,,50
+Grant,12,Supreme Court Retention,2,Mark E. Salter - Yes,,51
+Grant,12,Supreme Court Retention,2,Mark E. Salter - No,,14
+Grant,21,Supreme Court Retention,2,Mark E. Salter - Yes,,102
+Grant,21,Supreme Court Retention,2,Mark E. Salter - No,,19
+Grant,22,Supreme Court Retention,2,Mark E. Salter - Yes,,220
+Grant,22,Supreme Court Retention,2,Mark E. Salter - No,,43
+Grant,31,Supreme Court Retention,2,Mark E. Salter - Yes,,42
+Grant,31,Supreme Court Retention,2,Mark E. Salter - No,,9
+Grant,32,Supreme Court Retention,2,Mark E. Salter - Yes,,54
+Grant,32,Supreme Court Retention,2,Mark E. Salter - No,,12
+Grant,33,Supreme Court Retention,2,Mark E. Salter - Yes,,275
+Grant,33,Supreme Court Retention,2,Mark E. Salter - No,,44
+Grant,41,Supreme Court Retention,2,Mark E. Salter - Yes,,139
+Grant,41,Supreme Court Retention,2,Mark E. Salter - No,,34
+Grant,42,Supreme Court Retention,2,Mark E. Salter - Yes,,189
+Grant,42,Supreme Court Retention,2,Mark E. Salter - No,,35
+Grant,43,Supreme Court Retention,2,Mark E. Salter - Yes,,269
+Grant,43,Supreme Court Retention,2,Mark E. Salter - No,,44
+Grant,44,Supreme Court Retention,2,Mark E. Salter - Yes,,77
+Grant,44,Supreme Court Retention,2,Mark E. Salter - No,,15
+Grant,45,Supreme Court Retention,2,Mark E. Salter - Yes,,102
+Grant,45,Supreme Court Retention,2,Mark E. Salter - No,,17
+Grant,46,Supreme Court Retention,2,Mark E. Salter - Yes,,144
+Grant,46,Supreme Court Retention,2,Mark E. Salter - No,,27
+Grant,47,Supreme Court Retention,2,Mark E. Salter - Yes,,142
+Grant,47,Supreme Court Retention,2,Mark E. Salter - No,,24
+Grant,49,Supreme Court Retention,2,Mark E. Salter - Yes,,63
+Grant,49,Supreme Court Retention,2,Mark E. Salter - No,,20
+Grant,52,Supreme Court Retention,2,Mark E. Salter - Yes,,46
+Grant,52,Supreme Court Retention,2,Mark E. Salter - No,,12
+Grant,53,Supreme Court Retention,2,Mark E. Salter - Yes,,29
+Grant,53,Supreme Court Retention,2,Mark E. Salter - No,,13
+Grant,54,Supreme Court Retention,2,Mark E. Salter - Yes,,103
+Grant,54,Supreme Court Retention,2,Mark E. Salter - No,,26
+Grant,11,Constitutional Amendment D,,Yes,,150
+Grant,11,Constitutional Amendment D,,No,,140
+Grant,12,Constitutional Amendment D,,Yes,,33
+Grant,12,Constitutional Amendment D,,No,,41
+Grant,21,Constitutional Amendment D,,Yes,,73
+Grant,21,Constitutional Amendment D,,No,,57
+Grant,22,Constitutional Amendment D,,Yes,,158
+Grant,22,Constitutional Amendment D,,No,,156
+Grant,31,Constitutional Amendment D,,Yes,,33
+Grant,31,Constitutional Amendment D,,No,,22
+Grant,32,Constitutional Amendment D,,Yes,,42
+Grant,32,Constitutional Amendment D,,No,,40
+Grant,33,Constitutional Amendment D,,Yes,,183
+Grant,33,Constitutional Amendment D,,No,,172
+Grant,41,Constitutional Amendment D,,Yes,,107
+Grant,41,Constitutional Amendment D,,No,,95
+Grant,42,Constitutional Amendment D,,Yes,,105
+Grant,42,Constitutional Amendment D,,No,,149
+Grant,43,Constitutional Amendment D,,Yes,,175
+Grant,43,Constitutional Amendment D,,No,,178
+Grant,44,Constitutional Amendment D,,Yes,,52
+Grant,44,Constitutional Amendment D,,No,,54
+Grant,45,Constitutional Amendment D,,Yes,,66
+Grant,45,Constitutional Amendment D,,No,,72
+Grant,46,Constitutional Amendment D,,Yes,,83
+Grant,46,Constitutional Amendment D,,No,,112
+Grant,47,Constitutional Amendment D,,Yes,,75
+Grant,47,Constitutional Amendment D,,No,,107
+Grant,49,Constitutional Amendment D,,Yes,,35
+Grant,49,Constitutional Amendment D,,No,,58
+Grant,52,Constitutional Amendment D,,Yes,,36
+Grant,52,Constitutional Amendment D,,No,,37
+Grant,53,Constitutional Amendment D,,Yes,,35
+Grant,53,Constitutional Amendment D,,No,,20
+Grant,54,Constitutional Amendment D,,Yes,,65
+Grant,54,Constitutional Amendment D,,No,,81
+Grant,11,Initiated Measure 27,,Yes,,124
+Grant,11,Initiated Measure 27,,No,,176
+Grant,12,Initiated Measure 27,,Yes,,30
+Grant,12,Initiated Measure 27,,No,,44
+Grant,21,Initiated Measure 27,,Yes,,64
+Grant,21,Initiated Measure 27,,No,,68
+Grant,22,Initiated Measure 27,,Yes,,137
+Grant,22,Initiated Measure 27,,No,,175
+Grant,31,Initiated Measure 27,,Yes,,26
+Grant,31,Initiated Measure 27,,No,,29
+Grant,32,Initiated Measure 27,,Yes,,42
+Grant,32,Initiated Measure 27,,No,,40
+Grant,33,Initiated Measure 27,,Yes,,150
+Grant,33,Initiated Measure 27,,No,,215
+Grant,41,Initiated Measure 27,,Yes,,73
+Grant,41,Initiated Measure 27,,No,,135
+Grant,42,Initiated Measure 27,,Yes,,82
+Grant,42,Initiated Measure 27,,No,,178
+Grant,43,Initiated Measure 27,,Yes,,135
+Grant,43,Initiated Measure 27,,No,,222
+Grant,44,Initiated Measure 27,,Yes,,32
+Grant,44,Initiated Measure 27,,No,,77
+Grant,45,Initiated Measure 27,,Yes,,48
+Grant,45,Initiated Measure 27,,No,,92
+Grant,46,Initiated Measure 27,,Yes,,72
+Grant,46,Initiated Measure 27,,No,,126
+Grant,47,Initiated Measure 27,,Yes,,51
+Grant,47,Initiated Measure 27,,No,,133
+Grant,49,Initiated Measure 27,,Yes,,36
+Grant,49,Initiated Measure 27,,No,,62
+Grant,52,Initiated Measure 27,,Yes,,27
+Grant,52,Initiated Measure 27,,No,,48
+Grant,53,Initiated Measure 27,,Yes,,32
+Grant,53,Initiated Measure 27,,No,,25
+Grant,54,Initiated Measure 27,,Yes,,52
+Grant,54,Initiated Measure 27,,No,,98

--- a/2022/counties/20221108__sd__general__gregory__precinct.csv
+++ b/2022/counties/20221108__sd__general__gregory__precinct.csv
@@ -1,0 +1,109 @@
+county,precinct,office,district,candidate,party,votes
+Gregory,1,U.S. Senate,,Brian L. Bengs,DEM,119
+Gregory,1,U.S. Senate,,Tamara J Lesnar,LIB,49
+Gregory,1,U.S. Senate,,John R. Thune,REP,765
+Gregory,2,U.S. Senate,,Brian L. Bengs,DEM,105
+Gregory,2,U.S. Senate,,Tamara J Lesnar,LIB,27
+Gregory,2,U.S. Senate,,John R. Thune,REP,589
+Gregory,3,U.S. Senate,,Brian L. Bengs,DEM,55
+Gregory,3,U.S. Senate,,Tamara J Lesnar,LIB,6
+Gregory,3,U.S. Senate,,John R. Thune,REP,309
+Gregory,1,U.S. House,1,Collin Duprel,LIB,148
+Gregory,1,U.S. House,1,Dusty Johnson,REP,763
+Gregory,2,U.S. House,1,Collin Duprel,LIB,94
+Gregory,2,U.S. House,1,Dusty Johnson,REP,609
+Gregory,3,U.S. House,1,Collin Duprel,LIB,38
+Gregory,3,U.S. House,1,Dusty Johnson,REP,318
+Gregory,1,Governor,,Jamie Smith and Jennifer Keintz,DEM,175
+Gregory,1,Governor,,Tracey Quint and Ashley Strand,LIB,22
+Gregory,1,Governor,,Kristi Noem and Larry Rhoden,REP,756
+Gregory,2,Governor,,Jamie Smith and Jennifer Keintz,DEM,148
+Gregory,2,Governor,,Tracey Quint and Ashley Strand,LIB,17
+Gregory,2,Governor,,Kristi Noem and Larry Rhoden,REP,564
+Gregory,3,Governor,,Jamie Smith and Jennifer Keintz,DEM,70
+Gregory,3,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Gregory,3,Governor,,Kristi Noem and Larry Rhoden,REP,298
+Gregory,1,Secretary of State,,Thomas A Cool,DEM,207
+Gregory,1,Secretary of State,,Monae Johnson,REP,699
+Gregory,2,Secretary of State,,Thomas A Cool,DEM,181
+Gregory,2,Secretary of State,,Monae Johnson,REP,521
+Gregory,3,Secretary of State,,Thomas A Cool,DEM,74
+Gregory,3,Secretary of State,,Monae Johnson,REP,277
+Gregory,1,Attorney General,,Marty J. Jackley,REP,756
+Gregory,2,Attorney General,,Marty J. Jackley,REP,582
+Gregory,3,Attorney General,,Marty J. Jackley,REP,297
+Gregory,1,State Auditor,,Stephanie Marty,DEM,174
+Gregory,1,State Auditor,,Rene Meyer,LIB,38
+Gregory,1,State Auditor,,Richard Sattgast,REP,693
+Gregory,2,State Auditor,,Stephanie Marty,DEM,146
+Gregory,2,State Auditor,,Rene Meyer,LIB,32
+Gregory,2,State Auditor,,Richard Sattgast,REP,512
+Gregory,3,State Auditor,,Stephanie Marty,DEM,57
+Gregory,3,State Auditor,,Rene Meyer,LIB,10
+Gregory,3,State Auditor,,Richard Sattgast,REP,270
+Gregory,1,State Treasurer,,John Cunningham,DEM,188
+Gregory,1,State Treasurer,,Josh Haeder,REP,719
+Gregory,2,State Treasurer,,John Cunningham,DEM,141
+Gregory,2,State Treasurer,,Josh Haeder,REP,534
+Gregory,3,State Treasurer,,John Cunningham,DEM,62
+Gregory,3,State Treasurer,,Josh Haeder,REP,280
+Gregory,1,Commissioner of School and Public Lands,,Timothy Azure,DEM,164
+Gregory,1,Commissioner of School and Public Lands,,Brock Greenfield,REP,726
+Gregory,2,Commissioner of School and Public Lands,,Timothy Azure,DEM,137
+Gregory,2,Commissioner of School and Public Lands,,Brock Greenfield,REP,537
+Gregory,3,Commissioner of School and Public Lands,,Timothy Azure,DEM,59
+Gregory,3,Commissioner of School and Public Lands,,Brock Greenfield,REP,283
+Gregory,1,Public Utilities Commissioner,,Jeffrey Barth,DEM,155
+Gregory,1,Public Utilities Commissioner,,Chris Nelson,REP,752
+Gregory,2,Public Utilities Commissioner,,Jeffrey Barth,DEM,132
+Gregory,2,Public Utilities Commissioner,,Chris Nelson,REP,566
+Gregory,3,Public Utilities Commissioner,,Jeffrey Barth,DEM,58
+Gregory,3,Public Utilities Commissioner,,Chris Nelson,REP,289
+Gregory,1,State Senate,21,Dan Andersson,DEM,131
+Gregory,1,State Senate,21,Erin Tobin,REP,807
+Gregory,2,State Senate,21,Dan Andersson,DEM,109
+Gregory,2,State Senate,21,Erin Tobin,REP,607
+Gregory,3,State Senate,21,Dan Andersson,DEM,49
+Gregory,3,State Senate,21,Erin Tobin,REP,312
+Gregory,1,State House,21,Rocky Blare,REP,625
+Gregory,1,State House,21,Marty Overweg,REP,431
+Gregory,2,State House,21,Rocky Blare,REP,475
+Gregory,2,State House,21,Marty Overweg,REP,368
+Gregory,3,State House,21,Rocky Blare,REP,203
+Gregory,3,State House,21,Marty Overweg,REP,195
+Gregory,1,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,373
+Gregory,2,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,337
+Gregory,3,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,126
+Gregory,1,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,355
+Gregory,2,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,321
+Gregory,3,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,120
+Gregory,1,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,358
+Gregory,2,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,326
+Gregory,3,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,123
+Gregory,1,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,416
+Gregory,2,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,381
+Gregory,3,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,119
+Gregory,1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,656
+Gregory,1,Supreme Court Retention,3,Patricia J. DeVaney - No,,156
+Gregory,2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,521
+Gregory,2,Supreme Court Retention,3,Patricia J. DeVaney - No,,119
+Gregory,3,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,239
+Gregory,3,Supreme Court Retention,3,Patricia J. DeVaney - No,,57
+Gregory,1,Supreme Court Retention,2,Mark E. Salter - Yes,,656
+Gregory,1,Supreme Court Retention,2,Mark E. Salter - No,,155
+Gregory,2,Supreme Court Retention,2,Mark E. Salter - Yes,,521
+Gregory,2,Supreme Court Retention,2,Mark E. Salter - No,,113
+Gregory,3,Supreme Court Retention,2,Mark E. Salter - Yes,,250
+Gregory,3,Supreme Court Retention,2,Mark E. Salter - No,,44
+Gregory,1,Constitutional Amendment D,,Yes,,433
+Gregory,1,Constitutional Amendment D,,No,,488
+Gregory,2,Constitutional Amendment D,,Yes,,337
+Gregory,2,Constitutional Amendment D,,No,,376
+Gregory,3,Constitutional Amendment D,,Yes,,156
+Gregory,3,Constitutional Amendment D,,No,,198
+Gregory,1,Initiated Measure 27,,Yes,,287
+Gregory,1,Initiated Measure 27,,No,,644
+Gregory,2,Initiated Measure 27,,Yes,,224
+Gregory,2,Initiated Measure 27,,No,,496
+Gregory,3,Initiated Measure 27,,Yes,,76
+Gregory,3,Initiated Measure 27,,No,,285

--- a/2022/counties/20221108__sd__general__haakon__precinct.csv
+++ b/2022/counties/20221108__sd__general__haakon__precinct.csv
@@ -1,0 +1,176 @@
+county,precinct,office,district,candidate,party,votes
+Haakon,Absentee Precinct,U.S. Senate,,Brian L. Bengs,DEM,17
+Haakon,Absentee Precinct,U.S. Senate,,Tamara J Lesnar,LIB,9
+Haakon,Absentee Precinct,U.S. Senate,,John R. Thune,REP,239
+Haakon,?,U.S. Senate,,Brian L. Bengs,DEM,28
+Haakon,?,U.S. Senate,,Tamara J Lesnar,LIB,25
+Haakon,?,U.S. Senate,,John R. Thune,REP,397
+Haakon,Deep Creek Church,U.S. Senate,,Brian L. Bengs,DEM,5
+Haakon,Deep Creek Church,U.S. Senate,,Tamara J Lesnar,LIB,2
+Haakon,Deep Creek Church,U.S. Senate,,John R. Thune,REP,45
+Haakon,Midland Fire Hall,U.S. Senate,,Brian L. Bengs,DEM,4
+Haakon,Midland Fire Hall,U.S. Senate,,Tamara J Lesnar,LIB,8
+Haakon,Midland Fire Hall,U.S. Senate,,John R. Thune,REP,116
+Haakon,Milesville Hall,U.S. Senate,,Brian L. Bengs,DEM,2
+Haakon,Milesville Hall,U.S. Senate,,Tamara J Lesnar,LIB,6
+Haakon,Milesville Hall,U.S. Senate,,John R. Thune,REP,67
+Haakon,Absentee Precinct,U.S. House,1,Collin Duprel,LIB,38
+Haakon,Absentee Precinct,U.S. House,1,Dusty Johnson,REP,222
+Haakon,?,U.S. House,1,Collin Duprel,LIB,86
+Haakon,?,U.S. House,1,Dusty Johnson,REP,359
+Haakon,Deep Creek Church,U.S. House,1,Collin Duprel,LIB,8
+Haakon,Deep Creek Church,U.S. House,1,Dusty Johnson,REP,42
+Haakon,Midland Fire Hall,U.S. House,1,Collin Duprel,LIB,20
+Haakon,Midland Fire Hall,U.S. House,1,Dusty Johnson,REP,106
+Haakon,Milesville Hall,U.S. House,1,Collin Duprel,LIB,13
+Haakon,Milesville Hall,U.S. House,1,Dusty Johnson,REP,62
+Haakon,Absentee Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,24
+Haakon,Absentee Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Haakon,Absentee Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,240
+Haakon,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,46
+Haakon,?,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Haakon,?,Governor,,Kristi Noem and Larry Rhoden,REP,411
+Haakon,Deep Creek Church,Governor,,Jamie Smith and Jennifer Keintz,DEM,3
+Haakon,Deep Creek Church,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Haakon,Deep Creek Church,Governor,,Kristi Noem and Larry Rhoden,REP,47
+Haakon,Midland Fire Hall,Governor,,Jamie Smith and Jennifer Keintz,DEM,7
+Haakon,Midland Fire Hall,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Haakon,Midland Fire Hall,Governor,,Kristi Noem and Larry Rhoden,REP,124
+Haakon,Milesville Hall,Governor,,Jamie Smith and Jennifer Keintz,DEM,2
+Haakon,Milesville Hall,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Haakon,Milesville Hall,Governor,,Kristi Noem and Larry Rhoden,REP,70
+Haakon,Absentee Precinct,Secretary of State,,Thomas A Cool,DEM,29
+Haakon,Absentee Precinct,Secretary of State,,Monae Johnson,REP,224
+Haakon,?,Secretary of State,,Thomas A Cool,DEM,51
+Haakon,?,Secretary of State,,Monae Johnson,REP,403
+Haakon,Deep Creek Church,Secretary of State,,Thomas A Cool,DEM,6
+Haakon,Deep Creek Church,Secretary of State,,Monae Johnson,REP,46
+Haakon,Midland Fire Hall,Secretary of State,,Thomas A Cool,DEM,6
+Haakon,Midland Fire Hall,Secretary of State,,Monae Johnson,REP,115
+Haakon,Milesville Hall,Secretary of State,,Thomas A Cool,DEM,2
+Haakon,Milesville Hall,Secretary of State,,Monae Johnson,REP,68
+Haakon,Absentee Precinct,Attorney General,,Marty J. Jackley,REP,238
+Haakon,?,Attorney General,,Marty J. Jackley,REP,407
+Haakon,Deep Creek Church,Attorney General,,Marty J. Jackley,REP,41
+Haakon,Midland Fire Hall,Attorney General,,Marty J. Jackley,REP,114
+Haakon,Milesville Hall,Attorney General,,Marty J. Jackley,REP,70
+Haakon,Absentee Precinct,State Auditor,,Stephanie Marty,DEM,23
+Haakon,Absentee Precinct,State Auditor,,Rene Meyer,LIB,7
+Haakon,Absentee Precinct,State Auditor,,Richard Sattgast,REP,224
+Haakon,?,State Auditor,,Stephanie Marty,DEM,42
+Haakon,?,State Auditor,,Rene Meyer,LIB,22
+Haakon,?,State Auditor,,Richard Sattgast,REP,378
+Haakon,Deep Creek Church,State Auditor,,Stephanie Marty,DEM,5
+Haakon,Deep Creek Church,State Auditor,,Rene Meyer,LIB,0
+Haakon,Deep Creek Church,State Auditor,,Richard Sattgast,REP,45
+Haakon,Midland Fire Hall,State Auditor,,Stephanie Marty,DEM,6
+Haakon,Midland Fire Hall,State Auditor,,Rene Meyer,LIB,4
+Haakon,Midland Fire Hall,State Auditor,,Richard Sattgast,REP,110
+Haakon,Milesville Hall,State Auditor,,Stephanie Marty,DEM,2
+Haakon,Milesville Hall,State Auditor,,Rene Meyer,LIB,2
+Haakon,Milesville Hall,State Auditor,,Richard Sattgast,REP,69
+Haakon,Absentee Precinct,State Treasurer,,John Cunningham,DEM,22
+Haakon,Absentee Precinct,State Treasurer,,Josh Haeder,REP,228
+Haakon,?,State Treasurer,,John Cunningham,DEM,46
+Haakon,?,State Treasurer,,Josh Haeder,REP,393
+Haakon,Deep Creek Church,State Treasurer,,John Cunningham,DEM,6
+Haakon,Deep Creek Church,State Treasurer,,Josh Haeder,REP,43
+Haakon,Midland Fire Hall,State Treasurer,,John Cunningham,DEM,7
+Haakon,Midland Fire Hall,State Treasurer,,Josh Haeder,REP,113
+Haakon,Milesville Hall,State Treasurer,,John Cunningham,DEM,3
+Haakon,Milesville Hall,State Treasurer,,Josh Haeder,REP,69
+Haakon,Absentee Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,21
+Haakon,Absentee Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,233
+Haakon,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,48
+Haakon,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,392
+Haakon,Deep Creek Church,Commissioner of School and Public Lands,,Timothy Azure,DEM,5
+Haakon,Deep Creek Church,Commissioner of School and Public Lands,,Brock Greenfield,REP,45
+Haakon,Midland Fire Hall,Commissioner of School and Public Lands,,Timothy Azure,DEM,6
+Haakon,Midland Fire Hall,Commissioner of School and Public Lands,,Brock Greenfield,REP,111
+Haakon,Milesville Hall,Commissioner of School and Public Lands,,Timothy Azure,DEM,3
+Haakon,Milesville Hall,Commissioner of School and Public Lands,,Brock Greenfield,REP,69
+Haakon,Absentee Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,23
+Haakon,Absentee Precinct,Public Utilities Commissioner,,Chris Nelson,REP,233
+Haakon,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,43
+Haakon,?,Public Utilities Commissioner,,Chris Nelson,REP,402
+Haakon,Deep Creek Church,Public Utilities Commissioner,,Jeffrey Barth,DEM,6
+Haakon,Deep Creek Church,Public Utilities Commissioner,,Chris Nelson,REP,44
+Haakon,Midland Fire Hall,Public Utilities Commissioner,,Jeffrey Barth,DEM,8
+Haakon,Midland Fire Hall,Public Utilities Commissioner,,Chris Nelson,REP,116
+Haakon,Milesville Hall,Public Utilities Commissioner,,Jeffrey Barth,DEM,1
+Haakon,Milesville Hall,Public Utilities Commissioner,,Chris Nelson,REP,72
+Haakon,Absentee Precinct,State Senate,24,Jim Mehlhaff,REP,221
+Haakon,?,State Senate,24,Jim Mehlhaff,REP,392
+Haakon,Deep Creek Church,State Senate,24,Jim Mehlhaff,REP,41
+Haakon,Midland Fire Hall,State Senate,24,Jim Mehlhaff,REP,108
+Haakon,Milesville Hall,State Senate,24,Jim Mehlhaff,REP,73
+Haakon,Absentee Precinct,State House,24,Mike Weisgram,REP,143
+Haakon,Absentee Precinct,State House,24,Will D. Mortenson,REP,193
+Haakon,?,State House,24,Mike Weisgram,REP,224
+Haakon,?,State House,24,Will D. Mortenson,REP,345
+Haakon,Deep Creek Church,State House,24,Mike Weisgram,REP,21
+Haakon,Deep Creek Church,State House,24,Will D. Mortenson,REP,45
+Haakon,Midland Fire Hall,State House,24,Mike Weisgram,REP,58
+Haakon,Midland Fire Hall,State House,24,Will D. Mortenson,REP,105
+Haakon,Milesville Hall,State House,24,Mike Weisgram,REP,41
+Haakon,Milesville Hall,State House,24,Will D. Mortenson,REP,64
+Haakon,Absentee Precinct,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,146
+Haakon,?,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,228
+Haakon,Deep Creek Church,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,28
+Haakon,Midland Fire Hall,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,61
+Haakon,Milesville Hall,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,37
+Haakon,Absentee Precinct,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,143
+Haakon,?,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,221
+Haakon,Deep Creek Church,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,26
+Haakon,Midland Fire Hall,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,63
+Haakon,Milesville Hall,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,36
+Haakon,Absentee Precinct,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,135
+Haakon,?,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,228
+Haakon,Deep Creek Church,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,23
+Haakon,Midland Fire Hall,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,61
+Haakon,Milesville Hall,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,37
+Haakon,Absentee Precinct,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,136
+Haakon,?,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,220
+Haakon,Deep Creek Church,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,24
+Haakon,Midland Fire Hall,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,60
+Haakon,Milesville Hall,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,37
+Haakon,Absentee Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,189
+Haakon,Absentee Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,31
+Haakon,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,322
+Haakon,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,79
+Haakon,Deep Creek Church,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,36
+Haakon,Deep Creek Church,Supreme Court Retention,3,Patricia J. DeVaney - No,,10
+Haakon,Midland Fire Hall,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,89
+Haakon,Midland Fire Hall,Supreme Court Retention,3,Patricia J. DeVaney - No,,17
+Haakon,Milesville Hall,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,50
+Haakon,Milesville Hall,Supreme Court Retention,3,Patricia J. DeVaney - No,,8
+Haakon,Absentee Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,195
+Haakon,Absentee Precinct,Supreme Court Retention,2,Mark E. Salter - No,,25
+Haakon,?,Supreme Court Retention,2,Mark E. Salter - Yes,,324
+Haakon,?,Supreme Court Retention,2,Mark E. Salter - No,,74
+Haakon,Deep Creek Church,Supreme Court Retention,2,Mark E. Salter - Yes,,36
+Haakon,Deep Creek Church,Supreme Court Retention,2,Mark E. Salter - No,,9
+Haakon,Midland Fire Hall,Supreme Court Retention,2,Mark E. Salter - Yes,,84
+Haakon,Midland Fire Hall,Supreme Court Retention,2,Mark E. Salter - No,,21
+Haakon,Milesville Hall,Supreme Court Retention,2,Mark E. Salter - Yes,,52
+Haakon,Milesville Hall,Supreme Court Retention,2,Mark E. Salter - No,,5
+Haakon,Absentee Precinct,Constitutional Amendment D,,Yes,,90
+Haakon,Absentee Precinct,Constitutional Amendment D,,No,,168
+Haakon,?,Constitutional Amendment D,,Yes,,142
+Haakon,?,Constitutional Amendment D,,No,,307
+Haakon,Deep Creek Church,Constitutional Amendment D,,Yes,,19
+Haakon,Deep Creek Church,Constitutional Amendment D,,No,,31
+Haakon,Midland Fire Hall,Constitutional Amendment D,,Yes,,37
+Haakon,Midland Fire Hall,Constitutional Amendment D,,No,,90
+Haakon,Milesville Hall,Constitutional Amendment D,,Yes,,16
+Haakon,Milesville Hall,Constitutional Amendment D,,No,,56
+Haakon,Absentee Precinct,Initiated Measure 27,,Yes,,45
+Haakon,Absentee Precinct,Initiated Measure 27,,No,,217
+Haakon,?,Initiated Measure 27,,Yes,,95
+Haakon,?,Initiated Measure 27,,No,,360
+Haakon,Deep Creek Church,Initiated Measure 27,,Yes,,10
+Haakon,Deep Creek Church,Initiated Measure 27,,No,,41
+Haakon,Midland Fire Hall,Initiated Measure 27,,Yes,,17
+Haakon,Midland Fire Hall,Initiated Measure 27,,No,,114
+Haakon,Milesville Hall,Initiated Measure 27,,Yes,,9
+Haakon,Milesville Hall,Initiated Measure 27,,No,,67

--- a/2022/counties/20221108__sd__general__hamlin__precinct.csv
+++ b/2022/counties/20221108__sd__general__hamlin__precinct.csv
@@ -1,0 +1,267 @@
+county,precinct,office,district,candidate,party,votes
+Hamlin,02,U.S. Senate,,Brian L. Bengs,DEM,12
+Hamlin,02,U.S. Senate,,Tamara J Lesnar,LIB,3
+Hamlin,02,U.S. Senate,,John R. Thune,REP,130
+Hamlin,21,U.S. Senate,,Brian L. Bengs,DEM,105
+Hamlin,21,U.S. Senate,,Tamara J Lesnar,LIB,23
+Hamlin,21,U.S. Senate,,John R. Thune,REP,565
+Hamlin,22,U.S. Senate,,Brian L. Bengs,DEM,7
+Hamlin,22,U.S. Senate,,Tamara J Lesnar,LIB,12
+Hamlin,22,U.S. Senate,,John R. Thune,REP,101
+Hamlin,23,U.S. Senate,,Brian L. Bengs,DEM,28
+Hamlin,23,U.S. Senate,,Tamara J Lesnar,LIB,14
+Hamlin,23,U.S. Senate,,John R. Thune,REP,232
+Hamlin,24,U.S. Senate,,Brian L. Bengs,DEM,80
+Hamlin,24,U.S. Senate,,Tamara J Lesnar,LIB,32
+Hamlin,24,U.S. Senate,,John R. Thune,REP,511
+Hamlin,25,U.S. Senate,,Brian L. Bengs,DEM,114
+Hamlin,25,U.S. Senate,,Tamara J Lesnar,LIB,17
+Hamlin,25,U.S. Senate,,John R. Thune,REP,331
+Hamlin,26,U.S. Senate,,Brian L. Bengs,DEM,20
+Hamlin,26,U.S. Senate,,Tamara J Lesnar,LIB,22
+Hamlin,26,U.S. Senate,,John R. Thune,REP,344
+Hamlin,02,U.S. House,1,Collin Duprel,LIB,9
+Hamlin,02,U.S. House,1,Dusty Johnson,REP,129
+Hamlin,21,U.S. House,1,Collin Duprel,LIB,92
+Hamlin,21,U.S. House,1,Dusty Johnson,REP,576
+Hamlin,22,U.S. House,1,Collin Duprel,LIB,19
+Hamlin,22,U.S. House,1,Dusty Johnson,REP,100
+Hamlin,23,U.S. House,1,Collin Duprel,LIB,39
+Hamlin,23,U.S. House,1,Dusty Johnson,REP,226
+Hamlin,24,U.S. House,1,Collin Duprel,LIB,84
+Hamlin,24,U.S. House,1,Dusty Johnson,REP,523
+Hamlin,25,U.S. House,1,Collin Duprel,LIB,73
+Hamlin,25,U.S. House,1,Dusty Johnson,REP,367
+Hamlin,26,U.S. House,1,Collin Duprel,LIB,50
+Hamlin,26,U.S. House,1,Dusty Johnson,REP,334
+Hamlin,02,Governor,,Jamie Smith and Jennifer Keintz,DEM,19
+Hamlin,02,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Hamlin,02,Governor,,Kristi Noem and Larry Rhoden,REP,123
+Hamlin,21,Governor,,Jamie Smith and Jennifer Keintz,DEM,159
+Hamlin,21,Governor,,Tracey Quint and Ashley Strand,LIB,14
+Hamlin,21,Governor,,Kristi Noem and Larry Rhoden,REP,523
+Hamlin,22,Governor,,Jamie Smith and Jennifer Keintz,DEM,9
+Hamlin,22,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Hamlin,22,Governor,,Kristi Noem and Larry Rhoden,REP,114
+Hamlin,23,Governor,,Jamie Smith and Jennifer Keintz,DEM,50
+Hamlin,23,Governor,,Tracey Quint and Ashley Strand,LIB,6
+Hamlin,23,Governor,,Kristi Noem and Larry Rhoden,REP,222
+Hamlin,24,Governor,,Jamie Smith and Jennifer Keintz,DEM,104
+Hamlin,24,Governor,,Tracey Quint and Ashley Strand,LIB,13
+Hamlin,24,Governor,,Kristi Noem and Larry Rhoden,REP,509
+Hamlin,25,Governor,,Jamie Smith and Jennifer Keintz,DEM,164
+Hamlin,25,Governor,,Tracey Quint and Ashley Strand,LIB,18
+Hamlin,25,Governor,,Kristi Noem and Larry Rhoden,REP,283
+Hamlin,26,Governor,,Jamie Smith and Jennifer Keintz,DEM,43
+Hamlin,26,Governor,,Tracey Quint and Ashley Strand,LIB,8
+Hamlin,26,Governor,,Kristi Noem and Larry Rhoden,REP,344
+Hamlin,02,Secretary of State,,Thomas A Cool,DEM,22
+Hamlin,02,Secretary of State,,Monae Johnson,REP,117
+Hamlin,21,Secretary of State,,Thomas A Cool,DEM,153
+Hamlin,21,Secretary of State,,Monae Johnson,REP,496
+Hamlin,22,Secretary of State,,Thomas A Cool,DEM,12
+Hamlin,22,Secretary of State,,Monae Johnson,REP,106
+Hamlin,23,Secretary of State,,Thomas A Cool,DEM,49
+Hamlin,23,Secretary of State,,Monae Johnson,REP,214
+Hamlin,24,Secretary of State,,Thomas A Cool,DEM,117
+Hamlin,24,Secretary of State,,Monae Johnson,REP,483
+Hamlin,25,Secretary of State,,Thomas A Cool,DEM,159
+Hamlin,25,Secretary of State,,Monae Johnson,REP,278
+Hamlin,26,Secretary of State,,Thomas A Cool,DEM,39
+Hamlin,26,Secretary of State,,Monae Johnson,REP,327
+Hamlin,02,Attorney General,,Marty J. Jackley,REP,125
+Hamlin,21,Attorney General,,Marty J. Jackley,REP,571
+Hamlin,22,Attorney General,,Marty J. Jackley,REP,108
+Hamlin,23,Attorney General,,Marty J. Jackley,REP,243
+Hamlin,24,Attorney General,,Marty J. Jackley,REP,507
+Hamlin,25,Attorney General,,Marty J. Jackley,REP,350
+Hamlin,26,Attorney General,,Marty J. Jackley,REP,342
+Hamlin,02,State Auditor,,Stephanie Marty,DEM,16
+Hamlin,02,State Auditor,,Rene Meyer,LIB,6
+Hamlin,02,State Auditor,,Richard Sattgast,REP,117
+Hamlin,21,State Auditor,,Stephanie Marty,DEM,140
+Hamlin,21,State Auditor,,Rene Meyer,LIB,27
+Hamlin,21,State Auditor,,Richard Sattgast,REP,481
+Hamlin,22,State Auditor,,Stephanie Marty,DEM,10
+Hamlin,22,State Auditor,,Rene Meyer,LIB,3
+Hamlin,22,State Auditor,,Richard Sattgast,REP,103
+Hamlin,23,State Auditor,,Stephanie Marty,DEM,37
+Hamlin,23,State Auditor,,Rene Meyer,LIB,8
+Hamlin,23,State Auditor,,Richard Sattgast,REP,216
+Hamlin,24,State Auditor,,Stephanie Marty,DEM,101
+Hamlin,24,State Auditor,,Rene Meyer,LIB,27
+Hamlin,24,State Auditor,,Richard Sattgast,REP,460
+Hamlin,25,State Auditor,,Stephanie Marty,DEM,139
+Hamlin,25,State Auditor,,Rene Meyer,LIB,22
+Hamlin,25,State Auditor,,Richard Sattgast,REP,277
+Hamlin,26,State Auditor,,Stephanie Marty,DEM,29
+Hamlin,26,State Auditor,,Rene Meyer,LIB,12
+Hamlin,26,State Auditor,,Richard Sattgast,REP,321
+Hamlin,02,State Treasurer,,John Cunningham,DEM,16
+Hamlin,02,State Treasurer,,Josh Haeder,REP,121
+Hamlin,21,State Treasurer,,John Cunningham,DEM,141
+Hamlin,21,State Treasurer,,Josh Haeder,REP,501
+Hamlin,22,State Treasurer,,John Cunningham,DEM,10
+Hamlin,22,State Treasurer,,Josh Haeder,REP,107
+Hamlin,23,State Treasurer,,John Cunningham,DEM,44
+Hamlin,23,State Treasurer,,Josh Haeder,REP,212
+Hamlin,24,State Treasurer,,John Cunningham,DEM,106
+Hamlin,24,State Treasurer,,Josh Haeder,REP,479
+Hamlin,25,State Treasurer,,John Cunningham,DEM,145
+Hamlin,25,State Treasurer,,Josh Haeder,REP,285
+Hamlin,26,State Treasurer,,John Cunningham,DEM,29
+Hamlin,26,State Treasurer,,Josh Haeder,REP,329
+Hamlin,02,Commissioner of School and Public Lands,,Timothy Azure,DEM,19
+Hamlin,02,Commissioner of School and Public Lands,,Brock Greenfield,REP,117
+Hamlin,21,Commissioner of School and Public Lands,,Timothy Azure,DEM,136
+Hamlin,21,Commissioner of School and Public Lands,,Brock Greenfield,REP,530
+Hamlin,22,Commissioner of School and Public Lands,,Timothy Azure,DEM,10
+Hamlin,22,Commissioner of School and Public Lands,,Brock Greenfield,REP,111
+Hamlin,23,Commissioner of School and Public Lands,,Timothy Azure,DEM,52
+Hamlin,23,Commissioner of School and Public Lands,,Brock Greenfield,REP,213
+Hamlin,24,Commissioner of School and Public Lands,,Timothy Azure,DEM,120
+Hamlin,24,Commissioner of School and Public Lands,,Brock Greenfield,REP,476
+Hamlin,25,Commissioner of School and Public Lands,,Timothy Azure,DEM,149
+Hamlin,25,Commissioner of School and Public Lands,,Brock Greenfield,REP,294
+Hamlin,26,Commissioner of School and Public Lands,,Timothy Azure,DEM,38
+Hamlin,26,Commissioner of School and Public Lands,,Brock Greenfield,REP,335
+Hamlin,02,Public Utilities Commissioner,,Jeffrey Barth,DEM,19
+Hamlin,02,Public Utilities Commissioner,,Chris Nelson,REP,120
+Hamlin,21,Public Utilities Commissioner,,Jeffrey Barth,DEM,132
+Hamlin,21,Public Utilities Commissioner,,Chris Nelson,REP,522
+Hamlin,22,Public Utilities Commissioner,,Jeffrey Barth,DEM,9
+Hamlin,22,Public Utilities Commissioner,,Chris Nelson,REP,111
+Hamlin,23,Public Utilities Commissioner,,Jeffrey Barth,DEM,39
+Hamlin,23,Public Utilities Commissioner,,Chris Nelson,REP,226
+Hamlin,24,Public Utilities Commissioner,,Jeffrey Barth,DEM,95
+Hamlin,24,Public Utilities Commissioner,,Chris Nelson,REP,505
+Hamlin,25,Public Utilities Commissioner,,Jeffrey Barth,DEM,123
+Hamlin,25,Public Utilities Commissioner,,Chris Nelson,REP,314
+Hamlin,26,Public Utilities Commissioner,,Jeffrey Barth,DEM,29
+Hamlin,26,Public Utilities Commissioner,,Chris Nelson,REP,343
+Hamlin,02,State Senate,04,John Wiik,REP,124
+Hamlin,21,State Senate,04,John Wiik,REP,504
+Hamlin,22,State Senate,04,John Wiik,REP,108
+Hamlin,23,State Senate,04,John Wiik,REP,224
+Hamlin,24,State Senate,04,John Wiik,REP,470
+Hamlin,25,State Senate,04,John Wiik,REP,320
+Hamlin,26,State Senate,04,John Wiik,REP,311
+Hamlin,02,State House,04,Stephanie Sauder,REP,118
+Hamlin,02,State House,04,Fred Deutsch,REP,68
+Hamlin,21,State House,04,Stephanie Sauder,REP,378
+Hamlin,21,State House,04,Fred Deutsch,REP,409
+Hamlin,22,State House,04,Stephanie Sauder,REP,95
+Hamlin,22,State House,04,Fred Deutsch,REP,64
+Hamlin,23,State House,04,Stephanie Sauder,REP,221
+Hamlin,23,State House,04,Fred Deutsch,REP,108
+Hamlin,24,State House,04,Stephanie Sauder,REP,431
+Hamlin,24,State House,04,Fred Deutsch,REP,302
+Hamlin,25,State House,04,Stephanie Sauder,REP,247
+Hamlin,25,State House,04,Fred Deutsch,REP,234
+Hamlin,26,State House,04,Stephanie Sauder,REP,299
+Hamlin,26,State House,04,Fred Deutsch,REP,188
+Hamlin,02,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,69
+Hamlin,21,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,327
+Hamlin,22,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,45
+Hamlin,23,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,114
+Hamlin,24,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,239
+Hamlin,25,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,215
+Hamlin,26,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,153
+Hamlin,02,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,69
+Hamlin,21,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,339
+Hamlin,22,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,45
+Hamlin,23,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,117
+Hamlin,24,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,235
+Hamlin,25,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,212
+Hamlin,26,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,151
+Hamlin,02,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,71
+Hamlin,21,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,314
+Hamlin,22,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,44
+Hamlin,23,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,112
+Hamlin,24,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,235
+Hamlin,25,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,204
+Hamlin,26,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,147
+Hamlin,02,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,68
+Hamlin,21,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,330
+Hamlin,22,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,45
+Hamlin,23,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,110
+Hamlin,24,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,249
+Hamlin,25,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,235
+Hamlin,26,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,163
+Hamlin,02,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,66
+Hamlin,02,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,26
+Hamlin,21,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,265
+Hamlin,21,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,167
+Hamlin,22,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,49
+Hamlin,22,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,16
+Hamlin,23,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,77
+Hamlin,23,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,49
+Hamlin,24,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,170
+Hamlin,24,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,128
+Hamlin,25,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,135
+Hamlin,25,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,128
+Hamlin,26,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,152
+Hamlin,26,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,60
+Hamlin,02,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,66
+Hamlin,21,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,303
+Hamlin,22,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,44
+Hamlin,23,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,107
+Hamlin,24,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,229
+Hamlin,25,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,203
+Hamlin,26,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,142
+Hamlin,02,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,92
+Hamlin,02,Supreme Court Retention,3,Patricia J. DeVaney - No,,15
+Hamlin,21,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,480
+Hamlin,21,Supreme Court Retention,3,Patricia J. DeVaney - No,,90
+Hamlin,22,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,91
+Hamlin,22,Supreme Court Retention,3,Patricia J. DeVaney - No,,11
+Hamlin,23,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,179
+Hamlin,23,Supreme Court Retention,3,Patricia J. DeVaney - No,,29
+Hamlin,24,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,379
+Hamlin,24,Supreme Court Retention,3,Patricia J. DeVaney - No,,68
+Hamlin,25,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,333
+Hamlin,25,Supreme Court Retention,3,Patricia J. DeVaney - No,,68
+Hamlin,26,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,232
+Hamlin,26,Supreme Court Retention,3,Patricia J. DeVaney - No,,34
+Hamlin,02,Supreme Court Retention,2,Mark E. Salter - Yes,,91
+Hamlin,02,Supreme Court Retention,2,Mark E. Salter - No,,16
+Hamlin,21,Supreme Court Retention,2,Mark E. Salter - Yes,,488
+Hamlin,21,Supreme Court Retention,2,Mark E. Salter - No,,83
+Hamlin,22,Supreme Court Retention,2,Mark E. Salter - Yes,,89
+Hamlin,22,Supreme Court Retention,2,Mark E. Salter - No,,12
+Hamlin,23,Supreme Court Retention,2,Mark E. Salter - Yes,,180
+Hamlin,23,Supreme Court Retention,2,Mark E. Salter - No,,29
+Hamlin,24,Supreme Court Retention,2,Mark E. Salter - Yes,,382
+Hamlin,24,Supreme Court Retention,2,Mark E. Salter - No,,63
+Hamlin,25,Supreme Court Retention,2,Mark E. Salter - Yes,,337
+Hamlin,25,Supreme Court Retention,2,Mark E. Salter - No,,59
+Hamlin,26,Supreme Court Retention,2,Mark E. Salter - Yes,,237
+Hamlin,26,Supreme Court Retention,2,Mark E. Salter - No,,29
+Hamlin,02,Constitutional Amendment D,,Yes,,39
+Hamlin,02,Constitutional Amendment D,,No,,99
+Hamlin,21,Constitutional Amendment D,,Yes,,295
+Hamlin,21,Constitutional Amendment D,,No,,380
+Hamlin,22,Constitutional Amendment D,,Yes,,35
+Hamlin,22,Constitutional Amendment D,,No,,89
+Hamlin,23,Constitutional Amendment D,,Yes,,94
+Hamlin,23,Constitutional Amendment D,,No,,174
+Hamlin,24,Constitutional Amendment D,,Yes,,228
+Hamlin,24,Constitutional Amendment D,,No,,379
+Hamlin,25,Constitutional Amendment D,,Yes,,257
+Hamlin,25,Constitutional Amendment D,,No,,201
+Hamlin,26,Constitutional Amendment D,,Yes,,115
+Hamlin,26,Constitutional Amendment D,,No,,262
+Hamlin,02,Initiated Measure 27,,Yes,,35
+Hamlin,02,Initiated Measure 27,,No,,109
+Hamlin,21,Initiated Measure 27,,Yes,,199
+Hamlin,21,Initiated Measure 27,,No,,494
+Hamlin,22,Initiated Measure 27,,Yes,,30
+Hamlin,22,Initiated Measure 27,,No,,95
+Hamlin,23,Initiated Measure 27,,Yes,,73
+Hamlin,23,Initiated Measure 27,,No,,199
+Hamlin,24,Initiated Measure 27,,Yes,,153
+Hamlin,24,Initiated Measure 27,,No,,468
+Hamlin,25,Initiated Measure 27,,Yes,,217
+Hamlin,25,Initiated Measure 27,,No,,248
+Hamlin,26,Initiated Measure 27,,Yes,,77
+Hamlin,26,Initiated Measure 27,,No,,316

--- a/2022/counties/20221108__sd__general__hand__precinct.csv
+++ b/2022/counties/20221108__sd__general__hand__precinct.csv
@@ -1,0 +1,191 @@
+county,precinct,office,district,candidate,party,votes
+Hand,01,U.S. Senate,,Brian L. Bengs,DEM,16
+Hand,01,U.S. Senate,,Tamara J Lesnar,LIB,20
+Hand,01,U.S. Senate,,John R. Thune,REP,240
+Hand,02,U.S. Senate,,Brian L. Bengs,DEM,39
+Hand,02,U.S. Senate,,Tamara J Lesnar,LIB,14
+Hand,02,U.S. Senate,,John R. Thune,REP,213
+Hand,03,U.S. Senate,,Brian L. Bengs,DEM,55
+Hand,03,U.S. Senate,,Tamara J Lesnar,LIB,7
+Hand,03,U.S. Senate,,John R. Thune,REP,261
+Hand,04,U.S. Senate,,Brian L. Bengs,DEM,57
+Hand,04,U.S. Senate,,Tamara J Lesnar,LIB,15
+Hand,04,U.S. Senate,,John R. Thune,REP,269
+Hand,05,U.S. Senate,,Brian L. Bengs,DEM,31
+Hand,05,U.S. Senate,,Tamara J Lesnar,LIB,14
+Hand,05,U.S. Senate,,John R. Thune,REP,259
+Hand,01,U.S. House,1,Collin Duprel,LIB,27
+Hand,01,U.S. House,1,Dusty Johnson,REP,240
+Hand,02,U.S. House,1,Collin Duprel,LIB,36
+Hand,02,U.S. House,1,Dusty Johnson,REP,220
+Hand,03,U.S. House,1,Collin Duprel,LIB,50
+Hand,03,U.S. House,1,Dusty Johnson,REP,262
+Hand,04,U.S. House,1,Collin Duprel,LIB,50
+Hand,04,U.S. House,1,Dusty Johnson,REP,276
+Hand,05,U.S. House,1,Collin Duprel,LIB,34
+Hand,05,U.S. House,1,Dusty Johnson,REP,261
+Hand,01,Governor,,Jamie Smith and Jennifer Keintz,DEM,30
+Hand,01,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Hand,01,Governor,,Kristi Noem and Larry Rhoden,REP,241
+Hand,02,Governor,,Jamie Smith and Jennifer Keintz,DEM,53
+Hand,02,Governor,,Tracey Quint and Ashley Strand,LIB,9
+Hand,02,Governor,,Kristi Noem and Larry Rhoden,REP,198
+Hand,03,Governor,,Jamie Smith and Jennifer Keintz,DEM,78
+Hand,03,Governor,,Tracey Quint and Ashley Strand,LIB,12
+Hand,03,Governor,,Kristi Noem and Larry Rhoden,REP,232
+Hand,04,Governor,,Jamie Smith and Jennifer Keintz,DEM,81
+Hand,04,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Hand,04,Governor,,Kristi Noem and Larry Rhoden,REP,254
+Hand,05,Governor,,Jamie Smith and Jennifer Keintz,DEM,48
+Hand,05,Governor,,Tracey Quint and Ashley Strand,LIB,8
+Hand,05,Governor,,Kristi Noem and Larry Rhoden,REP,252
+Hand,01,Secretary of State,,Thomas A Cool,DEM,30
+Hand,01,Secretary of State,,Monae Johnson,REP,238
+Hand,02,Secretary of State,,Thomas A Cool,DEM,62
+Hand,02,Secretary of State,,Monae Johnson,REP,196
+Hand,03,Secretary of State,,Thomas A Cool,DEM,83
+Hand,03,Secretary of State,,Monae Johnson,REP,222
+Hand,04,Secretary of State,,Thomas A Cool,DEM,85
+Hand,04,Secretary of State,,Monae Johnson,REP,231
+Hand,05,Secretary of State,,Thomas A Cool,DEM,48
+Hand,05,Secretary of State,,Monae Johnson,REP,247
+Hand,01,Attorney General,,Marty J. Jackley,REP,239
+Hand,02,Attorney General,,Marty J. Jackley,REP,229
+Hand,03,Attorney General,,Marty J. Jackley,REP,269
+Hand,04,Attorney General,,Marty J. Jackley,REP,258
+Hand,05,Attorney General,,Marty J. Jackley,REP,271
+Hand,01,State Auditor,,Stephanie Marty,DEM,28
+Hand,01,State Auditor,,Rene Meyer,LIB,10
+Hand,01,State Auditor,,Richard Sattgast,REP,220
+Hand,02,State Auditor,,Stephanie Marty,DEM,46
+Hand,02,State Auditor,,Rene Meyer,LIB,10
+Hand,02,State Auditor,,Richard Sattgast,REP,199
+Hand,03,State Auditor,,Stephanie Marty,DEM,69
+Hand,03,State Auditor,,Rene Meyer,LIB,13
+Hand,03,State Auditor,,Richard Sattgast,REP,223
+Hand,04,State Auditor,,Stephanie Marty,DEM,77
+Hand,04,State Auditor,,Rene Meyer,LIB,17
+Hand,04,State Auditor,,Richard Sattgast,REP,232
+Hand,05,State Auditor,,Stephanie Marty,DEM,39
+Hand,05,State Auditor,,Rene Meyer,LIB,10
+Hand,05,State Auditor,,Richard Sattgast,REP,250
+Hand,01,State Treasurer,,John Cunningham,DEM,20
+Hand,01,State Treasurer,,Josh Haeder,REP,240
+Hand,02,State Treasurer,,John Cunningham,DEM,46
+Hand,02,State Treasurer,,Josh Haeder,REP,211
+Hand,03,State Treasurer,,John Cunningham,DEM,64
+Hand,03,State Treasurer,,Josh Haeder,REP,243
+Hand,04,State Treasurer,,John Cunningham,DEM,58
+Hand,04,State Treasurer,,Josh Haeder,REP,267
+Hand,05,State Treasurer,,John Cunningham,DEM,38
+Hand,05,State Treasurer,,Josh Haeder,REP,258
+Hand,01,Commissioner of School and Public Lands,,Timothy Azure,DEM,26
+Hand,01,Commissioner of School and Public Lands,,Brock Greenfield,REP,229
+Hand,02,Commissioner of School and Public Lands,,Timothy Azure,DEM,48
+Hand,02,Commissioner of School and Public Lands,,Brock Greenfield,REP,191
+Hand,03,Commissioner of School and Public Lands,,Timothy Azure,DEM,73
+Hand,03,Commissioner of School and Public Lands,,Brock Greenfield,REP,219
+Hand,04,Commissioner of School and Public Lands,,Timothy Azure,DEM,74
+Hand,04,Commissioner of School and Public Lands,,Brock Greenfield,REP,238
+Hand,05,Commissioner of School and Public Lands,,Timothy Azure,DEM,45
+Hand,05,Commissioner of School and Public Lands,,Brock Greenfield,REP,247
+Hand,01,Public Utilities Commissioner,,Jeffrey Barth,DEM,33
+Hand,01,Public Utilities Commissioner,,Chris Nelson,REP,228
+Hand,02,Public Utilities Commissioner,,Jeffrey Barth,DEM,51
+Hand,02,Public Utilities Commissioner,,Chris Nelson,REP,204
+Hand,03,Public Utilities Commissioner,,Jeffrey Barth,DEM,63
+Hand,03,Public Utilities Commissioner,,Chris Nelson,REP,238
+Hand,04,Public Utilities Commissioner,,Jeffrey Barth,DEM,80
+Hand,04,Public Utilities Commissioner,,Chris Nelson,REP,243
+Hand,05,Public Utilities Commissioner,,Jeffrey Barth,DEM,55
+Hand,05,Public Utilities Commissioner,,Chris Nelson,REP,246
+Hand,01,State Senate,23,Bryan J. Breitling,REP,219
+Hand,02,State Senate,23,Bryan J. Breitling,REP,209
+Hand,03,State Senate,23,Bryan J. Breitling,REP,243
+Hand,04,State Senate,23,Bryan J. Breitling,REP,249
+Hand,05,State Senate,23,Bryan J. Breitling,REP,246
+Hand,01,State House,23,James D. Wangsness,REP,180
+Hand,01,State House,23,Scott Moore,REP,187
+Hand,02,State House,23,James D. Wangsness,REP,198
+Hand,02,State House,23,Scott Moore,REP,147
+Hand,03,State House,23,James D. Wangsness,REP,216
+Hand,03,State House,23,Scott Moore,REP,179
+Hand,04,State House,23,James D. Wangsness,REP,201
+Hand,04,State House,23,Scott Moore,REP,180
+Hand,05,State House,23,James D. Wangsness,REP,182
+Hand,05,State House,23,Scott Moore,REP,205
+Hand,01,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,146
+Hand,02,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,156
+Hand,03,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,157
+Hand,04,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,148
+Hand,05,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,180
+Hand,01,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,147
+Hand,02,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,151
+Hand,03,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,157
+Hand,04,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,146
+Hand,05,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,178
+Hand,01,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,150
+Hand,02,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,164
+Hand,03,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,165
+Hand,04,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,170
+Hand,05,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,179
+Hand,01,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,143
+Hand,02,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,146
+Hand,03,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,154
+Hand,04,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,143
+Hand,05,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,175
+Hand,01,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,54
+Hand,01,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,109
+Hand,02,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,72
+Hand,02,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,106
+Hand,03,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,69
+Hand,03,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,125
+Hand,04,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,81
+Hand,04,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,112
+Hand,05,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,56
+Hand,05,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,149
+Hand,01,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,135
+Hand,02,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,143
+Hand,03,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,149
+Hand,04,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,137
+Hand,05,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,175
+Hand,01,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,217
+Hand,01,Supreme Court Retention,3,Patricia J. DeVaney - No,,17
+Hand,02,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,215
+Hand,02,Supreme Court Retention,3,Patricia J. DeVaney - No,,28
+Hand,03,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,233
+Hand,03,Supreme Court Retention,3,Patricia J. DeVaney - No,,40
+Hand,04,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,234
+Hand,04,Supreme Court Retention,3,Patricia J. DeVaney - No,,47
+Hand,05,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,236
+Hand,05,Supreme Court Retention,3,Patricia J. DeVaney - No,,40
+Hand,01,Supreme Court Retention,2,Mark E. Salter - Yes,,215
+Hand,01,Supreme Court Retention,2,Mark E. Salter - No,,19
+Hand,02,Supreme Court Retention,2,Mark E. Salter - Yes,,213
+Hand,02,Supreme Court Retention,2,Mark E. Salter - No,,27
+Hand,03,Supreme Court Retention,2,Mark E. Salter - Yes,,231
+Hand,03,Supreme Court Retention,2,Mark E. Salter - No,,42
+Hand,04,Supreme Court Retention,2,Mark E. Salter - Yes,,236
+Hand,04,Supreme Court Retention,2,Mark E. Salter - No,,42
+Hand,05,Supreme Court Retention,2,Mark E. Salter - Yes,,233
+Hand,05,Supreme Court Retention,2,Mark E. Salter - No,,39
+Hand,01,Constitutional Amendment D,,Yes,,122
+Hand,01,Constitutional Amendment D,,No,,143
+Hand,02,Constitutional Amendment D,,Yes,,143
+Hand,02,Constitutional Amendment D,,No,,113
+Hand,03,Constitutional Amendment D,,Yes,,174
+Hand,03,Constitutional Amendment D,,No,,135
+Hand,04,Constitutional Amendment D,,Yes,,182
+Hand,04,Constitutional Amendment D,,No,,151
+Hand,05,Constitutional Amendment D,,Yes,,121
+Hand,05,Constitutional Amendment D,,No,,180
+Hand,01,Initiated Measure 27,,Yes,,54
+Hand,01,Initiated Measure 27,,No,,220
+Hand,02,Initiated Measure 27,,Yes,,97
+Hand,02,Initiated Measure 27,,No,,164
+Hand,03,Initiated Measure 27,,Yes,,108
+Hand,03,Initiated Measure 27,,No,,207
+Hand,04,Initiated Measure 27,,Yes,,102
+Hand,04,Initiated Measure 27,,No,,232
+Hand,05,Initiated Measure 27,,Yes,,67
+Hand,05,Initiated Measure 27,,No,,237

--- a/2022/counties/20221108__sd__general__hanson__precinct.csv
+++ b/2022/counties/20221108__sd__general__hanson__precinct.csv
@@ -1,0 +1,191 @@
+county,precinct,office,district,candidate,party,votes
+Hanson,1,U.S. Senate,,Brian L. Bengs,DEM,101
+Hanson,1,U.S. Senate,,Tamara J Lesnar,LIB,16
+Hanson,1,U.S. Senate,,John R. Thune,REP,372
+Hanson,2,U.S. Senate,,Brian L. Bengs,DEM,57
+Hanson,2,U.S. Senate,,Tamara J Lesnar,LIB,12
+Hanson,2,U.S. Senate,,John R. Thune,REP,249
+Hanson,3,U.S. Senate,,Brian L. Bengs,DEM,39
+Hanson,3,U.S. Senate,,Tamara J Lesnar,LIB,6
+Hanson,3,U.S. Senate,,John R. Thune,REP,231
+Hanson,4,U.S. Senate,,Brian L. Bengs,DEM,28
+Hanson,4,U.S. Senate,,Tamara J Lesnar,LIB,12
+Hanson,4,U.S. Senate,,John R. Thune,REP,262
+Hanson,5,U.S. Senate,,Brian L. Bengs,DEM,29
+Hanson,5,U.S. Senate,,Tamara J Lesnar,LIB,6
+Hanson,5,U.S. Senate,,John R. Thune,REP,209
+Hanson,1,U.S. House,1,Collin Duprel,LIB,78
+Hanson,1,U.S. House,1,Dusty Johnson,REP,384
+Hanson,2,U.S. House,1,Collin Duprel,LIB,58
+Hanson,2,U.S. House,1,Dusty Johnson,REP,247
+Hanson,3,U.S. House,1,Collin Duprel,LIB,40
+Hanson,3,U.S. House,1,Dusty Johnson,REP,222
+Hanson,4,U.S. House,1,Collin Duprel,LIB,28
+Hanson,4,U.S. House,1,Dusty Johnson,REP,268
+Hanson,5,U.S. House,1,Collin Duprel,LIB,29
+Hanson,5,U.S. House,1,Dusty Johnson,REP,215
+Hanson,1,Governor,,Jamie Smith and Jennifer Keintz,DEM,122
+Hanson,1,Governor,,Tracey Quint and Ashley Strand,LIB,10
+Hanson,1,Governor,,Kristi Noem and Larry Rhoden,REP,358
+Hanson,2,Governor,,Jamie Smith and Jennifer Keintz,DEM,83
+Hanson,2,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Hanson,2,Governor,,Kristi Noem and Larry Rhoden,REP,232
+Hanson,3,Governor,,Jamie Smith and Jennifer Keintz,DEM,54
+Hanson,3,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Hanson,3,Governor,,Kristi Noem and Larry Rhoden,REP,213
+Hanson,4,Governor,,Jamie Smith and Jennifer Keintz,DEM,38
+Hanson,4,Governor,,Tracey Quint and Ashley Strand,LIB,11
+Hanson,4,Governor,,Kristi Noem and Larry Rhoden,REP,255
+Hanson,5,Governor,,Jamie Smith and Jennifer Keintz,DEM,39
+Hanson,5,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Hanson,5,Governor,,Kristi Noem and Larry Rhoden,REP,209
+Hanson,1,Secretary of State,,Thomas A Cool,DEM,118
+Hanson,1,Secretary of State,,Monae Johnson,REP,346
+Hanson,2,Secretary of State,,Thomas A Cool,DEM,90
+Hanson,2,Secretary of State,,Monae Johnson,REP,209
+Hanson,3,Secretary of State,,Thomas A Cool,DEM,71
+Hanson,3,Secretary of State,,Monae Johnson,REP,184
+Hanson,4,Secretary of State,,Thomas A Cool,DEM,40
+Hanson,4,Secretary of State,,Monae Johnson,REP,254
+Hanson,5,Secretary of State,,Thomas A Cool,DEM,51
+Hanson,5,Secretary of State,,Monae Johnson,REP,179
+Hanson,1,Attorney General,,Marty J. Jackley,REP,382
+Hanson,2,Attorney General,,Marty J. Jackley,REP,239
+Hanson,3,Attorney General,,Marty J. Jackley,REP,212
+Hanson,4,Attorney General,,Marty J. Jackley,REP,261
+Hanson,5,Attorney General,,Marty J. Jackley,REP,206
+Hanson,1,State Auditor,,Stephanie Marty,DEM,108
+Hanson,1,State Auditor,,Rene Meyer,LIB,19
+Hanson,1,State Auditor,,Richard Sattgast,REP,339
+Hanson,2,State Auditor,,Stephanie Marty,DEM,77
+Hanson,2,State Auditor,,Rene Meyer,LIB,9
+Hanson,2,State Auditor,,Richard Sattgast,REP,214
+Hanson,3,State Auditor,,Stephanie Marty,DEM,50
+Hanson,3,State Auditor,,Rene Meyer,LIB,14
+Hanson,3,State Auditor,,Richard Sattgast,REP,188
+Hanson,4,State Auditor,,Stephanie Marty,DEM,38
+Hanson,4,State Auditor,,Rene Meyer,LIB,17
+Hanson,4,State Auditor,,Richard Sattgast,REP,238
+Hanson,5,State Auditor,,Stephanie Marty,DEM,37
+Hanson,5,State Auditor,,Rene Meyer,LIB,6
+Hanson,5,State Auditor,,Richard Sattgast,REP,190
+Hanson,1,State Treasurer,,John Cunningham,DEM,113
+Hanson,1,State Treasurer,,Josh Haeder,REP,353
+Hanson,2,State Treasurer,,John Cunningham,DEM,76
+Hanson,2,State Treasurer,,Josh Haeder,REP,217
+Hanson,3,State Treasurer,,John Cunningham,DEM,43
+Hanson,3,State Treasurer,,Josh Haeder,REP,204
+Hanson,4,State Treasurer,,John Cunningham,DEM,40
+Hanson,4,State Treasurer,,Josh Haeder,REP,249
+Hanson,5,State Treasurer,,John Cunningham,DEM,35
+Hanson,5,State Treasurer,,Josh Haeder,REP,193
+Hanson,1,Commissioner of School and Public Lands,,Timothy Azure,DEM,107
+Hanson,1,Commissioner of School and Public Lands,,Brock Greenfield,REP,348
+Hanson,2,Commissioner of School and Public Lands,,Timothy Azure,DEM,73
+Hanson,2,Commissioner of School and Public Lands,,Brock Greenfield,REP,215
+Hanson,3,Commissioner of School and Public Lands,,Timothy Azure,DEM,51
+Hanson,3,Commissioner of School and Public Lands,,Brock Greenfield,REP,187
+Hanson,4,Commissioner of School and Public Lands,,Timothy Azure,DEM,38
+Hanson,4,Commissioner of School and Public Lands,,Brock Greenfield,REP,250
+Hanson,5,Commissioner of School and Public Lands,,Timothy Azure,DEM,31
+Hanson,5,Commissioner of School and Public Lands,,Brock Greenfield,REP,188
+Hanson,1,Public Utilities Commissioner,,Jeffrey Barth,DEM,102
+Hanson,1,Public Utilities Commissioner,,Chris Nelson,REP,358
+Hanson,2,Public Utilities Commissioner,,Jeffrey Barth,DEM,65
+Hanson,2,Public Utilities Commissioner,,Chris Nelson,REP,240
+Hanson,3,Public Utilities Commissioner,,Jeffrey Barth,DEM,46
+Hanson,3,Public Utilities Commissioner,,Chris Nelson,REP,207
+Hanson,4,Public Utilities Commissioner,,Jeffrey Barth,DEM,31
+Hanson,4,Public Utilities Commissioner,,Chris Nelson,REP,265
+Hanson,5,Public Utilities Commissioner,,Jeffrey Barth,DEM,38
+Hanson,5,Public Utilities Commissioner,,Chris Nelson,REP,199
+Hanson,1,State Senate,19,Russell Graeff,DEM,102
+Hanson,1,State Senate,19,Kyle Schoenfish,REP,363
+Hanson,2,State Senate,19,Russell Graeff,DEM,66
+Hanson,2,State Senate,19,Kyle Schoenfish,REP,228
+Hanson,3,State Senate,19,Russell Graeff,DEM,48
+Hanson,3,State Senate,19,Kyle Schoenfish,REP,205
+Hanson,4,State Senate,19,Russell Graeff,DEM,33
+Hanson,4,State Senate,19,Kyle Schoenfish,REP,258
+Hanson,5,State Senate,19,Russell Graeff,DEM,37
+Hanson,5,State Senate,19,Kyle Schoenfish,REP,192
+Hanson,1,State House,19,Jessica Bahmuller,REP,252
+Hanson,1,State House,19,Drew Peterson,REP,284
+Hanson,2,State House,19,Jessica Bahmuller,REP,247
+Hanson,2,State House,19,Drew Peterson,REP,139
+Hanson,3,State House,19,Jessica Bahmuller,REP,186
+Hanson,3,State House,19,Drew Peterson,REP,123
+Hanson,4,State House,19,Jessica Bahmuller,REP,172
+Hanson,4,State House,19,Drew Peterson,REP,222
+Hanson,5,State House,19,Jessica Bahmuller,REP,158
+Hanson,5,State House,19,Drew Peterson,REP,134
+Hanson,1,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,218
+Hanson,2,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,182
+Hanson,3,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,126
+Hanson,4,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,130
+Hanson,5,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,115
+Hanson,1,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,202
+Hanson,2,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,132
+Hanson,3,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,97
+Hanson,4,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,114
+Hanson,5,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,97
+Hanson,1,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,199
+Hanson,2,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,133
+Hanson,3,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,93
+Hanson,4,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,115
+Hanson,5,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,99
+Hanson,1,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,199
+Hanson,2,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,131
+Hanson,3,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,98
+Hanson,4,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,115
+Hanson,5,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,98
+Hanson,1,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,196
+Hanson,2,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,142
+Hanson,3,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,112
+Hanson,4,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,128
+Hanson,5,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,102
+Hanson,1,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,200
+Hanson,2,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,132
+Hanson,3,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,97
+Hanson,4,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,115
+Hanson,5,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,97
+Hanson,1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,346
+Hanson,1,Supreme Court Retention,3,Patricia J. DeVaney - No,,66
+Hanson,2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,233
+Hanson,2,Supreme Court Retention,3,Patricia J. DeVaney - No,,37
+Hanson,3,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,191
+Hanson,3,Supreme Court Retention,3,Patricia J. DeVaney - No,,34
+Hanson,4,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,193
+Hanson,4,Supreme Court Retention,3,Patricia J. DeVaney - No,,41
+Hanson,5,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,167
+Hanson,5,Supreme Court Retention,3,Patricia J. DeVaney - No,,34
+Hanson,1,Supreme Court Retention,2,Mark E. Salter - Yes,,340
+Hanson,1,Supreme Court Retention,2,Mark E. Salter - No,,62
+Hanson,2,Supreme Court Retention,2,Mark E. Salter - Yes,,232
+Hanson,2,Supreme Court Retention,2,Mark E. Salter - No,,36
+Hanson,3,Supreme Court Retention,2,Mark E. Salter - Yes,,195
+Hanson,3,Supreme Court Retention,2,Mark E. Salter - No,,29
+Hanson,4,Supreme Court Retention,2,Mark E. Salter - Yes,,195
+Hanson,4,Supreme Court Retention,2,Mark E. Salter - No,,39
+Hanson,5,Supreme Court Retention,2,Mark E. Salter - Yes,,159
+Hanson,5,Supreme Court Retention,2,Mark E. Salter - No,,40
+Hanson,1,Constitutional Amendment D,,Yes,,215
+Hanson,1,Constitutional Amendment D,,No,,249
+Hanson,2,Constitutional Amendment D,,Yes,,159
+Hanson,2,Constitutional Amendment D,,No,,153
+Hanson,3,Constitutional Amendment D,,Yes,,118
+Hanson,3,Constitutional Amendment D,,No,,154
+Hanson,4,Constitutional Amendment D,,Yes,,132
+Hanson,4,Constitutional Amendment D,,No,,159
+Hanson,5,Constitutional Amendment D,,Yes,,87
+Hanson,5,Constitutional Amendment D,,No,,140
+Hanson,1,Initiated Measure 27,,Yes,,187
+Hanson,1,Initiated Measure 27,,No,,286
+Hanson,2,Initiated Measure 27,,Yes,,109
+Hanson,2,Initiated Measure 27,,No,,201
+Hanson,3,Initiated Measure 27,,Yes,,64
+Hanson,3,Initiated Measure 27,,No,,208
+Hanson,4,Initiated Measure 27,,Yes,,62
+Hanson,4,Initiated Measure 27,,No,,240
+Hanson,5,Initiated Measure 27,,Yes,,55
+Hanson,5,Initiated Measure 27,,No,,176

--- a/2022/counties/20221108__sd__general__harding__precinct.csv
+++ b/2022/counties/20221108__sd__general__harding__precinct.csv
@@ -1,0 +1,313 @@
+county,precinct,office,district,candidate,party,votes
+Harding,01,U.S. Senate,,Brian L. Bengs,DEM,10
+Harding,01,U.S. Senate,,Tamara J Lesnar,LIB,8
+Harding,01,U.S. Senate,,John R. Thune,REP,106
+Harding,02,U.S. Senate,,Brian L. Bengs,DEM,6
+Harding,02,U.S. Senate,,Tamara J Lesnar,LIB,13
+Harding,02,U.S. Senate,,John R. Thune,REP,103
+Harding,03,U.S. Senate,,Brian L. Bengs,DEM,2
+Harding,03,U.S. Senate,,Tamara J Lesnar,LIB,2
+Harding,03,U.S. Senate,,John R. Thune,REP,39
+Harding,05,U.S. Senate,,Brian L. Bengs,DEM,1
+Harding,05,U.S. Senate,,Tamara J Lesnar,LIB,5
+Harding,05,U.S. Senate,,John R. Thune,REP,104
+Harding,06,U.S. Senate,,Brian L. Bengs,DEM,0
+Harding,06,U.S. Senate,,Tamara J Lesnar,LIB,3
+Harding,06,U.S. Senate,,John R. Thune,REP,28
+Harding,07,U.S. Senate,,Brian L. Bengs,DEM,3
+Harding,07,U.S. Senate,,Tamara J Lesnar,LIB,2
+Harding,07,U.S. Senate,,John R. Thune,REP,76
+Harding,08,U.S. Senate,,Brian L. Bengs,DEM,0
+Harding,08,U.S. Senate,,Tamara J Lesnar,LIB,1
+Harding,08,U.S. Senate,,John R. Thune,REP,48
+Harding,09,U.S. Senate,,Brian L. Bengs,DEM,0
+Harding,09,U.S. Senate,,Tamara J Lesnar,LIB,7
+Harding,09,U.S. Senate,,John R. Thune,REP,101
+Harding,01,U.S. House,1,Collin Duprel,LIB,22
+Harding,01,U.S. House,1,Dusty Johnson,REP,101
+Harding,02,U.S. House,1,Collin Duprel,LIB,33
+Harding,02,U.S. House,1,Dusty Johnson,REP,87
+Harding,03,U.S. House,1,Collin Duprel,LIB,8
+Harding,03,U.S. House,1,Dusty Johnson,REP,33
+Harding,05,U.S. House,1,Collin Duprel,LIB,21
+Harding,05,U.S. House,1,Dusty Johnson,REP,89
+Harding,06,U.S. House,1,Collin Duprel,LIB,8
+Harding,06,U.S. House,1,Dusty Johnson,REP,22
+Harding,07,U.S. House,1,Collin Duprel,LIB,13
+Harding,07,U.S. House,1,Dusty Johnson,REP,67
+Harding,08,U.S. House,1,Collin Duprel,LIB,10
+Harding,08,U.S. House,1,Dusty Johnson,REP,40
+Harding,09,U.S. House,1,Collin Duprel,LIB,28
+Harding,09,U.S. House,1,Dusty Johnson,REP,79
+Harding,01,Governor,,Jamie Smith and Jennifer Keintz,DEM,11
+Harding,01,Governor,,Tracey Quint and Ashley Strand,LIB,0
+Harding,01,Governor,,Kristi Noem and Larry Rhoden,REP,110
+Harding,02,Governor,,Jamie Smith and Jennifer Keintz,DEM,9
+Harding,02,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Harding,02,Governor,,Kristi Noem and Larry Rhoden,REP,113
+Harding,03,Governor,,Jamie Smith and Jennifer Keintz,DEM,2
+Harding,03,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Harding,03,Governor,,Kristi Noem and Larry Rhoden,REP,40
+Harding,05,Governor,,Jamie Smith and Jennifer Keintz,DEM,6
+Harding,05,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Harding,05,Governor,,Kristi Noem and Larry Rhoden,REP,102
+Harding,06,Governor,,Jamie Smith and Jennifer Keintz,DEM,0
+Harding,06,Governor,,Tracey Quint and Ashley Strand,LIB,0
+Harding,06,Governor,,Kristi Noem and Larry Rhoden,REP,31
+Harding,07,Governor,,Jamie Smith and Jennifer Keintz,DEM,3
+Harding,07,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Harding,07,Governor,,Kristi Noem and Larry Rhoden,REP,78
+Harding,08,Governor,,Jamie Smith and Jennifer Keintz,DEM,0
+Harding,08,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Harding,08,Governor,,Kristi Noem and Larry Rhoden,REP,51
+Harding,09,Governor,,Jamie Smith and Jennifer Keintz,DEM,2
+Harding,09,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Harding,09,Governor,,Kristi Noem and Larry Rhoden,REP,107
+Harding,01,Secretary of State,,Thomas A Cool,DEM,13
+Harding,01,Secretary of State,,Monae Johnson,REP,110
+Harding,02,Secretary of State,,Thomas A Cool,DEM,10
+Harding,02,Secretary of State,,Monae Johnson,REP,103
+Harding,03,Secretary of State,,Thomas A Cool,DEM,4
+Harding,03,Secretary of State,,Monae Johnson,REP,38
+Harding,05,Secretary of State,,Thomas A Cool,DEM,8
+Harding,05,Secretary of State,,Monae Johnson,REP,97
+Harding,06,Secretary of State,,Thomas A Cool,DEM,0
+Harding,06,Secretary of State,,Monae Johnson,REP,31
+Harding,07,Secretary of State,,Thomas A Cool,DEM,4
+Harding,07,Secretary of State,,Monae Johnson,REP,72
+Harding,08,Secretary of State,,Thomas A Cool,DEM,4
+Harding,08,Secretary of State,,Monae Johnson,REP,47
+Harding,09,Secretary of State,,Thomas A Cool,DEM,3
+Harding,09,Secretary of State,,Monae Johnson,REP,107
+Harding,01,Attorney General,,Marty J. Jackley,REP,113
+Harding,02,Attorney General,,Marty J. Jackley,REP,98
+Harding,03,Attorney General,,Marty J. Jackley,REP,41
+Harding,05,Attorney General,,Marty J. Jackley,REP,100
+Harding,06,Attorney General,,Marty J. Jackley,REP,31
+Harding,07,Attorney General,,Marty J. Jackley,REP,74
+Harding,08,Attorney General,,Marty J. Jackley,REP,49
+Harding,09,Attorney General,,Marty J. Jackley,REP,103
+Harding,01,State Auditor,,Stephanie Marty,DEM,17
+Harding,01,State Auditor,,Rene Meyer,LIB,6
+Harding,01,State Auditor,,Richard Sattgast,REP,100
+Harding,02,State Auditor,,Stephanie Marty,DEM,12
+Harding,02,State Auditor,,Rene Meyer,LIB,10
+Harding,02,State Auditor,,Richard Sattgast,REP,93
+Harding,03,State Auditor,,Stephanie Marty,DEM,4
+Harding,03,State Auditor,,Rene Meyer,LIB,2
+Harding,03,State Auditor,,Richard Sattgast,REP,35
+Harding,05,State Auditor,,Stephanie Marty,DEM,9
+Harding,05,State Auditor,,Rene Meyer,LIB,8
+Harding,05,State Auditor,,Richard Sattgast,REP,91
+Harding,06,State Auditor,,Stephanie Marty,DEM,0
+Harding,06,State Auditor,,Rene Meyer,LIB,1
+Harding,06,State Auditor,,Richard Sattgast,REP,30
+Harding,07,State Auditor,,Stephanie Marty,DEM,7
+Harding,07,State Auditor,,Rene Meyer,LIB,3
+Harding,07,State Auditor,,Richard Sattgast,REP,70
+Harding,08,State Auditor,,Stephanie Marty,DEM,1
+Harding,08,State Auditor,,Rene Meyer,LIB,1
+Harding,08,State Auditor,,Richard Sattgast,REP,49
+Harding,09,State Auditor,,Stephanie Marty,DEM,7
+Harding,09,State Auditor,,Rene Meyer,LIB,6
+Harding,09,State Auditor,,Richard Sattgast,REP,94
+Harding,01,State Treasurer,,John Cunningham,DEM,11
+Harding,01,State Treasurer,,Josh Haeder,REP,109
+Harding,02,State Treasurer,,John Cunningham,DEM,8
+Harding,02,State Treasurer,,Josh Haeder,REP,106
+Harding,03,State Treasurer,,John Cunningham,DEM,6
+Harding,03,State Treasurer,,Josh Haeder,REP,36
+Harding,05,State Treasurer,,John Cunningham,DEM,6
+Harding,05,State Treasurer,,Josh Haeder,REP,103
+Harding,06,State Treasurer,,John Cunningham,DEM,0
+Harding,06,State Treasurer,,Josh Haeder,REP,31
+Harding,07,State Treasurer,,John Cunningham,DEM,2
+Harding,07,State Treasurer,,Josh Haeder,REP,75
+Harding,08,State Treasurer,,John Cunningham,DEM,1
+Harding,08,State Treasurer,,Josh Haeder,REP,50
+Harding,09,State Treasurer,,John Cunningham,DEM,5
+Harding,09,State Treasurer,,Josh Haeder,REP,102
+Harding,01,Commissioner of School and Public Lands,,Timothy Azure,DEM,9
+Harding,01,Commissioner of School and Public Lands,,Brock Greenfield,REP,113
+Harding,02,Commissioner of School and Public Lands,,Timothy Azure,DEM,9
+Harding,02,Commissioner of School and Public Lands,,Brock Greenfield,REP,104
+Harding,03,Commissioner of School and Public Lands,,Timothy Azure,DEM,4
+Harding,03,Commissioner of School and Public Lands,,Brock Greenfield,REP,38
+Harding,05,Commissioner of School and Public Lands,,Timothy Azure,DEM,9
+Harding,05,Commissioner of School and Public Lands,,Brock Greenfield,REP,97
+Harding,06,Commissioner of School and Public Lands,,Timothy Azure,DEM,0
+Harding,06,Commissioner of School and Public Lands,,Brock Greenfield,REP,31
+Harding,07,Commissioner of School and Public Lands,,Timothy Azure,DEM,1
+Harding,07,Commissioner of School and Public Lands,,Brock Greenfield,REP,76
+Harding,08,Commissioner of School and Public Lands,,Timothy Azure,DEM,1
+Harding,08,Commissioner of School and Public Lands,,Brock Greenfield,REP,50
+Harding,09,Commissioner of School and Public Lands,,Timothy Azure,DEM,0
+Harding,09,Commissioner of School and Public Lands,,Brock Greenfield,REP,107
+Harding,01,Public Utilities Commissioner,,Jeffrey Barth,DEM,7
+Harding,01,Public Utilities Commissioner,,Chris Nelson,REP,112
+Harding,02,Public Utilities Commissioner,,Jeffrey Barth,DEM,11
+Harding,02,Public Utilities Commissioner,,Chris Nelson,REP,100
+Harding,03,Public Utilities Commissioner,,Jeffrey Barth,DEM,3
+Harding,03,Public Utilities Commissioner,,Chris Nelson,REP,39
+Harding,05,Public Utilities Commissioner,,Jeffrey Barth,DEM,6
+Harding,05,Public Utilities Commissioner,,Chris Nelson,REP,102
+Harding,06,Public Utilities Commissioner,,Jeffrey Barth,DEM,0
+Harding,06,Public Utilities Commissioner,,Chris Nelson,REP,31
+Harding,07,Public Utilities Commissioner,,Jeffrey Barth,DEM,2
+Harding,07,Public Utilities Commissioner,,Chris Nelson,REP,73
+Harding,08,Public Utilities Commissioner,,Jeffrey Barth,DEM,2
+Harding,08,Public Utilities Commissioner,,Chris Nelson,REP,49
+Harding,09,Public Utilities Commissioner,,Jeffrey Barth,DEM,3
+Harding,09,Public Utilities Commissioner,,Chris Nelson,REP,105
+Harding,01,State Senate,28,Ryan M. Maher,REP,111
+Harding,02,State Senate,28,Ryan M. Maher,REP,113
+Harding,03,State Senate,28,Ryan M. Maher,REP,39
+Harding,05,State Senate,28,Ryan M. Maher,REP,100
+Harding,06,State Senate,28,Ryan M. Maher,REP,31
+Harding,07,State Senate,28,Ryan M. Maher,REP,75
+Harding,08,State Senate,28,Ryan M. Maher,REP,51
+Harding,09,State Senate,28,Ryan M. Maher,REP,104
+Harding,01,State House,28B,Neal Pinnow,REP,101
+Harding,01,State House,28B,Calvin Reilly,IND,19
+Harding,02,State House,28B,Neal Pinnow,REP,94
+Harding,02,State House,28B,Calvin Reilly,IND,15
+Harding,03,State House,28B,Neal Pinnow,REP,36
+Harding,03,State House,28B,Calvin Reilly,IND,4
+Harding,05,State House,28B,Neal Pinnow,REP,98
+Harding,05,State House,28B,Calvin Reilly,IND,7
+Harding,06,State House,28B,Neal Pinnow,REP,29
+Harding,06,State House,28B,Calvin Reilly,IND,1
+Harding,07,State House,28B,Neal Pinnow,REP,73
+Harding,07,State House,28B,Calvin Reilly,IND,5
+Harding,08,State House,28B,Neal Pinnow,REP,48
+Harding,08,State House,28B,Calvin Reilly,IND,4
+Harding,09,State House,28B,Neal Pinnow,REP,98
+Harding,09,State House,28B,Calvin Reilly,IND,8
+Harding,01,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,68
+Harding,02,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,57
+Harding,03,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,24
+Harding,05,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,65
+Harding,06,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,17
+Harding,07,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,40
+Harding,08,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,31
+Harding,09,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,52
+Harding,01,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,70
+Harding,02,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,67
+Harding,03,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,23
+Harding,05,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,70
+Harding,06,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,17
+Harding,07,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,45
+Harding,08,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,32
+Harding,09,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,58
+Harding,01,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,64
+Harding,02,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,57
+Harding,03,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,22
+Harding,05,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,65
+Harding,06,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,18
+Harding,07,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,42
+Harding,08,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,30
+Harding,09,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,54
+Harding,01,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,5
+Harding,01,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,13
+Harding,01,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,13
+Harding,01,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,26
+Harding,01,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,30
+Harding,02,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,7
+Harding,02,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,10
+Harding,02,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,10
+Harding,02,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,20
+Harding,02,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,37
+Harding,03,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,2
+Harding,03,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,1
+Harding,03,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,7
+Harding,03,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,4
+Harding,03,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,10
+Harding,05,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,6
+Harding,05,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,18
+Harding,05,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,13
+Harding,05,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,23
+Harding,05,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,26
+Harding,06,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,4
+Harding,06,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,8
+Harding,06,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,2
+Harding,06,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,6
+Harding,06,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,3
+Harding,07,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,6
+Harding,07,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,8
+Harding,07,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,21
+Harding,07,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,8
+Harding,07,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,11
+Harding,08,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,0
+Harding,08,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,16
+Harding,08,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,6
+Harding,08,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,8
+Harding,08,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,9
+Harding,09,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,0
+Harding,09,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,22
+Harding,09,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,7
+Harding,09,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,14
+Harding,09,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,27
+Harding,01,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,84
+Harding,01,Supreme Court Retention,3,Patricia J. DeVaney - No,,16
+Harding,02,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,88
+Harding,02,Supreme Court Retention,3,Patricia J. DeVaney - No,,16
+Harding,03,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,33
+Harding,03,Supreme Court Retention,3,Patricia J. DeVaney - No,,2
+Harding,05,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,77
+Harding,05,Supreme Court Retention,3,Patricia J. DeVaney - No,,10
+Harding,06,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,21
+Harding,06,Supreme Court Retention,3,Patricia J. DeVaney - No,,3
+Harding,07,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,53
+Harding,07,Supreme Court Retention,3,Patricia J. DeVaney - No,,15
+Harding,08,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,35
+Harding,08,Supreme Court Retention,3,Patricia J. DeVaney - No,,6
+Harding,09,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,76
+Harding,09,Supreme Court Retention,3,Patricia J. DeVaney - No,,8
+Harding,01,Supreme Court Retention,2,Mark E. Salter - Yes,,88
+Harding,01,Supreme Court Retention,2,Mark E. Salter - No,,17
+Harding,02,Supreme Court Retention,2,Mark E. Salter - Yes,,89
+Harding,02,Supreme Court Retention,2,Mark E. Salter - No,,13
+Harding,03,Supreme Court Retention,2,Mark E. Salter - Yes,,31
+Harding,03,Supreme Court Retention,2,Mark E. Salter - No,,3
+Harding,05,Supreme Court Retention,2,Mark E. Salter - Yes,,74
+Harding,05,Supreme Court Retention,2,Mark E. Salter - No,,13
+Harding,06,Supreme Court Retention,2,Mark E. Salter - Yes,,22
+Harding,06,Supreme Court Retention,2,Mark E. Salter - No,,2
+Harding,07,Supreme Court Retention,2,Mark E. Salter - Yes,,50
+Harding,07,Supreme Court Retention,2,Mark E. Salter - No,,15
+Harding,08,Supreme Court Retention,2,Mark E. Salter - Yes,,34
+Harding,08,Supreme Court Retention,2,Mark E. Salter - No,,6
+Harding,09,Supreme Court Retention,2,Mark E. Salter - Yes,,75
+Harding,09,Supreme Court Retention,2,Mark E. Salter - No,,8
+Harding,01,Constitutional Amendment D,,Yes,,48
+Harding,01,Constitutional Amendment D,,No,,77
+Harding,02,Constitutional Amendment D,,Yes,,42
+Harding,02,Constitutional Amendment D,,No,,81
+Harding,03,Constitutional Amendment D,,Yes,,14
+Harding,03,Constitutional Amendment D,,No,,29
+Harding,05,Constitutional Amendment D,,Yes,,45
+Harding,05,Constitutional Amendment D,,No,,66
+Harding,06,Constitutional Amendment D,,Yes,,8
+Harding,06,Constitutional Amendment D,,No,,21
+Harding,07,Constitutional Amendment D,,Yes,,24
+Harding,07,Constitutional Amendment D,,No,,49
+Harding,08,Constitutional Amendment D,,Yes,,8
+Harding,08,Constitutional Amendment D,,No,,44
+Harding,09,Constitutional Amendment D,,Yes,,29
+Harding,09,Constitutional Amendment D,,No,,81
+Harding,01,Initiated Measure 27,,Yes,,27
+Harding,01,Initiated Measure 27,,No,,98
+Harding,02,Initiated Measure 27,,Yes,,23
+Harding,02,Initiated Measure 27,,No,,102
+Harding,03,Initiated Measure 27,,Yes,,6
+Harding,03,Initiated Measure 27,,No,,37
+Harding,05,Initiated Measure 27,,Yes,,23
+Harding,05,Initiated Measure 27,,No,,90
+Harding,06,Initiated Measure 27,,Yes,,4
+Harding,06,Initiated Measure 27,,No,,26
+Harding,07,Initiated Measure 27,,Yes,,22
+Harding,07,Initiated Measure 27,,No,,59
+Harding,08,Initiated Measure 27,,Yes,,7
+Harding,08,Initiated Measure 27,,No,,45
+Harding,09,Initiated Measure 27,,Yes,,9
+Harding,09,Initiated Measure 27,,No,,101

--- a/2022/counties/20221108__sd__general__hughes__precinct.csv
+++ b/2022/counties/20221108__sd__general__hughes__precinct.csv
@@ -1,0 +1,229 @@
+county,precinct,office,district,candidate,party,votes
+Hughes,Absentee Precinct,U.S. Senate,,Brian L. Bengs,DEM,555
+Hughes,Absentee Precinct,U.S. Senate,,Tamara J Lesnar,LIB,51
+Hughes,Absentee Precinct,U.S. Senate,,John R. Thune,REP,1205
+Hughes,Blunt Community Center,U.S. Senate,,Brian L. Bengs,DEM,26
+Hughes,Blunt Community Center,U.S. Senate,,Tamara J Lesnar,LIB,15
+Hughes,Blunt Community Center,U.S. Senate,,John R. Thune,REP,148
+Hughes,Capitol Lake Visitors Center,U.S. Senate,,Brian L. Bengs,DEM,195
+Hughes,Capitol Lake Visitors Center,U.S. Senate,,Tamara J Lesnar,LIB,44
+Hughes,Capitol Lake Visitors Center,U.S. Senate,,John R. Thune,REP,547
+Hughes,Faith Lutheran Church,U.S. Senate,,Brian L. Bengs,DEM,485
+Hughes,Faith Lutheran Church,U.S. Senate,,Tamara J Lesnar,LIB,95
+Hughes,Faith Lutheran Church,U.S. Senate,,John R. Thune,REP,1682
+Hughes,Harrold City Auditoruim,U.S. Senate,,Brian L. Bengs,DEM,8
+Hughes,Harrold City Auditoruim,U.S. Senate,,Tamara J Lesnar,LIB,5
+Hughes,Harrold City Auditoruim,U.S. Senate,,John R. Thune,REP,79
+Hughes,?,U.S. Senate,,Brian L. Bengs,DEM,414
+Hughes,?,U.S. Senate,,Tamara J Lesnar,LIB,91
+Hughes,?,U.S. Senate,,John R. Thune,REP,1806
+Hughes,Absentee Precinct,U.S. House,1,Collin Duprel,LIB,371
+Hughes,Absentee Precinct,U.S. House,1,Dusty Johnson,REP,1308
+Hughes,Blunt Community Center,U.S. House,1,Collin Duprel,LIB,32
+Hughes,Blunt Community Center,U.S. House,1,Dusty Johnson,REP,150
+Hughes,Capitol Lake Visitors Center,U.S. House,1,Collin Duprel,LIB,175
+Hughes,Capitol Lake Visitors Center,U.S. House,1,Dusty Johnson,REP,569
+Hughes,Faith Lutheran Church,U.S. House,1,Collin Duprel,LIB,408
+Hughes,Faith Lutheran Church,U.S. House,1,Dusty Johnson,REP,1760
+Hughes,Harrold City Auditoruim,U.S. House,1,Collin Duprel,LIB,17
+Hughes,Harrold City Auditoruim,U.S. House,1,Dusty Johnson,REP,73
+Hughes,?,U.S. House,1,Collin Duprel,LIB,407
+Hughes,?,U.S. House,1,Dusty Johnson,REP,1846
+Hughes,Absentee Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,817
+Hughes,Absentee Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,49
+Hughes,Absentee Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,955
+Hughes,Blunt Community Center,Governor,,Jamie Smith and Jennifer Keintz,DEM,32
+Hughes,Blunt Community Center,Governor,,Tracey Quint and Ashley Strand,LIB,8
+Hughes,Blunt Community Center,Governor,,Kristi Noem and Larry Rhoden,REP,151
+Hughes,Capitol Lake Visitors Center,Governor,,Jamie Smith and Jennifer Keintz,DEM,316
+Hughes,Capitol Lake Visitors Center,Governor,,Tracey Quint and Ashley Strand,LIB,29
+Hughes,Capitol Lake Visitors Center,Governor,,Kristi Noem and Larry Rhoden,REP,440
+Hughes,Faith Lutheran Church,Governor,,Jamie Smith and Jennifer Keintz,DEM,808
+Hughes,Faith Lutheran Church,Governor,,Tracey Quint and Ashley Strand,LIB,69
+Hughes,Faith Lutheran Church,Governor,,Kristi Noem and Larry Rhoden,REP,1373
+Hughes,Harrold City Auditoruim,Governor,,Jamie Smith and Jennifer Keintz,DEM,13
+Hughes,Harrold City Auditoruim,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Hughes,Harrold City Auditoruim,Governor,,Kristi Noem and Larry Rhoden,REP,80
+Hughes,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,666
+Hughes,?,Governor,,Tracey Quint and Ashley Strand,LIB,68
+Hughes,?,Governor,,Kristi Noem and Larry Rhoden,REP,1572
+Hughes,Absentee Precinct,Secretary of State,,Thomas A Cool,DEM,743
+Hughes,Absentee Precinct,Secretary of State,,Monae Johnson,REP,1008
+Hughes,Blunt Community Center,Secretary of State,,Thomas A Cool,DEM,36
+Hughes,Blunt Community Center,Secretary of State,,Monae Johnson,REP,143
+Hughes,Capitol Lake Visitors Center,Secretary of State,,Thomas A Cool,DEM,322
+Hughes,Capitol Lake Visitors Center,Secretary of State,,Monae Johnson,REP,409
+Hughes,Faith Lutheran Church,Secretary of State,,Thomas A Cool,DEM,770
+Hughes,Faith Lutheran Church,Secretary of State,,Monae Johnson,REP,1383
+Hughes,Harrold City Auditoruim,Secretary of State,,Thomas A Cool,DEM,12
+Hughes,Harrold City Auditoruim,Secretary of State,,Monae Johnson,REP,82
+Hughes,?,Secretary of State,,Thomas A Cool,DEM,680
+Hughes,?,Secretary of State,,Monae Johnson,REP,1538
+Hughes,Absentee Precinct,Attorney General,,Marty J. Jackley,REP,1411
+Hughes,Blunt Community Center,Attorney General,,Marty J. Jackley,REP,151
+Hughes,Capitol Lake Visitors Center,Attorney General,,Marty J. Jackley,REP,610
+Hughes,Faith Lutheran Church,Attorney General,,Marty J. Jackley,REP,1858
+Hughes,Harrold City Auditoruim,Attorney General,,Marty J. Jackley,REP,75
+Hughes,?,Attorney General,,Marty J. Jackley,REP,1910
+Hughes,Absentee Precinct,State Auditor,,Stephanie Marty,DEM,572
+Hughes,Absentee Precinct,State Auditor,,Rene Meyer,LIB,59
+Hughes,Absentee Precinct,State Auditor,,Richard Sattgast,REP,1160
+Hughes,Blunt Community Center,State Auditor,,Stephanie Marty,DEM,26
+Hughes,Blunt Community Center,State Auditor,,Rene Meyer,LIB,15
+Hughes,Blunt Community Center,State Auditor,,Richard Sattgast,REP,141
+Hughes,Capitol Lake Visitors Center,State Auditor,,Stephanie Marty,DEM,217
+Hughes,Capitol Lake Visitors Center,State Auditor,,Rene Meyer,LIB,57
+Hughes,Capitol Lake Visitors Center,State Auditor,,Richard Sattgast,REP,476
+Hughes,Faith Lutheran Church,State Auditor,,Stephanie Marty,DEM,511
+Hughes,Faith Lutheran Church,State Auditor,,Rene Meyer,LIB,109
+Hughes,Faith Lutheran Church,State Auditor,,Richard Sattgast,REP,1577
+Hughes,Harrold City Auditoruim,State Auditor,,Stephanie Marty,DEM,9
+Hughes,Harrold City Auditoruim,State Auditor,,Rene Meyer,LIB,3
+Hughes,Harrold City Auditoruim,State Auditor,,Richard Sattgast,REP,82
+Hughes,?,State Auditor,,Stephanie Marty,DEM,453
+Hughes,?,State Auditor,,Rene Meyer,LIB,117
+Hughes,?,State Auditor,,Richard Sattgast,REP,1682
+Hughes,Absentee Precinct,State Treasurer,,John Cunningham,DEM,586
+Hughes,Absentee Precinct,State Treasurer,,Josh Haeder,REP,1181
+Hughes,Blunt Community Center,State Treasurer,,John Cunningham,DEM,31
+Hughes,Blunt Community Center,State Treasurer,,Josh Haeder,REP,151
+Hughes,Capitol Lake Visitors Center,State Treasurer,,John Cunningham,DEM,224
+Hughes,Capitol Lake Visitors Center,State Treasurer,,Josh Haeder,REP,509
+Hughes,Faith Lutheran Church,State Treasurer,,John Cunningham,DEM,541
+Hughes,Faith Lutheran Church,State Treasurer,,Josh Haeder,REP,1648
+Hughes,Harrold City Auditoruim,State Treasurer,,John Cunningham,DEM,14
+Hughes,Harrold City Auditoruim,State Treasurer,,Josh Haeder,REP,81
+Hughes,?,State Treasurer,,John Cunningham,DEM,496
+Hughes,?,State Treasurer,,Josh Haeder,REP,1734
+Hughes,Absentee Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,658
+Hughes,Absentee Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,1069
+Hughes,Blunt Community Center,Commissioner of School and Public Lands,,Timothy Azure,DEM,31
+Hughes,Blunt Community Center,Commissioner of School and Public Lands,,Brock Greenfield,REP,150
+Hughes,Capitol Lake Visitors Center,Commissioner of School and Public Lands,,Timothy Azure,DEM,254
+Hughes,Capitol Lake Visitors Center,Commissioner of School and Public Lands,,Brock Greenfield,REP,465
+Hughes,Faith Lutheran Church,Commissioner of School and Public Lands,,Timothy Azure,DEM,621
+Hughes,Faith Lutheran Church,Commissioner of School and Public Lands,,Brock Greenfield,REP,1495
+Hughes,Harrold City Auditoruim,Commissioner of School and Public Lands,,Timothy Azure,DEM,10
+Hughes,Harrold City Auditoruim,Commissioner of School and Public Lands,,Brock Greenfield,REP,79
+Hughes,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,549
+Hughes,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,1606
+Hughes,Absentee Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,541
+Hughes,Absentee Precinct,Public Utilities Commissioner,,Chris Nelson,REP,1235
+Hughes,Blunt Community Center,Public Utilities Commissioner,,Jeffrey Barth,DEM,30
+Hughes,Blunt Community Center,Public Utilities Commissioner,,Chris Nelson,REP,151
+Hughes,Capitol Lake Visitors Center,Public Utilities Commissioner,,Jeffrey Barth,DEM,208
+Hughes,Capitol Lake Visitors Center,Public Utilities Commissioner,,Chris Nelson,REP,540
+Hughes,Faith Lutheran Church,Public Utilities Commissioner,,Jeffrey Barth,DEM,511
+Hughes,Faith Lutheran Church,Public Utilities Commissioner,,Chris Nelson,REP,1693
+Hughes,Harrold City Auditoruim,Public Utilities Commissioner,,Jeffrey Barth,DEM,11
+Hughes,Harrold City Auditoruim,Public Utilities Commissioner,,Chris Nelson,REP,83
+Hughes,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,445
+Hughes,?,Public Utilities Commissioner,,Chris Nelson,REP,1806
+Hughes,Absentee Precinct,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,1115
+Hughes,Blunt Community Center,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,111
+Hughes,Capitol Lake Visitors Center,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,483
+Hughes,Faith Lutheran Church,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,1516
+Hughes,Harrold City Auditoruim,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,51
+Hughes,?,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,1482
+Hughes,Absentee Precinct,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,1107
+Hughes,Blunt Community Center,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,104
+Hughes,Capitol Lake Visitors Center,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,486
+Hughes,Faith Lutheran Church,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,1518
+Hughes,Harrold City Auditoruim,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,49
+Hughes,?,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,1459
+Hughes,Absentee Precinct,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,1106
+Hughes,Blunt Community Center,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,101
+Hughes,Capitol Lake Visitors Center,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,481
+Hughes,Faith Lutheran Church,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,1510
+Hughes,Harrold City Auditoruim,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,46
+Hughes,?,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,1461
+Hughes,Absentee Precinct,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,1063
+Hughes,Blunt Community Center,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,100
+Hughes,Capitol Lake Visitors Center,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,484
+Hughes,Faith Lutheran Church,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,1457
+Hughes,Harrold City Auditoruim,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,45
+Hughes,?,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,1385
+Hughes,Absentee Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1421
+Hughes,Absentee Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,244
+Hughes,Blunt Community Center,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,145
+Hughes,Blunt Community Center,Supreme Court Retention,3,Patricia J. DeVaney - No,,24
+Hughes,Capitol Lake Visitors Center,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,580
+Hughes,Capitol Lake Visitors Center,Supreme Court Retention,3,Patricia J. DeVaney - No,,122
+Hughes,Faith Lutheran Church,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1779
+Hughes,Faith Lutheran Church,Supreme Court Retention,3,Patricia J. DeVaney - No,,287
+Hughes,Harrold City Auditoruim,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,73
+Hughes,Harrold City Auditoruim,Supreme Court Retention,3,Patricia J. DeVaney - No,,10
+Hughes,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1795
+Hughes,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,300
+Hughes,Absentee Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,1402
+Hughes,Absentee Precinct,Supreme Court Retention,2,Mark E. Salter - No,,231
+Hughes,Blunt Community Center,Supreme Court Retention,2,Mark E. Salter - Yes,,139
+Hughes,Blunt Community Center,Supreme Court Retention,2,Mark E. Salter - No,,30
+Hughes,Capitol Lake Visitors Center,Supreme Court Retention,2,Mark E. Salter - Yes,,574
+Hughes,Capitol Lake Visitors Center,Supreme Court Retention,2,Mark E. Salter - No,,117
+Hughes,Faith Lutheran Church,Supreme Court Retention,2,Mark E. Salter - Yes,,1742
+Hughes,Faith Lutheran Church,Supreme Court Retention,2,Mark E. Salter - No,,288
+Hughes,Harrold City Auditoruim,Supreme Court Retention,2,Mark E. Salter - Yes,,75
+Hughes,Harrold City Auditoruim,Supreme Court Retention,2,Mark E. Salter - No,,8
+Hughes,?,Supreme Court Retention,2,Mark E. Salter - Yes,,1770
+Hughes,?,Supreme Court Retention,2,Mark E. Salter - No,,285
+Hughes,Absentee Precinct,Constitutional Amendment D,,Yes,,1105
+Hughes,Absentee Precinct,Constitutional Amendment D,,No,,705
+Hughes,Blunt Community Center,Constitutional Amendment D,,Yes,,88
+Hughes,Blunt Community Center,Constitutional Amendment D,,No,,100
+Hughes,Capitol Lake Visitors Center,Constitutional Amendment D,,Yes,,454
+Hughes,Capitol Lake Visitors Center,Constitutional Amendment D,,No,,331
+Hughes,Faith Lutheran Church,Constitutional Amendment D,,Yes,,1259
+Hughes,Faith Lutheran Church,Constitutional Amendment D,,No,,990
+Hughes,Harrold City Auditoruim,Constitutional Amendment D,,Yes,,30
+Hughes,Harrold City Auditoruim,Constitutional Amendment D,,No,,61
+Hughes,?,Constitutional Amendment D,,Yes,,1179
+Hughes,?,Constitutional Amendment D,,No,,1108
+Hughes,Absentee Precinct,Initiated Measure 27,,Yes,,831
+Hughes,Absentee Precinct,Initiated Measure 27,,No,,1003
+Hughes,Blunt Community Center,Initiated Measure 27,,Yes,,70
+Hughes,Blunt Community Center,Initiated Measure 27,,No,,122
+Hughes,Capitol Lake Visitors Center,Initiated Measure 27,,Yes,,429
+Hughes,Capitol Lake Visitors Center,Initiated Measure 27,,No,,366
+Hughes,Faith Lutheran Church,Initiated Measure 27,,Yes,,1102
+Hughes,Faith Lutheran Church,Initiated Measure 27,,No,,1169
+Hughes,Harrold City Auditoruim,Initiated Measure 27,,Yes,,31
+Hughes,Harrold City Auditoruim,Initiated Measure 27,,No,,62
+Hughes,?,Initiated Measure 27,,Yes,,1013
+Hughes,?,Initiated Measure 27,,No,,1310
+Hughes,Absentee Precinct,State Senate,24,Jim Mehlhaff,REP,1169
+Hughes,Absentee Precinct,State Senate,26,Shawn Bordeaux,DEM,2
+Hughes,Absentee Precinct,State Senate,26,Joel Koskan,REP,2
+Hughes,Blunt Community Center,State Senate,24,Jim Mehlhaff,REP,140
+Hughes,Blunt Community Center,State Senate,26,Shawn Bordeaux,DEM,0
+Hughes,Blunt Community Center,State Senate,26,Joel Koskan,REP,0
+Hughes,Capitol Lake Visitors Center,State Senate,24,Jim Mehlhaff,REP,507
+Hughes,Capitol Lake Visitors Center,State Senate,26,Shawn Bordeaux,DEM,3
+Hughes,Capitol Lake Visitors Center,State Senate,26,Joel Koskan,REP,0
+Hughes,Faith Lutheran Church,State Senate,24,Jim Mehlhaff,REP,1653
+Hughes,Faith Lutheran Church,State Senate,26,Shawn Bordeaux,DEM,6
+Hughes,Faith Lutheran Church,State Senate,26,Joel Koskan,REP,2
+Hughes,Harrold City Auditoruim,State Senate,24,Jim Mehlhaff,REP,70
+Hughes,Harrold City Auditoruim,State Senate,26,Shawn Bordeaux,DEM,5
+Hughes,Harrold City Auditoruim,State Senate,26,Joel Koskan,REP,0
+Hughes,New Life Assembly of God Church 10 of 21,State Senate,24,Jim Mehlhaff,REP,1701
+Hughes,New Life Assembly of God Church 10 of 21,State Senate,26,Shawn Bordeaux,DEM,6
+Hughes,New Life Assembly of God Church 10 of 21,State Senate,26,Joel Koskan,REP,1
+Hughes,Absentee Precinct,State House,24,Mike Weisgram,REP,1135
+Hughes,Absentee Precinct,State House,24,Will D. Mortenson,REP,1185
+Hughes,Absentee Precinct,State House,26B,Rebecca Reimer,REP,2
+Hughes,Blunt Community Center,State House,24,Mike Weisgram,REP,106
+Hughes,Blunt Community Center,State House,24,Will D. Mortenson,REP,127
+Hughes,Blunt Community Center,State House,26B,Rebecca Reimer,REP,0
+Hughes,Capitol Lake Visitors Center,State House,24,Mike Weisgram,REP,453
+Hughes,Capitol Lake Visitors Center,State House,24,Will D. Mortenson,REP,509
+Hughes,Capitol Lake Visitors Center,State House,26B,Rebecca Reimer,REP,0
+Hughes,Faith Lutheran Church,State House,24,Mike Weisgram,REP,1475
+Hughes,Faith Lutheran Church,State House,24,Will D. Mortenson,REP,1610
+Hughes,Faith Lutheran Church,State House,26B,Rebecca Reimer,REP,8
+Hughes,Harrold City Auditoruim,State House,24,Mike Weisgram,REP,55
+Hughes,Harrold City Auditoruim,State House,24,Will D. Mortenson,REP,66
+Hughes,Harrold City Auditoruim,State House,26B,Rebecca Reimer,REP,0
+Hughes,New Life Assembly of God Church 11 of 21,State House,24,Mike Weisgram,REP,1467
+Hughes,New Life Assembly of God Church 11 of 21,State House,24,Will D. Mortenson,REP,1628
+Hughes,New Life Assembly of God Church 11 of 21,State House,26B,Rebecca Reimer,REP,1

--- a/2022/counties/20221108__sd__general__hutchinson__precinct.csv
+++ b/2022/counties/20221108__sd__general__hutchinson__precinct.csv
@@ -1,0 +1,229 @@
+county,precinct,office,district,candidate,party,votes
+Hutchinson,01,U.S. Senate,,Brian L. Bengs,DEM,70
+Hutchinson,01,U.S. Senate,,Tamara J Lesnar,LIB,25
+Hutchinson,01,U.S. Senate,,John R. Thune,REP,492
+Hutchinson,02,U.S. Senate,,Brian L. Bengs,DEM,143
+Hutchinson,02,U.S. Senate,,Tamara J Lesnar,LIB,32
+Hutchinson,02,U.S. Senate,,John R. Thune,REP,658
+Hutchinson,03,U.S. Senate,,Brian L. Bengs,DEM,54
+Hutchinson,03,U.S. Senate,,Tamara J Lesnar,LIB,12
+Hutchinson,03,U.S. Senate,,John R. Thune,REP,390
+Hutchinson,04,U.S. Senate,,Brian L. Bengs,DEM,102
+Hutchinson,04,U.S. Senate,,Tamara J Lesnar,LIB,18
+Hutchinson,04,U.S. Senate,,John R. Thune,REP,504
+Hutchinson,05,U.S. Senate,,Brian L. Bengs,DEM,30
+Hutchinson,05,U.S. Senate,,Tamara J Lesnar,LIB,10
+Hutchinson,05,U.S. Senate,,John R. Thune,REP,349
+Hutchinson,06,U.S. Senate,,Brian L. Bengs,DEM,18
+Hutchinson,06,U.S. Senate,,Tamara J Lesnar,LIB,9
+Hutchinson,06,U.S. Senate,,John R. Thune,REP,226
+Hutchinson,01,U.S. House,1,Collin Duprel,LIB,89
+Hutchinson,01,U.S. House,1,Dusty Johnson,REP,480
+Hutchinson,02,U.S. House,1,Collin Duprel,LIB,117
+Hutchinson,02,U.S. House,1,Dusty Johnson,REP,682
+Hutchinson,03,U.S. House,1,Collin Duprel,LIB,47
+Hutchinson,03,U.S. House,1,Dusty Johnson,REP,402
+Hutchinson,04,U.S. House,1,Collin Duprel,LIB,63
+Hutchinson,04,U.S. House,1,Dusty Johnson,REP,540
+Hutchinson,05,U.S. House,1,Collin Duprel,LIB,24
+Hutchinson,05,U.S. House,1,Dusty Johnson,REP,358
+Hutchinson,06,U.S. House,1,Collin Duprel,LIB,18
+Hutchinson,06,U.S. House,1,Dusty Johnson,REP,228
+Hutchinson,01,Governor,,Jamie Smith and Jennifer Keintz,DEM,90
+Hutchinson,01,Governor,,Tracey Quint and Ashley Strand,LIB,10
+Hutchinson,01,Governor,,Kristi Noem and Larry Rhoden,REP,498
+Hutchinson,02,Governor,,Jamie Smith and Jennifer Keintz,DEM,197
+Hutchinson,02,Governor,,Tracey Quint and Ashley Strand,LIB,19
+Hutchinson,02,Governor,,Kristi Noem and Larry Rhoden,REP,628
+Hutchinson,03,Governor,,Jamie Smith and Jennifer Keintz,DEM,78
+Hutchinson,03,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Hutchinson,03,Governor,,Kristi Noem and Larry Rhoden,REP,374
+Hutchinson,04,Governor,,Jamie Smith and Jennifer Keintz,DEM,160
+Hutchinson,04,Governor,,Tracey Quint and Ashley Strand,LIB,22
+Hutchinson,04,Governor,,Kristi Noem and Larry Rhoden,REP,446
+Hutchinson,05,Governor,,Jamie Smith and Jennifer Keintz,DEM,48
+Hutchinson,05,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Hutchinson,05,Governor,,Kristi Noem and Larry Rhoden,REP,339
+Hutchinson,06,Governor,,Jamie Smith and Jennifer Keintz,DEM,31
+Hutchinson,06,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Hutchinson,06,Governor,,Kristi Noem and Larry Rhoden,REP,222
+Hutchinson,01,Secretary of State,,Thomas A Cool,DEM,90
+Hutchinson,01,Secretary of State,,Monae Johnson,REP,474
+Hutchinson,02,Secretary of State,,Thomas A Cool,DEM,193
+Hutchinson,02,Secretary of State,,Monae Johnson,REP,606
+Hutchinson,03,Secretary of State,,Thomas A Cool,DEM,96
+Hutchinson,03,Secretary of State,,Monae Johnson,REP,344
+Hutchinson,04,Secretary of State,,Thomas A Cool,DEM,186
+Hutchinson,04,Secretary of State,,Monae Johnson,REP,397
+Hutchinson,05,Secretary of State,,Thomas A Cool,DEM,60
+Hutchinson,05,Secretary of State,,Monae Johnson,REP,313
+Hutchinson,06,Secretary of State,,Thomas A Cool,DEM,34
+Hutchinson,06,Secretary of State,,Monae Johnson,REP,208
+Hutchinson,01,Attorney General,,Marty J. Jackley,REP,483
+Hutchinson,02,Attorney General,,Marty J. Jackley,REP,678
+Hutchinson,03,Attorney General,,Marty J. Jackley,REP,388
+Hutchinson,04,Attorney General,,Marty J. Jackley,REP,518
+Hutchinson,05,Attorney General,,Marty J. Jackley,REP,343
+Hutchinson,06,Attorney General,,Marty J. Jackley,REP,224
+Hutchinson,01,State Auditor,,Stephanie Marty,DEM,83
+Hutchinson,01,State Auditor,,Rene Meyer,LIB,26
+Hutchinson,01,State Auditor,,Richard Sattgast,REP,445
+Hutchinson,02,State Auditor,,Stephanie Marty,DEM,164
+Hutchinson,02,State Auditor,,Rene Meyer,LIB,42
+Hutchinson,02,State Auditor,,Richard Sattgast,REP,586
+Hutchinson,03,State Auditor,,Stephanie Marty,DEM,82
+Hutchinson,03,State Auditor,,Rene Meyer,LIB,13
+Hutchinson,03,State Auditor,,Richard Sattgast,REP,334
+Hutchinson,04,State Auditor,,Stephanie Marty,DEM,150
+Hutchinson,04,State Auditor,,Rene Meyer,LIB,18
+Hutchinson,04,State Auditor,,Richard Sattgast,REP,399
+Hutchinson,05,State Auditor,,Stephanie Marty,DEM,40
+Hutchinson,05,State Auditor,,Rene Meyer,LIB,13
+Hutchinson,05,State Auditor,,Richard Sattgast,REP,313
+Hutchinson,06,State Auditor,,Stephanie Marty,DEM,29
+Hutchinson,06,State Auditor,,Rene Meyer,LIB,7
+Hutchinson,06,State Auditor,,Richard Sattgast,REP,206
+Hutchinson,01,State Treasurer,,John Cunningham,DEM,85
+Hutchinson,01,State Treasurer,,Josh Haeder,REP,463
+Hutchinson,02,State Treasurer,,John Cunningham,DEM,171
+Hutchinson,02,State Treasurer,,Josh Haeder,REP,623
+Hutchinson,03,State Treasurer,,John Cunningham,DEM,85
+Hutchinson,03,State Treasurer,,Josh Haeder,REP,347
+Hutchinson,04,State Treasurer,,John Cunningham,DEM,159
+Hutchinson,04,State Treasurer,,Josh Haeder,REP,414
+Hutchinson,05,State Treasurer,,John Cunningham,DEM,43
+Hutchinson,05,State Treasurer,,Josh Haeder,REP,322
+Hutchinson,06,State Treasurer,,John Cunningham,DEM,26
+Hutchinson,06,State Treasurer,,Josh Haeder,REP,216
+Hutchinson,01,Commissioner of School and Public Lands,,Timothy Azure,DEM,78
+Hutchinson,01,Commissioner of School and Public Lands,,Brock Greenfield,REP,467
+Hutchinson,02,Commissioner of School and Public Lands,,Timothy Azure,DEM,161
+Hutchinson,02,Commissioner of School and Public Lands,,Brock Greenfield,REP,619
+Hutchinson,03,Commissioner of School and Public Lands,,Timothy Azure,DEM,78
+Hutchinson,03,Commissioner of School and Public Lands,,Brock Greenfield,REP,350
+Hutchinson,04,Commissioner of School and Public Lands,,Timothy Azure,DEM,146
+Hutchinson,04,Commissioner of School and Public Lands,,Brock Greenfield,REP,419
+Hutchinson,05,Commissioner of School and Public Lands,,Timothy Azure,DEM,41
+Hutchinson,05,Commissioner of School and Public Lands,,Brock Greenfield,REP,322
+Hutchinson,06,Commissioner of School and Public Lands,,Timothy Azure,DEM,26
+Hutchinson,06,Commissioner of School and Public Lands,,Brock Greenfield,REP,212
+Hutchinson,01,Public Utilities Commissioner,,Jeffrey Barth,DEM,72
+Hutchinson,01,Public Utilities Commissioner,,Chris Nelson,REP,495
+Hutchinson,02,Public Utilities Commissioner,,Jeffrey Barth,DEM,149
+Hutchinson,02,Public Utilities Commissioner,,Chris Nelson,REP,647
+Hutchinson,03,Public Utilities Commissioner,,Jeffrey Barth,DEM,65
+Hutchinson,03,Public Utilities Commissioner,,Chris Nelson,REP,384
+Hutchinson,04,Public Utilities Commissioner,,Jeffrey Barth,DEM,138
+Hutchinson,04,Public Utilities Commissioner,,Chris Nelson,REP,452
+Hutchinson,05,Public Utilities Commissioner,,Jeffrey Barth,DEM,40
+Hutchinson,05,Public Utilities Commissioner,,Chris Nelson,REP,332
+Hutchinson,06,Public Utilities Commissioner,,Jeffrey Barth,DEM,26
+Hutchinson,06,Public Utilities Commissioner,,Chris Nelson,REP,221
+Hutchinson,01,State Senate,19,Russell Graeff,DEM,74
+Hutchinson,01,State Senate,19,Kyle Schoenfish,REP,494
+Hutchinson,02,State Senate,19,Russell Graeff,DEM,150
+Hutchinson,02,State Senate,19,Kyle Schoenfish,REP,667
+Hutchinson,03,State Senate,19,Russell Graeff,DEM,59
+Hutchinson,03,State Senate,19,Kyle Schoenfish,REP,390
+Hutchinson,04,State Senate,19,Russell Graeff,DEM,93
+Hutchinson,04,State Senate,19,Kyle Schoenfish,REP,513
+Hutchinson,05,State Senate,19,Russell Graeff,DEM,32
+Hutchinson,05,State Senate,19,Kyle Schoenfish,REP,343
+Hutchinson,06,State Senate,19,Russell Graeff,DEM,20
+Hutchinson,06,State Senate,19,Kyle Schoenfish,REP,224
+Hutchinson,01,State House,19,Jessica Bahmuller,REP,354
+Hutchinson,01,State House,19,Drew Peterson,REP,379
+Hutchinson,02,State House,19,Jessica Bahmuller,REP,455
+Hutchinson,02,State House,19,Drew Peterson,REP,535
+Hutchinson,03,State House,19,Jessica Bahmuller,REP,310
+Hutchinson,03,State House,19,Drew Peterson,REP,247
+Hutchinson,04,State House,19,Jessica Bahmuller,REP,363
+Hutchinson,04,State House,19,Drew Peterson,REP,380
+Hutchinson,05,State House,19,Jessica Bahmuller,REP,243
+Hutchinson,05,State House,19,Drew Peterson,REP,264
+Hutchinson,06,State House,19,Jessica Bahmuller,REP,169
+Hutchinson,06,State House,19,Drew Peterson,REP,169
+Hutchinson,01,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,287
+Hutchinson,02,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,361
+Hutchinson,03,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,210
+Hutchinson,04,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,320
+Hutchinson,05,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,200
+Hutchinson,06,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,127
+Hutchinson,01,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,273
+Hutchinson,02,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,349
+Hutchinson,03,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,202
+Hutchinson,04,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,302
+Hutchinson,05,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,201
+Hutchinson,06,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,125
+Hutchinson,01,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,289
+Hutchinson,02,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,363
+Hutchinson,03,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,208
+Hutchinson,04,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,320
+Hutchinson,05,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,207
+Hutchinson,06,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,125
+Hutchinson,01,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,347
+Hutchinson,02,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,496
+Hutchinson,03,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,201
+Hutchinson,04,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,310
+Hutchinson,05,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,199
+Hutchinson,06,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,131
+Hutchinson,01,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,276
+Hutchinson,02,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,355
+Hutchinson,03,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,207
+Hutchinson,04,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,312
+Hutchinson,05,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,193
+Hutchinson,06,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,124
+Hutchinson,01,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,271
+Hutchinson,02,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,357
+Hutchinson,03,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,197
+Hutchinson,04,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,299
+Hutchinson,05,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,188
+Hutchinson,06,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,122
+Hutchinson,01,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,431
+Hutchinson,01,Supreme Court Retention,3,Patricia J. DeVaney - No,,62
+Hutchinson,02,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,574
+Hutchinson,02,Supreme Court Retention,3,Patricia J. DeVaney - No,,107
+Hutchinson,03,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,303
+Hutchinson,03,Supreme Court Retention,3,Patricia J. DeVaney - No,,73
+Hutchinson,04,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,476
+Hutchinson,04,Supreme Court Retention,3,Patricia J. DeVaney - No,,66
+Hutchinson,05,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,272
+Hutchinson,05,Supreme Court Retention,3,Patricia J. DeVaney - No,,64
+Hutchinson,06,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,190
+Hutchinson,06,Supreme Court Retention,3,Patricia J. DeVaney - No,,33
+Hutchinson,01,Supreme Court Retention,2,Mark E. Salter - Yes,,433
+Hutchinson,01,Supreme Court Retention,2,Mark E. Salter - No,,60
+Hutchinson,02,Supreme Court Retention,2,Mark E. Salter - Yes,,584
+Hutchinson,02,Supreme Court Retention,2,Mark E. Salter - No,,96
+Hutchinson,03,Supreme Court Retention,2,Mark E. Salter - Yes,,306
+Hutchinson,03,Supreme Court Retention,2,Mark E. Salter - No,,69
+Hutchinson,04,Supreme Court Retention,2,Mark E. Salter - Yes,,478
+Hutchinson,04,Supreme Court Retention,2,Mark E. Salter - No,,63
+Hutchinson,05,Supreme Court Retention,2,Mark E. Salter - Yes,,279
+Hutchinson,05,Supreme Court Retention,2,Mark E. Salter - No,,53
+Hutchinson,06,Supreme Court Retention,2,Mark E. Salter - Yes,,191
+Hutchinson,06,Supreme Court Retention,2,Mark E. Salter - No,,33
+Hutchinson,01,Constitutional Amendment D,,Yes,,193
+Hutchinson,01,Constitutional Amendment D,,No,,381
+Hutchinson,02,Constitutional Amendment D,,Yes,,359
+Hutchinson,02,Constitutional Amendment D,,No,,449
+Hutchinson,03,Constitutional Amendment D,,Yes,,192
+Hutchinson,03,Constitutional Amendment D,,No,,253
+Hutchinson,04,Constitutional Amendment D,,Yes,,294
+Hutchinson,04,Constitutional Amendment D,,No,,321
+Hutchinson,05,Constitutional Amendment D,,Yes,,169
+Hutchinson,05,Constitutional Amendment D,,No,,204
+Hutchinson,06,Constitutional Amendment D,,Yes,,107
+Hutchinson,06,Constitutional Amendment D,,No,,144
+Hutchinson,01,Initiated Measure 27,,Yes,,146
+Hutchinson,01,Initiated Measure 27,,No,,437
+Hutchinson,02,Initiated Measure 27,,Yes,,246
+Hutchinson,02,Initiated Measure 27,,No,,571
+Hutchinson,03,Initiated Measure 27,,Yes,,100
+Hutchinson,03,Initiated Measure 27,,No,,355
+Hutchinson,04,Initiated Measure 27,,Yes,,181
+Hutchinson,04,Initiated Measure 27,,No,,450
+Hutchinson,05,Initiated Measure 27,,Yes,,111
+Hutchinson,05,Initiated Measure 27,,No,,269
+Hutchinson,06,Initiated Measure 27,,Yes,,63
+Hutchinson,06,Initiated Measure 27,,No,,187

--- a/2022/counties/20221108__sd__general__hyde__precinct.csv
+++ b/2022/counties/20221108__sd__general__hyde__precinct.csv
@@ -1,0 +1,39 @@
+county,precinct,office,district,candidate,party,votes
+Hyde,?,U.S. Senate,,Brian L. Bengs,DEM,78
+Hyde,?,U.S. Senate,,Tamara J Lesnar,LIB,18
+Hyde,?,U.S. Senate,,John R. Thune,REP,484
+Hyde,?,U.S. House,1,Collin Duprel,LIB,81
+Hyde,?,U.S. House,1,Dusty Johnson,REP,479
+Hyde,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,106
+Hyde,?,Governor,,Tracey Quint and Ashley Strand,LIB,9
+Hyde,?,Governor,,Kristi Noem and Larry Rhoden,REP,460
+Hyde,?,Secretary of State,,Thomas A Cool,DEM,137
+Hyde,?,Secretary of State,,Monae Johnson,REP,412
+Hyde,?,Attorney General,,Marty J. Jackley,REP,500
+Hyde,?,State Auditor,,Stephanie Marty,DEM,105
+Hyde,?,State Auditor,,Rene Meyer,LIB,22
+Hyde,?,State Auditor,,Richard Sattgast,REP,429
+Hyde,?,State Treasurer,,John Cunningham,DEM,109
+Hyde,?,State Treasurer,,Josh Haeder,REP,442
+Hyde,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,111
+Hyde,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,428
+Hyde,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,119
+Hyde,?,Public Utilities Commissioner,,Chris Nelson,REP,436
+Hyde,?,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,314
+Hyde,?,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,317
+Hyde,?,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,306
+Hyde,?,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,304
+Hyde,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,431
+Hyde,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,82
+Hyde,?,Supreme Court Retention,2,Mark E. Salter - Yes,,427
+Hyde,?,Supreme Court Retention,2,Mark E. Salter - No,,79
+Hyde,?,Constitutional Amendment D,,Yes,,265
+Hyde,?,Constitutional Amendment D,,No,,291
+Hyde,?,Initiated Measure 27,,Yes,,171
+Hyde,?,Initiated Measure 27,,No,,393
+Hyde,Hyde County Memorial Auditorium-East Wing 10 of 20,State Senate,24,Jim Mehlhaff,REP,448
+Hyde,Hyde County Memorial Auditorium-East Wing 10 of 20,State Senate,26,Shawn Bordeaux,DEM,11
+Hyde,Hyde County Memorial Auditorium-East Wing 10 of 20,State Senate,26,Joel Koskan,REP,3
+Hyde,Hyde County Memorial Auditorium-East Wing 11 of 20,State House,24,Mike Weisgram,REP,276
+Hyde,Hyde County Memorial Auditorium-East Wing 11 of 20,State House,24,Will D. Mortenson,REP,403
+Hyde,Hyde County Memorial Auditorium-East Wing 11 of 20,State House,26B,Rebecca Reimer,REP,7

--- a/2022/counties/20221108__sd__general__jackson__precinct.csv
+++ b/2022/counties/20221108__sd__general__jackson__precinct.csv
@@ -1,0 +1,305 @@
+county,precinct,office,district,candidate,party,votes
+Jackson,1,U.S. Senate,,Brian L. Bengs,DEM,0
+Jackson,1,U.S. Senate,,Tamara J Lesnar,LIB,3
+Jackson,1,U.S. Senate,,John R. Thune,REP,26
+Jackson,2,U.S. Senate,,Brian L. Bengs,DEM,15
+Jackson,2,U.S. Senate,,Tamara J Lesnar,LIB,4
+Jackson,2,U.S. Senate,,John R. Thune,REP,76
+Jackson,3,U.S. Senate,,Brian L. Bengs,DEM,9
+Jackson,3,U.S. Senate,,Tamara J Lesnar,LIB,15
+Jackson,3,U.S. Senate,,John R. Thune,REP,195
+Jackson,4,U.S. Senate,,Brian L. Bengs,DEM,15
+Jackson,4,U.S. Senate,,Tamara J Lesnar,LIB,3
+Jackson,4,U.S. Senate,,John R. Thune,REP,105
+Jackson,5,U.S. Senate,,Brian L. Bengs,DEM,6
+Jackson,5,U.S. Senate,,Tamara J Lesnar,LIB,7
+Jackson,5,U.S. Senate,,John R. Thune,REP,62
+Jackson,6,U.S. Senate,,Brian L. Bengs,DEM,15
+Jackson,6,U.S. Senate,,Tamara J Lesnar,LIB,10
+Jackson,6,U.S. Senate,,John R. Thune,REP,68
+Jackson,7,U.S. Senate,,Brian L. Bengs,DEM,137
+Jackson,7,U.S. Senate,,Tamara J Lesnar,LIB,20
+Jackson,7,U.S. Senate,,John R. Thune,REP,54
+Jackson,8,U.S. Senate,,Brian L. Bengs,DEM,18
+Jackson,8,U.S. Senate,,Tamara J Lesnar,LIB,5
+Jackson,8,U.S. Senate,,John R. Thune,REP,31
+Jackson,1,U.S. House,1,Collin Duprel,LIB,5
+Jackson,1,U.S. House,1,Dusty Johnson,REP,24
+Jackson,2,U.S. House,1,Collin Duprel,LIB,20
+Jackson,2,U.S. House,1,Dusty Johnson,REP,69
+Jackson,3,U.S. House,1,Collin Duprel,LIB,36
+Jackson,3,U.S. House,1,Dusty Johnson,REP,179
+Jackson,4,U.S. House,1,Collin Duprel,LIB,14
+Jackson,4,U.S. House,1,Dusty Johnson,REP,100
+Jackson,5,U.S. House,1,Collin Duprel,LIB,18
+Jackson,5,U.S. House,1,Dusty Johnson,REP,59
+Jackson,6,U.S. House,1,Collin Duprel,LIB,29
+Jackson,6,U.S. House,1,Dusty Johnson,REP,63
+Jackson,7,U.S. House,1,Collin Duprel,LIB,109
+Jackson,7,U.S. House,1,Dusty Johnson,REP,70
+Jackson,8,U.S. House,1,Collin Duprel,LIB,16
+Jackson,8,U.S. House,1,Dusty Johnson,REP,34
+Jackson,1,Governor,,Jamie Smith and Jennifer Keintz,DEM,1
+Jackson,1,Governor,,Tracey Quint and Ashley Strand,LIB,0
+Jackson,1,Governor,,Kristi Noem and Larry Rhoden,REP,30
+Jackson,2,Governor,,Jamie Smith and Jennifer Keintz,DEM,19
+Jackson,2,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Jackson,2,Governor,,Kristi Noem and Larry Rhoden,REP,75
+Jackson,3,Governor,,Jamie Smith and Jennifer Keintz,DEM,21
+Jackson,3,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Jackson,3,Governor,,Kristi Noem and Larry Rhoden,REP,201
+Jackson,4,Governor,,Jamie Smith and Jennifer Keintz,DEM,25
+Jackson,4,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Jackson,4,Governor,,Kristi Noem and Larry Rhoden,REP,100
+Jackson,5,Governor,,Jamie Smith and Jennifer Keintz,DEM,7
+Jackson,5,Governor,,Tracey Quint and Ashley Strand,LIB,0
+Jackson,5,Governor,,Kristi Noem and Larry Rhoden,REP,73
+Jackson,6,Governor,,Jamie Smith and Jennifer Keintz,DEM,20
+Jackson,6,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Jackson,6,Governor,,Kristi Noem and Larry Rhoden,REP,76
+Jackson,7,Governor,,Jamie Smith and Jennifer Keintz,DEM,165
+Jackson,7,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Jackson,7,Governor,,Kristi Noem and Larry Rhoden,REP,36
+Jackson,8,Governor,,Jamie Smith and Jennifer Keintz,DEM,22
+Jackson,8,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Jackson,8,Governor,,Kristi Noem and Larry Rhoden,REP,32
+Jackson,1,Secretary of State,,Thomas A Cool,DEM,2
+Jackson,1,Secretary of State,,Monae Johnson,REP,27
+Jackson,2,Secretary of State,,Thomas A Cool,DEM,18
+Jackson,2,Secretary of State,,Monae Johnson,REP,73
+Jackson,3,Secretary of State,,Thomas A Cool,DEM,25
+Jackson,3,Secretary of State,,Monae Johnson,REP,190
+Jackson,4,Secretary of State,,Thomas A Cool,DEM,21
+Jackson,4,Secretary of State,,Monae Johnson,REP,98
+Jackson,5,Secretary of State,,Thomas A Cool,DEM,6
+Jackson,5,Secretary of State,,Monae Johnson,REP,74
+Jackson,6,Secretary of State,,Thomas A Cool,DEM,19
+Jackson,6,Secretary of State,,Monae Johnson,REP,77
+Jackson,7,Secretary of State,,Thomas A Cool,DEM,161
+Jackson,7,Secretary of State,,Monae Johnson,REP,48
+Jackson,8,Secretary of State,,Thomas A Cool,DEM,27
+Jackson,8,Secretary of State,,Monae Johnson,REP,31
+Jackson,1,Attorney General,,Marty J. Jackley,REP,29
+Jackson,2,Attorney General,,Marty J. Jackley,REP,72
+Jackson,3,Attorney General,,Marty J. Jackley,REP,200
+Jackson,4,Attorney General,,Marty J. Jackley,REP,108
+Jackson,5,Attorney General,,Marty J. Jackley,REP,71
+Jackson,6,Attorney General,,Marty J. Jackley,REP,78
+Jackson,7,Attorney General,,Marty J. Jackley,REP,93
+Jackson,8,Attorney General,,Marty J. Jackley,REP,37
+Jackson,1,State Auditor,,Stephanie Marty,DEM,1
+Jackson,1,State Auditor,,Rene Meyer,LIB,1
+Jackson,1,State Auditor,,Richard Sattgast,REP,27
+Jackson,2,State Auditor,,Stephanie Marty,DEM,13
+Jackson,2,State Auditor,,Rene Meyer,LIB,5
+Jackson,2,State Auditor,,Richard Sattgast,REP,72
+Jackson,3,State Auditor,,Stephanie Marty,DEM,18
+Jackson,3,State Auditor,,Rene Meyer,LIB,12
+Jackson,3,State Auditor,,Richard Sattgast,REP,183
+Jackson,4,State Auditor,,Stephanie Marty,DEM,20
+Jackson,4,State Auditor,,Rene Meyer,LIB,3
+Jackson,4,State Auditor,,Richard Sattgast,REP,94
+Jackson,5,State Auditor,,Stephanie Marty,DEM,10
+Jackson,5,State Auditor,,Rene Meyer,LIB,3
+Jackson,5,State Auditor,,Richard Sattgast,REP,66
+Jackson,6,State Auditor,,Stephanie Marty,DEM,17
+Jackson,6,State Auditor,,Rene Meyer,LIB,5
+Jackson,6,State Auditor,,Richard Sattgast,REP,72
+Jackson,7,State Auditor,,Stephanie Marty,DEM,159
+Jackson,7,State Auditor,,Rene Meyer,LIB,14
+Jackson,7,State Auditor,,Richard Sattgast,REP,36
+Jackson,8,State Auditor,,Stephanie Marty,DEM,25
+Jackson,8,State Auditor,,Rene Meyer,LIB,5
+Jackson,8,State Auditor,,Richard Sattgast,REP,27
+Jackson,1,State Treasurer,,John Cunningham,DEM,1
+Jackson,1,State Treasurer,,Josh Haeder,REP,29
+Jackson,2,State Treasurer,,John Cunningham,DEM,16
+Jackson,2,State Treasurer,,Josh Haeder,REP,75
+Jackson,3,State Treasurer,,John Cunningham,DEM,21
+Jackson,3,State Treasurer,,Josh Haeder,REP,190
+Jackson,4,State Treasurer,,John Cunningham,DEM,22
+Jackson,4,State Treasurer,,Josh Haeder,REP,93
+Jackson,5,State Treasurer,,John Cunningham,DEM,8
+Jackson,5,State Treasurer,,Josh Haeder,REP,71
+Jackson,6,State Treasurer,,John Cunningham,DEM,18
+Jackson,6,State Treasurer,,Josh Haeder,REP,78
+Jackson,7,State Treasurer,,John Cunningham,DEM,167
+Jackson,7,State Treasurer,,Josh Haeder,REP,40
+Jackson,8,State Treasurer,,John Cunningham,DEM,27
+Jackson,8,State Treasurer,,Josh Haeder,REP,33
+Jackson,1,Commissioner of School and Public Lands,,Timothy Azure,DEM,2
+Jackson,1,Commissioner of School and Public Lands,,Brock Greenfield,REP,28
+Jackson,2,Commissioner of School and Public Lands,,Timothy Azure,DEM,17
+Jackson,2,Commissioner of School and Public Lands,,Brock Greenfield,REP,75
+Jackson,3,Commissioner of School and Public Lands,,Timothy Azure,DEM,18
+Jackson,3,Commissioner of School and Public Lands,,Brock Greenfield,REP,199
+Jackson,4,Commissioner of School and Public Lands,,Timothy Azure,DEM,21
+Jackson,4,Commissioner of School and Public Lands,,Brock Greenfield,REP,96
+Jackson,5,Commissioner of School and Public Lands,,Timothy Azure,DEM,7
+Jackson,5,Commissioner of School and Public Lands,,Brock Greenfield,REP,69
+Jackson,6,Commissioner of School and Public Lands,,Timothy Azure,DEM,20
+Jackson,6,Commissioner of School and Public Lands,,Brock Greenfield,REP,75
+Jackson,7,Commissioner of School and Public Lands,,Timothy Azure,DEM,162
+Jackson,7,Commissioner of School and Public Lands,,Brock Greenfield,REP,43
+Jackson,8,Commissioner of School and Public Lands,,Timothy Azure,DEM,22
+Jackson,8,Commissioner of School and Public Lands,,Brock Greenfield,REP,36
+Jackson,1,Public Utilities Commissioner,,Jeffrey Barth,DEM,1
+Jackson,1,Public Utilities Commissioner,,Chris Nelson,REP,30
+Jackson,2,Public Utilities Commissioner,,Jeffrey Barth,DEM,14
+Jackson,2,Public Utilities Commissioner,,Chris Nelson,REP,75
+Jackson,3,Public Utilities Commissioner,,Jeffrey Barth,DEM,13
+Jackson,3,Public Utilities Commissioner,,Chris Nelson,REP,202
+Jackson,4,Public Utilities Commissioner,,Jeffrey Barth,DEM,20
+Jackson,4,Public Utilities Commissioner,,Chris Nelson,REP,101
+Jackson,5,Public Utilities Commissioner,,Jeffrey Barth,DEM,6
+Jackson,5,Public Utilities Commissioner,,Chris Nelson,REP,72
+Jackson,6,Public Utilities Commissioner,,Jeffrey Barth,DEM,17
+Jackson,6,Public Utilities Commissioner,,Chris Nelson,REP,80
+Jackson,7,Public Utilities Commissioner,,Jeffrey Barth,DEM,163
+Jackson,7,Public Utilities Commissioner,,Chris Nelson,REP,44
+Jackson,8,Public Utilities Commissioner,,Jeffrey Barth,DEM,25
+Jackson,8,Public Utilities Commissioner,,Chris Nelson,REP,34
+Jackson,1,State Senate,27,Red Dawn Foster,DEM,1
+Jackson,1,State Senate,27,David Jones,REP,29
+Jackson,2,State Senate,27,Red Dawn Foster,DEM,16
+Jackson,2,State Senate,27,David Jones,REP,78
+Jackson,3,State Senate,27,Red Dawn Foster,DEM,18
+Jackson,3,State Senate,27,David Jones,REP,197
+Jackson,4,State Senate,27,Red Dawn Foster,DEM,21
+Jackson,4,State Senate,27,David Jones,REP,100
+Jackson,5,State Senate,27,Red Dawn Foster,DEM,8
+Jackson,5,State Senate,27,David Jones,REP,71
+Jackson,6,State Senate,27,Red Dawn Foster,DEM,20
+Jackson,6,State Senate,27,David Jones,REP,76
+Jackson,7,State Senate,27,Red Dawn Foster,DEM,177
+Jackson,7,State Senate,27,David Jones,REP,36
+Jackson,8,State Senate,27,Red Dawn Foster,DEM,25
+Jackson,8,State Senate,27,David Jones,REP,31
+Jackson,1,State House,27,Peri Pourier,DEM,2
+Jackson,1,State House,27,Norma Rendon,DEM,2
+Jackson,1,State House,27,Liz May,REP,26
+Jackson,1,State House,27,Bud May,REP,25
+Jackson,2,State House,27,Peri Pourier,DEM,17
+Jackson,2,State House,27,Norma Rendon,DEM,20
+Jackson,2,State House,27,Liz May,REP,72
+Jackson,2,State House,27,Bud May,REP,47
+Jackson,3,State House,27,Peri Pourier,DEM,31
+Jackson,3,State House,27,Norma Rendon,DEM,23
+Jackson,3,State House,27,Liz May,REP,178
+Jackson,3,State House,27,Bud May,REP,119
+Jackson,4,State House,27,Peri Pourier,DEM,24
+Jackson,4,State House,27,Norma Rendon,DEM,14
+Jackson,4,State House,27,Liz May,REP,92
+Jackson,4,State House,27,Bud May,REP,75
+Jackson,5,State House,27,Peri Pourier,DEM,10
+Jackson,5,State House,27,Norma Rendon,DEM,6
+Jackson,5,State House,27,Liz May,REP,71
+Jackson,5,State House,27,Bud May,REP,55
+Jackson,6,State House,27,Peri Pourier,DEM,20
+Jackson,6,State House,27,Norma Rendon,DEM,13
+Jackson,6,State House,27,Liz May,REP,75
+Jackson,6,State House,27,Bud May,REP,54
+Jackson,7,State House,27,Peri Pourier,DEM,170
+Jackson,7,State House,27,Norma Rendon,DEM,127
+Jackson,7,State House,27,Liz May,REP,37
+Jackson,7,State House,27,Bud May,REP,23
+Jackson,8,State House,27,Peri Pourier,DEM,39
+Jackson,8,State House,27,Norma Rendon,DEM,27
+Jackson,8,State House,27,Liz May,REP,24
+Jackson,8,State House,27,Bud May,REP,13
+Jackson,1,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,16
+Jackson,2,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,35
+Jackson,3,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,95
+Jackson,4,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,62
+Jackson,5,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,39
+Jackson,6,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,36
+Jackson,7,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,69
+Jackson,8,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,20
+Jackson,1,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,17
+Jackson,2,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,33
+Jackson,3,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,87
+Jackson,4,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,57
+Jackson,5,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,40
+Jackson,6,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,38
+Jackson,7,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,68
+Jackson,8,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,21
+Jackson,1,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,17
+Jackson,2,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,34
+Jackson,3,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,88
+Jackson,4,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,61
+Jackson,5,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,37
+Jackson,6,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,36
+Jackson,7,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,63
+Jackson,8,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,22
+Jackson,1,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,16
+Jackson,2,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,33
+Jackson,3,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,86
+Jackson,4,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,58
+Jackson,5,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,36
+Jackson,6,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,36
+Jackson,7,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,61
+Jackson,8,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,20
+Jackson,1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,23
+Jackson,1,Supreme Court Retention,3,Patricia J. DeVaney - No,,5
+Jackson,2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,53
+Jackson,2,Supreme Court Retention,3,Patricia J. DeVaney - No,,18
+Jackson,3,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,149
+Jackson,3,Supreme Court Retention,3,Patricia J. DeVaney - No,,39
+Jackson,4,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,89
+Jackson,4,Supreme Court Retention,3,Patricia J. DeVaney - No,,14
+Jackson,5,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,53
+Jackson,5,Supreme Court Retention,3,Patricia J. DeVaney - No,,15
+Jackson,6,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,65
+Jackson,6,Supreme Court Retention,3,Patricia J. DeVaney - No,,18
+Jackson,7,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,118
+Jackson,7,Supreme Court Retention,3,Patricia J. DeVaney - No,,62
+Jackson,8,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,35
+Jackson,8,Supreme Court Retention,3,Patricia J. DeVaney - No,,16
+Jackson,1,Supreme Court Retention,2,Mark E. Salter - Yes,,23
+Jackson,1,Supreme Court Retention,2,Mark E. Salter - No,,4
+Jackson,2,Supreme Court Retention,2,Mark E. Salter - Yes,,55
+Jackson,2,Supreme Court Retention,2,Mark E. Salter - No,,16
+Jackson,3,Supreme Court Retention,2,Mark E. Salter - Yes,,157
+Jackson,3,Supreme Court Retention,2,Mark E. Salter - No,,31
+Jackson,4,Supreme Court Retention,2,Mark E. Salter - Yes,,89
+Jackson,4,Supreme Court Retention,2,Mark E. Salter - No,,14
+Jackson,5,Supreme Court Retention,2,Mark E. Salter - Yes,,50
+Jackson,5,Supreme Court Retention,2,Mark E. Salter - No,,17
+Jackson,6,Supreme Court Retention,2,Mark E. Salter - Yes,,65
+Jackson,6,Supreme Court Retention,2,Mark E. Salter - No,,15
+Jackson,7,Supreme Court Retention,2,Mark E. Salter - Yes,,111
+Jackson,7,Supreme Court Retention,2,Mark E. Salter - No,,65
+Jackson,8,Supreme Court Retention,2,Mark E. Salter - Yes,,33
+Jackson,8,Supreme Court Retention,2,Mark E. Salter - No,,17
+Jackson,1,Constitutional Amendment D,,Yes,,7
+Jackson,1,Constitutional Amendment D,,No,,23
+Jackson,2,Constitutional Amendment D,,Yes,,31
+Jackson,2,Constitutional Amendment D,,No,,62
+Jackson,3,Constitutional Amendment D,,Yes,,98
+Jackson,3,Constitutional Amendment D,,No,,120
+Jackson,4,Constitutional Amendment D,,Yes,,53
+Jackson,4,Constitutional Amendment D,,No,,67
+Jackson,5,Constitutional Amendment D,,Yes,,29
+Jackson,5,Constitutional Amendment D,,No,,48
+Jackson,6,Constitutional Amendment D,,Yes,,38
+Jackson,6,Constitutional Amendment D,,No,,59
+Jackson,7,Constitutional Amendment D,,Yes,,172
+Jackson,7,Constitutional Amendment D,,No,,34
+Jackson,8,Constitutional Amendment D,,Yes,,34
+Jackson,8,Constitutional Amendment D,,No,,24
+Jackson,1,Initiated Measure 27,,Yes,,8
+Jackson,1,Initiated Measure 27,,No,,23
+Jackson,2,Initiated Measure 27,,Yes,,29
+Jackson,2,Initiated Measure 27,,No,,66
+Jackson,3,Initiated Measure 27,,Yes,,51
+Jackson,3,Initiated Measure 27,,No,,172
+Jackson,4,Initiated Measure 27,,Yes,,42
+Jackson,4,Initiated Measure 27,,No,,80
+Jackson,5,Initiated Measure 27,,Yes,,23
+Jackson,5,Initiated Measure 27,,No,,54
+Jackson,6,Initiated Measure 27,,Yes,,21
+Jackson,6,Initiated Measure 27,,No,,76
+Jackson,7,Initiated Measure 27,,Yes,,161
+Jackson,7,Initiated Measure 27,,No,,52
+Jackson,8,Initiated Measure 27,,Yes,,27
+Jackson,8,Initiated Measure 27,,No,,32

--- a/2022/counties/20221108__sd__general__jerauld__precinct.csv
+++ b/2022/counties/20221108__sd__general__jerauld__precinct.csv
@@ -1,0 +1,191 @@
+county,precinct,office,district,candidate,party,votes
+Jerauld,1,U.S. Senate,,Brian L. Bengs,DEM,89
+Jerauld,1,U.S. Senate,,Tamara J Lesnar,LIB,19
+Jerauld,1,U.S. Senate,,John R. Thune,REP,316
+Jerauld,2,U.S. Senate,,Brian L. Bengs,DEM,22
+Jerauld,2,U.S. Senate,,Tamara J Lesnar,LIB,6
+Jerauld,2,U.S. Senate,,John R. Thune,REP,108
+Jerauld,3,U.S. Senate,,Brian L. Bengs,DEM,14
+Jerauld,3,U.S. Senate,,Tamara J Lesnar,LIB,1
+Jerauld,3,U.S. Senate,,John R. Thune,REP,107
+Jerauld,4,U.S. Senate,,Brian L. Bengs,DEM,15
+Jerauld,4,U.S. Senate,,Tamara J Lesnar,LIB,4
+Jerauld,4,U.S. Senate,,John R. Thune,REP,70
+Jerauld,5,U.S. Senate,,Brian L. Bengs,DEM,14
+Jerauld,5,U.S. Senate,,Tamara J Lesnar,LIB,4
+Jerauld,5,U.S. Senate,,John R. Thune,REP,75
+Jerauld,1,U.S. House,1,Collin Duprel,LIB,59
+Jerauld,1,U.S. House,1,Dusty Johnson,REP,339
+Jerauld,2,U.S. House,1,Collin Duprel,LIB,12
+Jerauld,2,U.S. House,1,Dusty Johnson,REP,122
+Jerauld,3,U.S. House,1,Collin Duprel,LIB,12
+Jerauld,3,U.S. House,1,Dusty Johnson,REP,107
+Jerauld,4,U.S. House,1,Collin Duprel,LIB,15
+Jerauld,4,U.S. House,1,Dusty Johnson,REP,68
+Jerauld,5,U.S. House,1,Collin Duprel,LIB,7
+Jerauld,5,U.S. House,1,Dusty Johnson,REP,84
+Jerauld,1,Governor,,Jamie Smith and Jennifer Keintz,DEM,139
+Jerauld,1,Governor,,Tracey Quint and Ashley Strand,LIB,8
+Jerauld,1,Governor,,Kristi Noem and Larry Rhoden,REP,277
+Jerauld,2,Governor,,Jamie Smith and Jennifer Keintz,DEM,31
+Jerauld,2,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Jerauld,2,Governor,,Kristi Noem and Larry Rhoden,REP,103
+Jerauld,3,Governor,,Jamie Smith and Jennifer Keintz,DEM,22
+Jerauld,3,Governor,,Tracey Quint and Ashley Strand,LIB,6
+Jerauld,3,Governor,,Kristi Noem and Larry Rhoden,REP,95
+Jerauld,4,Governor,,Jamie Smith and Jennifer Keintz,DEM,23
+Jerauld,4,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Jerauld,4,Governor,,Kristi Noem and Larry Rhoden,REP,60
+Jerauld,5,Governor,,Jamie Smith and Jennifer Keintz,DEM,23
+Jerauld,5,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Jerauld,5,Governor,,Kristi Noem and Larry Rhoden,REP,69
+Jerauld,1,Secretary of State,,Thomas A Cool,DEM,148
+Jerauld,1,Secretary of State,,Monae Johnson,REP,252
+Jerauld,2,Secretary of State,,Thomas A Cool,DEM,35
+Jerauld,2,Secretary of State,,Monae Johnson,REP,93
+Jerauld,3,Secretary of State,,Thomas A Cool,DEM,31
+Jerauld,3,Secretary of State,,Monae Johnson,REP,79
+Jerauld,4,Secretary of State,,Thomas A Cool,DEM,28
+Jerauld,4,Secretary of State,,Monae Johnson,REP,53
+Jerauld,5,Secretary of State,,Thomas A Cool,DEM,23
+Jerauld,5,Secretary of State,,Monae Johnson,REP,62
+Jerauld,1,Attorney General,,Marty J. Jackley,REP,332
+Jerauld,2,Attorney General,,Marty J. Jackley,REP,112
+Jerauld,3,Attorney General,,Marty J. Jackley,REP,105
+Jerauld,4,Attorney General,,Marty J. Jackley,REP,70
+Jerauld,5,Attorney General,,Marty J. Jackley,REP,78
+Jerauld,1,State Auditor,,Stephanie Marty,DEM,111
+Jerauld,1,State Auditor,,Rene Meyer,LIB,11
+Jerauld,1,State Auditor,,Richard Sattgast,REP,272
+Jerauld,2,State Auditor,,Stephanie Marty,DEM,28
+Jerauld,2,State Auditor,,Rene Meyer,LIB,5
+Jerauld,2,State Auditor,,Richard Sattgast,REP,98
+Jerauld,3,State Auditor,,Stephanie Marty,DEM,23
+Jerauld,3,State Auditor,,Rene Meyer,LIB,4
+Jerauld,3,State Auditor,,Richard Sattgast,REP,89
+Jerauld,4,State Auditor,,Stephanie Marty,DEM,24
+Jerauld,4,State Auditor,,Rene Meyer,LIB,3
+Jerauld,4,State Auditor,,Richard Sattgast,REP,54
+Jerauld,5,State Auditor,,Stephanie Marty,DEM,22
+Jerauld,5,State Auditor,,Rene Meyer,LIB,1
+Jerauld,5,State Auditor,,Richard Sattgast,REP,66
+Jerauld,1,State Treasurer,,John Cunningham,DEM,99
+Jerauld,1,State Treasurer,,Josh Haeder,REP,295
+Jerauld,2,State Treasurer,,John Cunningham,DEM,26
+Jerauld,2,State Treasurer,,Josh Haeder,REP,107
+Jerauld,3,State Treasurer,,John Cunningham,DEM,19
+Jerauld,3,State Treasurer,,Josh Haeder,REP,101
+Jerauld,4,State Treasurer,,John Cunningham,DEM,21
+Jerauld,4,State Treasurer,,Josh Haeder,REP,61
+Jerauld,5,State Treasurer,,John Cunningham,DEM,12
+Jerauld,5,State Treasurer,,Josh Haeder,REP,76
+Jerauld,1,Commissioner of School and Public Lands,,Timothy Azure,DEM,146
+Jerauld,1,Commissioner of School and Public Lands,,Brock Greenfield,REP,254
+Jerauld,2,Commissioner of School and Public Lands,,Timothy Azure,DEM,44
+Jerauld,2,Commissioner of School and Public Lands,,Brock Greenfield,REP,90
+Jerauld,3,Commissioner of School and Public Lands,,Timothy Azure,DEM,30
+Jerauld,3,Commissioner of School and Public Lands,,Brock Greenfield,REP,86
+Jerauld,4,Commissioner of School and Public Lands,,Timothy Azure,DEM,30
+Jerauld,4,Commissioner of School and Public Lands,,Brock Greenfield,REP,52
+Jerauld,5,Commissioner of School and Public Lands,,Timothy Azure,DEM,23
+Jerauld,5,Commissioner of School and Public Lands,,Brock Greenfield,REP,62
+Jerauld,1,Public Utilities Commissioner,,Jeffrey Barth,DEM,94
+Jerauld,1,Public Utilities Commissioner,,Chris Nelson,REP,313
+Jerauld,2,Public Utilities Commissioner,,Jeffrey Barth,DEM,27
+Jerauld,2,Public Utilities Commissioner,,Chris Nelson,REP,108
+Jerauld,3,Public Utilities Commissioner,,Jeffrey Barth,DEM,19
+Jerauld,3,Public Utilities Commissioner,,Chris Nelson,REP,100
+Jerauld,4,Public Utilities Commissioner,,Jeffrey Barth,DEM,27
+Jerauld,4,Public Utilities Commissioner,,Chris Nelson,REP,59
+Jerauld,5,Public Utilities Commissioner,,Jeffrey Barth,DEM,15
+Jerauld,5,Public Utilities Commissioner,,Chris Nelson,REP,71
+Jerauld,1,State Senate,20,Joshua Klumb,REP,315
+Jerauld,2,State Senate,20,Joshua Klumb,REP,104
+Jerauld,3,State Senate,20,Joshua Klumb,REP,96
+Jerauld,4,State Senate,20,Joshua Klumb,REP,63
+Jerauld,5,State Senate,20,Joshua Klumb,REP,66
+Jerauld,1,State House,20,Ben Krohmer,REP,199
+Jerauld,1,State House,20,Lance Koth,REP,273
+Jerauld,2,State House,20,Ben Krohmer,REP,80
+Jerauld,2,State House,20,Lance Koth,REP,92
+Jerauld,3,State House,20,Ben Krohmer,REP,56
+Jerauld,3,State House,20,Lance Koth,REP,85
+Jerauld,4,State House,20,Ben Krohmer,REP,40
+Jerauld,4,State House,20,Lance Koth,REP,51
+Jerauld,5,State House,20,Ben Krohmer,REP,39
+Jerauld,5,State House,20,Lance Koth,REP,65
+Jerauld,1,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,208
+Jerauld,2,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,67
+Jerauld,3,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,63
+Jerauld,4,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,35
+Jerauld,5,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,41
+Jerauld,1,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,190
+Jerauld,2,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,61
+Jerauld,3,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,57
+Jerauld,4,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,33
+Jerauld,5,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,37
+Jerauld,1,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,199
+Jerauld,2,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,69
+Jerauld,3,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,77
+Jerauld,4,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,39
+Jerauld,5,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,37
+Jerauld,1,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,178
+Jerauld,2,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,65
+Jerauld,3,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,57
+Jerauld,4,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,33
+Jerauld,5,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,38
+Jerauld,1,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,112
+Jerauld,1,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,117
+Jerauld,2,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,25
+Jerauld,2,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,52
+Jerauld,3,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,23
+Jerauld,3,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,57
+Jerauld,4,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,22
+Jerauld,4,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,22
+Jerauld,5,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,15
+Jerauld,5,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,30
+Jerauld,1,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,200
+Jerauld,2,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,70
+Jerauld,3,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,60
+Jerauld,4,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,34
+Jerauld,5,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,41
+Jerauld,1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,296
+Jerauld,1,Supreme Court Retention,3,Patricia J. DeVaney - No,,58
+Jerauld,2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,99
+Jerauld,2,Supreme Court Retention,3,Patricia J. DeVaney - No,,25
+Jerauld,3,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,91
+Jerauld,3,Supreme Court Retention,3,Patricia J. DeVaney - No,,16
+Jerauld,4,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,60
+Jerauld,4,Supreme Court Retention,3,Patricia J. DeVaney - No,,15
+Jerauld,5,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,62
+Jerauld,5,Supreme Court Retention,3,Patricia J. DeVaney - No,,13
+Jerauld,1,Supreme Court Retention,2,Mark E. Salter - Yes,,299
+Jerauld,1,Supreme Court Retention,2,Mark E. Salter - No,,58
+Jerauld,2,Supreme Court Retention,2,Mark E. Salter - Yes,,102
+Jerauld,2,Supreme Court Retention,2,Mark E. Salter - No,,23
+Jerauld,3,Supreme Court Retention,2,Mark E. Salter - Yes,,91
+Jerauld,3,Supreme Court Retention,2,Mark E. Salter - No,,15
+Jerauld,4,Supreme Court Retention,2,Mark E. Salter - Yes,,62
+Jerauld,4,Supreme Court Retention,2,Mark E. Salter - No,,11
+Jerauld,5,Supreme Court Retention,2,Mark E. Salter - Yes,,63
+Jerauld,5,Supreme Court Retention,2,Mark E. Salter - No,,12
+Jerauld,1,Constitutional Amendment D,,Yes,,230
+Jerauld,1,Constitutional Amendment D,,No,,186
+Jerauld,2,Constitutional Amendment D,,Yes,,64
+Jerauld,2,Constitutional Amendment D,,No,,71
+Jerauld,3,Constitutional Amendment D,,Yes,,57
+Jerauld,3,Constitutional Amendment D,,No,,64
+Jerauld,4,Constitutional Amendment D,,Yes,,40
+Jerauld,4,Constitutional Amendment D,,No,,49
+Jerauld,5,Constitutional Amendment D,,Yes,,43
+Jerauld,5,Constitutional Amendment D,,No,,48
+Jerauld,1,Initiated Measure 27,,Yes,,150
+Jerauld,1,Initiated Measure 27,,No,,267
+Jerauld,2,Initiated Measure 27,,Yes,,32
+Jerauld,2,Initiated Measure 27,,No,,103
+Jerauld,3,Initiated Measure 27,,Yes,,58
+Jerauld,3,Initiated Measure 27,,No,,65
+Jerauld,4,Initiated Measure 27,,Yes,,26
+Jerauld,4,Initiated Measure 27,,No,,63
+Jerauld,5,Initiated Measure 27,,Yes,,16
+Jerauld,5,Initiated Measure 27,,No,,76

--- a/2022/counties/20221108__sd__general__jones__precinct.csv
+++ b/2022/counties/20221108__sd__general__jones__precinct.csv
@@ -1,0 +1,72 @@
+county,precinct,office,district,candidate,party,votes
+Jones,1,U.S. Senate,,Brian L. Bengs,DEM,16
+Jones,1,U.S. Senate,,Tamara J Lesnar,LIB,5
+Jones,1,U.S. Senate,,John R. Thune,REP,109
+Jones,2,U.S. Senate,,Brian L. Bengs,DEM,30
+Jones,2,U.S. Senate,,Tamara J Lesnar,LIB,31
+Jones,2,U.S. Senate,,John R. Thune,REP,274
+Jones,1,U.S. House,1,Collin Duprel,LIB,29
+Jones,1,U.S. House,1,Dusty Johnson,REP,100
+Jones,2,U.S. House,1,Collin Duprel,LIB,43
+Jones,2,U.S. House,1,Dusty Johnson,REP,291
+Jones,1,Governor,,Jamie Smith and Jennifer Keintz,DEM,17
+Jones,1,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Jones,1,Governor,,Kristi Noem and Larry Rhoden,REP,112
+Jones,2,Governor,,Jamie Smith and Jennifer Keintz,DEM,47
+Jones,2,Governor,,Tracey Quint and Ashley Strand,LIB,10
+Jones,2,Governor,,Kristi Noem and Larry Rhoden,REP,283
+Jones,1,Secretary of State,,Thomas A Cool,DEM,20
+Jones,1,Secretary of State,,Monae Johnson,REP,107
+Jones,2,Secretary of State,,Thomas A Cool,DEM,46
+Jones,2,Secretary of State,,Monae Johnson,REP,284
+Jones,1,Attorney General,,Marty J. Jackley,REP,113
+Jones,2,Attorney General,,Marty J. Jackley,REP,292
+Jones,1,State Auditor,,Stephanie Marty,DEM,14
+Jones,1,State Auditor,,Rene Meyer,LIB,6
+Jones,1,State Auditor,,Richard Sattgast,REP,106
+Jones,2,State Auditor,,Stephanie Marty,DEM,36
+Jones,2,State Auditor,,Rene Meyer,LIB,16
+Jones,2,State Auditor,,Richard Sattgast,REP,279
+Jones,1,State Treasurer,,John Cunningham,DEM,12
+Jones,1,State Treasurer,,Josh Haeder,REP,112
+Jones,2,State Treasurer,,John Cunningham,DEM,41
+Jones,2,State Treasurer,,Josh Haeder,REP,285
+Jones,1,Commissioner of School and Public Lands,,Timothy Azure,DEM,17
+Jones,1,Commissioner of School and Public Lands,,Brock Greenfield,REP,108
+Jones,2,Commissioner of School and Public Lands,,Timothy Azure,DEM,37
+Jones,2,Commissioner of School and Public Lands,,Brock Greenfield,REP,283
+Jones,1,Public Utilities Commissioner,,Jeffrey Barth,DEM,15
+Jones,1,Public Utilities Commissioner,,Chris Nelson,REP,112
+Jones,2,Public Utilities Commissioner,,Jeffrey Barth,DEM,41
+Jones,2,Public Utilities Commissioner,,Chris Nelson,REP,290
+Jones,1,State Senate,26,Shawn Bordeaux,DEM,24
+Jones,1,State Senate,26,Joel Koskan,REP,77
+Jones,2,State Senate,26,Shawn Bordeaux,DEM,95
+Jones,2,State Senate,26,Joel Koskan,REP,173
+Jones,1,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,69
+Jones,2,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,156
+Jones,1,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,70
+Jones,2,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,152
+Jones,1,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,68
+Jones,2,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,153
+Jones,1,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,69
+Jones,2,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,146
+Jones,1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,88
+Jones,1,Supreme Court Retention,3,Patricia J. DeVaney - No,,23
+Jones,2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,233
+Jones,2,Supreme Court Retention,3,Patricia J. DeVaney - No,,51
+Jones,1,Supreme Court Retention,2,Mark E. Salter - Yes,,88
+Jones,1,Supreme Court Retention,2,Mark E. Salter - No,,23
+Jones,2,Supreme Court Retention,2,Mark E. Salter - Yes,,227
+Jones,2,Supreme Court Retention,2,Mark E. Salter - No,,55
+Jones,1,Constitutional Amendment D,,Yes,,54
+Jones,1,Constitutional Amendment D,,No,,78
+Jones,2,Constitutional Amendment D,,Yes,,145
+Jones,2,Constitutional Amendment D,,No,,189
+Jones,1,Initiated Measure 27,,Yes,,30
+Jones,1,Initiated Measure 27,,No,,103
+Jones,2,Initiated Measure 27,,Yes,,114
+Jones,2,Initiated Measure 27,,No,,225
+Jones,1,State House,26A,Eric Emery,DEM,15
+Jones,1,State House,26A,Joyce Glynn,REP,114
+Jones,2 11 of 20,State House,26B,Rebecca Reimer,REP,278

--- a/2022/counties/20221108__sd__general__kingsbury__precinct.csv
+++ b/2022/counties/20221108__sd__general__kingsbury__precinct.csv
@@ -1,0 +1,267 @@
+county,precinct,office,district,candidate,party,votes
+Kingsbury,Absentee Precinct,U.S. Senate,,Brian L. Bengs,DEM,121
+Kingsbury,Absentee Precinct,U.S. Senate,,Tamara J Lesnar,LIB,15
+Kingsbury,Absentee Precinct,U.S. Senate,,John R. Thune,REP,310
+Kingsbury,Arlington Precinct,U.S. Senate,,Brian L. Bengs,DEM,94
+Kingsbury,Arlington Precinct,U.S. Senate,,Tamara J Lesnar,LIB,26
+Kingsbury,Arlington Precinct,U.S. Senate,,John R. Thune,REP,379
+Kingsbury,Badger Precinct,U.S. Senate,,Brian L. Bengs,DEM,27
+Kingsbury,Badger Precinct,U.S. Senate,,Tamara J Lesnar,LIB,11
+Kingsbury,Badger Precinct,U.S. Senate,,John R. Thune,REP,198
+Kingsbury,De Smet Precinct,U.S. Senate,,Brian L. Bengs,DEM,110
+Kingsbury,De Smet Precinct,U.S. Senate,,Tamara J Lesnar,LIB,15
+Kingsbury,De Smet Precinct,U.S. Senate,,John R. Thune,REP,526
+Kingsbury,Iroquois Precinct,U.S. Senate,,Brian L. Bengs,DEM,21
+Kingsbury,Iroquois Precinct,U.S. Senate,,Tamara J Lesnar,LIB,4
+Kingsbury,Iroquois Precinct,U.S. Senate,,John R. Thune,REP,133
+Kingsbury,Lake Preston Precinct,U.S. Senate,,Brian L. Bengs,DEM,47
+Kingsbury,Lake Preston Precinct,U.S. Senate,,Tamara J Lesnar,LIB,11
+Kingsbury,Lake Preston Precinct,U.S. Senate,,John R. Thune,REP,312
+Kingsbury,Oldham Precinct,U.S. Senate,,Brian L. Bengs,DEM,21
+Kingsbury,Oldham Precinct,U.S. Senate,,Tamara J Lesnar,LIB,7
+Kingsbury,Oldham Precinct,U.S. Senate,,John R. Thune,REP,142
+Kingsbury,Absentee Precinct,U.S. House,1,Collin Duprel,LIB,86
+Kingsbury,Absentee Precinct,U.S. House,1,Dusty Johnson,REP,332
+Kingsbury,Arlington Precinct,U.S. House,1,Collin Duprel,LIB,71
+Kingsbury,Arlington Precinct,U.S. House,1,Dusty Johnson,REP,409
+Kingsbury,Badger Precinct,U.S. House,1,Collin Duprel,LIB,33
+Kingsbury,Badger Precinct,U.S. House,1,Dusty Johnson,REP,200
+Kingsbury,De Smet Precinct,U.S. House,1,Collin Duprel,LIB,101
+Kingsbury,De Smet Precinct,U.S. House,1,Dusty Johnson,REP,542
+Kingsbury,Iroquois Precinct,U.S. House,1,Collin Duprel,LIB,20
+Kingsbury,Iroquois Precinct,U.S. House,1,Dusty Johnson,REP,132
+Kingsbury,Lake Preston Precinct,U.S. House,1,Collin Duprel,LIB,54
+Kingsbury,Lake Preston Precinct,U.S. House,1,Dusty Johnson,REP,304
+Kingsbury,Oldham Precinct,U.S. House,1,Collin Duprel,LIB,25
+Kingsbury,Oldham Precinct,U.S. House,1,Dusty Johnson,REP,136
+Kingsbury,Absentee Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,167
+Kingsbury,Absentee Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,15
+Kingsbury,Absentee Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,273
+Kingsbury,Arlington Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,154
+Kingsbury,Arlington Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,11
+Kingsbury,Arlington Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,334
+Kingsbury,Badger Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,43
+Kingsbury,Badger Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,9
+Kingsbury,Badger Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,185
+Kingsbury,De Smet Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,179
+Kingsbury,De Smet Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,14
+Kingsbury,De Smet Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,466
+Kingsbury,Iroquois Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,37
+Kingsbury,Iroquois Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,9
+Kingsbury,Iroquois Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,113
+Kingsbury,Lake Preston Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,74
+Kingsbury,Lake Preston Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,8
+Kingsbury,Lake Preston Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,291
+Kingsbury,Oldham Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,38
+Kingsbury,Oldham Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Kingsbury,Oldham Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,130
+Kingsbury,Absentee Precinct,Secretary of State,,Thomas A Cool,DEM,154
+Kingsbury,Absentee Precinct,Secretary of State,,Monae Johnson,REP,269
+Kingsbury,Arlington Precinct,Secretary of State,,Thomas A Cool,DEM,149
+Kingsbury,Arlington Precinct,Secretary of State,,Monae Johnson,REP,321
+Kingsbury,Badger Precinct,Secretary of State,,Thomas A Cool,DEM,53
+Kingsbury,Badger Precinct,Secretary of State,,Monae Johnson,REP,171
+Kingsbury,De Smet Precinct,Secretary of State,,Thomas A Cool,DEM,194
+Kingsbury,De Smet Precinct,Secretary of State,,Monae Johnson,REP,427
+Kingsbury,Iroquois Precinct,Secretary of State,,Thomas A Cool,DEM,40
+Kingsbury,Iroquois Precinct,Secretary of State,,Monae Johnson,REP,107
+Kingsbury,Lake Preston Precinct,Secretary of State,,Thomas A Cool,DEM,86
+Kingsbury,Lake Preston Precinct,Secretary of State,,Monae Johnson,REP,264
+Kingsbury,Oldham Precinct,Secretary of State,,Thomas A Cool,DEM,44
+Kingsbury,Oldham Precinct,Secretary of State,,Monae Johnson,REP,114
+Kingsbury,Absentee Precinct,Attorney General,,Marty J. Jackley,REP,333
+Kingsbury,Arlington Precinct,Attorney General,,Marty J. Jackley,REP,408
+Kingsbury,Badger Precinct,Attorney General,,Marty J. Jackley,REP,197
+Kingsbury,De Smet Precinct,Attorney General,,Marty J. Jackley,REP,542
+Kingsbury,Iroquois Precinct,Attorney General,,Marty J. Jackley,REP,121
+Kingsbury,Lake Preston Precinct,Attorney General,,Marty J. Jackley,REP,311
+Kingsbury,Oldham Precinct,Attorney General,,Marty J. Jackley,REP,142
+Kingsbury,Absentee Precinct,State Auditor,,Stephanie Marty,DEM,131
+Kingsbury,Absentee Precinct,State Auditor,,Rene Meyer,LIB,20
+Kingsbury,Absentee Precinct,State Auditor,,Richard Sattgast,REP,265
+Kingsbury,Arlington Precinct,State Auditor,,Stephanie Marty,DEM,133
+Kingsbury,Arlington Precinct,State Auditor,,Rene Meyer,LIB,18
+Kingsbury,Arlington Precinct,State Auditor,,Richard Sattgast,REP,314
+Kingsbury,Badger Precinct,State Auditor,,Stephanie Marty,DEM,35
+Kingsbury,Badger Precinct,State Auditor,,Rene Meyer,LIB,13
+Kingsbury,Badger Precinct,State Auditor,,Richard Sattgast,REP,177
+Kingsbury,De Smet Precinct,State Auditor,,Stephanie Marty,DEM,149
+Kingsbury,De Smet Precinct,State Auditor,,Rene Meyer,LIB,26
+Kingsbury,De Smet Precinct,State Auditor,,Richard Sattgast,REP,451
+Kingsbury,Iroquois Precinct,State Auditor,,Stephanie Marty,DEM,37
+Kingsbury,Iroquois Precinct,State Auditor,,Rene Meyer,LIB,5
+Kingsbury,Iroquois Precinct,State Auditor,,Richard Sattgast,REP,107
+Kingsbury,Lake Preston Precinct,State Auditor,,Stephanie Marty,DEM,71
+Kingsbury,Lake Preston Precinct,State Auditor,,Rene Meyer,LIB,8
+Kingsbury,Lake Preston Precinct,State Auditor,,Richard Sattgast,REP,262
+Kingsbury,Oldham Precinct,State Auditor,,Stephanie Marty,DEM,27
+Kingsbury,Oldham Precinct,State Auditor,,Rene Meyer,LIB,7
+Kingsbury,Oldham Precinct,State Auditor,,Richard Sattgast,REP,120
+Kingsbury,Absentee Precinct,State Treasurer,,John Cunningham,DEM,133
+Kingsbury,Absentee Precinct,State Treasurer,,Josh Haeder,REP,285
+Kingsbury,Arlington Precinct,State Treasurer,,John Cunningham,DEM,120
+Kingsbury,Arlington Precinct,State Treasurer,,Josh Haeder,REP,340
+Kingsbury,Badger Precinct,State Treasurer,,John Cunningham,DEM,42
+Kingsbury,Badger Precinct,State Treasurer,,Josh Haeder,REP,176
+Kingsbury,De Smet Precinct,State Treasurer,,John Cunningham,DEM,147
+Kingsbury,De Smet Precinct,State Treasurer,,Josh Haeder,REP,473
+Kingsbury,Iroquois Precinct,State Treasurer,,John Cunningham,DEM,34
+Kingsbury,Iroquois Precinct,State Treasurer,,Josh Haeder,REP,118
+Kingsbury,Lake Preston Precinct,State Treasurer,,John Cunningham,DEM,70
+Kingsbury,Lake Preston Precinct,State Treasurer,,Josh Haeder,REP,269
+Kingsbury,Oldham Precinct,State Treasurer,,John Cunningham,DEM,33
+Kingsbury,Oldham Precinct,State Treasurer,,Josh Haeder,REP,119
+Kingsbury,Absentee Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,151
+Kingsbury,Absentee Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,267
+Kingsbury,Arlington Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,129
+Kingsbury,Arlington Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,337
+Kingsbury,Badger Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,39
+Kingsbury,Badger Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,187
+Kingsbury,De Smet Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,155
+Kingsbury,De Smet Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,469
+Kingsbury,Iroquois Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,33
+Kingsbury,Iroquois Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,113
+Kingsbury,Lake Preston Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,79
+Kingsbury,Lake Preston Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,273
+Kingsbury,Oldham Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,30
+Kingsbury,Oldham Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,131
+Kingsbury,Absentee Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,135
+Kingsbury,Absentee Precinct,Public Utilities Commissioner,,Chris Nelson,REP,282
+Kingsbury,Arlington Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,115
+Kingsbury,Arlington Precinct,Public Utilities Commissioner,,Chris Nelson,REP,360
+Kingsbury,Badger Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,32
+Kingsbury,Badger Precinct,Public Utilities Commissioner,,Chris Nelson,REP,189
+Kingsbury,De Smet Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,141
+Kingsbury,De Smet Precinct,Public Utilities Commissioner,,Chris Nelson,REP,484
+Kingsbury,Iroquois Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,39
+Kingsbury,Iroquois Precinct,Public Utilities Commissioner,,Chris Nelson,REP,110
+Kingsbury,Lake Preston Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,61
+Kingsbury,Lake Preston Precinct,Public Utilities Commissioner,,Chris Nelson,REP,294
+Kingsbury,Oldham Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,31
+Kingsbury,Oldham Precinct,Public Utilities Commissioner,,Chris Nelson,REP,129
+Kingsbury,Absentee Precinct,State Senate,08,Casey Crabtree,REP,295
+Kingsbury,Arlington Precinct,State Senate,08,Casey Crabtree,REP,413
+Kingsbury,Badger Precinct,State Senate,08,Casey Crabtree,REP,196
+Kingsbury,De Smet Precinct,State Senate,08,Casey Crabtree,REP,496
+Kingsbury,Iroquois Precinct,State Senate,08,Casey Crabtree,REP,114
+Kingsbury,Lake Preston Precinct,State Senate,08,Casey Crabtree,REP,302
+Kingsbury,Oldham Precinct,State Senate,08,Casey Crabtree,REP,140
+Kingsbury,Absentee Precinct,State House,08,Tim Reisch,REP,235
+Kingsbury,Absentee Precinct,State House,08,John Mills,REP,199
+Kingsbury,Arlington Precinct,State House,08,Tim Reisch,REP,254
+Kingsbury,Arlington Precinct,State House,08,John Mills,REP,279
+Kingsbury,Badger Precinct,State House,08,Tim Reisch,REP,119
+Kingsbury,Badger Precinct,State House,08,John Mills,REP,144
+Kingsbury,De Smet Precinct,State House,08,Tim Reisch,REP,395
+Kingsbury,De Smet Precinct,State House,08,John Mills,REP,332
+Kingsbury,Iroquois Precinct,State House,08,Tim Reisch,REP,85
+Kingsbury,Iroquois Precinct,State House,08,John Mills,REP,90
+Kingsbury,Lake Preston Precinct,State House,08,Tim Reisch,REP,184
+Kingsbury,Lake Preston Precinct,State House,08,John Mills,REP,217
+Kingsbury,Oldham Precinct,State House,08,Tim Reisch,REP,97
+Kingsbury,Oldham Precinct,State House,08,John Mills,REP,88
+Kingsbury,Absentee Precinct,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,195
+Kingsbury,Arlington Precinct,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,230
+Kingsbury,Badger Precinct,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,101
+Kingsbury,De Smet Precinct,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,308
+Kingsbury,Iroquois Precinct,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,78
+Kingsbury,Lake Preston Precinct,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,172
+Kingsbury,Oldham Precinct,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,69
+Kingsbury,Absentee Precinct,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,183
+Kingsbury,Arlington Precinct,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,234
+Kingsbury,Badger Precinct,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,99
+Kingsbury,De Smet Precinct,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,296
+Kingsbury,Iroquois Precinct,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,74
+Kingsbury,Lake Preston Precinct,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,166
+Kingsbury,Oldham Precinct,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,68
+Kingsbury,Absentee Precinct,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,179
+Kingsbury,Arlington Precinct,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,233
+Kingsbury,Badger Precinct,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,101
+Kingsbury,De Smet Precinct,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,305
+Kingsbury,Iroquois Precinct,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,86
+Kingsbury,Lake Preston Precinct,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,168
+Kingsbury,Oldham Precinct,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,68
+Kingsbury,Absentee Precinct,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,188
+Kingsbury,Arlington Precinct,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,252
+Kingsbury,Badger Precinct,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,101
+Kingsbury,De Smet Precinct,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,317
+Kingsbury,Iroquois Precinct,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,85
+Kingsbury,Lake Preston Precinct,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,173
+Kingsbury,Oldham Precinct,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,71
+Kingsbury,Absentee Precinct,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,106
+Kingsbury,Absentee Precinct,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,124
+Kingsbury,Arlington Precinct,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,117
+Kingsbury,Arlington Precinct,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,155
+Kingsbury,Badger Precinct,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,56
+Kingsbury,Badger Precinct,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,57
+Kingsbury,De Smet Precinct,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,195
+Kingsbury,De Smet Precinct,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,185
+Kingsbury,Iroquois Precinct,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,51
+Kingsbury,Iroquois Precinct,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,67
+Kingsbury,Lake Preston Precinct,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,62
+Kingsbury,Lake Preston Precinct,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,145
+Kingsbury,Oldham Precinct,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,38
+Kingsbury,Oldham Precinct,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,37
+Kingsbury,Absentee Precinct,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,180
+Kingsbury,Arlington Precinct,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,231
+Kingsbury,Badger Precinct,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,98
+Kingsbury,De Smet Precinct,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,359
+Kingsbury,Iroquois Precinct,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,74
+Kingsbury,Lake Preston Precinct,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,169
+Kingsbury,Oldham Precinct,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,72
+Kingsbury,Absentee Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,311
+Kingsbury,Absentee Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,54
+Kingsbury,Arlington Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,352
+Kingsbury,Arlington Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,62
+Kingsbury,Badger Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,165
+Kingsbury,Badger Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,26
+Kingsbury,De Smet Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,489
+Kingsbury,De Smet Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,78
+Kingsbury,Iroquois Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,118
+Kingsbury,Iroquois Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,19
+Kingsbury,Lake Preston Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,255
+Kingsbury,Lake Preston Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,49
+Kingsbury,Oldham Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,117
+Kingsbury,Oldham Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,17
+Kingsbury,Absentee Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,304
+Kingsbury,Absentee Precinct,Supreme Court Retention,2,Mark E. Salter - No,,59
+Kingsbury,Arlington Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,357
+Kingsbury,Arlington Precinct,Supreme Court Retention,2,Mark E. Salter - No,,52
+Kingsbury,Badger Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,164
+Kingsbury,Badger Precinct,Supreme Court Retention,2,Mark E. Salter - No,,28
+Kingsbury,De Smet Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,480
+Kingsbury,De Smet Precinct,Supreme Court Retention,2,Mark E. Salter - No,,82
+Kingsbury,Iroquois Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,112
+Kingsbury,Iroquois Precinct,Supreme Court Retention,2,Mark E. Salter - No,,22
+Kingsbury,Lake Preston Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,265
+Kingsbury,Lake Preston Precinct,Supreme Court Retention,2,Mark E. Salter - No,,40
+Kingsbury,Oldham Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,118
+Kingsbury,Oldham Precinct,Supreme Court Retention,2,Mark E. Salter - No,,17
+Kingsbury,Absentee Precinct,Constitutional Amendment D,,Yes,,240
+Kingsbury,Absentee Precinct,Constitutional Amendment D,,No,,194
+Kingsbury,Arlington Precinct,Constitutional Amendment D,,Yes,,235
+Kingsbury,Arlington Precinct,Constitutional Amendment D,,No,,252
+Kingsbury,Badger Precinct,Constitutional Amendment D,,Yes,,90
+Kingsbury,Badger Precinct,Constitutional Amendment D,,No,,136
+Kingsbury,De Smet Precinct,Constitutional Amendment D,,Yes,,302
+Kingsbury,De Smet Precinct,Constitutional Amendment D,,No,,336
+Kingsbury,Iroquois Precinct,Constitutional Amendment D,,Yes,,71
+Kingsbury,Iroquois Precinct,Constitutional Amendment D,,No,,79
+Kingsbury,Lake Preston Precinct,Constitutional Amendment D,,Yes,,165
+Kingsbury,Lake Preston Precinct,Constitutional Amendment D,,No,,201
+Kingsbury,Oldham Precinct,Constitutional Amendment D,,Yes,,70
+Kingsbury,Oldham Precinct,Constitutional Amendment D,,No,,90
+Kingsbury,Absentee Precinct,Initiated Measure 27,,Yes,,173
+Kingsbury,Absentee Precinct,Initiated Measure 27,,No,,265
+Kingsbury,Arlington Precinct,Initiated Measure 27,,Yes,,208
+Kingsbury,Arlington Precinct,Initiated Measure 27,,No,,285
+Kingsbury,Badger Precinct,Initiated Measure 27,,Yes,,74
+Kingsbury,Badger Precinct,Initiated Measure 27,,No,,163
+Kingsbury,De Smet Precinct,Initiated Measure 27,,Yes,,243
+Kingsbury,De Smet Precinct,Initiated Measure 27,,No,,410
+Kingsbury,Iroquois Precinct,Initiated Measure 27,,Yes,,48
+Kingsbury,Iroquois Precinct,Initiated Measure 27,,No,,108
+Kingsbury,Lake Preston Precinct,Initiated Measure 27,,Yes,,140
+Kingsbury,Lake Preston Precinct,Initiated Measure 27,,No,,236
+Kingsbury,Oldham Precinct,Initiated Measure 27,,Yes,,44
+Kingsbury,Oldham Precinct,Initiated Measure 27,,No,,121

--- a/2022/counties/20221108__sd__general__lake__precinct.csv
+++ b/2022/counties/20221108__sd__general__lake__precinct.csv
@@ -1,0 +1,381 @@
+county,precinct,office,district,candidate,party,votes
+Lake,Chester-Franklin,U.S. Senate,,Brian L. Bengs,DEM,82
+Lake,Chester-Franklin,U.S. Senate,,Tamara J Lesnar,LIB,18
+Lake,Chester-Franklin,U.S. Senate,,John R. Thune,REP,363
+Lake,?,U.S. Senate,,Brian L. Bengs,DEM,43
+Lake,?,U.S. Senate,,Tamara J Lesnar,LIB,6
+Lake,?,U.S. Senate,,John R. Thune,REP,178
+Lake,?,U.S. Senate,,Brian L. Bengs,DEM,57
+Lake,?,U.S. Senate,,Tamara J Lesnar,LIB,12
+Lake,?,U.S. Senate,,John R. Thune,REP,248
+Lake,Herman-Winfred,U.S. Senate,,Brian L. Bengs,DEM,88
+Lake,Herman-Winfred,U.S. Senate,,Tamara J Lesnar,LIB,10
+Lake,Herman-Winfred,U.S. Senate,,John R. Thune,REP,320
+Lake,Lakeview,U.S. Senate,,Brian L. Bengs,DEM,108
+Lake,Lakeview,U.S. Senate,,Tamara J Lesnar,LIB,18
+Lake,Lakeview,U.S. Senate,,John R. Thune,REP,380
+Lake,Nunda-Summit,U.S. Senate,,Brian L. Bengs,DEM,19
+Lake,Nunda-Summit,U.S. Senate,,Tamara J Lesnar,LIB,10
+Lake,Nunda-Summit,U.S. Senate,,John R. Thune,REP,161
+Lake,Ward One,U.S. Senate,,Brian L. Bengs,DEM,297
+Lake,Ward One,U.S. Senate,,Tamara J Lesnar,LIB,33
+Lake,Ward One,U.S. Senate,,John R. Thune,REP,774
+Lake,Ward Three,U.S. Senate,,Brian L. Bengs,DEM,159
+Lake,Ward Three,U.S. Senate,,Tamara J Lesnar,LIB,19
+Lake,Ward Three,U.S. Senate,,John R. Thune,REP,401
+Lake,Ward Two,U.S. Senate,,Brian L. Bengs,DEM,179
+Lake,Ward Two,U.S. Senate,,Tamara J Lesnar,LIB,26
+Lake,Ward Two,U.S. Senate,,John R. Thune,REP,424
+Lake,Wentworth-Rutland,U.S. Senate,,Brian L. Bengs,DEM,107
+Lake,Wentworth-Rutland,U.S. Senate,,Tamara J Lesnar,LIB,12
+Lake,Wentworth-Rutland,U.S. Senate,,John R. Thune,REP,366
+Lake,Chester-Franklin,U.S. House,1,Collin Duprel,LIB,78
+Lake,Chester-Franklin,U.S. House,1,Dusty Johnson,REP,365
+Lake,?,U.S. House,1,Collin Duprel,LIB,32
+Lake,?,U.S. House,1,Dusty Johnson,REP,185
+Lake,?,U.S. House,1,Collin Duprel,LIB,46
+Lake,?,U.S. House,1,Dusty Johnson,REP,254
+Lake,Herman-Winfred,U.S. House,1,Collin Duprel,LIB,55
+Lake,Herman-Winfred,U.S. House,1,Dusty Johnson,REP,345
+Lake,Lakeview,U.S. House,1,Collin Duprel,LIB,74
+Lake,Lakeview,U.S. House,1,Dusty Johnson,REP,404
+Lake,Nunda-Summit,U.S. House,1,Collin Duprel,LIB,26
+Lake,Nunda-Summit,U.S. House,1,Dusty Johnson,REP,160
+Lake,Ward One,U.S. House,1,Collin Duprel,LIB,196
+Lake,Ward One,U.S. House,1,Dusty Johnson,REP,843
+Lake,Ward Three,U.S. House,1,Collin Duprel,LIB,134
+Lake,Ward Three,U.S. House,1,Dusty Johnson,REP,416
+Lake,Ward Two,U.S. House,1,Collin Duprel,LIB,131
+Lake,Ward Two,U.S. House,1,Dusty Johnson,REP,451
+Lake,Wentworth-Rutland,U.S. House,1,Collin Duprel,LIB,73
+Lake,Wentworth-Rutland,U.S. House,1,Dusty Johnson,REP,387
+Lake,Chester-Franklin,Governor,,Jamie Smith and Jennifer Keintz,DEM,130
+Lake,Chester-Franklin,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Lake,Chester-Franklin,Governor,,Kristi Noem and Larry Rhoden,REP,335
+Lake,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,63
+Lake,?,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Lake,?,Governor,,Kristi Noem and Larry Rhoden,REP,166
+Lake,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,78
+Lake,?,Governor,,Tracey Quint and Ashley Strand,LIB,10
+Lake,?,Governor,,Kristi Noem and Larry Rhoden,REP,228
+Lake,Herman-Winfred,Governor,,Jamie Smith and Jennifer Keintz,DEM,135
+Lake,Herman-Winfred,Governor,,Tracey Quint and Ashley Strand,LIB,10
+Lake,Herman-Winfred,Governor,,Kristi Noem and Larry Rhoden,REP,275
+Lake,Lakeview,Governor,,Jamie Smith and Jennifer Keintz,DEM,178
+Lake,Lakeview,Governor,,Tracey Quint and Ashley Strand,LIB,6
+Lake,Lakeview,Governor,,Kristi Noem and Larry Rhoden,REP,319
+Lake,Nunda-Summit,Governor,,Jamie Smith and Jennifer Keintz,DEM,32
+Lake,Nunda-Summit,Governor,,Tracey Quint and Ashley Strand,LIB,6
+Lake,Nunda-Summit,Governor,,Kristi Noem and Larry Rhoden,REP,153
+Lake,Ward One,Governor,,Jamie Smith and Jennifer Keintz,DEM,472
+Lake,Ward One,Governor,,Tracey Quint and Ashley Strand,LIB,28
+Lake,Ward One,Governor,,Kristi Noem and Larry Rhoden,REP,623
+Lake,Ward Three,Governor,,Jamie Smith and Jennifer Keintz,DEM,230
+Lake,Ward Three,Governor,,Tracey Quint and Ashley Strand,LIB,20
+Lake,Ward Three,Governor,,Kristi Noem and Larry Rhoden,REP,336
+Lake,Ward Two,Governor,,Jamie Smith and Jennifer Keintz,DEM,260
+Lake,Ward Two,Governor,,Tracey Quint and Ashley Strand,LIB,18
+Lake,Ward Two,Governor,,Kristi Noem and Larry Rhoden,REP,358
+Lake,Wentworth-Rutland,Governor,,Jamie Smith and Jennifer Keintz,DEM,142
+Lake,Wentworth-Rutland,Governor,,Tracey Quint and Ashley Strand,LIB,10
+Lake,Wentworth-Rutland,Governor,,Kristi Noem and Larry Rhoden,REP,338
+Lake,Chester-Franklin,Secretary of State,,Thomas A Cool,DEM,129
+Lake,Chester-Franklin,Secretary of State,,Monae Johnson,REP,315
+Lake,?,Secretary of State,,Thomas A Cool,DEM,68
+Lake,?,Secretary of State,,Monae Johnson,REP,152
+Lake,?,Secretary of State,,Thomas A Cool,DEM,80
+Lake,?,Secretary of State,,Monae Johnson,REP,222
+Lake,Herman-Winfred,Secretary of State,,Thomas A Cool,DEM,132
+Lake,Herman-Winfred,Secretary of State,,Monae Johnson,REP,264
+Lake,Lakeview,Secretary of State,,Thomas A Cool,DEM,171
+Lake,Lakeview,Secretary of State,,Monae Johnson,REP,310
+Lake,Nunda-Summit,Secretary of State,,Thomas A Cool,DEM,40
+Lake,Nunda-Summit,Secretary of State,,Monae Johnson,REP,136
+Lake,Ward One,Secretary of State,,Thomas A Cool,DEM,428
+Lake,Ward One,Secretary of State,,Monae Johnson,REP,613
+Lake,Ward Three,Secretary of State,,Thomas A Cool,DEM,228
+Lake,Ward Three,Secretary of State,,Monae Johnson,REP,325
+Lake,Ward Two,Secretary of State,,Thomas A Cool,DEM,257
+Lake,Ward Two,Secretary of State,,Monae Johnson,REP,337
+Lake,Wentworth-Rutland,Secretary of State,,Thomas A Cool,DEM,146
+Lake,Wentworth-Rutland,Secretary of State,,Monae Johnson,REP,333
+Lake,Chester-Franklin,Attorney General,,Marty J. Jackley,REP,378
+Lake,?,Attorney General,,Marty J. Jackley,REP,185
+Lake,?,Attorney General,,Marty J. Jackley,REP,254
+Lake,Herman-Winfred,Attorney General,,Marty J. Jackley,REP,347
+Lake,Lakeview,Attorney General,,Marty J. Jackley,REP,406
+Lake,Nunda-Summit,Attorney General,,Marty J. Jackley,REP,164
+Lake,Ward One,Attorney General,,Marty J. Jackley,REP,846
+Lake,Ward Three,Attorney General,,Marty J. Jackley,REP,432
+Lake,Ward Two,Attorney General,,Marty J. Jackley,REP,476
+Lake,Wentworth-Rutland,Attorney General,,Marty J. Jackley,REP,400
+Lake,Chester-Franklin,State Auditor,,Stephanie Marty,DEM,110
+Lake,Chester-Franklin,State Auditor,,Rene Meyer,LIB,15
+Lake,Chester-Franklin,State Auditor,,Richard Sattgast,REP,300
+Lake,?,State Auditor,,Stephanie Marty,DEM,52
+Lake,?,State Auditor,,Rene Meyer,LIB,4
+Lake,?,State Auditor,,Richard Sattgast,REP,154
+Lake,?,State Auditor,,Stephanie Marty,DEM,64
+Lake,?,State Auditor,,Rene Meyer,LIB,7
+Lake,?,State Auditor,,Richard Sattgast,REP,223
+Lake,Herman-Winfred,State Auditor,,Stephanie Marty,DEM,118
+Lake,Herman-Winfred,State Auditor,,Rene Meyer,LIB,11
+Lake,Herman-Winfred,State Auditor,,Richard Sattgast,REP,266
+Lake,Lakeview,State Auditor,,Stephanie Marty,DEM,143
+Lake,Lakeview,State Auditor,,Rene Meyer,LIB,15
+Lake,Lakeview,State Auditor,,Richard Sattgast,REP,325
+Lake,Nunda-Summit,State Auditor,,Stephanie Marty,DEM,26
+Lake,Nunda-Summit,State Auditor,,Rene Meyer,LIB,4
+Lake,Nunda-Summit,State Auditor,,Richard Sattgast,REP,152
+Lake,Ward One,State Auditor,,Stephanie Marty,DEM,372
+Lake,Ward One,State Auditor,,Rene Meyer,LIB,51
+Lake,Ward One,State Auditor,,Richard Sattgast,REP,612
+Lake,Ward Three,State Auditor,,Stephanie Marty,DEM,198
+Lake,Ward Three,State Auditor,,Rene Meyer,LIB,37
+Lake,Ward Three,State Auditor,,Richard Sattgast,REP,309
+Lake,Ward Two,State Auditor,,Stephanie Marty,DEM,220
+Lake,Ward Two,State Auditor,,Rene Meyer,LIB,33
+Lake,Ward Two,State Auditor,,Richard Sattgast,REP,338
+Lake,Wentworth-Rutland,State Auditor,,Stephanie Marty,DEM,129
+Lake,Wentworth-Rutland,State Auditor,,Rene Meyer,LIB,18
+Lake,Wentworth-Rutland,State Auditor,,Richard Sattgast,REP,322
+Lake,Chester-Franklin,State Treasurer,,John Cunningham,DEM,112
+Lake,Chester-Franklin,State Treasurer,,Josh Haeder,REP,313
+Lake,?,State Treasurer,,John Cunningham,DEM,54
+Lake,?,State Treasurer,,Josh Haeder,REP,153
+Lake,?,State Treasurer,,John Cunningham,DEM,70
+Lake,?,State Treasurer,,Josh Haeder,REP,216
+Lake,Herman-Winfred,State Treasurer,,John Cunningham,DEM,115
+Lake,Herman-Winfred,State Treasurer,,Josh Haeder,REP,274
+Lake,Lakeview,State Treasurer,,John Cunningham,DEM,147
+Lake,Lakeview,State Treasurer,,Josh Haeder,REP,328
+Lake,Nunda-Summit,State Treasurer,,John Cunningham,DEM,29
+Lake,Nunda-Summit,State Treasurer,,Josh Haeder,REP,149
+Lake,Ward One,State Treasurer,,John Cunningham,DEM,386
+Lake,Ward One,State Treasurer,,Josh Haeder,REP,635
+Lake,Ward Three,State Treasurer,,John Cunningham,DEM,206
+Lake,Ward Three,State Treasurer,,Josh Haeder,REP,330
+Lake,Ward Two,State Treasurer,,John Cunningham,DEM,218
+Lake,Ward Two,State Treasurer,,Josh Haeder,REP,360
+Lake,Wentworth-Rutland,State Treasurer,,John Cunningham,DEM,124
+Lake,Wentworth-Rutland,State Treasurer,,Josh Haeder,REP,334
+Lake,Chester-Franklin,Commissioner of School and Public Lands,,Timothy Azure,DEM,113
+Lake,Chester-Franklin,Commissioner of School and Public Lands,,Brock Greenfield,REP,311
+Lake,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,53
+Lake,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,150
+Lake,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,62
+Lake,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,223
+Lake,Herman-Winfred,Commissioner of School and Public Lands,,Timothy Azure,DEM,117
+Lake,Herman-Winfred,Commissioner of School and Public Lands,,Brock Greenfield,REP,273
+Lake,Lakeview,Commissioner of School and Public Lands,,Timothy Azure,DEM,144
+Lake,Lakeview,Commissioner of School and Public Lands,,Brock Greenfield,REP,325
+Lake,Nunda-Summit,Commissioner of School and Public Lands,,Timothy Azure,DEM,29
+Lake,Nunda-Summit,Commissioner of School and Public Lands,,Brock Greenfield,REP,150
+Lake,Ward One,Commissioner of School and Public Lands,,Timothy Azure,DEM,368
+Lake,Ward One,Commissioner of School and Public Lands,,Brock Greenfield,REP,632
+Lake,Ward Three,Commissioner of School and Public Lands,,Timothy Azure,DEM,203
+Lake,Ward Three,Commissioner of School and Public Lands,,Brock Greenfield,REP,329
+Lake,Ward Two,Commissioner of School and Public Lands,,Timothy Azure,DEM,228
+Lake,Ward Two,Commissioner of School and Public Lands,,Brock Greenfield,REP,345
+Lake,Wentworth-Rutland,Commissioner of School and Public Lands,,Timothy Azure,DEM,118
+Lake,Wentworth-Rutland,Commissioner of School and Public Lands,,Brock Greenfield,REP,333
+Lake,Chester-Franklin,Public Utilities Commissioner,,Jeffrey Barth,DEM,104
+Lake,Chester-Franklin,Public Utilities Commissioner,,Chris Nelson,REP,335
+Lake,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,42
+Lake,?,Public Utilities Commissioner,,Chris Nelson,REP,176
+Lake,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,67
+Lake,?,Public Utilities Commissioner,,Chris Nelson,REP,232
+Lake,Herman-Winfred,Public Utilities Commissioner,,Jeffrey Barth,DEM,109
+Lake,Herman-Winfred,Public Utilities Commissioner,,Chris Nelson,REP,290
+Lake,Lakeview,Public Utilities Commissioner,,Jeffrey Barth,DEM,143
+Lake,Lakeview,Public Utilities Commissioner,,Chris Nelson,REP,349
+Lake,Nunda-Summit,Public Utilities Commissioner,,Jeffrey Barth,DEM,27
+Lake,Nunda-Summit,Public Utilities Commissioner,,Chris Nelson,REP,154
+Lake,Ward One,Public Utilities Commissioner,,Jeffrey Barth,DEM,335
+Lake,Ward One,Public Utilities Commissioner,,Chris Nelson,REP,712
+Lake,Ward Three,Public Utilities Commissioner,,Jeffrey Barth,DEM,197
+Lake,Ward Three,Public Utilities Commissioner,,Chris Nelson,REP,362
+Lake,Ward Two,Public Utilities Commissioner,,Jeffrey Barth,DEM,198
+Lake,Ward Two,Public Utilities Commissioner,,Chris Nelson,REP,400
+Lake,Wentworth-Rutland,Public Utilities Commissioner,,Jeffrey Barth,DEM,103
+Lake,Wentworth-Rutland,Public Utilities Commissioner,,Chris Nelson,REP,359
+Lake,Chester-Franklin,State Senate,08,Casey Crabtree,REP,355
+Lake,?,State Senate,08,Casey Crabtree,REP,176
+Lake,?,State Senate,08,Casey Crabtree,REP,245
+Lake,Herman-Winfred,State Senate,08,Casey Crabtree,REP,339
+Lake,Lakeview,State Senate,08,Casey Crabtree,REP,385
+Lake,Nunda-Summit,State Senate,08,Casey Crabtree,REP,157
+Lake,Ward One,State Senate,08,Casey Crabtree,REP,848
+Lake,Ward Three,State Senate,08,Casey Crabtree,REP,418
+Lake,Ward Two,State Senate,08,Casey Crabtree,REP,464
+Lake,Wentworth-Rutland,State Senate,08,Casey Crabtree,REP,379
+Lake,Chester-Franklin,State House,08,Tim Reisch,REP,286
+Lake,Chester-Franklin,State House,08,John Mills,REP,262
+Lake,?,State House,08,Tim Reisch,REP,146
+Lake,?,State House,08,John Mills,REP,115
+Lake,?,State House,08,Tim Reisch,REP,211
+Lake,?,State House,08,John Mills,REP,183
+Lake,Herman-Winfred,State House,08,Tim Reisch,REP,302
+Lake,Herman-Winfred,State House,08,John Mills,REP,213
+Lake,Lakeview,State House,08,Tim Reisch,REP,314
+Lake,Lakeview,State House,08,John Mills,REP,270
+Lake,Nunda-Summit,State House,08,Tim Reisch,REP,121
+Lake,Nunda-Summit,State House,08,John Mills,REP,111
+Lake,Ward One,State House,08,Tim Reisch,REP,697
+Lake,Ward One,State House,08,John Mills,REP,559
+Lake,Ward Three,State House,08,Tim Reisch,REP,344
+Lake,Ward Three,State House,08,John Mills,REP,270
+Lake,Ward Two,State House,08,Tim Reisch,REP,390
+Lake,Ward Two,State House,08,John Mills,REP,310
+Lake,Wentworth-Rutland,State House,08,Tim Reisch,REP,283
+Lake,Wentworth-Rutland,State House,08,John Mills,REP,276
+Lake,Chester-Franklin,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,195
+Lake,?,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,93
+Lake,?,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,153
+Lake,Herman-Winfred,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,193
+Lake,Lakeview,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,266
+Lake,Nunda-Summit,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,90
+Lake,Ward One,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,575
+Lake,Ward Three,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,302
+Lake,Ward Two,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,342
+Lake,Wentworth-Rutland,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,233
+Lake,Chester-Franklin,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,181
+Lake,?,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,92
+Lake,?,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,148
+Lake,Herman-Winfred,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,182
+Lake,Lakeview,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,252
+Lake,Nunda-Summit,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,87
+Lake,Ward One,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,532
+Lake,Ward Three,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,282
+Lake,Ward Two,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,304
+Lake,Wentworth-Rutland,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,227
+Lake,Chester-Franklin,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,185
+Lake,?,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,91
+Lake,?,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,142
+Lake,Herman-Winfred,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,180
+Lake,Lakeview,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,242
+Lake,Nunda-Summit,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,84
+Lake,Ward One,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,526
+Lake,Ward Three,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,272
+Lake,Ward Two,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,303
+Lake,Wentworth-Rutland,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,218
+Lake,Chester-Franklin,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,191
+Lake,?,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,95
+Lake,?,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,141
+Lake,Herman-Winfred,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,184
+Lake,Lakeview,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,244
+Lake,Nunda-Summit,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,83
+Lake,Ward One,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,533
+Lake,Ward Three,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,277
+Lake,Ward Two,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,309
+Lake,Wentworth-Rutland,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,222
+Lake,Chester-Franklin,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,81
+Lake,Chester-Franklin,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,114
+Lake,?,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,48
+Lake,?,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,61
+Lake,?,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,62
+Lake,?,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,92
+Lake,Herman-Winfred,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,70
+Lake,Herman-Winfred,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,118
+Lake,Lakeview,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,107
+Lake,Lakeview,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,146
+Lake,Nunda-Summit,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,40
+Lake,Nunda-Summit,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,55
+Lake,Ward One,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,216
+Lake,Ward One,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,330
+Lake,Ward Three,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,122
+Lake,Ward Three,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,181
+Lake,Ward Two,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,131
+Lake,Ward Two,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,209
+Lake,Wentworth-Rutland,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,92
+Lake,Wentworth-Rutland,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,127
+Lake,Chester-Franklin,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,226
+Lake,?,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,129
+Lake,?,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,180
+Lake,Herman-Winfred,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,247
+Lake,Lakeview,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,288
+Lake,Nunda-Summit,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,95
+Lake,Ward One,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,655
+Lake,Ward Three,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,344
+Lake,Ward Two,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,378
+Lake,Wentworth-Rutland,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,241
+Lake,Chester-Franklin,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,327
+Lake,Chester-Franklin,Supreme Court Retention,3,Patricia J. DeVaney - No,,63
+Lake,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,151
+Lake,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,29
+Lake,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,228
+Lake,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,35
+Lake,Herman-Winfred,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,312
+Lake,Herman-Winfred,Supreme Court Retention,3,Patricia J. DeVaney - No,,45
+Lake,Lakeview,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,393
+Lake,Lakeview,Supreme Court Retention,3,Patricia J. DeVaney - No,,49
+Lake,Nunda-Summit,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,137
+Lake,Nunda-Summit,Supreme Court Retention,3,Patricia J. DeVaney - No,,14
+Lake,Ward One,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,826
+Lake,Ward One,Supreme Court Retention,3,Patricia J. DeVaney - No,,145
+Lake,Ward Three,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,414
+Lake,Ward Three,Supreme Court Retention,3,Patricia J. DeVaney - No,,85
+Lake,Ward Two,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,454
+Lake,Ward Two,Supreme Court Retention,3,Patricia J. DeVaney - No,,93
+Lake,Wentworth-Rutland,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,373
+Lake,Wentworth-Rutland,Supreme Court Retention,3,Patricia J. DeVaney - No,,49
+Lake,Chester-Franklin,Supreme Court Retention,2,Mark E. Salter - Yes,,316
+Lake,Chester-Franklin,Supreme Court Retention,2,Mark E. Salter - No,,68
+Lake,?,Supreme Court Retention,2,Mark E. Salter - Yes,,155
+Lake,?,Supreme Court Retention,2,Mark E. Salter - No,,26
+Lake,?,Supreme Court Retention,2,Mark E. Salter - Yes,,221
+Lake,?,Supreme Court Retention,2,Mark E. Salter - No,,42
+Lake,Herman-Winfred,Supreme Court Retention,2,Mark E. Salter - Yes,,309
+Lake,Herman-Winfred,Supreme Court Retention,2,Mark E. Salter - No,,44
+Lake,Lakeview,Supreme Court Retention,2,Mark E. Salter - Yes,,391
+Lake,Lakeview,Supreme Court Retention,2,Mark E. Salter - No,,49
+Lake,Nunda-Summit,Supreme Court Retention,2,Mark E. Salter - Yes,,140
+Lake,Nunda-Summit,Supreme Court Retention,2,Mark E. Salter - No,,12
+Lake,Ward One,Supreme Court Retention,2,Mark E. Salter - Yes,,816
+Lake,Ward One,Supreme Court Retention,2,Mark E. Salter - No,,145
+Lake,Ward Three,Supreme Court Retention,2,Mark E. Salter - Yes,,408
+Lake,Ward Three,Supreme Court Retention,2,Mark E. Salter - No,,83
+Lake,Ward Two,Supreme Court Retention,2,Mark E. Salter - Yes,,443
+Lake,Ward Two,Supreme Court Retention,2,Mark E. Salter - No,,90
+Lake,Wentworth-Rutland,Supreme Court Retention,2,Mark E. Salter - Yes,,369
+Lake,Wentworth-Rutland,Supreme Court Retention,2,Mark E. Salter - No,,51
+Lake,Chester-Franklin,Constitutional Amendment D,,Yes,,198
+Lake,Chester-Franklin,Constitutional Amendment D,,No,,261
+Lake,?,Constitutional Amendment D,,Yes,,110
+Lake,?,Constitutional Amendment D,,No,,109
+Lake,?,Constitutional Amendment D,,Yes,,124
+Lake,?,Constitutional Amendment D,,No,,177
+Lake,Herman-Winfred,Constitutional Amendment D,,Yes,,208
+Lake,Herman-Winfred,Constitutional Amendment D,,No,,195
+Lake,Lakeview,Constitutional Amendment D,,Yes,,249
+Lake,Lakeview,Constitutional Amendment D,,No,,246
+Lake,Nunda-Summit,Constitutional Amendment D,,Yes,,77
+Lake,Nunda-Summit,Constitutional Amendment D,,No,,96
+Lake,Ward One,Constitutional Amendment D,,Yes,,636
+Lake,Ward One,Constitutional Amendment D,,No,,463
+Lake,Ward Three,Constitutional Amendment D,,Yes,,351
+Lake,Ward Three,Constitutional Amendment D,,No,,222
+Lake,Ward Two,Constitutional Amendment D,,Yes,,352
+Lake,Ward Two,Constitutional Amendment D,,No,,266
+Lake,Wentworth-Rutland,Constitutional Amendment D,,Yes,,235
+Lake,Wentworth-Rutland,Constitutional Amendment D,,No,,238
+Lake,Chester-Franklin,Initiated Measure 27,,Yes,,199
+Lake,Chester-Franklin,Initiated Measure 27,,No,,262
+Lake,?,Initiated Measure 27,,Yes,,104
+Lake,?,Initiated Measure 27,,No,,120
+Lake,?,Initiated Measure 27,,Yes,,117
+Lake,?,Initiated Measure 27,,No,,190
+Lake,Herman-Winfred,Initiated Measure 27,,Yes,,174
+Lake,Herman-Winfred,Initiated Measure 27,,No,,238
+Lake,Lakeview,Initiated Measure 27,,Yes,,240
+Lake,Lakeview,Initiated Measure 27,,No,,262
+Lake,Nunda-Summit,Initiated Measure 27,,Yes,,61
+Lake,Nunda-Summit,Initiated Measure 27,,No,,120
+Lake,Ward One,Initiated Measure 27,,Yes,,558
+Lake,Ward One,Initiated Measure 27,,No,,552
+Lake,Ward Three,Initiated Measure 27,,Yes,,292
+Lake,Ward Three,Initiated Measure 27,,No,,287
+Lake,Ward Two,Initiated Measure 27,,Yes,,334
+Lake,Ward Two,Initiated Measure 27,,No,,294
+Lake,Wentworth-Rutland,Initiated Measure 27,,Yes,,223
+Lake,Wentworth-Rutland,Initiated Measure 27,,No,,258

--- a/2022/counties/20221108__sd__general__lawrence__precinct.csv
+++ b/2022/counties/20221108__sd__general__lawrence__precinct.csv
@@ -1,0 +1,430 @@
+county,precinct,office,district,candidate,party,votes
+Lawrence,Absentee Precinct,U.S. Senate,,Brian L. Bengs,DEM,1667
+Lawrence,Absentee Precinct,U.S. Senate,,Tamara J Lesnar,LIB,229
+Lawrence,Absentee Precinct,U.S. Senate,,John R. Thune,REP,3521
+Lawrence,01,U.S. Senate,,Brian L. Bengs,DEM,232
+Lawrence,01,U.S. Senate,,Tamara J Lesnar,LIB,47
+Lawrence,01,U.S. Senate,,John R. Thune,REP,560
+Lawrence,02,U.S. Senate,,Brian L. Bengs,DEM,255
+Lawrence,02,U.S. Senate,,Tamara J Lesnar,LIB,59
+Lawrence,02,U.S. Senate,,John R. Thune,REP,644
+Lawrence,03,U.S. Senate,,Brian L. Bengs,DEM,257
+Lawrence,03,U.S. Senate,,Tamara J Lesnar,LIB,52
+Lawrence,03,U.S. Senate,,John R. Thune,REP,779
+Lawrence,04,U.S. Senate,,Brian L. Bengs,DEM,181
+Lawrence,04,U.S. Senate,,Tamara J Lesnar,LIB,50
+Lawrence,04,U.S. Senate,,John R. Thune,REP,476
+Lawrence,05,U.S. Senate,,Brian L. Bengs,DEM,60
+Lawrence,05,U.S. Senate,,Tamara J Lesnar,LIB,22
+Lawrence,05,U.S. Senate,,John R. Thune,REP,180
+Lawrence,06,U.S. Senate,,Brian L. Bengs,DEM,30
+Lawrence,06,U.S. Senate,,Tamara J Lesnar,LIB,3
+Lawrence,06,U.S. Senate,,John R. Thune,REP,125
+Lawrence,07,U.S. Senate,,Brian L. Bengs,DEM,73
+Lawrence,07,U.S. Senate,,Tamara J Lesnar,LIB,34
+Lawrence,07,U.S. Senate,,John R. Thune,REP,383
+Lawrence,08,U.S. Senate,,Brian L. Bengs,DEM,17
+Lawrence,08,U.S. Senate,,Tamara J Lesnar,LIB,9
+Lawrence,08,U.S. Senate,,John R. Thune,REP,115
+Lawrence,09,U.S. Senate,,Brian L. Bengs,DEM,76
+Lawrence,09,U.S. Senate,,Tamara J Lesnar,LIB,43
+Lawrence,09,U.S. Senate,,John R. Thune,REP,559
+Lawrence,10,U.S. Senate,,Brian L. Bengs,DEM,213
+Lawrence,10,U.S. Senate,,Tamara J Lesnar,LIB,98
+Lawrence,10,U.S. Senate,,John R. Thune,REP,1097
+Lawrence,Absentee Precinct,U.S. House,1,Collin Duprel,LIB,1344
+Lawrence,Absentee Precinct,U.S. House,1,Dusty Johnson,REP,3670
+Lawrence,01,U.S. House,1,Collin Duprel,LIB,218
+Lawrence,01,U.S. House,1,Dusty Johnson,REP,579
+Lawrence,02,U.S. House,1,Collin Duprel,LIB,253
+Lawrence,02,U.S. House,1,Dusty Johnson,REP,666
+Lawrence,03,U.S. House,1,Collin Duprel,LIB,258
+Lawrence,03,U.S. House,1,Dusty Johnson,REP,783
+Lawrence,04,U.S. House,1,Collin Duprel,LIB,197
+Lawrence,04,U.S. House,1,Dusty Johnson,REP,471
+Lawrence,05,U.S. House,1,Collin Duprel,LIB,79
+Lawrence,05,U.S. House,1,Dusty Johnson,REP,172
+Lawrence,06,U.S. House,1,Collin Duprel,LIB,32
+Lawrence,06,U.S. House,1,Dusty Johnson,REP,121
+Lawrence,07,U.S. House,1,Collin Duprel,LIB,108
+Lawrence,07,U.S. House,1,Dusty Johnson,REP,367
+Lawrence,08,U.S. House,1,Collin Duprel,LIB,37
+Lawrence,08,U.S. House,1,Dusty Johnson,REP,103
+Lawrence,09,U.S. House,1,Collin Duprel,LIB,179
+Lawrence,09,U.S. House,1,Dusty Johnson,REP,488
+Lawrence,10,U.S. House,1,Collin Duprel,LIB,294
+Lawrence,10,U.S. House,1,Dusty Johnson,REP,1059
+Lawrence,Absentee Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,2118
+Lawrence,Absentee Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,158
+Lawrence,Absentee Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,3178
+Lawrence,01,Governor,,Jamie Smith and Jennifer Keintz,DEM,326
+Lawrence,01,Governor,,Tracey Quint and Ashley Strand,LIB,40
+Lawrence,01,Governor,,Kristi Noem and Larry Rhoden,REP,473
+Lawrence,02,Governor,,Jamie Smith and Jennifer Keintz,DEM,337
+Lawrence,02,Governor,,Tracey Quint and Ashley Strand,LIB,41
+Lawrence,02,Governor,,Kristi Noem and Larry Rhoden,REP,597
+Lawrence,03,Governor,,Jamie Smith and Jennifer Keintz,DEM,338
+Lawrence,03,Governor,,Tracey Quint and Ashley Strand,LIB,47
+Lawrence,03,Governor,,Kristi Noem and Larry Rhoden,REP,716
+Lawrence,04,Governor,,Jamie Smith and Jennifer Keintz,DEM,256
+Lawrence,04,Governor,,Tracey Quint and Ashley Strand,LIB,30
+Lawrence,04,Governor,,Kristi Noem and Larry Rhoden,REP,416
+Lawrence,05,Governor,,Jamie Smith and Jennifer Keintz,DEM,86
+Lawrence,05,Governor,,Tracey Quint and Ashley Strand,LIB,22
+Lawrence,05,Governor,,Kristi Noem and Larry Rhoden,REP,162
+Lawrence,06,Governor,,Jamie Smith and Jennifer Keintz,DEM,35
+Lawrence,06,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Lawrence,06,Governor,,Kristi Noem and Larry Rhoden,REP,119
+Lawrence,07,Governor,,Jamie Smith and Jennifer Keintz,DEM,110
+Lawrence,07,Governor,,Tracey Quint and Ashley Strand,LIB,19
+Lawrence,07,Governor,,Kristi Noem and Larry Rhoden,REP,367
+Lawrence,08,Governor,,Jamie Smith and Jennifer Keintz,DEM,21
+Lawrence,08,Governor,,Tracey Quint and Ashley Strand,LIB,8
+Lawrence,08,Governor,,Kristi Noem and Larry Rhoden,REP,114
+Lawrence,09,Governor,,Jamie Smith and Jennifer Keintz,DEM,102
+Lawrence,09,Governor,,Tracey Quint and Ashley Strand,LIB,34
+Lawrence,09,Governor,,Kristi Noem and Larry Rhoden,REP,549
+Lawrence,10,Governor,,Jamie Smith and Jennifer Keintz,DEM,312
+Lawrence,10,Governor,,Tracey Quint and Ashley Strand,LIB,54
+Lawrence,10,Governor,,Kristi Noem and Larry Rhoden,REP,1058
+Lawrence,Absentee Precinct,Secretary of State,,Thomas A Cool,DEM,1966
+Lawrence,Absentee Precinct,Secretary of State,,Monae Johnson,REP,3229
+Lawrence,01,Secretary of State,,Thomas A Cool,DEM,312
+Lawrence,01,Secretary of State,,Monae Johnson,REP,484
+Lawrence,02,Secretary of State,,Thomas A Cool,DEM,306
+Lawrence,02,Secretary of State,,Monae Johnson,REP,603
+Lawrence,03,Secretary of State,,Thomas A Cool,DEM,341
+Lawrence,03,Secretary of State,,Monae Johnson,REP,707
+Lawrence,04,Secretary of State,,Thomas A Cool,DEM,246
+Lawrence,04,Secretary of State,,Monae Johnson,REP,421
+Lawrence,05,Secretary of State,,Thomas A Cool,DEM,85
+Lawrence,05,Secretary of State,,Monae Johnson,REP,165
+Lawrence,06,Secretary of State,,Thomas A Cool,DEM,37
+Lawrence,06,Secretary of State,,Monae Johnson,REP,116
+Lawrence,07,Secretary of State,,Thomas A Cool,DEM,103
+Lawrence,07,Secretary of State,,Monae Johnson,REP,365
+Lawrence,08,Secretary of State,,Thomas A Cool,DEM,21
+Lawrence,08,Secretary of State,,Monae Johnson,REP,116
+Lawrence,09,Secretary of State,,Thomas A Cool,DEM,111
+Lawrence,09,Secretary of State,,Monae Johnson,REP,543
+Lawrence,10,Secretary of State,,Thomas A Cool,DEM,303
+Lawrence,10,Secretary of State,,Monae Johnson,REP,1063
+Lawrence,Absentee Precinct,Attorney General,,Marty J. Jackley,REP,3877
+Lawrence,01,Attorney General,,Marty J. Jackley,REP,591
+Lawrence,02,Attorney General,,Marty J. Jackley,REP,694
+Lawrence,03,Attorney General,,Marty J. Jackley,REP,834
+Lawrence,04,Attorney General,,Marty J. Jackley,REP,506
+Lawrence,05,Attorney General,,Marty J. Jackley,REP,203
+Lawrence,06,Attorney General,,Marty J. Jackley,REP,124
+Lawrence,07,Attorney General,,Marty J. Jackley,REP,400
+Lawrence,08,Attorney General,,Marty J. Jackley,REP,124
+Lawrence,09,Attorney General,,Marty J. Jackley,REP,577
+Lawrence,10,Attorney General,,Marty J. Jackley,REP,1128
+Lawrence,Absentee Precinct,State Auditor,,Stephanie Marty,DEM,1793
+Lawrence,Absentee Precinct,State Auditor,,Rene Meyer,LIB,258
+Lawrence,Absentee Precinct,State Auditor,,Richard Sattgast,REP,3194
+Lawrence,01,State Auditor,,Stephanie Marty,DEM,257
+Lawrence,01,State Auditor,,Rene Meyer,LIB,72
+Lawrence,01,State Auditor,,Richard Sattgast,REP,472
+Lawrence,02,State Auditor,,Stephanie Marty,DEM,269
+Lawrence,02,State Auditor,,Rene Meyer,LIB,71
+Lawrence,02,State Auditor,,Richard Sattgast,REP,571
+Lawrence,03,State Auditor,,Stephanie Marty,DEM,289
+Lawrence,03,State Auditor,,Rene Meyer,LIB,70
+Lawrence,03,State Auditor,,Richard Sattgast,REP,678
+Lawrence,04,State Auditor,,Stephanie Marty,DEM,205
+Lawrence,04,State Auditor,,Rene Meyer,LIB,68
+Lawrence,04,State Auditor,,Richard Sattgast,REP,394
+Lawrence,05,State Auditor,,Stephanie Marty,DEM,80
+Lawrence,05,State Auditor,,Rene Meyer,LIB,30
+Lawrence,05,State Auditor,,Richard Sattgast,REP,144
+Lawrence,06,State Auditor,,Stephanie Marty,DEM,33
+Lawrence,06,State Auditor,,Rene Meyer,LIB,6
+Lawrence,06,State Auditor,,Richard Sattgast,REP,113
+Lawrence,07,State Auditor,,Stephanie Marty,DEM,89
+Lawrence,07,State Auditor,,Rene Meyer,LIB,39
+Lawrence,07,State Auditor,,Richard Sattgast,REP,340
+Lawrence,08,State Auditor,,Stephanie Marty,DEM,21
+Lawrence,08,State Auditor,,Rene Meyer,LIB,9
+Lawrence,08,State Auditor,,Richard Sattgast,REP,110
+Lawrence,09,State Auditor,,Stephanie Marty,DEM,74
+Lawrence,09,State Auditor,,Rene Meyer,LIB,63
+Lawrence,09,State Auditor,,Richard Sattgast,REP,510
+Lawrence,10,State Auditor,,Stephanie Marty,DEM,252
+Lawrence,10,State Auditor,,Rene Meyer,LIB,94
+Lawrence,10,State Auditor,,Richard Sattgast,REP,1018
+Lawrence,Absentee Precinct,State Treasurer,,John Cunningham,DEM,1869
+Lawrence,Absentee Precinct,State Treasurer,,Josh Haeder,REP,3338
+Lawrence,01,State Treasurer,,John Cunningham,DEM,276
+Lawrence,01,State Treasurer,,Josh Haeder,REP,505
+Lawrence,02,State Treasurer,,John Cunningham,DEM,290
+Lawrence,02,State Treasurer,,Josh Haeder,REP,603
+Lawrence,03,State Treasurer,,John Cunningham,DEM,305
+Lawrence,03,State Treasurer,,Josh Haeder,REP,721
+Lawrence,04,State Treasurer,,John Cunningham,DEM,226
+Lawrence,04,State Treasurer,,Josh Haeder,REP,429
+Lawrence,05,State Treasurer,,John Cunningham,DEM,79
+Lawrence,05,State Treasurer,,Josh Haeder,REP,166
+Lawrence,06,State Treasurer,,John Cunningham,DEM,33
+Lawrence,06,State Treasurer,,Josh Haeder,REP,118
+Lawrence,07,State Treasurer,,John Cunningham,DEM,104
+Lawrence,07,State Treasurer,,Josh Haeder,REP,361
+Lawrence,08,State Treasurer,,John Cunningham,DEM,24
+Lawrence,08,State Treasurer,,Josh Haeder,REP,113
+Lawrence,09,State Treasurer,,John Cunningham,DEM,93
+Lawrence,09,State Treasurer,,Josh Haeder,REP,552
+Lawrence,10,State Treasurer,,John Cunningham,DEM,273
+Lawrence,10,State Treasurer,,Josh Haeder,REP,1076
+Lawrence,Absentee Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,1871
+Lawrence,Absentee Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,3233
+Lawrence,01,Commissioner of School and Public Lands,,Timothy Azure,DEM,281
+Lawrence,01,Commissioner of School and Public Lands,,Brock Greenfield,REP,499
+Lawrence,02,Commissioner of School and Public Lands,,Timothy Azure,DEM,290
+Lawrence,02,Commissioner of School and Public Lands,,Brock Greenfield,REP,594
+Lawrence,03,Commissioner of School and Public Lands,,Timothy Azure,DEM,311
+Lawrence,03,Commissioner of School and Public Lands,,Brock Greenfield,REP,710
+Lawrence,04,Commissioner of School and Public Lands,,Timothy Azure,DEM,218
+Lawrence,04,Commissioner of School and Public Lands,,Brock Greenfield,REP,437
+Lawrence,05,Commissioner of School and Public Lands,,Timothy Azure,DEM,84
+Lawrence,05,Commissioner of School and Public Lands,,Brock Greenfield,REP,163
+Lawrence,06,Commissioner of School and Public Lands,,Timothy Azure,DEM,30
+Lawrence,06,Commissioner of School and Public Lands,,Brock Greenfield,REP,117
+Lawrence,07,Commissioner of School and Public Lands,,Timothy Azure,DEM,98
+Lawrence,07,Commissioner of School and Public Lands,,Brock Greenfield,REP,365
+Lawrence,08,Commissioner of School and Public Lands,,Timothy Azure,DEM,21
+Lawrence,08,Commissioner of School and Public Lands,,Brock Greenfield,REP,114
+Lawrence,09,Commissioner of School and Public Lands,,Timothy Azure,DEM,96
+Lawrence,09,Commissioner of School and Public Lands,,Brock Greenfield,REP,543
+Lawrence,10,Commissioner of School and Public Lands,,Timothy Azure,DEM,276
+Lawrence,10,Commissioner of School and Public Lands,,Brock Greenfield,REP,1057
+Lawrence,Absentee Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,1800
+Lawrence,Absentee Precinct,Public Utilities Commissioner,,Chris Nelson,REP,3408
+Lawrence,01,Public Utilities Commissioner,,Jeffrey Barth,DEM,255
+Lawrence,01,Public Utilities Commissioner,,Chris Nelson,REP,514
+Lawrence,02,Public Utilities Commissioner,,Jeffrey Barth,DEM,280
+Lawrence,02,Public Utilities Commissioner,,Chris Nelson,REP,616
+Lawrence,03,Public Utilities Commissioner,,Jeffrey Barth,DEM,302
+Lawrence,03,Public Utilities Commissioner,,Chris Nelson,REP,728
+Lawrence,04,Public Utilities Commissioner,,Jeffrey Barth,DEM,221
+Lawrence,04,Public Utilities Commissioner,,Chris Nelson,REP,449
+Lawrence,05,Public Utilities Commissioner,,Jeffrey Barth,DEM,86
+Lawrence,05,Public Utilities Commissioner,,Chris Nelson,REP,163
+Lawrence,06,Public Utilities Commissioner,,Jeffrey Barth,DEM,31
+Lawrence,06,Public Utilities Commissioner,,Chris Nelson,REP,120
+Lawrence,07,Public Utilities Commissioner,,Jeffrey Barth,DEM,106
+Lawrence,07,Public Utilities Commissioner,,Chris Nelson,REP,364
+Lawrence,08,Public Utilities Commissioner,,Jeffrey Barth,DEM,22
+Lawrence,08,Public Utilities Commissioner,,Chris Nelson,REP,115
+Lawrence,09,Public Utilities Commissioner,,Jeffrey Barth,DEM,99
+Lawrence,09,Public Utilities Commissioner,,Chris Nelson,REP,544
+Lawrence,10,Public Utilities Commissioner,,Jeffrey Barth,DEM,252
+Lawrence,10,Public Utilities Commissioner,,Chris Nelson,REP,1100
+Lawrence,Absentee Precinct,State Senate,31,Randy Deibert,REP,3607
+Lawrence,01,State Senate,31,Randy Deibert,REP,562
+Lawrence,02,State Senate,31,Randy Deibert,REP,679
+Lawrence,03,State Senate,31,Randy Deibert,REP,791
+Lawrence,04,State Senate,31,Randy Deibert,REP,470
+Lawrence,05,State Senate,31,Randy Deibert,REP,183
+Lawrence,06,State Senate,31,Randy Deibert,REP,122
+Lawrence,07,State Senate,31,Randy Deibert,REP,370
+Lawrence,08,State Senate,31,Randy Deibert,REP,119
+Lawrence,09,State Senate,31,Randy Deibert,REP,531
+Lawrence,10,State Senate,31,Randy Deibert,REP,1102
+Lawrence,Absentee Precinct,State House,31,Mary J. Fitzgerald,REP,2611
+Lawrence,Absentee Precinct,State House,31,Scott Odenbach,REP,3055
+Lawrence,01,State House,31,Mary J. Fitzgerald,REP,415
+Lawrence,01,State House,31,Scott Odenbach,REP,466
+Lawrence,02,State House,31,Mary J. Fitzgerald,REP,463
+Lawrence,02,State House,31,Scott Odenbach,REP,560
+Lawrence,03,State House,31,Mary J. Fitzgerald,REP,574
+Lawrence,03,State House,31,Scott Odenbach,REP,669
+Lawrence,04,State House,31,Mary J. Fitzgerald,REP,359
+Lawrence,04,State House,31,Scott Odenbach,REP,380
+Lawrence,05,State House,31,Mary J. Fitzgerald,REP,128
+Lawrence,05,State House,31,Scott Odenbach,REP,154
+Lawrence,06,State House,31,Mary J. Fitzgerald,REP,82
+Lawrence,06,State House,31,Scott Odenbach,REP,104
+Lawrence,07,State House,31,Mary J. Fitzgerald,REP,255
+Lawrence,07,State House,31,Scott Odenbach,REP,321
+Lawrence,08,State House,31,Mary J. Fitzgerald,REP,80
+Lawrence,08,State House,31,Scott Odenbach,REP,94
+Lawrence,09,State House,31,Mary J. Fitzgerald,REP,372
+Lawrence,09,State House,31,Scott Odenbach,REP,472
+Lawrence,10,State House,31,Mary J. Fitzgerald,REP,777
+Lawrence,10,State House,31,Scott Odenbach,REP,955
+Lawrence,Absentee Precinct,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,2743
+Lawrence,01,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,459
+Lawrence,02,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,523
+Lawrence,03,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,623
+Lawrence,04,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,354
+Lawrence,05,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,129
+Lawrence,06,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,62
+Lawrence,07,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,243
+Lawrence,08,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,80
+Lawrence,09,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,366
+Lawrence,10,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,813
+Lawrence,Absentee Precinct,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,2571
+Lawrence,01,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,423
+Lawrence,02,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,486
+Lawrence,03,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,570
+Lawrence,04,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,335
+Lawrence,05,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,127
+Lawrence,06,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,63
+Lawrence,07,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,241
+Lawrence,08,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,83
+Lawrence,09,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,353
+Lawrence,10,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,761
+Lawrence,Absentee Precinct,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,2720
+Lawrence,01,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,437
+Lawrence,02,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,488
+Lawrence,03,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,568
+Lawrence,04,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,398
+Lawrence,05,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,144
+Lawrence,06,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,60
+Lawrence,07,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,262
+Lawrence,08,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,77
+Lawrence,09,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,353
+Lawrence,10,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,763
+Lawrence,Absentee Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,390
+Lawrence,Absentee Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,710
+Lawrence,Absentee Precinct,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,345
+Lawrence,Absentee Precinct,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,1822
+Lawrence,Absentee Precinct,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,640
+Lawrence,01,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,57
+Lawrence,01,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,105
+Lawrence,01,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,56
+Lawrence,01,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,255
+Lawrence,01,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,143
+Lawrence,02,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,50
+Lawrence,02,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,121
+Lawrence,02,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,63
+Lawrence,02,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,332
+Lawrence,02,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,144
+Lawrence,03,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,58
+Lawrence,03,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,133
+Lawrence,03,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,59
+Lawrence,03,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,358
+Lawrence,03,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,165
+Lawrence,04,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,70
+Lawrence,04,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,93
+Lawrence,04,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,41
+Lawrence,04,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,251
+Lawrence,04,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,50
+Lawrence,05,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,18
+Lawrence,05,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,25
+Lawrence,05,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,16
+Lawrence,05,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,101
+Lawrence,05,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,44
+Lawrence,06,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,13
+Lawrence,06,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,7
+Lawrence,06,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,5
+Lawrence,06,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,45
+Lawrence,06,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,17
+Lawrence,07,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,47
+Lawrence,07,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,68
+Lawrence,07,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,30
+Lawrence,07,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,139
+Lawrence,07,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,53
+Lawrence,08,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,4
+Lawrence,08,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,15
+Lawrence,08,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,6
+Lawrence,08,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,68
+Lawrence,08,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,26
+Lawrence,09,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,68
+Lawrence,09,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,64
+Lawrence,09,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,39
+Lawrence,09,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,212
+Lawrence,09,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,115
+Lawrence,10,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,54
+Lawrence,10,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,186
+Lawrence,10,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,74
+Lawrence,10,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,540
+Lawrence,10,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,238
+Lawrence,Absentee Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,3547
+Lawrence,Absentee Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,1021
+Lawrence,01,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,514
+Lawrence,01,Supreme Court Retention,3,Patricia J. DeVaney - No,,157
+Lawrence,02,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,590
+Lawrence,02,Supreme Court Retention,3,Patricia J. DeVaney - No,,191
+Lawrence,03,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,690
+Lawrence,03,Supreme Court Retention,3,Patricia J. DeVaney - No,,190
+Lawrence,04,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,456
+Lawrence,04,Supreme Court Retention,3,Patricia J. DeVaney - No,,143
+Lawrence,05,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,177
+Lawrence,05,Supreme Court Retention,3,Patricia J. DeVaney - No,,46
+Lawrence,06,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,97
+Lawrence,06,Supreme Court Retention,3,Patricia J. DeVaney - No,,30
+Lawrence,07,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,333
+Lawrence,07,Supreme Court Retention,3,Patricia J. DeVaney - No,,75
+Lawrence,08,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,96
+Lawrence,08,Supreme Court Retention,3,Patricia J. DeVaney - No,,29
+Lawrence,09,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,454
+Lawrence,09,Supreme Court Retention,3,Patricia J. DeVaney - No,,111
+Lawrence,10,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,954
+Lawrence,10,Supreme Court Retention,3,Patricia J. DeVaney - No,,248
+Lawrence,Absentee Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,3553
+Lawrence,Absentee Precinct,Supreme Court Retention,2,Mark E. Salter - No,,983
+Lawrence,01,Supreme Court Retention,2,Mark E. Salter - Yes,,508
+Lawrence,01,Supreme Court Retention,2,Mark E. Salter - No,,158
+Lawrence,02,Supreme Court Retention,2,Mark E. Salter - Yes,,581
+Lawrence,02,Supreme Court Retention,2,Mark E. Salter - No,,197
+Lawrence,03,Supreme Court Retention,2,Mark E. Salter - Yes,,688
+Lawrence,03,Supreme Court Retention,2,Mark E. Salter - No,,191
+Lawrence,04,Supreme Court Retention,2,Mark E. Salter - Yes,,449
+Lawrence,04,Supreme Court Retention,2,Mark E. Salter - No,,150
+Lawrence,05,Supreme Court Retention,2,Mark E. Salter - Yes,,170
+Lawrence,05,Supreme Court Retention,2,Mark E. Salter - No,,50
+Lawrence,06,Supreme Court Retention,2,Mark E. Salter - Yes,,97
+Lawrence,06,Supreme Court Retention,2,Mark E. Salter - No,,31
+Lawrence,07,Supreme Court Retention,2,Mark E. Salter - Yes,,339
+Lawrence,07,Supreme Court Retention,2,Mark E. Salter - No,,69
+Lawrence,08,Supreme Court Retention,2,Mark E. Salter - Yes,,98
+Lawrence,08,Supreme Court Retention,2,Mark E. Salter - No,,29
+Lawrence,09,Supreme Court Retention,2,Mark E. Salter - Yes,,442
+Lawrence,09,Supreme Court Retention,2,Mark E. Salter - No,,120
+Lawrence,10,Supreme Court Retention,2,Mark E. Salter - Yes,,940
+Lawrence,10,Supreme Court Retention,2,Mark E. Salter - No,,252
+Lawrence,Absentee Precinct,Constitutional Amendment D,,Yes,,3154
+Lawrence,Absentee Precinct,Constitutional Amendment D,,No,,2233
+Lawrence,01,Constitutional Amendment D,,Yes,,476
+Lawrence,01,Constitutional Amendment D,,No,,354
+Lawrence,02,Constitutional Amendment D,,Yes,,588
+Lawrence,02,Constitutional Amendment D,,No,,374
+Lawrence,03,Constitutional Amendment D,,Yes,,595
+Lawrence,03,Constitutional Amendment D,,No,,477
+Lawrence,04,Constitutional Amendment D,,Yes,,474
+Lawrence,04,Constitutional Amendment D,,No,,226
+Lawrence,05,Constitutional Amendment D,,Yes,,168
+Lawrence,05,Constitutional Amendment D,,No,,98
+Lawrence,06,Constitutional Amendment D,,Yes,,64
+Lawrence,06,Constitutional Amendment D,,No,,90
+Lawrence,07,Constitutional Amendment D,,Yes,,243
+Lawrence,07,Constitutional Amendment D,,No,,245
+Lawrence,08,Constitutional Amendment D,,Yes,,58
+Lawrence,08,Constitutional Amendment D,,No,,83
+Lawrence,09,Constitutional Amendment D,,Yes,,282
+Lawrence,09,Constitutional Amendment D,,No,,392
+Lawrence,10,Constitutional Amendment D,,Yes,,670
+Lawrence,10,Constitutional Amendment D,,No,,737
+Lawrence,Absentee Precinct,Initiated Measure 27,,Yes,,2728
+Lawrence,Absentee Precinct,Initiated Measure 27,,No,,2736
+Lawrence,01,Initiated Measure 27,,Yes,,439
+Lawrence,01,Initiated Measure 27,,No,,412
+Lawrence,02,Initiated Measure 27,,Yes,,550
+Lawrence,02,Initiated Measure 27,,No,,427
+Lawrence,03,Initiated Measure 27,,Yes,,488
+Lawrence,03,Initiated Measure 27,,No,,609
+Lawrence,04,Initiated Measure 27,,Yes,,432
+Lawrence,04,Initiated Measure 27,,No,,273
+Lawrence,05,Initiated Measure 27,,Yes,,159
+Lawrence,05,Initiated Measure 27,,No,,112
+Lawrence,06,Initiated Measure 27,,Yes,,59
+Lawrence,06,Initiated Measure 27,,No,,96
+Lawrence,07,Initiated Measure 27,,Yes,,226
+Lawrence,07,Initiated Measure 27,,No,,273
+Lawrence,08,Initiated Measure 27,,Yes,,54
+Lawrence,08,Initiated Measure 27,,No,,88
+Lawrence,09,Initiated Measure 27,,Yes,,295
+Lawrence,09,Initiated Measure 27,,No,,395
+Lawrence,10,Initiated Measure 27,,Yes,,549
+Lawrence,10,Initiated Measure 27,,No,,884

--- a/2022/counties/20221108__sd__general__lincoln__precinct.csv
+++ b/2022/counties/20221108__sd__general__lincoln__precinct.csv
@@ -1,0 +1,1446 @@
+county,precinct,office,district,candidate,party,votes
+Lincoln,?,U.S. Senate,,Brian L. Bengs,DEM,46
+Lincoln,?,U.S. Senate,,Tamara J Lesnar,LIB,9
+Lincoln,?,U.S. Senate,,John R. Thune,REP,184
+Lincoln,06-Highland & Canton,U.S. Senate,,Brian L. Bengs,DEM,83
+Lincoln,06-Highland & Canton,U.S. Senate,,Tamara J Lesnar,LIB,18
+Lincoln,06-Highland & Canton,U.S. Senate,,John R. Thune,REP,321
+Lincoln,08-Lincoln & Delaware,U.S. Senate,,Brian L. Bengs,DEM,44
+Lincoln,08-Lincoln & Delaware,U.S. Senate,,Tamara J Lesnar,LIB,9
+Lincoln,08-Lincoln & Delaware,U.S. Senate,,John R. Thune,REP,161
+Lincoln,11-Grant,U.S. Senate,,Brian L. Bengs,DEM,42
+Lincoln,11-Grant,U.S. Senate,,Tamara J Lesnar,LIB,5
+Lincoln,11-Grant,U.S. Senate,,John R. Thune,REP,161
+Lincoln,12-Dayton,U.S. Senate,,Brian L. Bengs,DEM,57
+Lincoln,12-Dayton,U.S. Senate,,Tamara J Lesnar,LIB,11
+Lincoln,12-Dayton,U.S. Senate,,John R. Thune,REP,315
+Lincoln,13-LaValley,U.S. Senate,,Brian L. Bengs,DEM,45
+Lincoln,13-LaValley,U.S. Senate,,Tamara J Lesnar,LIB,6
+Lincoln,13-LaValley,U.S. Senate,,John R. Thune,REP,269
+Lincoln,14-Perry,U.S. Senate,,Brian L. Bengs,DEM,81
+Lincoln,14-Perry,U.S. Senate,,Tamara J Lesnar,LIB,21
+Lincoln,14-Perry,U.S. Senate,,John R. Thune,REP,319
+Lincoln,15-Springdale,U.S. Senate,,Brian L. Bengs,DEM,202
+Lincoln,15-Springdale,U.S. Senate,,Tamara J Lesnar,LIB,30
+Lincoln,15-Springdale,U.S. Senate,,John R. Thune,REP,840
+Lincoln,16-Delapre,U.S. Senate,,Brian L. Bengs,DEM,168
+Lincoln,16-Delapre,U.S. Senate,,Tamara J Lesnar,LIB,35
+Lincoln,16-Delapre,U.S. Senate,,John R. Thune,REP,687
+Lincoln,"20-Canton 1, 2, 3",U.S. Senate,,Brian L. Bengs,DEM,198
+Lincoln,"20-Canton 1, 2, 3",U.S. Senate,,Tamara J Lesnar,LIB,37
+Lincoln,"20-Canton 1, 2, 3",U.S. Senate,,John R. Thune,REP,609
+Lincoln,21-Hudson & Eden,U.S. Senate,,Brian L. Bengs,DEM,42
+Lincoln,21-Hudson & Eden,U.S. Senate,,Tamara J Lesnar,LIB,8
+Lincoln,21-Hudson & Eden,U.S. Senate,,John R. Thune,REP,157
+Lincoln,23-Worthing & Lynn,U.S. Senate,,Brian L. Bengs,DEM,89
+Lincoln,23-Worthing & Lynn,U.S. Senate,,Tamara J Lesnar,LIB,26
+Lincoln,23-Worthing & Lynn,U.S. Senate,,John R. Thune,REP,384
+Lincoln,24-Tea,U.S. Senate,,Brian L. Bengs,DEM,458
+Lincoln,24-Tea,U.S. Senate,,Tamara J Lesnar,LIB,80
+Lincoln,24-Tea,U.S. Senate,,John R. Thune,REP,1480
+Lincoln,25-Lennox,U.S. Senate,,Brian L. Bengs,DEM,173
+Lincoln,25-Lennox,U.S. Senate,,Tamara J Lesnar,LIB,40
+Lincoln,25-Lennox,U.S. Senate,,John R. Thune,REP,710
+Lincoln,?,U.S. Senate,,Brian L. Bengs,DEM,78
+Lincoln,?,U.S. Senate,,Tamara J Lesnar,LIB,12
+Lincoln,?,U.S. Senate,,John R. Thune,REP,325
+Lincoln,27-Harrisburg 1,U.S. Senate,,Brian L. Bengs,DEM,306
+Lincoln,27-Harrisburg 1,U.S. Senate,,Tamara J Lesnar,LIB,47
+Lincoln,27-Harrisburg 1,U.S. Senate,,John R. Thune,REP,791
+Lincoln,29-Harrisburg 2,U.S. Senate,,Brian L. Bengs,DEM,279
+Lincoln,29-Harrisburg 2,U.S. Senate,,Tamara J Lesnar,LIB,47
+Lincoln,29-Harrisburg 2,U.S. Senate,,John R. Thune,REP,792
+Lincoln,30-Canton 4 & 5,U.S. Senate,,Brian L. Bengs,DEM,114
+Lincoln,30-Canton 4 & 5,U.S. Senate,,Tamara J Lesnar,LIB,30
+Lincoln,30-Canton 4 & 5,U.S. Senate,,John R. Thune,REP,282
+Lincoln,Sioux Falls 1-11,U.S. Senate,,Brian L. Bengs,DEM,343
+Lincoln,Sioux Falls 1-11,U.S. Senate,,Tamara J Lesnar,LIB,26
+Lincoln,Sioux Falls 1-11,U.S. Senate,,John R. Thune,REP,1115
+Lincoln,Sioux Falls 1-12,U.S. Senate,,Brian L. Bengs,DEM,485
+Lincoln,Sioux Falls 1-12,U.S. Senate,,Tamara J Lesnar,LIB,49
+Lincoln,Sioux Falls 1-12,U.S. Senate,,John R. Thune,REP,978
+Lincoln,Sioux Falls 1-13,U.S. Senate,,Brian L. Bengs,DEM,239
+Lincoln,Sioux Falls 1-13,U.S. Senate,,Tamara J Lesnar,LIB,21
+Lincoln,Sioux Falls 1-13,U.S. Senate,,John R. Thune,REP,344
+Lincoln,Sioux Falls 1-14,U.S. Senate,,Brian L. Bengs,DEM,237
+Lincoln,Sioux Falls 1-14,U.S. Senate,,Tamara J Lesnar,LIB,26
+Lincoln,Sioux Falls 1-14,U.S. Senate,,John R. Thune,REP,609
+Lincoln,Sioux Falls 1-15,U.S. Senate,,Brian L. Bengs,DEM,287
+Lincoln,Sioux Falls 1-15,U.S. Senate,,Tamara J Lesnar,LIB,32
+Lincoln,Sioux Falls 1-15,U.S. Senate,,John R. Thune,REP,462
+Lincoln,Sioux Falls 1-16,U.S. Senate,,Brian L. Bengs,DEM,202
+Lincoln,Sioux Falls 1-16,U.S. Senate,,Tamara J Lesnar,LIB,30
+Lincoln,Sioux Falls 1-16,U.S. Senate,,John R. Thune,REP,385
+Lincoln,Sioux Falls 1-18,U.S. Senate,,Brian L. Bengs,DEM,328
+Lincoln,Sioux Falls 1-18,U.S. Senate,,Tamara J Lesnar,LIB,39
+Lincoln,Sioux Falls 1-18,U.S. Senate,,John R. Thune,REP,978
+Lincoln,Sioux Falls 2-10,U.S. Senate,,Brian L. Bengs,DEM,381
+Lincoln,Sioux Falls 2-10,U.S. Senate,,Tamara J Lesnar,LIB,31
+Lincoln,Sioux Falls 2-10,U.S. Senate,,John R. Thune,REP,1128
+Lincoln,Sioux Falls 2-11,U.S. Senate,,Brian L. Bengs,DEM,552
+Lincoln,Sioux Falls 2-11,U.S. Senate,,Tamara J Lesnar,LIB,32
+Lincoln,Sioux Falls 2-11,U.S. Senate,,John R. Thune,REP,1335
+Lincoln,Sioux Falls 2-12,U.S. Senate,,Brian L. Bengs,DEM,264
+Lincoln,Sioux Falls 2-12,U.S. Senate,,Tamara J Lesnar,LIB,20
+Lincoln,Sioux Falls 2-12,U.S. Senate,,John R. Thune,REP,464
+Lincoln,Sioux Falls 2-13,U.S. Senate,,Brian L. Bengs,DEM,670
+Lincoln,Sioux Falls 2-13,U.S. Senate,,Tamara J Lesnar,LIB,52
+Lincoln,Sioux Falls 2-13,U.S. Senate,,John R. Thune,REP,1171
+Lincoln,Sioux Falls 2-15,U.S. Senate,,Brian L. Bengs,DEM,281
+Lincoln,Sioux Falls 2-15,U.S. Senate,,Tamara J Lesnar,LIB,34
+Lincoln,Sioux Falls 2-15,U.S. Senate,,John R. Thune,REP,844
+Lincoln,Sioux Falls 2-16,U.S. Senate,,Brian L. Bengs,DEM,591
+Lincoln,Sioux Falls 2-16,U.S. Senate,,Tamara J Lesnar,LIB,49
+Lincoln,Sioux Falls 2-16,U.S. Senate,,John R. Thune,REP,1103
+Lincoln,?,U.S. House,1,Collin Duprel,LIB,33
+Lincoln,?,U.S. House,1,Dusty Johnson,REP,200
+Lincoln,06-Highland & Canton,U.S. House,1,Collin Duprel,LIB,72
+Lincoln,06-Highland & Canton,U.S. House,1,Dusty Johnson,REP,337
+Lincoln,08-Lincoln & Delaware,U.S. House,1,Collin Duprel,LIB,34
+Lincoln,08-Lincoln & Delaware,U.S. House,1,Dusty Johnson,REP,175
+Lincoln,11-Grant,U.S. House,1,Collin Duprel,LIB,27
+Lincoln,11-Grant,U.S. House,1,Dusty Johnson,REP,172
+Lincoln,12-Dayton,U.S. House,1,Collin Duprel,LIB,57
+Lincoln,12-Dayton,U.S. House,1,Dusty Johnson,REP,309
+Lincoln,13-LaValley,U.S. House,1,Collin Duprel,LIB,43
+Lincoln,13-LaValley,U.S. House,1,Dusty Johnson,REP,268
+Lincoln,14-Perry,U.S. House,1,Collin Duprel,LIB,82
+Lincoln,14-Perry,U.S. House,1,Dusty Johnson,REP,323
+Lincoln,15-Springdale,U.S. House,1,Collin Duprel,LIB,153
+Lincoln,15-Springdale,U.S. House,1,Dusty Johnson,REP,866
+Lincoln,16-Delapre,U.S. House,1,Collin Duprel,LIB,151
+Lincoln,16-Delapre,U.S. House,1,Dusty Johnson,REP,709
+Lincoln,"20-Canton 1, 2, 3",U.S. House,1,Collin Duprel,LIB,157
+Lincoln,"20-Canton 1, 2, 3",U.S. House,1,Dusty Johnson,REP,639
+Lincoln,21-Hudson & Eden,U.S. House,1,Collin Duprel,LIB,35
+Lincoln,21-Hudson & Eden,U.S. House,1,Dusty Johnson,REP,165
+Lincoln,23-Worthing & Lynn,U.S. House,1,Collin Duprel,LIB,89
+Lincoln,23-Worthing & Lynn,U.S. House,1,Dusty Johnson,REP,397
+Lincoln,24-Tea,U.S. House,1,Collin Duprel,LIB,404
+Lincoln,24-Tea,U.S. House,1,Dusty Johnson,REP,1540
+Lincoln,25-Lennox,U.S. House,1,Collin Duprel,LIB,163
+Lincoln,25-Lennox,U.S. House,1,Dusty Johnson,REP,722
+Lincoln,?,U.S. House,1,Collin Duprel,LIB,66
+Lincoln,?,U.S. House,1,Dusty Johnson,REP,334
+Lincoln,27-Harrisburg 1,U.S. House,1,Collin Duprel,LIB,264
+Lincoln,27-Harrisburg 1,U.S. House,1,Dusty Johnson,REP,821
+Lincoln,29-Harrisburg 2,U.S. House,1,Collin Duprel,LIB,226
+Lincoln,29-Harrisburg 2,U.S. House,1,Dusty Johnson,REP,837
+Lincoln,30-Canton 4 & 5,U.S. House,1,Collin Duprel,LIB,103
+Lincoln,30-Canton 4 & 5,U.S. House,1,Dusty Johnson,REP,308
+Lincoln,Sioux Falls 1-11,U.S. House,1,Collin Duprel,LIB,207
+Lincoln,Sioux Falls 1-11,U.S. House,1,Dusty Johnson,REP,1195
+Lincoln,Sioux Falls 1-12,U.S. House,1,Collin Duprel,LIB,330
+Lincoln,Sioux Falls 1-12,U.S. House,1,Dusty Johnson,REP,1082
+Lincoln,Sioux Falls 1-13,U.S. House,1,Collin Duprel,LIB,179
+Lincoln,Sioux Falls 1-13,U.S. House,1,Dusty Johnson,REP,381
+Lincoln,Sioux Falls 1-14,U.S. House,1,Collin Duprel,LIB,178
+Lincoln,Sioux Falls 1-14,U.S. House,1,Dusty Johnson,REP,641
+Lincoln,Sioux Falls 1-15,U.S. House,1,Collin Duprel,LIB,213
+Lincoln,Sioux Falls 1-15,U.S. House,1,Dusty Johnson,REP,517
+Lincoln,Sioux Falls 1-16,U.S. House,1,Collin Duprel,LIB,160
+Lincoln,Sioux Falls 1-16,U.S. House,1,Dusty Johnson,REP,410
+Lincoln,Sioux Falls 1-18,U.S. House,1,Collin Duprel,LIB,224
+Lincoln,Sioux Falls 1-18,U.S. House,1,Dusty Johnson,REP,1032
+Lincoln,Sioux Falls 2-10,U.S. House,1,Collin Duprel,LIB,220
+Lincoln,Sioux Falls 2-10,U.S. House,1,Dusty Johnson,REP,1224
+Lincoln,Sioux Falls 2-11,U.S. House,1,Collin Duprel,LIB,315
+Lincoln,Sioux Falls 2-11,U.S. House,1,Dusty Johnson,REP,1479
+Lincoln,Sioux Falls 2-12,U.S. House,1,Collin Duprel,LIB,161
+Lincoln,Sioux Falls 2-12,U.S. House,1,Dusty Johnson,REP,525
+Lincoln,Sioux Falls 2-13,U.S. House,1,Collin Duprel,LIB,423
+Lincoln,Sioux Falls 2-13,U.S. House,1,Dusty Johnson,REP,1296
+Lincoln,Sioux Falls 2-15,U.S. House,1,Collin Duprel,LIB,191
+Lincoln,Sioux Falls 2-15,U.S. House,1,Dusty Johnson,REP,898
+Lincoln,Sioux Falls 2-16,U.S. House,1,Collin Duprel,LIB,400
+Lincoln,Sioux Falls 2-16,U.S. House,1,Dusty Johnson,REP,1200
+Lincoln,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,60
+Lincoln,?,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Lincoln,?,Governor,,Kristi Noem and Larry Rhoden,REP,177
+Lincoln,06-Highland & Canton,Governor,,Jamie Smith and Jennifer Keintz,DEM,128
+Lincoln,06-Highland & Canton,Governor,,Tracey Quint and Ashley Strand,LIB,14
+Lincoln,06-Highland & Canton,Governor,,Kristi Noem and Larry Rhoden,REP,281
+Lincoln,08-Lincoln & Delaware,Governor,,Jamie Smith and Jennifer Keintz,DEM,58
+Lincoln,08-Lincoln & Delaware,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Lincoln,08-Lincoln & Delaware,Governor,,Kristi Noem and Larry Rhoden,REP,151
+Lincoln,11-Grant,Governor,,Jamie Smith and Jennifer Keintz,DEM,61
+Lincoln,11-Grant,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Lincoln,11-Grant,Governor,,Kristi Noem and Larry Rhoden,REP,145
+Lincoln,12-Dayton,Governor,,Jamie Smith and Jennifer Keintz,DEM,90
+Lincoln,12-Dayton,Governor,,Tracey Quint and Ashley Strand,LIB,6
+Lincoln,12-Dayton,Governor,,Kristi Noem and Larry Rhoden,REP,287
+Lincoln,13-LaValley,Governor,,Jamie Smith and Jennifer Keintz,DEM,65
+Lincoln,13-LaValley,Governor,,Tracey Quint and Ashley Strand,LIB,6
+Lincoln,13-LaValley,Governor,,Kristi Noem and Larry Rhoden,REP,249
+Lincoln,14-Perry,Governor,,Jamie Smith and Jennifer Keintz,DEM,117
+Lincoln,14-Perry,Governor,,Tracey Quint and Ashley Strand,LIB,13
+Lincoln,14-Perry,Governor,,Kristi Noem and Larry Rhoden,REP,292
+Lincoln,15-Springdale,Governor,,Jamie Smith and Jennifer Keintz,DEM,316
+Lincoln,15-Springdale,Governor,,Tracey Quint and Ashley Strand,LIB,22
+Lincoln,15-Springdale,Governor,,Kristi Noem and Larry Rhoden,REP,744
+Lincoln,16-Delapre,Governor,,Jamie Smith and Jennifer Keintz,DEM,257
+Lincoln,16-Delapre,Governor,,Tracey Quint and Ashley Strand,LIB,23
+Lincoln,16-Delapre,Governor,,Kristi Noem and Larry Rhoden,REP,626
+Lincoln,"20-Canton 1, 2, 3",Governor,,Jamie Smith and Jennifer Keintz,DEM,273
+Lincoln,"20-Canton 1, 2, 3",Governor,,Tracey Quint and Ashley Strand,LIB,33
+Lincoln,"20-Canton 1, 2, 3",Governor,,Kristi Noem and Larry Rhoden,REP,541
+Lincoln,21-Hudson & Eden,Governor,,Jamie Smith and Jennifer Keintz,DEM,54
+Lincoln,21-Hudson & Eden,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Lincoln,21-Hudson & Eden,Governor,,Kristi Noem and Larry Rhoden,REP,151
+Lincoln,23-Worthing & Lynn,Governor,,Jamie Smith and Jennifer Keintz,DEM,132
+Lincoln,23-Worthing & Lynn,Governor,,Tracey Quint and Ashley Strand,LIB,21
+Lincoln,23-Worthing & Lynn,Governor,,Kristi Noem and Larry Rhoden,REP,351
+Lincoln,24-Tea,Governor,,Jamie Smith and Jennifer Keintz,DEM,716
+Lincoln,24-Tea,Governor,,Tracey Quint and Ashley Strand,LIB,52
+Lincoln,24-Tea,Governor,,Kristi Noem and Larry Rhoden,REP,1270
+Lincoln,25-Lennox,Governor,,Jamie Smith and Jennifer Keintz,DEM,270
+Lincoln,25-Lennox,Governor,,Tracey Quint and Ashley Strand,LIB,32
+Lincoln,25-Lennox,Governor,,Kristi Noem and Larry Rhoden,REP,625
+Lincoln,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,106
+Lincoln,?,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Lincoln,?,Governor,,Kristi Noem and Larry Rhoden,REP,302
+Lincoln,27-Harrisburg 1,Governor,,Jamie Smith and Jennifer Keintz,DEM,430
+Lincoln,27-Harrisburg 1,Governor,,Tracey Quint and Ashley Strand,LIB,32
+Lincoln,27-Harrisburg 1,Governor,,Kristi Noem and Larry Rhoden,REP,695
+Lincoln,29-Harrisburg 2,Governor,,Jamie Smith and Jennifer Keintz,DEM,424
+Lincoln,29-Harrisburg 2,Governor,,Tracey Quint and Ashley Strand,LIB,28
+Lincoln,29-Harrisburg 2,Governor,,Kristi Noem and Larry Rhoden,REP,678
+Lincoln,30-Canton 4 & 5,Governor,,Jamie Smith and Jennifer Keintz,DEM,168
+Lincoln,30-Canton 4 & 5,Governor,,Tracey Quint and Ashley Strand,LIB,15
+Lincoln,30-Canton 4 & 5,Governor,,Kristi Noem and Larry Rhoden,REP,251
+Lincoln,Sioux Falls 1-11,Governor,,Jamie Smith and Jennifer Keintz,DEM,539
+Lincoln,Sioux Falls 1-11,Governor,,Tracey Quint and Ashley Strand,LIB,22
+Lincoln,Sioux Falls 1-11,Governor,,Kristi Noem and Larry Rhoden,REP,923
+Lincoln,Sioux Falls 1-12,Governor,,Jamie Smith and Jennifer Keintz,DEM,662
+Lincoln,Sioux Falls 1-12,Governor,,Tracey Quint and Ashley Strand,LIB,32
+Lincoln,Sioux Falls 1-12,Governor,,Kristi Noem and Larry Rhoden,REP,822
+Lincoln,Sioux Falls 1-13,Governor,,Jamie Smith and Jennifer Keintz,DEM,289
+Lincoln,Sioux Falls 1-13,Governor,,Tracey Quint and Ashley Strand,LIB,12
+Lincoln,Sioux Falls 1-13,Governor,,Kristi Noem and Larry Rhoden,REP,310
+Lincoln,Sioux Falls 1-14,Governor,,Jamie Smith and Jennifer Keintz,DEM,363
+Lincoln,Sioux Falls 1-14,Governor,,Tracey Quint and Ashley Strand,LIB,24
+Lincoln,Sioux Falls 1-14,Governor,,Kristi Noem and Larry Rhoden,REP,495
+Lincoln,Sioux Falls 1-15,Governor,,Jamie Smith and Jennifer Keintz,DEM,407
+Lincoln,Sioux Falls 1-15,Governor,,Tracey Quint and Ashley Strand,LIB,23
+Lincoln,Sioux Falls 1-15,Governor,,Kristi Noem and Larry Rhoden,REP,350
+Lincoln,Sioux Falls 1-16,Governor,,Jamie Smith and Jennifer Keintz,DEM,282
+Lincoln,Sioux Falls 1-16,Governor,,Tracey Quint and Ashley Strand,LIB,21
+Lincoln,Sioux Falls 1-16,Governor,,Kristi Noem and Larry Rhoden,REP,317
+Lincoln,Sioux Falls 1-18,Governor,,Jamie Smith and Jennifer Keintz,DEM,518
+Lincoln,Sioux Falls 1-18,Governor,,Tracey Quint and Ashley Strand,LIB,21
+Lincoln,Sioux Falls 1-18,Governor,,Kristi Noem and Larry Rhoden,REP,808
+Lincoln,Sioux Falls 2-10,Governor,,Jamie Smith and Jennifer Keintz,DEM,578
+Lincoln,Sioux Falls 2-10,Governor,,Tracey Quint and Ashley Strand,LIB,19
+Lincoln,Sioux Falls 2-10,Governor,,Kristi Noem and Larry Rhoden,REP,950
+Lincoln,Sioux Falls 2-11,Governor,,Jamie Smith and Jennifer Keintz,DEM,821
+Lincoln,Sioux Falls 2-11,Governor,,Tracey Quint and Ashley Strand,LIB,19
+Lincoln,Sioux Falls 2-11,Governor,,Kristi Noem and Larry Rhoden,REP,1097
+Lincoln,Sioux Falls 2-12,Governor,,Jamie Smith and Jennifer Keintz,DEM,365
+Lincoln,Sioux Falls 2-12,Governor,,Tracey Quint and Ashley Strand,LIB,14
+Lincoln,Sioux Falls 2-12,Governor,,Kristi Noem and Larry Rhoden,REP,374
+Lincoln,Sioux Falls 2-13,Governor,,Jamie Smith and Jennifer Keintz,DEM,924
+Lincoln,Sioux Falls 2-13,Governor,,Tracey Quint and Ashley Strand,LIB,23
+Lincoln,Sioux Falls 2-13,Governor,,Kristi Noem and Larry Rhoden,REP,948
+Lincoln,Sioux Falls 2-15,Governor,,Jamie Smith and Jennifer Keintz,DEM,466
+Lincoln,Sioux Falls 2-15,Governor,,Tracey Quint and Ashley Strand,LIB,22
+Lincoln,Sioux Falls 2-15,Governor,,Kristi Noem and Larry Rhoden,REP,681
+Lincoln,Sioux Falls 2-16,Governor,,Jamie Smith and Jennifer Keintz,DEM,788
+Lincoln,Sioux Falls 2-16,Governor,,Tracey Quint and Ashley Strand,LIB,33
+Lincoln,Sioux Falls 2-16,Governor,,Kristi Noem and Larry Rhoden,REP,937
+Lincoln,?,Secretary of State,,Thomas A Cool,DEM,56
+Lincoln,?,Secretary of State,,Monae Johnson,REP,177
+Lincoln,06-Highland & Canton,Secretary of State,,Thomas A Cool,DEM,122
+Lincoln,06-Highland & Canton,Secretary of State,,Monae Johnson,REP,283
+Lincoln,08-Lincoln & Delaware,Secretary of State,,Thomas A Cool,DEM,60
+Lincoln,08-Lincoln & Delaware,Secretary of State,,Monae Johnson,REP,146
+Lincoln,11-Grant,Secretary of State,,Thomas A Cool,DEM,62
+Lincoln,11-Grant,Secretary of State,,Monae Johnson,REP,136
+Lincoln,12-Dayton,Secretary of State,,Thomas A Cool,DEM,76
+Lincoln,12-Dayton,Secretary of State,,Monae Johnson,REP,282
+Lincoln,13-LaValley,Secretary of State,,Thomas A Cool,DEM,69
+Lincoln,13-LaValley,Secretary of State,,Monae Johnson,REP,240
+Lincoln,14-Perry,Secretary of State,,Thomas A Cool,DEM,121
+Lincoln,14-Perry,Secretary of State,,Monae Johnson,REP,273
+Lincoln,15-Springdale,Secretary of State,,Thomas A Cool,DEM,288
+Lincoln,15-Springdale,Secretary of State,,Monae Johnson,REP,742
+Lincoln,16-Delapre,Secretary of State,,Thomas A Cool,DEM,247
+Lincoln,16-Delapre,Secretary of State,,Monae Johnson,REP,615
+Lincoln,"20-Canton 1, 2, 3",Secretary of State,,Thomas A Cool,DEM,279
+Lincoln,"20-Canton 1, 2, 3",Secretary of State,,Monae Johnson,REP,508
+Lincoln,21-Hudson & Eden,Secretary of State,,Thomas A Cool,DEM,61
+Lincoln,21-Hudson & Eden,Secretary of State,,Monae Johnson,REP,130
+Lincoln,23-Worthing & Lynn,Secretary of State,,Thomas A Cool,DEM,132
+Lincoln,23-Worthing & Lynn,Secretary of State,,Monae Johnson,REP,332
+Lincoln,24-Tea,Secretary of State,,Thomas A Cool,DEM,627
+Lincoln,24-Tea,Secretary of State,,Monae Johnson,REP,1253
+Lincoln,25-Lennox,Secretary of State,,Thomas A Cool,DEM,256
+Lincoln,25-Lennox,Secretary of State,,Monae Johnson,REP,609
+Lincoln,?,Secretary of State,,Thomas A Cool,DEM,113
+Lincoln,?,Secretary of State,,Monae Johnson,REP,283
+Lincoln,27-Harrisburg 1,Secretary of State,,Thomas A Cool,DEM,404
+Lincoln,27-Harrisburg 1,Secretary of State,,Monae Johnson,REP,693
+Lincoln,29-Harrisburg 2,Secretary of State,,Thomas A Cool,DEM,367
+Lincoln,29-Harrisburg 2,Secretary of State,,Monae Johnson,REP,676
+Lincoln,30-Canton 4 & 5,Secretary of State,,Thomas A Cool,DEM,158
+Lincoln,30-Canton 4 & 5,Secretary of State,,Monae Johnson,REP,242
+Lincoln,Sioux Falls 1-11,Secretary of State,,Thomas A Cool,DEM,505
+Lincoln,Sioux Falls 1-11,Secretary of State,,Monae Johnson,REP,919
+Lincoln,Sioux Falls 1-12,Secretary of State,,Thomas A Cool,DEM,616
+Lincoln,Sioux Falls 1-12,Secretary of State,,Monae Johnson,REP,807
+Lincoln,Sioux Falls 1-13,Secretary of State,,Thomas A Cool,DEM,282
+Lincoln,Sioux Falls 1-13,Secretary of State,,Monae Johnson,REP,294
+Lincoln,Sioux Falls 1-14,Secretary of State,,Thomas A Cool,DEM,324
+Lincoln,Sioux Falls 1-14,Secretary of State,,Monae Johnson,REP,495
+Lincoln,Sioux Falls 1-15,Secretary of State,,Thomas A Cool,DEM,388
+Lincoln,Sioux Falls 1-15,Secretary of State,,Monae Johnson,REP,354
+Lincoln,Sioux Falls 1-16,Secretary of State,,Thomas A Cool,DEM,264
+Lincoln,Sioux Falls 1-16,Secretary of State,,Monae Johnson,REP,319
+Lincoln,Sioux Falls 1-18,Secretary of State,,Thomas A Cool,DEM,446
+Lincoln,Sioux Falls 1-18,Secretary of State,,Monae Johnson,REP,809
+Lincoln,Sioux Falls 2-10,Secretary of State,,Thomas A Cool,DEM,533
+Lincoln,Sioux Falls 2-10,Secretary of State,,Monae Johnson,REP,952
+Lincoln,Sioux Falls 2-11,Secretary of State,,Thomas A Cool,DEM,752
+Lincoln,Sioux Falls 2-11,Secretary of State,,Monae Johnson,REP,1107
+Lincoln,Sioux Falls 2-12,Secretary of State,,Thomas A Cool,DEM,329
+Lincoln,Sioux Falls 2-12,Secretary of State,,Monae Johnson,REP,393
+Lincoln,Sioux Falls 2-13,Secretary of State,,Thomas A Cool,DEM,843
+Lincoln,Sioux Falls 2-13,Secretary of State,,Monae Johnson,REP,957
+Lincoln,Sioux Falls 2-15,Secretary of State,,Thomas A Cool,DEM,417
+Lincoln,Sioux Falls 2-15,Secretary of State,,Monae Johnson,REP,675
+Lincoln,Sioux Falls 2-16,Secretary of State,,Thomas A Cool,DEM,719
+Lincoln,Sioux Falls 2-16,Secretary of State,,Monae Johnson,REP,941
+Lincoln,?,Attorney General,,Marty J. Jackley,REP,186
+Lincoln,06-Highland & Canton,Attorney General,,Marty J. Jackley,REP,340
+Lincoln,08-Lincoln & Delaware,Attorney General,,Marty J. Jackley,REP,168
+Lincoln,11-Grant,Attorney General,,Marty J. Jackley,REP,167
+Lincoln,12-Dayton,Attorney General,,Marty J. Jackley,REP,312
+Lincoln,13-LaValley,Attorney General,,Marty J. Jackley,REP,271
+Lincoln,14-Perry,Attorney General,,Marty J. Jackley,REP,325
+Lincoln,15-Springdale,Attorney General,,Marty J. Jackley,REP,852
+Lincoln,16-Delapre,Attorney General,,Marty J. Jackley,REP,718
+Lincoln,"20-Canton 1, 2, 3",Attorney General,,Marty J. Jackley,REP,637
+Lincoln,21-Hudson & Eden,Attorney General,,Marty J. Jackley,REP,159
+Lincoln,23-Worthing & Lynn,Attorney General,,Marty J. Jackley,REP,381
+Lincoln,24-Tea,Attorney General,,Marty J. Jackley,REP,1532
+Lincoln,25-Lennox,Attorney General,,Marty J. Jackley,REP,723
+Lincoln,?,Attorney General,,Marty J. Jackley,REP,323
+Lincoln,27-Harrisburg 1,Attorney General,,Marty J. Jackley,REP,861
+Lincoln,29-Harrisburg 2,Attorney General,,Marty J. Jackley,REP,852
+Lincoln,30-Canton 4 & 5,Attorney General,,Marty J. Jackley,REP,311
+Lincoln,Sioux Falls 1-11,Attorney General,,Marty J. Jackley,REP,1190
+Lincoln,Sioux Falls 1-12,Attorney General,,Marty J. Jackley,REP,1047
+Lincoln,Sioux Falls 1-13,Attorney General,,Marty J. Jackley,REP,408
+Lincoln,Sioux Falls 1-14,Attorney General,,Marty J. Jackley,REP,634
+Lincoln,Sioux Falls 1-15,Attorney General,,Marty J. Jackley,REP,510
+Lincoln,Sioux Falls 1-16,Attorney General,,Marty J. Jackley,REP,406
+Lincoln,Sioux Falls 1-18,Attorney General,,Marty J. Jackley,REP,1007
+Lincoln,Sioux Falls 2-10,Attorney General,,Marty J. Jackley,REP,1177
+Lincoln,Sioux Falls 2-11,Attorney General,,Marty J. Jackley,REP,1438
+Lincoln,Sioux Falls 2-12,Attorney General,,Marty J. Jackley,REP,511
+Lincoln,Sioux Falls 2-13,Attorney General,,Marty J. Jackley,REP,1292
+Lincoln,Sioux Falls 2-15,Attorney General,,Marty J. Jackley,REP,885
+Lincoln,Sioux Falls 2-16,Attorney General,,Marty J. Jackley,REP,1224
+Lincoln,?,State Auditor,,Stephanie Marty,DEM,53
+Lincoln,?,State Auditor,,Rene Meyer,LIB,9
+Lincoln,?,State Auditor,,Richard Sattgast,REP,167
+Lincoln,06-Highland & Canton,State Auditor,,Stephanie Marty,DEM,94
+Lincoln,06-Highland & Canton,State Auditor,,Rene Meyer,LIB,18
+Lincoln,06-Highland & Canton,State Auditor,,Richard Sattgast,REP,293
+Lincoln,08-Lincoln & Delaware,State Auditor,,Stephanie Marty,DEM,49
+Lincoln,08-Lincoln & Delaware,State Auditor,,Rene Meyer,LIB,9
+Lincoln,08-Lincoln & Delaware,State Auditor,,Richard Sattgast,REP,143
+Lincoln,11-Grant,State Auditor,,Stephanie Marty,DEM,57
+Lincoln,11-Grant,State Auditor,,Rene Meyer,LIB,6
+Lincoln,11-Grant,State Auditor,,Richard Sattgast,REP,131
+Lincoln,12-Dayton,State Auditor,,Stephanie Marty,DEM,63
+Lincoln,12-Dayton,State Auditor,,Rene Meyer,LIB,11
+Lincoln,12-Dayton,State Auditor,,Richard Sattgast,REP,285
+Lincoln,13-LaValley,State Auditor,,Stephanie Marty,DEM,51
+Lincoln,13-LaValley,State Auditor,,Rene Meyer,LIB,10
+Lincoln,13-LaValley,State Auditor,,Richard Sattgast,REP,243
+Lincoln,14-Perry,State Auditor,,Stephanie Marty,DEM,100
+Lincoln,14-Perry,State Auditor,,Rene Meyer,LIB,22
+Lincoln,14-Perry,State Auditor,,Richard Sattgast,REP,275
+Lincoln,15-Springdale,State Auditor,,Stephanie Marty,DEM,231
+Lincoln,15-Springdale,State Auditor,,Rene Meyer,LIB,35
+Lincoln,15-Springdale,State Auditor,,Richard Sattgast,REP,751
+Lincoln,16-Delapre,State Auditor,,Stephanie Marty,DEM,206
+Lincoln,16-Delapre,State Auditor,,Rene Meyer,LIB,25
+Lincoln,16-Delapre,State Auditor,,Richard Sattgast,REP,616
+Lincoln,"20-Canton 1, 2, 3",State Auditor,,Stephanie Marty,DEM,223
+Lincoln,"20-Canton 1, 2, 3",State Auditor,,Rene Meyer,LIB,41
+Lincoln,"20-Canton 1, 2, 3",State Auditor,,Richard Sattgast,REP,510
+Lincoln,21-Hudson & Eden,State Auditor,,Stephanie Marty,DEM,54
+Lincoln,21-Hudson & Eden,State Auditor,,Rene Meyer,LIB,11
+Lincoln,21-Hudson & Eden,State Auditor,,Richard Sattgast,REP,129
+Lincoln,23-Worthing & Lynn,State Auditor,,Stephanie Marty,DEM,111
+Lincoln,23-Worthing & Lynn,State Auditor,,Rene Meyer,LIB,38
+Lincoln,23-Worthing & Lynn,State Auditor,,Richard Sattgast,REP,316
+Lincoln,24-Tea,State Auditor,,Stephanie Marty,DEM,550
+Lincoln,24-Tea,State Auditor,,Rene Meyer,LIB,110
+Lincoln,24-Tea,State Auditor,,Richard Sattgast,REP,1206
+Lincoln,25-Lennox,State Auditor,,Stephanie Marty,DEM,216
+Lincoln,25-Lennox,State Auditor,,Rene Meyer,LIB,58
+Lincoln,25-Lennox,State Auditor,,Richard Sattgast,REP,570
+Lincoln,?,State Auditor,,Stephanie Marty,DEM,98
+Lincoln,?,State Auditor,,Rene Meyer,LIB,16
+Lincoln,?,State Auditor,,Richard Sattgast,REP,282
+Lincoln,27-Harrisburg 1,State Auditor,,Stephanie Marty,DEM,334
+Lincoln,27-Harrisburg 1,State Auditor,,Rene Meyer,LIB,69
+Lincoln,27-Harrisburg 1,State Auditor,,Richard Sattgast,REP,677
+Lincoln,29-Harrisburg 2,State Auditor,,Stephanie Marty,DEM,304
+Lincoln,29-Harrisburg 2,State Auditor,,Rene Meyer,LIB,73
+Lincoln,29-Harrisburg 2,State Auditor,,Richard Sattgast,REP,666
+Lincoln,30-Canton 4 & 5,State Auditor,,Stephanie Marty,DEM,138
+Lincoln,30-Canton 4 & 5,State Auditor,,Rene Meyer,LIB,23
+Lincoln,30-Canton 4 & 5,State Auditor,,Richard Sattgast,REP,238
+Lincoln,Sioux Falls 1-11,State Auditor,,Stephanie Marty,DEM,425
+Lincoln,Sioux Falls 1-11,State Auditor,,Rene Meyer,LIB,34
+Lincoln,Sioux Falls 1-11,State Auditor,,Richard Sattgast,REP,962
+Lincoln,Sioux Falls 1-12,State Auditor,,Stephanie Marty,DEM,528
+Lincoln,Sioux Falls 1-12,State Auditor,,Rene Meyer,LIB,65
+Lincoln,Sioux Falls 1-12,State Auditor,,Richard Sattgast,REP,797
+Lincoln,Sioux Falls 1-13,State Auditor,,Stephanie Marty,DEM,256
+Lincoln,Sioux Falls 1-13,State Auditor,,Rene Meyer,LIB,27
+Lincoln,Sioux Falls 1-13,State Auditor,,Richard Sattgast,REP,284
+Lincoln,Sioux Falls 1-14,State Auditor,,Stephanie Marty,DEM,286
+Lincoln,Sioux Falls 1-14,State Auditor,,Rene Meyer,LIB,38
+Lincoln,Sioux Falls 1-14,State Auditor,,Richard Sattgast,REP,480
+Lincoln,Sioux Falls 1-15,State Auditor,,Stephanie Marty,DEM,336
+Lincoln,Sioux Falls 1-15,State Auditor,,Rene Meyer,LIB,43
+Lincoln,Sioux Falls 1-15,State Auditor,,Richard Sattgast,REP,352
+Lincoln,Sioux Falls 1-16,State Auditor,,Stephanie Marty,DEM,231
+Lincoln,Sioux Falls 1-16,State Auditor,,Rene Meyer,LIB,38
+Lincoln,Sioux Falls 1-16,State Auditor,,Richard Sattgast,REP,305
+Lincoln,Sioux Falls 1-18,State Auditor,,Stephanie Marty,DEM,390
+Lincoln,Sioux Falls 1-18,State Auditor,,Rene Meyer,LIB,46
+Lincoln,Sioux Falls 1-18,State Auditor,,Richard Sattgast,REP,807
+Lincoln,Sioux Falls 2-10,State Auditor,,Stephanie Marty,DEM,435
+Lincoln,Sioux Falls 2-10,State Auditor,,Rene Meyer,LIB,34
+Lincoln,Sioux Falls 2-10,State Auditor,,Richard Sattgast,REP,1006
+Lincoln,Sioux Falls 2-11,State Auditor,,Stephanie Marty,DEM,655
+Lincoln,Sioux Falls 2-11,State Auditor,,Rene Meyer,LIB,45
+Lincoln,Sioux Falls 2-11,State Auditor,,Richard Sattgast,REP,1146
+Lincoln,Sioux Falls 2-12,State Auditor,,Stephanie Marty,DEM,265
+Lincoln,Sioux Falls 2-12,State Auditor,,Rene Meyer,LIB,28
+Lincoln,Sioux Falls 2-12,State Auditor,,Richard Sattgast,REP,413
+Lincoln,Sioux Falls 2-13,State Auditor,,Stephanie Marty,DEM,741
+Lincoln,Sioux Falls 2-13,State Auditor,,Rene Meyer,LIB,69
+Lincoln,Sioux Falls 2-13,State Auditor,,Richard Sattgast,REP,984
+Lincoln,Sioux Falls 2-15,State Auditor,,Stephanie Marty,DEM,338
+Lincoln,Sioux Falls 2-15,State Auditor,,Rene Meyer,LIB,36
+Lincoln,Sioux Falls 2-15,State Auditor,,Richard Sattgast,REP,719
+Lincoln,Sioux Falls 2-16,State Auditor,,Stephanie Marty,DEM,643
+Lincoln,Sioux Falls 2-16,State Auditor,,Rene Meyer,LIB,57
+Lincoln,Sioux Falls 2-16,State Auditor,,Richard Sattgast,REP,936
+Lincoln,?,State Treasurer,,John Cunningham,DEM,57
+Lincoln,?,State Treasurer,,Josh Haeder,REP,177
+Lincoln,06-Highland & Canton,State Treasurer,,John Cunningham,DEM,110
+Lincoln,06-Highland & Canton,State Treasurer,,Josh Haeder,REP,290
+Lincoln,08-Lincoln & Delaware,State Treasurer,,John Cunningham,DEM,53
+Lincoln,08-Lincoln & Delaware,State Treasurer,,Josh Haeder,REP,147
+Lincoln,11-Grant,State Treasurer,,John Cunningham,DEM,52
+Lincoln,11-Grant,State Treasurer,,Josh Haeder,REP,138
+Lincoln,12-Dayton,State Treasurer,,John Cunningham,DEM,68
+Lincoln,12-Dayton,State Treasurer,,Josh Haeder,REP,284
+Lincoln,13-LaValley,State Treasurer,,John Cunningham,DEM,57
+Lincoln,13-LaValley,State Treasurer,,Josh Haeder,REP,247
+Lincoln,14-Perry,State Treasurer,,John Cunningham,DEM,108
+Lincoln,14-Perry,State Treasurer,,Josh Haeder,REP,278
+Lincoln,15-Springdale,State Treasurer,,John Cunningham,DEM,250
+Lincoln,15-Springdale,State Treasurer,,Josh Haeder,REP,756
+Lincoln,16-Delapre,State Treasurer,,John Cunningham,DEM,208
+Lincoln,16-Delapre,State Treasurer,,Josh Haeder,REP,637
+Lincoln,"20-Canton 1, 2, 3",State Treasurer,,John Cunningham,DEM,237
+Lincoln,"20-Canton 1, 2, 3",State Treasurer,,Josh Haeder,REP,537
+Lincoln,21-Hudson & Eden,State Treasurer,,John Cunningham,DEM,55
+Lincoln,21-Hudson & Eden,State Treasurer,,Josh Haeder,REP,142
+Lincoln,23-Worthing & Lynn,State Treasurer,,John Cunningham,DEM,122
+Lincoln,23-Worthing & Lynn,State Treasurer,,Josh Haeder,REP,339
+Lincoln,24-Tea,State Treasurer,,John Cunningham,DEM,530
+Lincoln,24-Tea,State Treasurer,,Josh Haeder,REP,1313
+Lincoln,25-Lennox,State Treasurer,,John Cunningham,DEM,220
+Lincoln,25-Lennox,State Treasurer,,Josh Haeder,REP,622
+Lincoln,?,State Treasurer,,John Cunningham,DEM,101
+Lincoln,?,State Treasurer,,Josh Haeder,REP,290
+Lincoln,27-Harrisburg 1,State Treasurer,,John Cunningham,DEM,351
+Lincoln,27-Harrisburg 1,State Treasurer,,Josh Haeder,REP,714
+Lincoln,29-Harrisburg 2,State Treasurer,,John Cunningham,DEM,340
+Lincoln,29-Harrisburg 2,State Treasurer,,Josh Haeder,REP,695
+Lincoln,30-Canton 4 & 5,State Treasurer,,John Cunningham,DEM,147
+Lincoln,30-Canton 4 & 5,State Treasurer,,Josh Haeder,REP,247
+Lincoln,Sioux Falls 1-11,State Treasurer,,John Cunningham,DEM,434
+Lincoln,Sioux Falls 1-11,State Treasurer,,Josh Haeder,REP,967
+Lincoln,Sioux Falls 1-12,State Treasurer,,John Cunningham,DEM,523
+Lincoln,Sioux Falls 1-12,State Treasurer,,Josh Haeder,REP,852
+Lincoln,Sioux Falls 1-13,State Treasurer,,John Cunningham,DEM,251
+Lincoln,Sioux Falls 1-13,State Treasurer,,Josh Haeder,REP,312
+Lincoln,Sioux Falls 1-14,State Treasurer,,John Cunningham,DEM,279
+Lincoln,Sioux Falls 1-14,State Treasurer,,Josh Haeder,REP,510
+Lincoln,Sioux Falls 1-15,State Treasurer,,John Cunningham,DEM,333
+Lincoln,Sioux Falls 1-15,State Treasurer,,Josh Haeder,REP,390
+Lincoln,Sioux Falls 1-16,State Treasurer,,John Cunningham,DEM,234
+Lincoln,Sioux Falls 1-16,State Treasurer,,Josh Haeder,REP,339
+Lincoln,Sioux Falls 1-18,State Treasurer,,John Cunningham,DEM,397
+Lincoln,Sioux Falls 1-18,State Treasurer,,Josh Haeder,REP,834
+Lincoln,Sioux Falls 2-10,State Treasurer,,John Cunningham,DEM,437
+Lincoln,Sioux Falls 2-10,State Treasurer,,Josh Haeder,REP,1021
+Lincoln,Sioux Falls 2-11,State Treasurer,,John Cunningham,DEM,661
+Lincoln,Sioux Falls 2-11,State Treasurer,,Josh Haeder,REP,1177
+Lincoln,Sioux Falls 2-12,State Treasurer,,John Cunningham,DEM,278
+Lincoln,Sioux Falls 2-12,State Treasurer,,Josh Haeder,REP,417
+Lincoln,Sioux Falls 2-13,State Treasurer,,John Cunningham,DEM,739
+Lincoln,Sioux Falls 2-13,State Treasurer,,Josh Haeder,REP,1018
+Lincoln,Sioux Falls 2-15,State Treasurer,,John Cunningham,DEM,329
+Lincoln,Sioux Falls 2-15,State Treasurer,,Josh Haeder,REP,745
+Lincoln,Sioux Falls 2-16,State Treasurer,,John Cunningham,DEM,623
+Lincoln,Sioux Falls 2-16,State Treasurer,,Josh Haeder,REP,998
+Lincoln,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,58
+Lincoln,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,175
+Lincoln,06-Highland & Canton,Commissioner of School and Public Lands,,Timothy Azure,DEM,93
+Lincoln,06-Highland & Canton,Commissioner of School and Public Lands,,Brock Greenfield,REP,297
+Lincoln,08-Lincoln & Delaware,Commissioner of School and Public Lands,,Timothy Azure,DEM,53
+Lincoln,08-Lincoln & Delaware,Commissioner of School and Public Lands,,Brock Greenfield,REP,140
+Lincoln,11-Grant,Commissioner of School and Public Lands,,Timothy Azure,DEM,56
+Lincoln,11-Grant,Commissioner of School and Public Lands,,Brock Greenfield,REP,140
+Lincoln,12-Dayton,Commissioner of School and Public Lands,,Timothy Azure,DEM,68
+Lincoln,12-Dayton,Commissioner of School and Public Lands,,Brock Greenfield,REP,277
+Lincoln,13-LaValley,Commissioner of School and Public Lands,,Timothy Azure,DEM,55
+Lincoln,13-LaValley,Commissioner of School and Public Lands,,Brock Greenfield,REP,242
+Lincoln,14-Perry,Commissioner of School and Public Lands,,Timothy Azure,DEM,101
+Lincoln,14-Perry,Commissioner of School and Public Lands,,Brock Greenfield,REP,275
+Lincoln,15-Springdale,Commissioner of School and Public Lands,,Timothy Azure,DEM,246
+Lincoln,15-Springdale,Commissioner of School and Public Lands,,Brock Greenfield,REP,748
+Lincoln,16-Delapre,Commissioner of School and Public Lands,,Timothy Azure,DEM,200
+Lincoln,16-Delapre,Commissioner of School and Public Lands,,Brock Greenfield,REP,625
+Lincoln,"20-Canton 1, 2, 3",Commissioner of School and Public Lands,,Timothy Azure,DEM,238
+Lincoln,"20-Canton 1, 2, 3",Commissioner of School and Public Lands,,Brock Greenfield,REP,515
+Lincoln,21-Hudson & Eden,Commissioner of School and Public Lands,,Timothy Azure,DEM,49
+Lincoln,21-Hudson & Eden,Commissioner of School and Public Lands,,Brock Greenfield,REP,138
+Lincoln,23-Worthing & Lynn,Commissioner of School and Public Lands,,Timothy Azure,DEM,117
+Lincoln,23-Worthing & Lynn,Commissioner of School and Public Lands,,Brock Greenfield,REP,341
+Lincoln,24-Tea,Commissioner of School and Public Lands,,Timothy Azure,DEM,552
+Lincoln,24-Tea,Commissioner of School and Public Lands,,Brock Greenfield,REP,1268
+Lincoln,25-Lennox,Commissioner of School and Public Lands,,Timothy Azure,DEM,215
+Lincoln,25-Lennox,Commissioner of School and Public Lands,,Brock Greenfield,REP,626
+Lincoln,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,94
+Lincoln,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,294
+Lincoln,27-Harrisburg 1,Commissioner of School and Public Lands,,Timothy Azure,DEM,357
+Lincoln,27-Harrisburg 1,Commissioner of School and Public Lands,,Brock Greenfield,REP,693
+Lincoln,29-Harrisburg 2,Commissioner of School and Public Lands,,Timothy Azure,DEM,339
+Lincoln,29-Harrisburg 2,Commissioner of School and Public Lands,,Brock Greenfield,REP,675
+Lincoln,30-Canton 4 & 5,Commissioner of School and Public Lands,,Timothy Azure,DEM,135
+Lincoln,30-Canton 4 & 5,Commissioner of School and Public Lands,,Brock Greenfield,REP,250
+Lincoln,Sioux Falls 1-11,Commissioner of School and Public Lands,,Timothy Azure,DEM,431
+Lincoln,Sioux Falls 1-11,Commissioner of School and Public Lands,,Brock Greenfield,REP,954
+Lincoln,Sioux Falls 1-12,Commissioner of School and Public Lands,,Timothy Azure,DEM,537
+Lincoln,Sioux Falls 1-12,Commissioner of School and Public Lands,,Brock Greenfield,REP,834
+Lincoln,Sioux Falls 1-13,Commissioner of School and Public Lands,,Timothy Azure,DEM,259
+Lincoln,Sioux Falls 1-13,Commissioner of School and Public Lands,,Brock Greenfield,REP,301
+Lincoln,Sioux Falls 1-14,Commissioner of School and Public Lands,,Timothy Azure,DEM,281
+Lincoln,Sioux Falls 1-14,Commissioner of School and Public Lands,,Brock Greenfield,REP,505
+Lincoln,Sioux Falls 1-15,Commissioner of School and Public Lands,,Timothy Azure,DEM,337
+Lincoln,Sioux Falls 1-15,Commissioner of School and Public Lands,,Brock Greenfield,REP,375
+Lincoln,Sioux Falls 1-16,Commissioner of School and Public Lands,,Timothy Azure,DEM,234
+Lincoln,Sioux Falls 1-16,Commissioner of School and Public Lands,,Brock Greenfield,REP,331
+Lincoln,Sioux Falls 1-18,Commissioner of School and Public Lands,,Timothy Azure,DEM,389
+Lincoln,Sioux Falls 1-18,Commissioner of School and Public Lands,,Brock Greenfield,REP,821
+Lincoln,Sioux Falls 2-10,Commissioner of School and Public Lands,,Timothy Azure,DEM,446
+Lincoln,Sioux Falls 2-10,Commissioner of School and Public Lands,,Brock Greenfield,REP,991
+Lincoln,Sioux Falls 2-11,Commissioner of School and Public Lands,,Timothy Azure,DEM,659
+Lincoln,Sioux Falls 2-11,Commissioner of School and Public Lands,,Brock Greenfield,REP,1141
+Lincoln,Sioux Falls 2-12,Commissioner of School and Public Lands,,Timothy Azure,DEM,280
+Lincoln,Sioux Falls 2-12,Commissioner of School and Public Lands,,Brock Greenfield,REP,403
+Lincoln,Sioux Falls 2-13,Commissioner of School and Public Lands,,Timothy Azure,DEM,745
+Lincoln,Sioux Falls 2-13,Commissioner of School and Public Lands,,Brock Greenfield,REP,993
+Lincoln,Sioux Falls 2-15,Commissioner of School and Public Lands,,Timothy Azure,DEM,331
+Lincoln,Sioux Falls 2-15,Commissioner of School and Public Lands,,Brock Greenfield,REP,729
+Lincoln,Sioux Falls 2-16,Commissioner of School and Public Lands,,Timothy Azure,DEM,626
+Lincoln,Sioux Falls 2-16,Commissioner of School and Public Lands,,Brock Greenfield,REP,975
+Lincoln,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,59
+Lincoln,?,Public Utilities Commissioner,,Chris Nelson,REP,175
+Lincoln,06-Highland & Canton,Public Utilities Commissioner,,Jeffrey Barth,DEM,112
+Lincoln,06-Highland & Canton,Public Utilities Commissioner,,Chris Nelson,REP,294
+Lincoln,08-Lincoln & Delaware,Public Utilities Commissioner,,Jeffrey Barth,DEM,53
+Lincoln,08-Lincoln & Delaware,Public Utilities Commissioner,,Chris Nelson,REP,154
+Lincoln,11-Grant,Public Utilities Commissioner,,Jeffrey Barth,DEM,55
+Lincoln,11-Grant,Public Utilities Commissioner,,Chris Nelson,REP,145
+Lincoln,12-Dayton,Public Utilities Commissioner,,Jeffrey Barth,DEM,81
+Lincoln,12-Dayton,Public Utilities Commissioner,,Chris Nelson,REP,275
+Lincoln,13-LaValley,Public Utilities Commissioner,,Jeffrey Barth,DEM,76
+Lincoln,13-LaValley,Public Utilities Commissioner,,Chris Nelson,REP,229
+Lincoln,14-Perry,Public Utilities Commissioner,,Jeffrey Barth,DEM,105
+Lincoln,14-Perry,Public Utilities Commissioner,,Chris Nelson,REP,293
+Lincoln,15-Springdale,Public Utilities Commissioner,,Jeffrey Barth,DEM,253
+Lincoln,15-Springdale,Public Utilities Commissioner,,Chris Nelson,REP,768
+Lincoln,16-Delapre,Public Utilities Commissioner,,Jeffrey Barth,DEM,203
+Lincoln,16-Delapre,Public Utilities Commissioner,,Chris Nelson,REP,651
+Lincoln,"20-Canton 1, 2, 3",Public Utilities Commissioner,,Jeffrey Barth,DEM,246
+Lincoln,"20-Canton 1, 2, 3",Public Utilities Commissioner,,Chris Nelson,REP,535
+Lincoln,21-Hudson & Eden,Public Utilities Commissioner,,Jeffrey Barth,DEM,48
+Lincoln,21-Hudson & Eden,Public Utilities Commissioner,,Chris Nelson,REP,146
+Lincoln,23-Worthing & Lynn,Public Utilities Commissioner,,Jeffrey Barth,DEM,119
+Lincoln,23-Worthing & Lynn,Public Utilities Commissioner,,Chris Nelson,REP,343
+Lincoln,24-Tea,Public Utilities Commissioner,,Jeffrey Barth,DEM,522
+Lincoln,24-Tea,Public Utilities Commissioner,,Chris Nelson,REP,1354
+Lincoln,25-Lennox,Public Utilities Commissioner,,Jeffrey Barth,DEM,210
+Lincoln,25-Lennox,Public Utilities Commissioner,,Chris Nelson,REP,653
+Lincoln,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,102
+Lincoln,?,Public Utilities Commissioner,,Chris Nelson,REP,294
+Lincoln,27-Harrisburg 1,Public Utilities Commissioner,,Jeffrey Barth,DEM,351
+Lincoln,27-Harrisburg 1,Public Utilities Commissioner,,Chris Nelson,REP,723
+Lincoln,29-Harrisburg 2,Public Utilities Commissioner,,Jeffrey Barth,DEM,322
+Lincoln,29-Harrisburg 2,Public Utilities Commissioner,,Chris Nelson,REP,723
+Lincoln,30-Canton 4 & 5,Public Utilities Commissioner,,Jeffrey Barth,DEM,133
+Lincoln,30-Canton 4 & 5,Public Utilities Commissioner,,Chris Nelson,REP,267
+Lincoln,Sioux Falls 1-11,Public Utilities Commissioner,,Jeffrey Barth,DEM,405
+Lincoln,Sioux Falls 1-11,Public Utilities Commissioner,,Chris Nelson,REP,1025
+Lincoln,Sioux Falls 1-12,Public Utilities Commissioner,,Jeffrey Barth,DEM,512
+Lincoln,Sioux Falls 1-12,Public Utilities Commissioner,,Chris Nelson,REP,882
+Lincoln,Sioux Falls 1-13,Public Utilities Commissioner,,Jeffrey Barth,DEM,248
+Lincoln,Sioux Falls 1-13,Public Utilities Commissioner,,Chris Nelson,REP,323
+Lincoln,Sioux Falls 1-14,Public Utilities Commissioner,,Jeffrey Barth,DEM,283
+Lincoln,Sioux Falls 1-14,Public Utilities Commissioner,,Chris Nelson,REP,519
+Lincoln,Sioux Falls 1-15,Public Utilities Commissioner,,Jeffrey Barth,DEM,311
+Lincoln,Sioux Falls 1-15,Public Utilities Commissioner,,Chris Nelson,REP,416
+Lincoln,Sioux Falls 1-16,Public Utilities Commissioner,,Jeffrey Barth,DEM,225
+Lincoln,Sioux Falls 1-16,Public Utilities Commissioner,,Chris Nelson,REP,350
+Lincoln,Sioux Falls 1-18,Public Utilities Commissioner,,Jeffrey Barth,DEM,386
+Lincoln,Sioux Falls 1-18,Public Utilities Commissioner,,Chris Nelson,REP,857
+Lincoln,Sioux Falls 2-10,Public Utilities Commissioner,,Jeffrey Barth,DEM,423
+Lincoln,Sioux Falls 2-10,Public Utilities Commissioner,,Chris Nelson,REP,1048
+Lincoln,Sioux Falls 2-11,Public Utilities Commissioner,,Jeffrey Barth,DEM,662
+Lincoln,Sioux Falls 2-11,Public Utilities Commissioner,,Chris Nelson,REP,1193
+Lincoln,Sioux Falls 2-12,Public Utilities Commissioner,,Jeffrey Barth,DEM,276
+Lincoln,Sioux Falls 2-12,Public Utilities Commissioner,,Chris Nelson,REP,434
+Lincoln,Sioux Falls 2-13,Public Utilities Commissioner,,Jeffrey Barth,DEM,733
+Lincoln,Sioux Falls 2-13,Public Utilities Commissioner,,Chris Nelson,REP,1041
+Lincoln,Sioux Falls 2-15,Public Utilities Commissioner,,Jeffrey Barth,DEM,337
+Lincoln,Sioux Falls 2-15,Public Utilities Commissioner,,Chris Nelson,REP,754
+Lincoln,Sioux Falls 2-16,Public Utilities Commissioner,,Jeffrey Barth,DEM,611
+Lincoln,Sioux Falls 2-16,Public Utilities Commissioner,,Chris Nelson,REP,1034
+Lincoln,?,State House,16,Matt Ness,DEM,55
+Lincoln,?,State House,16,Kevin D. Jensen,REP,151
+Lincoln,?,State House,16,Karla J. Lems,REP,146
+Lincoln,06-Highland & Canton,State House,16,Matt Ness,DEM,119
+Lincoln,06-Highland & Canton,State House,16,Kevin D. Jensen,REP,253
+Lincoln,06-Highland & Canton,State House,16,Karla J. Lems,REP,267
+Lincoln,08-Lincoln & Delaware,State House,16,Matt Ness,DEM,60
+Lincoln,08-Lincoln & Delaware,State House,16,Kevin D. Jensen,REP,125
+Lincoln,08-Lincoln & Delaware,State House,16,Karla J. Lems,REP,121
+Lincoln,11-Grant,State House,16,Matt Ness,DEM,58
+Lincoln,11-Grant,State House,16,Kevin D. Jensen,REP,103
+Lincoln,11-Grant,State House,16,Karla J. Lems,REP,115
+Lincoln,12-Dayton,State House,16,Matt Ness,DEM,74
+Lincoln,12-Dayton,State House,16,Kevin D. Jensen,REP,233
+Lincoln,12-Dayton,State House,16,Karla J. Lems,REP,225
+Lincoln,13-LaValley,State House,16,Matt Ness,DEM,23
+Lincoln,13-LaValley,State House,16,Kevin D. Jensen,REP,68
+Lincoln,13-LaValley,State House,16,Karla J. Lems,REP,69
+Lincoln,14-Perry,State House,16,Matt Ness,DEM,53
+Lincoln,14-Perry,State House,16,Kevin D. Jensen,REP,86
+Lincoln,14-Perry,State House,16,Karla J. Lems,REP,98
+Lincoln,"20-Canton 1, 2, 3",State House,16,Matt Ness,DEM,263
+Lincoln,"20-Canton 1, 2, 3",State House,16,Kevin D. Jensen,REP,433
+Lincoln,"20-Canton 1, 2, 3",State House,16,Karla J. Lems,REP,509
+Lincoln,21-Hudson & Eden,State House,16,Matt Ness,DEM,53
+Lincoln,21-Hudson & Eden,State House,16,Kevin D. Jensen,REP,113
+Lincoln,21-Hudson & Eden,State House,16,Karla J. Lems,REP,121
+Lincoln,23-Worthing & Lynn,State House,16,Matt Ness,DEM,121
+Lincoln,23-Worthing & Lynn,State House,16,Kevin D. Jensen,REP,278
+Lincoln,23-Worthing & Lynn,State House,16,Karla J. Lems,REP,250
+Lincoln,25-Lennox,State House,16,Matt Ness,DEM,245
+Lincoln,25-Lennox,State House,16,Kevin D. Jensen,REP,465
+Lincoln,25-Lennox,State House,16,Karla J. Lems,REP,466
+Lincoln,?,State House,16,Matt Ness,DEM,111
+Lincoln,?,State House,16,Kevin D. Jensen,REP,243
+Lincoln,?,State House,16,Karla J. Lems,REP,226
+Lincoln,29-Harrisburg 2,State House,16,Matt Ness,DEM,0
+Lincoln,29-Harrisburg 2,State House,16,Kevin D. Jensen,REP,0
+Lincoln,29-Harrisburg 2,State House,16,Karla J. Lems,REP,0
+Lincoln,30-Canton 4 & 5,State House,16,Matt Ness,DEM,148
+Lincoln,30-Canton 4 & 5,State House,16,Kevin D. Jensen,REP,191
+Lincoln,30-Canton 4 & 5,State House,16,Karla J. Lems,REP,243
+Lincoln,?,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,121
+Lincoln,06-Highland & Canton,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,204
+Lincoln,08-Lincoln & Delaware,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,87
+Lincoln,11-Grant,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,113
+Lincoln,12-Dayton,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,160
+Lincoln,13-LaValley,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,159
+Lincoln,14-Perry,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,199
+Lincoln,15-Springdale,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,541
+Lincoln,16-Delapre,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,420
+Lincoln,"20-Canton 1, 2, 3",Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,401
+Lincoln,21-Hudson & Eden,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,93
+Lincoln,23-Worthing & Lynn,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,243
+Lincoln,24-Tea,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,996
+Lincoln,25-Lennox,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,453
+Lincoln,?,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,227
+Lincoln,27-Harrisburg 1,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,588
+Lincoln,29-Harrisburg 2,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,560
+Lincoln,30-Canton 4 & 5,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,220
+Lincoln,Sioux Falls 1-11,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,786
+Lincoln,Sioux Falls 1-12,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,687
+Lincoln,Sioux Falls 1-13,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,284
+Lincoln,Sioux Falls 1-14,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,408
+Lincoln,Sioux Falls 1-15,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,371
+Lincoln,Sioux Falls 1-16,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,298
+Lincoln,Sioux Falls 1-18,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,642
+Lincoln,Sioux Falls 2-10,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,779
+Lincoln,Sioux Falls 2-11,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,999
+Lincoln,Sioux Falls 2-12,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,353
+Lincoln,Sioux Falls 2-13,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,890
+Lincoln,Sioux Falls 2-15,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,576
+Lincoln,Sioux Falls 2-16,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,846
+Lincoln,?,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,122
+Lincoln,06-Highland & Canton,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,208
+Lincoln,08-Lincoln & Delaware,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,83
+Lincoln,11-Grant,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,111
+Lincoln,12-Dayton,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,159
+Lincoln,13-LaValley,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,155
+Lincoln,14-Perry,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,200
+Lincoln,15-Springdale,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,524
+Lincoln,16-Delapre,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,411
+Lincoln,"20-Canton 1, 2, 3",Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,398
+Lincoln,21-Hudson & Eden,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,92
+Lincoln,23-Worthing & Lynn,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,245
+Lincoln,24-Tea,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,977
+Lincoln,25-Lennox,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,450
+Lincoln,?,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,224
+Lincoln,27-Harrisburg 1,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,570
+Lincoln,29-Harrisburg 2,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,560
+Lincoln,30-Canton 4 & 5,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,223
+Lincoln,Sioux Falls 1-11,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,742
+Lincoln,Sioux Falls 1-12,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,674
+Lincoln,Sioux Falls 1-13,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,272
+Lincoln,Sioux Falls 1-14,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,391
+Lincoln,Sioux Falls 1-15,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,362
+Lincoln,Sioux Falls 1-16,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,294
+Lincoln,Sioux Falls 1-18,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,634
+Lincoln,Sioux Falls 2-10,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,737
+Lincoln,Sioux Falls 2-11,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,930
+Lincoln,Sioux Falls 2-12,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,335
+Lincoln,Sioux Falls 2-13,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,862
+Lincoln,Sioux Falls 2-15,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,557
+Lincoln,Sioux Falls 2-16,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,824
+Lincoln,?,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,75
+Lincoln,?,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,62
+Lincoln,06-Highland & Canton,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,168
+Lincoln,06-Highland & Canton,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,83
+Lincoln,08-Lincoln & Delaware,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,74
+Lincoln,08-Lincoln & Delaware,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,34
+Lincoln,11-Grant,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,81
+Lincoln,11-Grant,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,41
+Lincoln,12-Dayton,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,137
+Lincoln,12-Dayton,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,65
+Lincoln,13-LaValley,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,122
+Lincoln,13-LaValley,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,55
+Lincoln,14-Perry,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,142
+Lincoln,14-Perry,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,86
+Lincoln,15-Springdale,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,366
+Lincoln,15-Springdale,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,201
+Lincoln,16-Delapre,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,332
+Lincoln,16-Delapre,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,164
+Lincoln,"20-Canton 1, 2, 3",Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,297
+Lincoln,"20-Canton 1, 2, 3",Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,202
+Lincoln,21-Hudson & Eden,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,66
+Lincoln,21-Hudson & Eden,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,54
+Lincoln,23-Worthing & Lynn,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,171
+Lincoln,23-Worthing & Lynn,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,117
+Lincoln,24-Tea,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,727
+Lincoln,24-Tea,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,401
+Lincoln,25-Lennox,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,326
+Lincoln,25-Lennox,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,187
+Lincoln,?,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,135
+Lincoln,?,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,99
+Lincoln,27-Harrisburg 1,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,343
+Lincoln,27-Harrisburg 1,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,269
+Lincoln,29-Harrisburg 2,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,360
+Lincoln,29-Harrisburg 2,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,242
+Lincoln,30-Canton 4 & 5,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,141
+Lincoln,30-Canton 4 & 5,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,107
+Lincoln,Sioux Falls 1-11,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,627
+Lincoln,Sioux Falls 1-11,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,243
+Lincoln,Sioux Falls 1-12,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,477
+Lincoln,Sioux Falls 1-12,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,312
+Lincoln,Sioux Falls 1-13,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,199
+Lincoln,Sioux Falls 1-13,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,132
+Lincoln,Sioux Falls 1-14,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,256
+Lincoln,Sioux Falls 1-14,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,197
+Lincoln,Sioux Falls 1-15,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,251
+Lincoln,Sioux Falls 1-15,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,182
+Lincoln,Sioux Falls 1-16,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,199
+Lincoln,Sioux Falls 1-16,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,149
+Lincoln,Sioux Falls 1-18,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,450
+Lincoln,Sioux Falls 1-18,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,265
+Lincoln,Sioux Falls 2-10,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,647
+Lincoln,Sioux Falls 2-10,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,267
+Lincoln,Sioux Falls 2-11,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,780
+Lincoln,Sioux Falls 2-11,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,341
+Lincoln,Sioux Falls 2-12,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,273
+Lincoln,Sioux Falls 2-12,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,141
+Lincoln,Sioux Falls 2-13,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,691
+Lincoln,Sioux Falls 2-13,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,328
+Lincoln,Sioux Falls 2-15,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,449
+Lincoln,Sioux Falls 2-15,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,218
+Lincoln,Sioux Falls 2-16,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,602
+Lincoln,Sioux Falls 2-16,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,347
+Lincoln,?,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,115
+Lincoln,06-Highland & Canton,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,196
+Lincoln,08-Lincoln & Delaware,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,86
+Lincoln,11-Grant,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,108
+Lincoln,12-Dayton,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,157
+Lincoln,13-LaValley,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,150
+Lincoln,14-Perry,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,191
+Lincoln,15-Springdale,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,504
+Lincoln,16-Delapre,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,408
+Lincoln,"20-Canton 1, 2, 3",Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,384
+Lincoln,21-Hudson & Eden,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,86
+Lincoln,23-Worthing & Lynn,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,237
+Lincoln,24-Tea,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,963
+Lincoln,25-Lennox,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,424
+Lincoln,?,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,217
+Lincoln,27-Harrisburg 1,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,555
+Lincoln,29-Harrisburg 2,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,537
+Lincoln,30-Canton 4 & 5,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,214
+Lincoln,Sioux Falls 1-11,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,723
+Lincoln,Sioux Falls 1-12,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,658
+Lincoln,Sioux Falls 1-13,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,275
+Lincoln,Sioux Falls 1-14,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,379
+Lincoln,Sioux Falls 1-15,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,351
+Lincoln,Sioux Falls 1-16,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,284
+Lincoln,Sioux Falls 1-18,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,626
+Lincoln,Sioux Falls 2-10,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,731
+Lincoln,Sioux Falls 2-11,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,924
+Lincoln,Sioux Falls 2-12,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,324
+Lincoln,Sioux Falls 2-13,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,841
+Lincoln,Sioux Falls 2-15,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,553
+Lincoln,Sioux Falls 2-16,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,814
+Lincoln,?,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,104
+Lincoln,06-Highland & Canton,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,172
+Lincoln,08-Lincoln & Delaware,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,73
+Lincoln,11-Grant,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,87
+Lincoln,12-Dayton,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,143
+Lincoln,13-LaValley,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,141
+Lincoln,14-Perry,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,184
+Lincoln,15-Springdale,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,449
+Lincoln,16-Delapre,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,343
+Lincoln,"20-Canton 1, 2, 3",Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,355
+Lincoln,21-Hudson & Eden,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,84
+Lincoln,23-Worthing & Lynn,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,195
+Lincoln,24-Tea,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,819
+Lincoln,25-Lennox,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,385
+Lincoln,?,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,194
+Lincoln,27-Harrisburg 1,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,484
+Lincoln,29-Harrisburg 2,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,474
+Lincoln,30-Canton 4 & 5,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,198
+Lincoln,Sioux Falls 1-11,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,692
+Lincoln,Sioux Falls 1-12,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,579
+Lincoln,Sioux Falls 1-13,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,243
+Lincoln,Sioux Falls 1-14,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,340
+Lincoln,Sioux Falls 1-15,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,311
+Lincoln,Sioux Falls 1-16,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,246
+Lincoln,Sioux Falls 1-18,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,538
+Lincoln,Sioux Falls 2-10,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,689
+Lincoln,Sioux Falls 2-11,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,925
+Lincoln,Sioux Falls 2-12,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,320
+Lincoln,Sioux Falls 2-13,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,799
+Lincoln,Sioux Falls 2-15,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,503
+Lincoln,Sioux Falls 2-16,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,738
+Lincoln,?,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,103
+Lincoln,06-Highland & Canton,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,164
+Lincoln,08-Lincoln & Delaware,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,68
+Lincoln,11-Grant,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,90
+Lincoln,12-Dayton,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,135
+Lincoln,13-LaValley,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,128
+Lincoln,14-Perry,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,172
+Lincoln,15-Springdale,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,425
+Lincoln,16-Delapre,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,325
+Lincoln,"20-Canton 1, 2, 3",Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,328
+Lincoln,21-Hudson & Eden,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,78
+Lincoln,23-Worthing & Lynn,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,196
+Lincoln,24-Tea,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,791
+Lincoln,25-Lennox,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,368
+Lincoln,?,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,195
+Lincoln,27-Harrisburg 1,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,464
+Lincoln,29-Harrisburg 2,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,457
+Lincoln,30-Canton 4 & 5,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,187
+Lincoln,Sioux Falls 1-11,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,659
+Lincoln,Sioux Falls 1-12,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,562
+Lincoln,Sioux Falls 1-13,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,232
+Lincoln,Sioux Falls 1-14,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,330
+Lincoln,Sioux Falls 1-15,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,293
+Lincoln,Sioux Falls 1-16,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,235
+Lincoln,Sioux Falls 1-18,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,533
+Lincoln,Sioux Falls 2-10,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,616
+Lincoln,Sioux Falls 2-11,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,822
+Lincoln,Sioux Falls 2-12,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,285
+Lincoln,Sioux Falls 2-13,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,735
+Lincoln,Sioux Falls 2-15,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,472
+Lincoln,Sioux Falls 2-16,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,685
+Lincoln,?,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,103
+Lincoln,06-Highland & Canton,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,171
+Lincoln,08-Lincoln & Delaware,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,71
+Lincoln,11-Grant,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,90
+Lincoln,12-Dayton,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,136
+Lincoln,13-LaValley,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,130
+Lincoln,14-Perry,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,174
+Lincoln,15-Springdale,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,434
+Lincoln,16-Delapre,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,325
+Lincoln,"20-Canton 1, 2, 3",Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,330
+Lincoln,21-Hudson & Eden,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,79
+Lincoln,23-Worthing & Lynn,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,194
+Lincoln,24-Tea,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,787
+Lincoln,25-Lennox,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,378
+Lincoln,?,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,200
+Lincoln,27-Harrisburg 1,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,472
+Lincoln,29-Harrisburg 2,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,457
+Lincoln,30-Canton 4 & 5,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,187
+Lincoln,Sioux Falls 1-11,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,644
+Lincoln,Sioux Falls 1-12,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,566
+Lincoln,Sioux Falls 1-13,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,230
+Lincoln,Sioux Falls 1-14,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,332
+Lincoln,Sioux Falls 1-15,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,293
+Lincoln,Sioux Falls 1-16,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,241
+Lincoln,Sioux Falls 1-18,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,524
+Lincoln,Sioux Falls 2-10,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,608
+Lincoln,Sioux Falls 2-11,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,819
+Lincoln,Sioux Falls 2-12,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,287
+Lincoln,Sioux Falls 2-13,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,736
+Lincoln,Sioux Falls 2-15,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,461
+Lincoln,Sioux Falls 2-16,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,688
+Lincoln,?,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,103
+Lincoln,06-Highland & Canton,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,180
+Lincoln,08-Lincoln & Delaware,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,66
+Lincoln,11-Grant,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,92
+Lincoln,12-Dayton,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,141
+Lincoln,13-LaValley,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,128
+Lincoln,14-Perry,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,176
+Lincoln,15-Springdale,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,432
+Lincoln,16-Delapre,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,333
+Lincoln,"20-Canton 1, 2, 3",Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,331
+Lincoln,21-Hudson & Eden,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,75
+Lincoln,23-Worthing & Lynn,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,196
+Lincoln,24-Tea,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,803
+Lincoln,25-Lennox,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,373
+Lincoln,?,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,195
+Lincoln,27-Harrisburg 1,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,475
+Lincoln,29-Harrisburg 2,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,465
+Lincoln,30-Canton 4 & 5,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,186
+Lincoln,Sioux Falls 1-11,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,676
+Lincoln,Sioux Falls 1-12,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,570
+Lincoln,Sioux Falls 1-13,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,229
+Lincoln,Sioux Falls 1-14,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,331
+Lincoln,Sioux Falls 1-15,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,301
+Lincoln,Sioux Falls 1-16,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,235
+Lincoln,Sioux Falls 1-18,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,531
+Lincoln,Sioux Falls 2-10,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,646
+Lincoln,Sioux Falls 2-11,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,870
+Lincoln,Sioux Falls 2-12,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,303
+Lincoln,Sioux Falls 2-13,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,751
+Lincoln,Sioux Falls 2-15,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,478
+Lincoln,Sioux Falls 2-16,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,706
+Lincoln,?,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,106
+Lincoln,06-Highland & Canton,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,173
+Lincoln,08-Lincoln & Delaware,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,73
+Lincoln,11-Grant,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,92
+Lincoln,12-Dayton,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,143
+Lincoln,13-LaValley,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,134
+Lincoln,14-Perry,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,179
+Lincoln,15-Springdale,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,440
+Lincoln,16-Delapre,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,329
+Lincoln,"20-Canton 1, 2, 3",Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,333
+Lincoln,21-Hudson & Eden,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,82
+Lincoln,23-Worthing & Lynn,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,198
+Lincoln,24-Tea,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,796
+Lincoln,25-Lennox,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,378
+Lincoln,?,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,194
+Lincoln,27-Harrisburg 1,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,467
+Lincoln,29-Harrisburg 2,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,461
+Lincoln,30-Canton 4 & 5,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,193
+Lincoln,Sioux Falls 1-11,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,644
+Lincoln,Sioux Falls 1-12,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,564
+Lincoln,Sioux Falls 1-13,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,227
+Lincoln,Sioux Falls 1-14,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,335
+Lincoln,Sioux Falls 1-15,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,295
+Lincoln,Sioux Falls 1-16,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,228
+Lincoln,Sioux Falls 1-18,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,526
+Lincoln,Sioux Falls 2-10,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,621
+Lincoln,Sioux Falls 2-11,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,836
+Lincoln,Sioux Falls 2-12,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,285
+Lincoln,Sioux Falls 2-13,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,751
+Lincoln,Sioux Falls 2-15,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,466
+Lincoln,Sioux Falls 2-16,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,703
+Lincoln,?,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,100
+Lincoln,06-Highland & Canton,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,167
+Lincoln,08-Lincoln & Delaware,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,67
+Lincoln,11-Grant,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,88
+Lincoln,12-Dayton,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,139
+Lincoln,13-LaValley,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,138
+Lincoln,14-Perry,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,175
+Lincoln,15-Springdale,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,425
+Lincoln,16-Delapre,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,323
+Lincoln,"20-Canton 1, 2, 3",Judge of the Circuit Court,Position J Second Circuit,James Power,NON,315
+Lincoln,21-Hudson & Eden,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,76
+Lincoln,23-Worthing & Lynn,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,190
+Lincoln,24-Tea,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,765
+Lincoln,25-Lennox,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,362
+Lincoln,?,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,188
+Lincoln,27-Harrisburg 1,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,457
+Lincoln,29-Harrisburg 2,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,450
+Lincoln,30-Canton 4 & 5,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,181
+Lincoln,Sioux Falls 1-11,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,633
+Lincoln,Sioux Falls 1-12,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,553
+Lincoln,Sioux Falls 1-13,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,216
+Lincoln,Sioux Falls 1-14,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,332
+Lincoln,Sioux Falls 1-15,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,283
+Lincoln,Sioux Falls 1-16,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,230
+Lincoln,Sioux Falls 1-18,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,514
+Lincoln,Sioux Falls 2-10,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,604
+Lincoln,Sioux Falls 2-11,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,802
+Lincoln,Sioux Falls 2-12,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,279
+Lincoln,Sioux Falls 2-13,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,723
+Lincoln,Sioux Falls 2-15,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,459
+Lincoln,Sioux Falls 2-16,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,679
+Lincoln,?,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,121
+Lincoln,06-Highland & Canton,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,226
+Lincoln,08-Lincoln & Delaware,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,74
+Lincoln,11-Grant,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,92
+Lincoln,12-Dayton,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,145
+Lincoln,13-LaValley,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,134
+Lincoln,14-Perry,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,173
+Lincoln,15-Springdale,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,440
+Lincoln,16-Delapre,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,323
+Lincoln,"20-Canton 1, 2, 3",Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,398
+Lincoln,21-Hudson & Eden,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,87
+Lincoln,23-Worthing & Lynn,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,199
+Lincoln,24-Tea,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,779
+Lincoln,25-Lennox,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,364
+Lincoln,?,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,207
+Lincoln,27-Harrisburg 1,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,473
+Lincoln,29-Harrisburg 2,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,456
+Lincoln,30-Canton 4 & 5,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,228
+Lincoln,Sioux Falls 1-11,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,654
+Lincoln,Sioux Falls 1-12,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,562
+Lincoln,Sioux Falls 1-13,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,217
+Lincoln,Sioux Falls 1-14,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,329
+Lincoln,Sioux Falls 1-15,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,291
+Lincoln,Sioux Falls 1-16,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,230
+Lincoln,Sioux Falls 1-18,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,521
+Lincoln,Sioux Falls 2-10,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,671
+Lincoln,Sioux Falls 2-11,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,888
+Lincoln,Sioux Falls 2-12,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,317
+Lincoln,Sioux Falls 2-13,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,763
+Lincoln,Sioux Falls 2-15,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,483
+Lincoln,Sioux Falls 2-16,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,699
+Lincoln,?,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,122
+Lincoln,06-Highland & Canton,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,211
+Lincoln,08-Lincoln & Delaware,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,80
+Lincoln,11-Grant,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,97
+Lincoln,12-Dayton,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,146
+Lincoln,13-LaValley,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,128
+Lincoln,14-Perry,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,183
+Lincoln,15-Springdale,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,433
+Lincoln,16-Delapre,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,333
+Lincoln,"20-Canton 1, 2, 3",Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,381
+Lincoln,21-Hudson & Eden,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,89
+Lincoln,23-Worthing & Lynn,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,208
+Lincoln,24-Tea,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,795
+Lincoln,25-Lennox,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,382
+Lincoln,?,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,242
+Lincoln,27-Harrisburg 1,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,473
+Lincoln,29-Harrisburg 2,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,465
+Lincoln,30-Canton 4 & 5,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,217
+Lincoln,Sioux Falls 1-11,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,644
+Lincoln,Sioux Falls 1-12,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,568
+Lincoln,Sioux Falls 1-13,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,239
+Lincoln,Sioux Falls 1-14,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,332
+Lincoln,Sioux Falls 1-15,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,293
+Lincoln,Sioux Falls 1-16,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,244
+Lincoln,Sioux Falls 1-18,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,519
+Lincoln,Sioux Falls 2-10,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,608
+Lincoln,Sioux Falls 2-11,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,818
+Lincoln,Sioux Falls 2-12,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,281
+Lincoln,Sioux Falls 2-13,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,731
+Lincoln,Sioux Falls 2-15,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,465
+Lincoln,Sioux Falls 2-16,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,687
+Lincoln,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,166
+Lincoln,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,35
+Lincoln,06-Highland & Canton,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,304
+Lincoln,06-Highland & Canton,Supreme Court Retention,3,Patricia J. DeVaney - No,,55
+Lincoln,08-Lincoln & Delaware,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,147
+Lincoln,08-Lincoln & Delaware,Supreme Court Retention,3,Patricia J. DeVaney - No,,24
+Lincoln,11-Grant,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,144
+Lincoln,11-Grant,Supreme Court Retention,3,Patricia J. DeVaney - No,,26
+Lincoln,12-Dayton,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,256
+Lincoln,12-Dayton,Supreme Court Retention,3,Patricia J. DeVaney - No,,57
+Lincoln,13-LaValley,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,212
+Lincoln,13-LaValley,Supreme Court Retention,3,Patricia J. DeVaney - No,,43
+Lincoln,14-Perry,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,288
+Lincoln,14-Perry,Supreme Court Retention,3,Patricia J. DeVaney - No,,48
+Lincoln,15-Springdale,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,761
+Lincoln,15-Springdale,Supreme Court Retention,3,Patricia J. DeVaney - No,,114
+Lincoln,16-Delapre,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,592
+Lincoln,16-Delapre,Supreme Court Retention,3,Patricia J. DeVaney - No,,115
+Lincoln,"20-Canton 1, 2, 3",Supreme Court Retention,3,Patricia J. DeVaney - Yes,,543
+Lincoln,"20-Canton 1, 2, 3",Supreme Court Retention,3,Patricia J. DeVaney - No,,152
+Lincoln,21-Hudson & Eden,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,136
+Lincoln,21-Hudson & Eden,Supreme Court Retention,3,Patricia J. DeVaney - No,,41
+Lincoln,23-Worthing & Lynn,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,311
+Lincoln,23-Worthing & Lynn,Supreme Court Retention,3,Patricia J. DeVaney - No,,92
+Lincoln,24-Tea,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1327
+Lincoln,24-Tea,Supreme Court Retention,3,Patricia J. DeVaney - No,,305
+Lincoln,25-Lennox,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,633
+Lincoln,25-Lennox,Supreme Court Retention,3,Patricia J. DeVaney - No,,126
+Lincoln,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,275
+Lincoln,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,67
+Lincoln,27-Harrisburg 1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,730
+Lincoln,27-Harrisburg 1,Supreme Court Retention,3,Patricia J. DeVaney - No,,173
+Lincoln,29-Harrisburg 2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,732
+Lincoln,29-Harrisburg 2,Supreme Court Retention,3,Patricia J. DeVaney - No,,177
+Lincoln,30-Canton 4 & 5,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,276
+Lincoln,30-Canton 4 & 5,Supreme Court Retention,3,Patricia J. DeVaney - No,,65
+Lincoln,Sioux Falls 1-11,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1055
+Lincoln,Sioux Falls 1-11,Supreme Court Retention,3,Patricia J. DeVaney - No,,138
+Lincoln,Sioux Falls 1-12,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,977
+Lincoln,Sioux Falls 1-12,Supreme Court Retention,3,Patricia J. DeVaney - No,,248
+Lincoln,Sioux Falls 1-13,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,371
+Lincoln,Sioux Falls 1-13,Supreme Court Retention,3,Patricia J. DeVaney - No,,111
+Lincoln,Sioux Falls 1-14,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,515
+Lincoln,Sioux Falls 1-14,Supreme Court Retention,3,Patricia J. DeVaney - No,,157
+Lincoln,Sioux Falls 1-15,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,490
+Lincoln,Sioux Falls 1-15,Supreme Court Retention,3,Patricia J. DeVaney - No,,136
+Lincoln,Sioux Falls 1-16,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,392
+Lincoln,Sioux Falls 1-16,Supreme Court Retention,3,Patricia J. DeVaney - No,,103
+Lincoln,Sioux Falls 1-18,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,868
+Lincoln,Sioux Falls 1-18,Supreme Court Retention,3,Patricia J. DeVaney - No,,174
+Lincoln,Sioux Falls 2-10,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1025
+Lincoln,Sioux Falls 2-10,Supreme Court Retention,3,Patricia J. DeVaney - No,,182
+Lincoln,Sioux Falls 2-11,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1353
+Lincoln,Sioux Falls 2-11,Supreme Court Retention,3,Patricia J. DeVaney - No,,209
+Lincoln,Sioux Falls 2-12,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,484
+Lincoln,Sioux Falls 2-12,Supreme Court Retention,3,Patricia J. DeVaney - No,,107
+Lincoln,Sioux Falls 2-13,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1238
+Lincoln,Sioux Falls 2-13,Supreme Court Retention,3,Patricia J. DeVaney - No,,267
+Lincoln,Sioux Falls 2-15,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,777
+Lincoln,Sioux Falls 2-15,Supreme Court Retention,3,Patricia J. DeVaney - No,,150
+Lincoln,Sioux Falls 2-16,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1133
+Lincoln,Sioux Falls 2-16,Supreme Court Retention,3,Patricia J. DeVaney - No,,258
+Lincoln,?,Supreme Court Retention,2,Mark E. Salter - Yes,,165
+Lincoln,?,Supreme Court Retention,2,Mark E. Salter - No,,33
+Lincoln,06-Highland & Canton,Supreme Court Retention,2,Mark E. Salter - Yes,,303
+Lincoln,06-Highland & Canton,Supreme Court Retention,2,Mark E. Salter - No,,56
+Lincoln,08-Lincoln & Delaware,Supreme Court Retention,2,Mark E. Salter - Yes,,147
+Lincoln,08-Lincoln & Delaware,Supreme Court Retention,2,Mark E. Salter - No,,22
+Lincoln,11-Grant,Supreme Court Retention,2,Mark E. Salter - Yes,,151
+Lincoln,11-Grant,Supreme Court Retention,2,Mark E. Salter - No,,20
+Lincoln,12-Dayton,Supreme Court Retention,2,Mark E. Salter - Yes,,264
+Lincoln,12-Dayton,Supreme Court Retention,2,Mark E. Salter - No,,49
+Lincoln,13-LaValley,Supreme Court Retention,2,Mark E. Salter - Yes,,211
+Lincoln,13-LaValley,Supreme Court Retention,2,Mark E. Salter - No,,37
+Lincoln,14-Perry,Supreme Court Retention,2,Mark E. Salter - Yes,,278
+Lincoln,14-Perry,Supreme Court Retention,2,Mark E. Salter - No,,54
+Lincoln,15-Springdale,Supreme Court Retention,2,Mark E. Salter - Yes,,753
+Lincoln,15-Springdale,Supreme Court Retention,2,Mark E. Salter - No,,107
+Lincoln,16-Delapre,Supreme Court Retention,2,Mark E. Salter - Yes,,591
+Lincoln,16-Delapre,Supreme Court Retention,2,Mark E. Salter - No,,113
+Lincoln,"20-Canton 1, 2, 3",Supreme Court Retention,2,Mark E. Salter - Yes,,541
+Lincoln,"20-Canton 1, 2, 3",Supreme Court Retention,2,Mark E. Salter - No,,141
+Lincoln,21-Hudson & Eden,Supreme Court Retention,2,Mark E. Salter - Yes,,134
+Lincoln,21-Hudson & Eden,Supreme Court Retention,2,Mark E. Salter - No,,40
+Lincoln,23-Worthing & Lynn,Supreme Court Retention,2,Mark E. Salter - Yes,,298
+Lincoln,23-Worthing & Lynn,Supreme Court Retention,2,Mark E. Salter - No,,103
+Lincoln,24-Tea,Supreme Court Retention,2,Mark E. Salter - Yes,,1319
+Lincoln,24-Tea,Supreme Court Retention,2,Mark E. Salter - No,,304
+Lincoln,25-Lennox,Supreme Court Retention,2,Mark E. Salter - Yes,,629
+Lincoln,25-Lennox,Supreme Court Retention,2,Mark E. Salter - No,,124
+Lincoln,?,Supreme Court Retention,2,Mark E. Salter - Yes,,272
+Lincoln,?,Supreme Court Retention,2,Mark E. Salter - No,,68
+Lincoln,27-Harrisburg 1,Supreme Court Retention,2,Mark E. Salter - Yes,,717
+Lincoln,27-Harrisburg 1,Supreme Court Retention,2,Mark E. Salter - No,,182
+Lincoln,29-Harrisburg 2,Supreme Court Retention,2,Mark E. Salter - Yes,,743
+Lincoln,29-Harrisburg 2,Supreme Court Retention,2,Mark E. Salter - No,,167
+Lincoln,30-Canton 4 & 5,Supreme Court Retention,2,Mark E. Salter - Yes,,280
+Lincoln,30-Canton 4 & 5,Supreme Court Retention,2,Mark E. Salter - No,,63
+Lincoln,Sioux Falls 1-11,Supreme Court Retention,2,Mark E. Salter - Yes,,1066
+Lincoln,Sioux Falls 1-11,Supreme Court Retention,2,Mark E. Salter - No,,134
+Lincoln,Sioux Falls 1-12,Supreme Court Retention,2,Mark E. Salter - Yes,,973
+Lincoln,Sioux Falls 1-12,Supreme Court Retention,2,Mark E. Salter - No,,245
+Lincoln,Sioux Falls 1-13,Supreme Court Retention,2,Mark E. Salter - Yes,,359
+Lincoln,Sioux Falls 1-13,Supreme Court Retention,2,Mark E. Salter - No,,111
+Lincoln,Sioux Falls 1-14,Supreme Court Retention,2,Mark E. Salter - Yes,,515
+Lincoln,Sioux Falls 1-14,Supreme Court Retention,2,Mark E. Salter - No,,153
+Lincoln,Sioux Falls 1-15,Supreme Court Retention,2,Mark E. Salter - Yes,,495
+Lincoln,Sioux Falls 1-15,Supreme Court Retention,2,Mark E. Salter - No,,130
+Lincoln,Sioux Falls 1-16,Supreme Court Retention,2,Mark E. Salter - Yes,,383
+Lincoln,Sioux Falls 1-16,Supreme Court Retention,2,Mark E. Salter - No,,104
+Lincoln,Sioux Falls 1-18,Supreme Court Retention,2,Mark E. Salter - Yes,,867
+Lincoln,Sioux Falls 1-18,Supreme Court Retention,2,Mark E. Salter - No,,166
+Lincoln,Sioux Falls 2-10,Supreme Court Retention,2,Mark E. Salter - Yes,,1053
+Lincoln,Sioux Falls 2-10,Supreme Court Retention,2,Mark E. Salter - No,,160
+Lincoln,Sioux Falls 2-11,Supreme Court Retention,2,Mark E. Salter - Yes,,1372
+Lincoln,Sioux Falls 2-11,Supreme Court Retention,2,Mark E. Salter - No,,210
+Lincoln,Sioux Falls 2-12,Supreme Court Retention,2,Mark E. Salter - Yes,,497
+Lincoln,Sioux Falls 2-12,Supreme Court Retention,2,Mark E. Salter - No,,104
+Lincoln,Sioux Falls 2-13,Supreme Court Retention,2,Mark E. Salter - Yes,,1223
+Lincoln,Sioux Falls 2-13,Supreme Court Retention,2,Mark E. Salter - No,,270
+Lincoln,Sioux Falls 2-15,Supreme Court Retention,2,Mark E. Salter - Yes,,785
+Lincoln,Sioux Falls 2-15,Supreme Court Retention,2,Mark E. Salter - No,,145
+Lincoln,Sioux Falls 2-16,Supreme Court Retention,2,Mark E. Salter - Yes,,1135
+Lincoln,Sioux Falls 2-16,Supreme Court Retention,2,Mark E. Salter - No,,259
+Lincoln,?,Constitutional Amendment D,,Yes,,115
+Lincoln,?,Constitutional Amendment D,,No,,115
+Lincoln,06-Highland & Canton,Constitutional Amendment D,,Yes,,179
+Lincoln,06-Highland & Canton,Constitutional Amendment D,,No,,233
+Lincoln,08-Lincoln & Delaware,Constitutional Amendment D,,Yes,,103
+Lincoln,08-Lincoln & Delaware,Constitutional Amendment D,,No,,100
+Lincoln,11-Grant,Constitutional Amendment D,,Yes,,103
+Lincoln,11-Grant,Constitutional Amendment D,,No,,104
+Lincoln,12-Dayton,Constitutional Amendment D,,Yes,,159
+Lincoln,12-Dayton,Constitutional Amendment D,,No,,215
+Lincoln,13-LaValley,Constitutional Amendment D,,Yes,,133
+Lincoln,13-LaValley,Constitutional Amendment D,,No,,179
+Lincoln,14-Perry,Constitutional Amendment D,,Yes,,204
+Lincoln,14-Perry,Constitutional Amendment D,,No,,208
+Lincoln,15-Springdale,Constitutional Amendment D,,Yes,,535
+Lincoln,15-Springdale,Constitutional Amendment D,,No,,508
+Lincoln,16-Delapre,Constitutional Amendment D,,Yes,,449
+Lincoln,16-Delapre,Constitutional Amendment D,,No,,437
+Lincoln,"20-Canton 1, 2, 3",Constitutional Amendment D,,Yes,,461
+Lincoln,"20-Canton 1, 2, 3",Constitutional Amendment D,,No,,364
+Lincoln,21-Hudson & Eden,Constitutional Amendment D,,Yes,,126
+Lincoln,21-Hudson & Eden,Constitutional Amendment D,,No,,73
+Lincoln,23-Worthing & Lynn,Constitutional Amendment D,,Yes,,255
+Lincoln,23-Worthing & Lynn,Constitutional Amendment D,,No,,230
+Lincoln,24-Tea,Constitutional Amendment D,,Yes,,1166
+Lincoln,24-Tea,Constitutional Amendment D,,No,,807
+Lincoln,25-Lennox,Constitutional Amendment D,,Yes,,512
+Lincoln,25-Lennox,Constitutional Amendment D,,No,,383
+Lincoln,?,Constitutional Amendment D,,Yes,,182
+Lincoln,?,Constitutional Amendment D,,No,,222
+Lincoln,27-Harrisburg 1,Constitutional Amendment D,,Yes,,682
+Lincoln,27-Harrisburg 1,Constitutional Amendment D,,No,,430
+Lincoln,29-Harrisburg 2,Constitutional Amendment D,,Yes,,653
+Lincoln,29-Harrisburg 2,Constitutional Amendment D,,No,,447
+Lincoln,30-Canton 4 & 5,Constitutional Amendment D,,Yes,,259
+Lincoln,30-Canton 4 & 5,Constitutional Amendment D,,No,,158
+Lincoln,Sioux Falls 1-11,Constitutional Amendment D,,Yes,,838
+Lincoln,Sioux Falls 1-11,Constitutional Amendment D,,No,,593
+Lincoln,Sioux Falls 1-12,Constitutional Amendment D,,Yes,,919
+Lincoln,Sioux Falls 1-12,Constitutional Amendment D,,No,,560
+Lincoln,Sioux Falls 1-13,Constitutional Amendment D,,Yes,,384
+Lincoln,Sioux Falls 1-13,Constitutional Amendment D,,No,,212
+Lincoln,Sioux Falls 1-14,Constitutional Amendment D,,Yes,,518
+Lincoln,Sioux Falls 1-14,Constitutional Amendment D,,No,,344
+Lincoln,Sioux Falls 1-15,Constitutional Amendment D,,Yes,,530
+Lincoln,Sioux Falls 1-15,Constitutional Amendment D,,No,,232
+Lincoln,Sioux Falls 1-16,Constitutional Amendment D,,Yes,,417
+Lincoln,Sioux Falls 1-16,Constitutional Amendment D,,No,,183
+Lincoln,Sioux Falls 1-18,Constitutional Amendment D,,Yes,,768
+Lincoln,Sioux Falls 1-18,Constitutional Amendment D,,No,,537
+Lincoln,Sioux Falls 2-10,Constitutional Amendment D,,Yes,,868
+Lincoln,Sioux Falls 2-10,Constitutional Amendment D,,No,,642
+Lincoln,Sioux Falls 2-11,Constitutional Amendment D,,Yes,,1155
+Lincoln,Sioux Falls 2-11,Constitutional Amendment D,,No,,745
+Lincoln,Sioux Falls 2-12,Constitutional Amendment D,,Yes,,480
+Lincoln,Sioux Falls 2-12,Constitutional Amendment D,,No,,263
+Lincoln,Sioux Falls 2-13,Constitutional Amendment D,,Yes,,1208
+Lincoln,Sioux Falls 2-13,Constitutional Amendment D,,No,,645
+Lincoln,Sioux Falls 2-15,Constitutional Amendment D,,Yes,,693
+Lincoln,Sioux Falls 2-15,Constitutional Amendment D,,No,,439
+Lincoln,Sioux Falls 2-16,Constitutional Amendment D,,Yes,,1102
+Lincoln,Sioux Falls 2-16,Constitutional Amendment D,,No,,604
+Lincoln,?,Initiated Measure 27,,Yes,,86
+Lincoln,?,Initiated Measure 27,,No,,152
+Lincoln,06-Highland & Canton,Initiated Measure 27,,Yes,,179
+Lincoln,06-Highland & Canton,Initiated Measure 27,,No,,244
+Lincoln,08-Lincoln & Delaware,Initiated Measure 27,,Yes,,86
+Lincoln,08-Lincoln & Delaware,Initiated Measure 27,,No,,124
+Lincoln,11-Grant,Initiated Measure 27,,Yes,,93
+Lincoln,11-Grant,Initiated Measure 27,,No,,117
+Lincoln,12-Dayton,Initiated Measure 27,,Yes,,125
+Lincoln,12-Dayton,Initiated Measure 27,,No,,253
+Lincoln,13-LaValley,Initiated Measure 27,,Yes,,109
+Lincoln,13-LaValley,Initiated Measure 27,,No,,206
+Lincoln,14-Perry,Initiated Measure 27,,Yes,,172
+Lincoln,14-Perry,Initiated Measure 27,,No,,239
+Lincoln,15-Springdale,Initiated Measure 27,,Yes,,431
+Lincoln,15-Springdale,Initiated Measure 27,,No,,642
+Lincoln,16-Delapre,Initiated Measure 27,,Yes,,373
+Lincoln,16-Delapre,Initiated Measure 27,,No,,524
+Lincoln,"20-Canton 1, 2, 3",Initiated Measure 27,,Yes,,436
+Lincoln,"20-Canton 1, 2, 3",Initiated Measure 27,,No,,404
+Lincoln,21-Hudson & Eden,Initiated Measure 27,,Yes,,99
+Lincoln,21-Hudson & Eden,Initiated Measure 27,,No,,105
+Lincoln,23-Worthing & Lynn,Initiated Measure 27,,Yes,,251
+Lincoln,23-Worthing & Lynn,Initiated Measure 27,,No,,245
+Lincoln,24-Tea,Initiated Measure 27,,Yes,,1121
+Lincoln,24-Tea,Initiated Measure 27,,No,,897
+Lincoln,25-Lennox,Initiated Measure 27,,Yes,,465
+Lincoln,25-Lennox,Initiated Measure 27,,No,,450
+Lincoln,?,Initiated Measure 27,,Yes,,142
+Lincoln,?,Initiated Measure 27,,No,,269
+Lincoln,27-Harrisburg 1,Initiated Measure 27,,Yes,,678
+Lincoln,27-Harrisburg 1,Initiated Measure 27,,No,,461
+Lincoln,29-Harrisburg 2,Initiated Measure 27,,Yes,,623
+Lincoln,29-Harrisburg 2,Initiated Measure 27,,No,,499
+Lincoln,30-Canton 4 & 5,Initiated Measure 27,,Yes,,229
+Lincoln,30-Canton 4 & 5,Initiated Measure 27,,No,,194
+Lincoln,Sioux Falls 1-11,Initiated Measure 27,,Yes,,570
+Lincoln,Sioux Falls 1-11,Initiated Measure 27,,No,,901
+Lincoln,Sioux Falls 1-12,Initiated Measure 27,,Yes,,872
+Lincoln,Sioux Falls 1-12,Initiated Measure 27,,No,,639
+Lincoln,Sioux Falls 1-13,Initiated Measure 27,,Yes,,356
+Lincoln,Sioux Falls 1-13,Initiated Measure 27,,No,,253
+Lincoln,Sioux Falls 1-14,Initiated Measure 27,,Yes,,539
+Lincoln,Sioux Falls 1-14,Initiated Measure 27,,No,,346
+Lincoln,Sioux Falls 1-15,Initiated Measure 27,,Yes,,456
+Lincoln,Sioux Falls 1-15,Initiated Measure 27,,No,,326
+Lincoln,Sioux Falls 1-16,Initiated Measure 27,,Yes,,385
+Lincoln,Sioux Falls 1-16,Initiated Measure 27,,No,,232
+Lincoln,Sioux Falls 1-18,Initiated Measure 27,,Yes,,686
+Lincoln,Sioux Falls 1-18,Initiated Measure 27,,No,,656
+Lincoln,Sioux Falls 2-10,Initiated Measure 27,,Yes,,662
+Lincoln,Sioux Falls 2-10,Initiated Measure 27,,No,,880
+Lincoln,Sioux Falls 2-11,Initiated Measure 27,,Yes,,809
+Lincoln,Sioux Falls 2-11,Initiated Measure 27,,No,,1121
+Lincoln,Sioux Falls 2-12,Initiated Measure 27,,Yes,,382
+Lincoln,Sioux Falls 2-12,Initiated Measure 27,,No,,371
+Lincoln,Sioux Falls 2-13,Initiated Measure 27,,Yes,,982
+Lincoln,Sioux Falls 2-13,Initiated Measure 27,,No,,914
+Lincoln,Sioux Falls 2-15,Initiated Measure 27,,Yes,,531
+Lincoln,Sioux Falls 2-15,Initiated Measure 27,,No,,640
+Lincoln,Sioux Falls 2-16,Initiated Measure 27,,Yes,,938
+Lincoln,Sioux Falls 2-16,Initiated Measure 27,,No,,811
+Lincoln,"02-Norway & Fairview, Fairview, Inc",State Senate,16,Donn Larson,DEM,70
+Lincoln,"02-Norway & Fairview, Fairview, Inc",State Senate,16,Jim Bolin,REP,162
+Lincoln,"02-Norway & Fairview, Fairview, Inc",State Senate,16,Brian J. Burge,IND,8
+Lincoln,06-Highland & Canton,State Senate,16,Donn Larson,DEM,104
+Lincoln,06-Highland & Canton,State Senate,16,Jim Bolin,REP,293
+Lincoln,06-Highland & Canton,State Senate,16,Brian J. Burge,IND,17
+Lincoln,08-Lincoln & Delaware,State Senate,16,Donn Larson,DEM,56
+Lincoln,08-Lincoln & Delaware,State Senate,16,Jim Bolin,REP,142
+Lincoln,08-Lincoln & Delaware,State Senate,16,Brian J. Burge,IND,13
+Lincoln,11-Grant,State Senate,16,Donn Larson,DEM,52
+Lincoln,11-Grant,State Senate,16,Jim Bolin,REP,126
+Lincoln,11-Grant,State Senate,16,Brian J. Burge,IND,18
+Lincoln,12-Dayton,State Senate,16,Donn Larson,DEM,56
+Lincoln,12-Dayton,State Senate,16,Jim Bolin,REP,278
+Lincoln,12-Dayton,State Senate,16,Brian J. Burge,IND,21
+Lincoln,13-LaValley,State Senate,06,Herman Otten,REP,168
+Lincoln,13-LaValley,State Senate,16,Donn Larson,DEM,23
+Lincoln,13-LaValley,State Senate,16,Jim Bolin,REP,82
+Lincoln,13-LaValley,State Senate,16,Brian J. Burge,IND,2
+Lincoln,14-Perry,State Senate,06,Herman Otten,REP,194
+Lincoln,14-Perry,State Senate,16,Donn Larson,DEM,48
+Lincoln,14-Perry,State Senate,16,Jim Bolin,REP,111
+Lincoln,14-Perry,State Senate,16,Brian J. Burge,IND,10
+Lincoln,15-Springdale,State Senate,06,Herman Otten,REP,786
+Lincoln,16-Delapre,State Senate,06,Herman Otten,REP,672
+Lincoln,16-Delapre,State Senate,12,Jessica Meyers,DEM,0
+Lincoln,16-Delapre,State Senate,12,Arch Beal,REP,2
+Lincoln,"20-Canton 1, 2, 3",State Senate,16,Donn Larson,DEM,231
+Lincoln,"20-Canton 1, 2, 3",State Senate,16,Jim Bolin,REP,541
+Lincoln,"20-Canton 1, 2, 3",State Senate,16,Brian J. Burge,IND,52
+Lincoln,21-Hudson & Eden,State Senate,16,Donn Larson,DEM,81
+Lincoln,21-Hudson & Eden,State Senate,16,Jim Bolin,REP,116
+Lincoln,21-Hudson & Eden,State Senate,16,Brian J. Burge,IND,9
+Lincoln,23-Worthing & Lynn,State Senate,16,Donn Larson,DEM,92
+Lincoln,23-Worthing & Lynn,State Senate,16,Jim Bolin,REP,337
+Lincoln,23-Worthing & Lynn,State Senate,16,Brian J. Burge,IND,47
+Lincoln,24-Tea,State Senate,06,Herman Otten,REP,1498
+Lincoln,25-Lennox,State Senate,16,Donn Larson,DEM,198
+Lincoln,25-Lennox,State Senate,16,Jim Bolin,REP,578
+Lincoln,25-Lennox,State Senate,16,Brian J. Burge,IND,76
+Lincoln,"26-Brooklyn & Pleasant, Beresford",State Senate,16,Donn Larson,DEM,123
+Lincoln,"26-Brooklyn & Pleasant, Beresford",State Senate,16,Jim Bolin,REP,261
+Lincoln,"26-Brooklyn & Pleasant, Beresford",State Senate,16,Brian J. Burge,IND,22
+Lincoln,27-Harrisburg 1,State Senate,06,Herman Otten,REP,769
+Lincoln,29-Harrisburg 2,State Senate,06,Herman Otten,REP,777
+Lincoln,29-Harrisburg 2,State Senate,16,Donn Larson,DEM,0
+Lincoln,29-Harrisburg 2,State Senate,16,Jim Bolin,REP,0
+Lincoln,29-Harrisburg 2,State Senate,16,Brian J. Burge,IND,0
+Lincoln,30-Canton 4 & 5,State Senate,16,Donn Larson,DEM,136
+Lincoln,30-Canton 4 & 5,State Senate,16,Jim Bolin,REP,262
+Lincoln,30-Canton 4 & 5,State Senate,16,Brian J. Burge,IND,22
+Lincoln,Sioux Falls 1-11,State Senate,12,Jessica Meyers,DEM,494
+Lincoln,Sioux Falls 1-11,State Senate,12,Arch Beal,REP,955
+Lincoln,Sioux Falls 1-12,State Senate,06,Herman Otten,REP,337
+Lincoln,Sioux Falls 1-12,State Senate,12,Jessica Meyers,DEM,392
+Lincoln,Sioux Falls 1-12,State Senate,12,Arch Beal,REP,536
+Lincoln,Sioux Falls 1-13,State Senate,06,Herman Otten,REP,360
+Lincoln,Sioux Falls 1-14,State Senate,06,Herman Otten,REP,568
+Lincoln,Sioux Falls 1-15,State Senate,12,Jessica Meyers,DEM,360
+Lincoln,Sioux Falls 1-15,State Senate,12,Arch Beal,REP,376
+Lincoln,Sioux Falls 1-16,State Senate,06,Herman Otten,REP,383
+Lincoln,Sioux Falls 1-18,State Senate,12,Jessica Meyers,DEM,447
+Lincoln,Sioux Falls 1-18,State Senate,12,Arch Beal,REP,817
+Lincoln,Sioux Falls 2-10,State Senate,13,Jack Kolbeck,REP,1065
+Lincoln,Sioux Falls 2-10,State Senate,13,Lora Hubbel,IND,295
+Lincoln,Sioux Falls 2-11,State Senate,06,Herman Otten,REP,1
+Lincoln,Sioux Falls 2-11,State Senate,13,Jack Kolbeck,REP,1288
+Lincoln,Sioux Falls 2-11,State Senate,13,Lora Hubbel,IND,438
+Lincoln,Sioux Falls 2-12,State Senate,13,Jack Kolbeck,REP,445
+Lincoln,Sioux Falls 2-12,State Senate,13,Lora Hubbel,IND,202
+Lincoln,Sioux Falls 2-13,State Senate,13,Jack Kolbeck,REP,1095
+Lincoln,Sioux Falls 2-13,State Senate,13,Lora Hubbel,IND,504
+Lincoln,Sioux Falls 2-15,State Senate,13,Jack Kolbeck,REP,772
+Lincoln,Sioux Falls 2-15,State Senate,13,Lora Hubbel,IND,249
+Lincoln,Sioux Falls 2-16 10 of 29,State Senate,13,Jack Kolbeck,REP,1045
+Lincoln,Sioux Falls 2-16 10 of 29,State Senate,13,Lora Hubbel,IND,474
+Lincoln,"02-Norway & Fairview, Fairview, Inc 06-Highland & Canton 08-Lincoln & Delaware 11-Grant 12-Dayton 13-LaValley",State House,06,Aaron Aylward,REP,94
+Lincoln,"02-Norway & Fairview, Fairview, Inc 06-Highland & Canton 08-Lincoln & Delaware 11-Grant 12-Dayton 13-LaValley",State House,06,Ernie Otten,REP,155
+Lincoln,14-Perry,State House,06,Aaron Aylward,REP,73
+Lincoln,14-Perry,State House,06,Ernie Otten,REP,171
+Lincoln,15-Springdale,State House,06,Aaron Aylward,REP,494
+Lincoln,15-Springdale,State House,06,Ernie Otten,REP,711
+Lincoln,"16-Delapre 20-Canton 1, 2, 3 21-Hudson & Eden",State House,06,Aaron Aylward,REP,362
+Lincoln,"16-Delapre 20-Canton 1, 2, 3 21-Hudson & Eden",State House,06,Ernie Otten,REP,589
+Lincoln,"16-Delapre 20-Canton 1, 2, 3 21-Hudson & Eden",State House,12,Kristin Hayward,DEM,0
+Lincoln,"16-Delapre 20-Canton 1, 2, 3 21-Hudson & Eden",State House,12,Erin Royer,DEM,0
+Lincoln,"16-Delapre 20-Canton 1, 2, 3 21-Hudson & Eden",State House,12,Greg Jamison,REP,2
+Lincoln,"16-Delapre 20-Canton 1, 2, 3 21-Hudson & Eden",State House,12,Amber Arlint,REP,2
+Lincoln,"23-Worthing & Lynn 24-Tea 25-Lennox 26-Brooklyn & Pleasant,",State House,06,Aaron Aylward,REP,786
+Lincoln,"23-Worthing & Lynn 24-Tea 25-Lennox 26-Brooklyn & Pleasant,",State House,06,Ernie Otten,REP,1289
+Lincoln,Beresford 27-Harrisburg 1,State House,06,Aaron Aylward,REP,476
+Lincoln,Beresford 27-Harrisburg 1,State House,06,Ernie Otten,REP,613
+Lincoln,29-Harrisburg 2,State House,06,Aaron Aylward,REP,472
+Lincoln,29-Harrisburg 2,State House,06,Ernie Otten,REP,642
+Lincoln,30-Canton 4 & 5 Sioux Falls 1-11,State House,12,Kristin Hayward,DEM,366
+Lincoln,30-Canton 4 & 5 Sioux Falls 1-11,State House,12,Erin Royer,DEM,420
+Lincoln,30-Canton 4 & 5 Sioux Falls 1-11,State House,12,Greg Jamison,REP,915
+Lincoln,30-Canton 4 & 5 Sioux Falls 1-11,State House,12,Amber Arlint,REP,928
+Lincoln,Sioux Falls 1-12,State House,06,Aaron Aylward,REP,210
+Lincoln,Sioux Falls 1-12,State House,06,Ernie Otten,REP,283
+Lincoln,Sioux Falls 1-12,State House,12,Kristin Hayward,DEM,334
+Lincoln,Sioux Falls 1-12,State House,12,Erin Royer,DEM,341
+Lincoln,Sioux Falls 1-12,State House,12,Greg Jamison,REP,458
+Lincoln,Sioux Falls 1-12,State House,12,Amber Arlint,REP,486
+Lincoln,Sioux Falls 1-13,State House,06,Aaron Aylward,REP,211
+Lincoln,Sioux Falls 1-13,State House,06,Ernie Otten,REP,295
+Lincoln,Sioux Falls 1-14,State House,06,Aaron Aylward,REP,316
+Lincoln,Sioux Falls 1-14,State House,06,Ernie Otten,REP,490
+Lincoln,Sioux Falls 1-15,State House,12,Kristin Hayward,DEM,284
+Lincoln,Sioux Falls 1-15,State House,12,Erin Royer,DEM,310
+Lincoln,Sioux Falls 1-15,State House,12,Greg Jamison,REP,339
+Lincoln,Sioux Falls 1-15,State House,12,Amber Arlint,REP,362
+Lincoln,Sioux Falls 1-16,State House,06,Aaron Aylward,REP,221
+Lincoln,Sioux Falls 1-16,State House,06,Ernie Otten,REP,319
+Lincoln,Sioux Falls 1-18,State House,12,Kristin Hayward,DEM,339
+Lincoln,Sioux Falls 1-18,State House,12,Erin Royer,DEM,376
+Lincoln,Sioux Falls 1-18,State House,12,Greg Jamison,REP,736
+Lincoln,Sioux Falls 1-18,State House,12,Amber Arlint,REP,786
+Lincoln,Sioux Falls 2-10,State House,13,Tony Venhuizen,REP,849
+Lincoln,Sioux Falls 2-10,State House,13,Sue Peterson,REP,824
+Lincoln,Sioux Falls 2-11,State House,06,Aaron Aylward,REP,0
+Lincoln,Sioux Falls 2-11,State House,06,Ernie Otten,REP,2
+Lincoln,Sioux Falls 2-11,State House,13,Tony Venhuizen,REP,1046
+Lincoln,Sioux Falls 2-11,State House,13,Sue Peterson,REP,977
+Lincoln,Sioux Falls 2-12,State House,13,Tony Venhuizen,REP,359
+Lincoln,Sioux Falls 2-12,State House,13,Sue Peterson,REP,348
+Lincoln,Sioux Falls 2-13,State House,13,Tony Venhuizen,REP,915
+Lincoln,Sioux Falls 2-13,State House,13,Sue Peterson,REP,884
+Lincoln,Sioux Falls 2-15,State House,13,Tony Venhuizen,REP,589
+Lincoln,Sioux Falls 2-15,State House,13,Sue Peterson,REP,596
+Lincoln,Sioux Falls 2-16 11 of 29,State House,13,Tony Venhuizen,REP,858
+Lincoln,Sioux Falls 2-16 11 of 29,State House,13,Sue Peterson,REP,827

--- a/2022/counties/20221108__sd__general__lyman__precinct.csv
+++ b/2022/counties/20221108__sd__general__lyman__precinct.csv
@@ -1,0 +1,246 @@
+county,precinct,office,district,candidate,party,votes
+Lyman,01,U.S. Senate,,Brian L. Bengs,DEM,8
+Lyman,01,U.S. Senate,,Tamara J Lesnar,LIB,7
+Lyman,01,U.S. Senate,,John R. Thune,REP,49
+Lyman,04,U.S. Senate,,Brian L. Bengs,DEM,57
+Lyman,04,U.S. Senate,,Tamara J Lesnar,LIB,8
+Lyman,04,U.S. Senate,,John R. Thune,REP,207
+Lyman,06,U.S. Senate,,Brian L. Bengs,DEM,20
+Lyman,06,U.S. Senate,,Tamara J Lesnar,LIB,6
+Lyman,06,U.S. Senate,,John R. Thune,REP,99
+Lyman,07,U.S. Senate,,Brian L. Bengs,DEM,137
+Lyman,07,U.S. Senate,,Tamara J Lesnar,LIB,15
+Lyman,07,U.S. Senate,,John R. Thune,REP,33
+Lyman,09,U.S. Senate,,Brian L. Bengs,DEM,16
+Lyman,09,U.S. Senate,,Tamara J Lesnar,LIB,10
+Lyman,09,U.S. Senate,,John R. Thune,REP,197
+Lyman,12,U.S. Senate,,Brian L. Bengs,DEM,43
+Lyman,12,U.S. Senate,,Tamara J Lesnar,LIB,12
+Lyman,12,U.S. Senate,,John R. Thune,REP,289
+Lyman,13,U.S. Senate,,Brian L. Bengs,DEM,9
+Lyman,13,U.S. Senate,,Tamara J Lesnar,LIB,7
+Lyman,13,U.S. Senate,,John R. Thune,REP,70
+Lyman,01,U.S. House,1,Collin Duprel,LIB,14
+Lyman,01,U.S. House,1,Dusty Johnson,REP,47
+Lyman,04,U.S. House,1,Collin Duprel,LIB,57
+Lyman,04,U.S. House,1,Dusty Johnson,REP,205
+Lyman,06,U.S. House,1,Collin Duprel,LIB,19
+Lyman,06,U.S. House,1,Dusty Johnson,REP,104
+Lyman,07,U.S. House,1,Collin Duprel,LIB,95
+Lyman,07,U.S. House,1,Dusty Johnson,REP,74
+Lyman,09,U.S. House,1,Collin Duprel,LIB,24
+Lyman,09,U.S. House,1,Dusty Johnson,REP,190
+Lyman,12,U.S. House,1,Collin Duprel,LIB,42
+Lyman,12,U.S. House,1,Dusty Johnson,REP,296
+Lyman,13,U.S. House,1,Collin Duprel,LIB,16
+Lyman,13,U.S. House,1,Dusty Johnson,REP,66
+Lyman,01,Governor,,Jamie Smith and Jennifer Keintz,DEM,12
+Lyman,01,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Lyman,01,Governor,,Kristi Noem and Larry Rhoden,REP,54
+Lyman,04,Governor,,Jamie Smith and Jennifer Keintz,DEM,78
+Lyman,04,Governor,,Tracey Quint and Ashley Strand,LIB,10
+Lyman,04,Governor,,Kristi Noem and Larry Rhoden,REP,188
+Lyman,06,Governor,,Jamie Smith and Jennifer Keintz,DEM,29
+Lyman,06,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Lyman,06,Governor,,Kristi Noem and Larry Rhoden,REP,93
+Lyman,07,Governor,,Jamie Smith and Jennifer Keintz,DEM,171
+Lyman,07,Governor,,Tracey Quint and Ashley Strand,LIB,8
+Lyman,07,Governor,,Kristi Noem and Larry Rhoden,REP,12
+Lyman,09,Governor,,Jamie Smith and Jennifer Keintz,DEM,27
+Lyman,09,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Lyman,09,Governor,,Kristi Noem and Larry Rhoden,REP,191
+Lyman,12,Governor,,Jamie Smith and Jennifer Keintz,DEM,70
+Lyman,12,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Lyman,12,Governor,,Kristi Noem and Larry Rhoden,REP,273
+Lyman,13,Governor,,Jamie Smith and Jennifer Keintz,DEM,18
+Lyman,13,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Lyman,13,Governor,,Kristi Noem and Larry Rhoden,REP,68
+Lyman,01,Secretary of State,,Thomas A Cool,DEM,16
+Lyman,01,Secretary of State,,Monae Johnson,REP,45
+Lyman,04,Secretary of State,,Thomas A Cool,DEM,87
+Lyman,04,Secretary of State,,Monae Johnson,REP,182
+Lyman,06,Secretary of State,,Thomas A Cool,DEM,30
+Lyman,06,Secretary of State,,Monae Johnson,REP,91
+Lyman,07,Secretary of State,,Thomas A Cool,DEM,155
+Lyman,07,Secretary of State,,Monae Johnson,REP,22
+Lyman,09,Secretary of State,,Thomas A Cool,DEM,39
+Lyman,09,Secretary of State,,Monae Johnson,REP,168
+Lyman,12,Secretary of State,,Thomas A Cool,DEM,66
+Lyman,12,Secretary of State,,Monae Johnson,REP,257
+Lyman,13,Secretary of State,,Thomas A Cool,DEM,11
+Lyman,13,Secretary of State,,Monae Johnson,REP,66
+Lyman,01,Attorney General,,Marty J. Jackley,REP,52
+Lyman,04,Attorney General,,Marty J. Jackley,REP,215
+Lyman,06,Attorney General,,Marty J. Jackley,REP,100
+Lyman,07,Attorney General,,Marty J. Jackley,REP,68
+Lyman,09,Attorney General,,Marty J. Jackley,REP,173
+Lyman,12,Attorney General,,Marty J. Jackley,REP,303
+Lyman,13,Attorney General,,Marty J. Jackley,REP,73
+Lyman,01,State Auditor,,Stephanie Marty,DEM,15
+Lyman,01,State Auditor,,Rene Meyer,LIB,1
+Lyman,01,State Auditor,,Richard Sattgast,REP,47
+Lyman,04,State Auditor,,Stephanie Marty,DEM,68
+Lyman,04,State Auditor,,Rene Meyer,LIB,10
+Lyman,04,State Auditor,,Richard Sattgast,REP,183
+Lyman,06,State Auditor,,Stephanie Marty,DEM,25
+Lyman,06,State Auditor,,Rene Meyer,LIB,5
+Lyman,06,State Auditor,,Richard Sattgast,REP,91
+Lyman,07,State Auditor,,Stephanie Marty,DEM,140
+Lyman,07,State Auditor,,Rene Meyer,LIB,16
+Lyman,07,State Auditor,,Richard Sattgast,REP,15
+Lyman,09,State Auditor,,Stephanie Marty,DEM,28
+Lyman,09,State Auditor,,Rene Meyer,LIB,12
+Lyman,09,State Auditor,,Richard Sattgast,REP,162
+Lyman,12,State Auditor,,Stephanie Marty,DEM,61
+Lyman,12,State Auditor,,Rene Meyer,LIB,11
+Lyman,12,State Auditor,,Richard Sattgast,REP,253
+Lyman,13,State Auditor,,Stephanie Marty,DEM,9
+Lyman,13,State Auditor,,Rene Meyer,LIB,7
+Lyman,13,State Auditor,,Richard Sattgast,REP,64
+Lyman,01,State Treasurer,,John Cunningham,DEM,17
+Lyman,01,State Treasurer,,Josh Haeder,REP,48
+Lyman,04,State Treasurer,,John Cunningham,DEM,72
+Lyman,04,State Treasurer,,Josh Haeder,REP,186
+Lyman,06,State Treasurer,,John Cunningham,DEM,25
+Lyman,06,State Treasurer,,Josh Haeder,REP,91
+Lyman,07,State Treasurer,,John Cunningham,DEM,153
+Lyman,07,State Treasurer,,Josh Haeder,REP,18
+Lyman,09,State Treasurer,,John Cunningham,DEM,28
+Lyman,09,State Treasurer,,Josh Haeder,REP,171
+Lyman,12,State Treasurer,,John Cunningham,DEM,65
+Lyman,12,State Treasurer,,Josh Haeder,REP,257
+Lyman,13,State Treasurer,,John Cunningham,DEM,11
+Lyman,13,State Treasurer,,Josh Haeder,REP,65
+Lyman,01,Commissioner of School and Public Lands,,Timothy Azure,DEM,12
+Lyman,01,Commissioner of School and Public Lands,,Brock Greenfield,REP,48
+Lyman,04,Commissioner of School and Public Lands,,Timothy Azure,DEM,77
+Lyman,04,Commissioner of School and Public Lands,,Brock Greenfield,REP,180
+Lyman,06,Commissioner of School and Public Lands,,Timothy Azure,DEM,25
+Lyman,06,Commissioner of School and Public Lands,,Brock Greenfield,REP,90
+Lyman,07,Commissioner of School and Public Lands,,Timothy Azure,DEM,153
+Lyman,07,Commissioner of School and Public Lands,,Brock Greenfield,REP,24
+Lyman,09,Commissioner of School and Public Lands,,Timothy Azure,DEM,23
+Lyman,09,Commissioner of School and Public Lands,,Brock Greenfield,REP,172
+Lyman,12,Commissioner of School and Public Lands,,Timothy Azure,DEM,55
+Lyman,12,Commissioner of School and Public Lands,,Brock Greenfield,REP,266
+Lyman,13,Commissioner of School and Public Lands,,Timothy Azure,DEM,6
+Lyman,13,Commissioner of School and Public Lands,,Brock Greenfield,REP,71
+Lyman,01,Public Utilities Commissioner,,Jeffrey Barth,DEM,13
+Lyman,01,Public Utilities Commissioner,,Chris Nelson,REP,54
+Lyman,04,Public Utilities Commissioner,,Jeffrey Barth,DEM,61
+Lyman,04,Public Utilities Commissioner,,Chris Nelson,REP,203
+Lyman,06,Public Utilities Commissioner,,Jeffrey Barth,DEM,25
+Lyman,06,Public Utilities Commissioner,,Chris Nelson,REP,93
+Lyman,07,Public Utilities Commissioner,,Jeffrey Barth,DEM,153
+Lyman,07,Public Utilities Commissioner,,Chris Nelson,REP,19
+Lyman,09,Public Utilities Commissioner,,Jeffrey Barth,DEM,20
+Lyman,09,Public Utilities Commissioner,,Chris Nelson,REP,181
+Lyman,12,Public Utilities Commissioner,,Jeffrey Barth,DEM,44
+Lyman,12,Public Utilities Commissioner,,Chris Nelson,REP,289
+Lyman,13,Public Utilities Commissioner,,Jeffrey Barth,DEM,8
+Lyman,13,Public Utilities Commissioner,,Chris Nelson,REP,73
+Lyman,01,State Senate,26,Shawn Bordeaux,DEM,20
+Lyman,01,State Senate,26,Joel Koskan,REP,34
+Lyman,04,State Senate,26,Shawn Bordeaux,DEM,97
+Lyman,04,State Senate,26,Joel Koskan,REP,135
+Lyman,06,State Senate,26,Shawn Bordeaux,DEM,48
+Lyman,06,State Senate,26,Joel Koskan,REP,52
+Lyman,07,State Senate,26,Shawn Bordeaux,DEM,175
+Lyman,07,State Senate,26,Joel Koskan,REP,10
+Lyman,09,State Senate,26,Shawn Bordeaux,DEM,68
+Lyman,09,State Senate,26,Joel Koskan,REP,112
+Lyman,12,State Senate,26,Shawn Bordeaux,DEM,121
+Lyman,12,State Senate,26,Joel Koskan,REP,143
+Lyman,13,State Senate,26,Shawn Bordeaux,DEM,24
+Lyman,13,State Senate,26,Joel Koskan,REP,34
+Lyman,01,State House,26B,Rebecca Reimer,REP,50
+Lyman,04,State House,26B,Rebecca Reimer,REP,207
+Lyman,06,State House,26B,Rebecca Reimer,REP,96
+Lyman,07,State House,26B,Rebecca Reimer,REP,43
+Lyman,09,State House,26B,Rebecca Reimer,REP,179
+Lyman,12,State House,26B,Rebecca Reimer,REP,284
+Lyman,13,State House,26B,Rebecca Reimer,REP,69
+Lyman,01,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,33
+Lyman,04,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,121
+Lyman,06,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,50
+Lyman,07,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,53
+Lyman,09,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,91
+Lyman,12,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,159
+Lyman,13,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,36
+Lyman,01,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,32
+Lyman,04,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,113
+Lyman,06,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,43
+Lyman,07,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,47
+Lyman,09,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,85
+Lyman,12,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,158
+Lyman,13,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,34
+Lyman,01,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,32
+Lyman,04,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,117
+Lyman,06,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,46
+Lyman,07,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,46
+Lyman,09,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,80
+Lyman,12,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,159
+Lyman,13,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,31
+Lyman,01,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,38
+Lyman,04,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,115
+Lyman,06,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,44
+Lyman,07,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,65
+Lyman,09,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,83
+Lyman,12,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,159
+Lyman,13,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,31
+Lyman,01,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,44
+Lyman,01,Supreme Court Retention,3,Patricia J. DeVaney - No,,8
+Lyman,04,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,191
+Lyman,04,Supreme Court Retention,3,Patricia J. DeVaney - No,,57
+Lyman,06,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,89
+Lyman,06,Supreme Court Retention,3,Patricia J. DeVaney - No,,16
+Lyman,07,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,94
+Lyman,07,Supreme Court Retention,3,Patricia J. DeVaney - No,,65
+Lyman,09,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,145
+Lyman,09,Supreme Court Retention,3,Patricia J. DeVaney - No,,31
+Lyman,12,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,251
+Lyman,12,Supreme Court Retention,3,Patricia J. DeVaney - No,,49
+Lyman,13,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,60
+Lyman,13,Supreme Court Retention,3,Patricia J. DeVaney - No,,10
+Lyman,01,Supreme Court Retention,2,Mark E. Salter - Yes,,44
+Lyman,01,Supreme Court Retention,2,Mark E. Salter - No,,8
+Lyman,04,Supreme Court Retention,2,Mark E. Salter - Yes,,192
+Lyman,04,Supreme Court Retention,2,Mark E. Salter - No,,53
+Lyman,06,Supreme Court Retention,2,Mark E. Salter - Yes,,85
+Lyman,06,Supreme Court Retention,2,Mark E. Salter - No,,17
+Lyman,07,Supreme Court Retention,2,Mark E. Salter - Yes,,81
+Lyman,07,Supreme Court Retention,2,Mark E. Salter - No,,72
+Lyman,09,Supreme Court Retention,2,Mark E. Salter - Yes,,147
+Lyman,09,Supreme Court Retention,2,Mark E. Salter - No,,33
+Lyman,12,Supreme Court Retention,2,Mark E. Salter - Yes,,255
+Lyman,12,Supreme Court Retention,2,Mark E. Salter - No,,42
+Lyman,13,Supreme Court Retention,2,Mark E. Salter - Yes,,60
+Lyman,13,Supreme Court Retention,2,Mark E. Salter - No,,9
+Lyman,01,Constitutional Amendment D,,Yes,,22
+Lyman,01,Constitutional Amendment D,,No,,41
+Lyman,04,Constitutional Amendment D,,Yes,,143
+Lyman,04,Constitutional Amendment D,,No,,131
+Lyman,06,Constitutional Amendment D,,Yes,,71
+Lyman,06,Constitutional Amendment D,,No,,47
+Lyman,07,Constitutional Amendment D,,Yes,,172
+Lyman,07,Constitutional Amendment D,,No,,20
+Lyman,09,Constitutional Amendment D,,Yes,,110
+Lyman,09,Constitutional Amendment D,,No,,99
+Lyman,12,Constitutional Amendment D,,Yes,,183
+Lyman,12,Constitutional Amendment D,,No,,145
+Lyman,13,Constitutional Amendment D,,Yes,,39
+Lyman,13,Constitutional Amendment D,,No,,44
+Lyman,01,Initiated Measure 27,,Yes,,12
+Lyman,01,Initiated Measure 27,,No,,52
+Lyman,04,Initiated Measure 27,,Yes,,121
+Lyman,04,Initiated Measure 27,,No,,156
+Lyman,06,Initiated Measure 27,,Yes,,47
+Lyman,06,Initiated Measure 27,,No,,74
+Lyman,07,Initiated Measure 27,,Yes,,160
+Lyman,07,Initiated Measure 27,,No,,31
+Lyman,09,Initiated Measure 27,,Yes,,61
+Lyman,09,Initiated Measure 27,,No,,152
+Lyman,12,Initiated Measure 27,,Yes,,123
+Lyman,12,Initiated Measure 27,,No,,219
+Lyman,13,Initiated Measure 27,,Yes,,28
+Lyman,13,Initiated Measure 27,,No,,58

--- a/2022/counties/20221108__sd__general__marshall__precinct.csv
+++ b/2022/counties/20221108__sd__general__marshall__precinct.csv
@@ -1,0 +1,343 @@
+county,precinct,office,district,candidate,party,votes
+Marshall,A1,U.S. Senate,,Brian L. Bengs,DEM,62
+Marshall,A1,U.S. Senate,,Tamara J Lesnar,LIB,10
+Marshall,A1,U.S. Senate,,John R. Thune,REP,125
+Marshall,A2,U.S. Senate,,Brian L. Bengs,DEM,53
+Marshall,A2,U.S. Senate,,Tamara J Lesnar,LIB,6
+Marshall,A2,U.S. Senate,,John R. Thune,REP,125
+Marshall,A3,U.S. Senate,,Brian L. Bengs,DEM,46
+Marshall,A3,U.S. Senate,,Tamara J Lesnar,LIB,3
+Marshall,A3,U.S. Senate,,John R. Thune,REP,91
+Marshall,A4,U.S. Senate,,Brian L. Bengs,DEM,69
+Marshall,A4,U.S. Senate,,Tamara J Lesnar,LIB,4
+Marshall,A4,U.S. Senate,,John R. Thune,REP,167
+Marshall,A5,U.S. Senate,,Brian L. Bengs,DEM,49
+Marshall,A5,U.S. Senate,,Tamara J Lesnar,LIB,8
+Marshall,A5,U.S. Senate,,John R. Thune,REP,103
+Marshall,A6,U.S. Senate,,Brian L. Bengs,DEM,98
+Marshall,A6,U.S. Senate,,Tamara J Lesnar,LIB,12
+Marshall,A6,U.S. Senate,,John R. Thune,REP,190
+Marshall,A7,U.S. Senate,,Brian L. Bengs,DEM,50
+Marshall,A7,U.S. Senate,,Tamara J Lesnar,LIB,5
+Marshall,A7,U.S. Senate,,John R. Thune,REP,129
+Marshall,A8,U.S. Senate,,Brian L. Bengs,DEM,40
+Marshall,A8,U.S. Senate,,Tamara J Lesnar,LIB,6
+Marshall,A8,U.S. Senate,,John R. Thune,REP,158
+Marshall,A9,U.S. Senate,,Brian L. Bengs,DEM,78
+Marshall,A9,U.S. Senate,,Tamara J Lesnar,LIB,8
+Marshall,A9,U.S. Senate,,John R. Thune,REP,184
+Marshall,A1,U.S. House,1,Collin Duprel,LIB,49
+Marshall,A1,U.S. House,1,Dusty Johnson,REP,132
+Marshall,A2,U.S. House,1,Collin Duprel,LIB,35
+Marshall,A2,U.S. House,1,Dusty Johnson,REP,139
+Marshall,A3,U.S. House,1,Collin Duprel,LIB,30
+Marshall,A3,U.S. House,1,Dusty Johnson,REP,97
+Marshall,A4,U.S. House,1,Collin Duprel,LIB,51
+Marshall,A4,U.S. House,1,Dusty Johnson,REP,176
+Marshall,A5,U.S. House,1,Collin Duprel,LIB,44
+Marshall,A5,U.S. House,1,Dusty Johnson,REP,105
+Marshall,A6,U.S. House,1,Collin Duprel,LIB,70
+Marshall,A6,U.S. House,1,Dusty Johnson,REP,220
+Marshall,A7,U.S. House,1,Collin Duprel,LIB,32
+Marshall,A7,U.S. House,1,Dusty Johnson,REP,140
+Marshall,A8,U.S. House,1,Collin Duprel,LIB,24
+Marshall,A8,U.S. House,1,Dusty Johnson,REP,174
+Marshall,A9,U.S. House,1,Collin Duprel,LIB,56
+Marshall,A9,U.S. House,1,Dusty Johnson,REP,195
+Marshall,A1,Governor,,Jamie Smith and Jennifer Keintz,DEM,82
+Marshall,A1,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Marshall,A1,Governor,,Kristi Noem and Larry Rhoden,REP,110
+Marshall,A2,Governor,,Jamie Smith and Jennifer Keintz,DEM,73
+Marshall,A2,Governor,,Tracey Quint and Ashley Strand,LIB,8
+Marshall,A2,Governor,,Kristi Noem and Larry Rhoden,REP,104
+Marshall,A3,Governor,,Jamie Smith and Jennifer Keintz,DEM,59
+Marshall,A3,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Marshall,A3,Governor,,Kristi Noem and Larry Rhoden,REP,83
+Marshall,A4,Governor,,Jamie Smith and Jennifer Keintz,DEM,103
+Marshall,A4,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Marshall,A4,Governor,,Kristi Noem and Larry Rhoden,REP,132
+Marshall,A5,Governor,,Jamie Smith and Jennifer Keintz,DEM,65
+Marshall,A5,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Marshall,A5,Governor,,Kristi Noem and Larry Rhoden,REP,94
+Marshall,A6,Governor,,Jamie Smith and Jennifer Keintz,DEM,130
+Marshall,A6,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Marshall,A6,Governor,,Kristi Noem and Larry Rhoden,REP,172
+Marshall,A7,Governor,,Jamie Smith and Jennifer Keintz,DEM,66
+Marshall,A7,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Marshall,A7,Governor,,Kristi Noem and Larry Rhoden,REP,119
+Marshall,A8,Governor,,Jamie Smith and Jennifer Keintz,DEM,65
+Marshall,A8,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Marshall,A8,Governor,,Kristi Noem and Larry Rhoden,REP,137
+Marshall,A9,Governor,,Jamie Smith and Jennifer Keintz,DEM,94
+Marshall,A9,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Marshall,A9,Governor,,Kristi Noem and Larry Rhoden,REP,172
+Marshall,A1,Secretary of State,,Thomas A Cool,DEM,77
+Marshall,A1,Secretary of State,,Monae Johnson,REP,108
+Marshall,A2,Secretary of State,,Thomas A Cool,DEM,76
+Marshall,A2,Secretary of State,,Monae Johnson,REP,98
+Marshall,A3,Secretary of State,,Thomas A Cool,DEM,58
+Marshall,A3,Secretary of State,,Monae Johnson,REP,77
+Marshall,A4,Secretary of State,,Thomas A Cool,DEM,102
+Marshall,A4,Secretary of State,,Monae Johnson,REP,126
+Marshall,A5,Secretary of State,,Thomas A Cool,DEM,70
+Marshall,A5,Secretary of State,,Monae Johnson,REP,85
+Marshall,A6,Secretary of State,,Thomas A Cool,DEM,128
+Marshall,A6,Secretary of State,,Monae Johnson,REP,164
+Marshall,A7,Secretary of State,,Thomas A Cool,DEM,66
+Marshall,A7,Secretary of State,,Monae Johnson,REP,105
+Marshall,A8,Secretary of State,,Thomas A Cool,DEM,70
+Marshall,A8,Secretary of State,,Monae Johnson,REP,123
+Marshall,A9,Secretary of State,,Thomas A Cool,DEM,104
+Marshall,A9,Secretary of State,,Monae Johnson,REP,150
+Marshall,A1,Attorney General,,Marty J. Jackley,REP,139
+Marshall,A2,Attorney General,,Marty J. Jackley,REP,132
+Marshall,A3,Attorney General,,Marty J. Jackley,REP,101
+Marshall,A4,Attorney General,,Marty J. Jackley,REP,167
+Marshall,A5,Attorney General,,Marty J. Jackley,REP,106
+Marshall,A6,Attorney General,,Marty J. Jackley,REP,221
+Marshall,A7,Attorney General,,Marty J. Jackley,REP,133
+Marshall,A8,Attorney General,,Marty J. Jackley,REP,161
+Marshall,A9,Attorney General,,Marty J. Jackley,REP,191
+Marshall,A1,State Auditor,,Stephanie Marty,DEM,65
+Marshall,A1,State Auditor,,Rene Meyer,LIB,5
+Marshall,A1,State Auditor,,Richard Sattgast,REP,108
+Marshall,A2,State Auditor,,Stephanie Marty,DEM,65
+Marshall,A2,State Auditor,,Rene Meyer,LIB,15
+Marshall,A2,State Auditor,,Richard Sattgast,REP,94
+Marshall,A3,State Auditor,,Stephanie Marty,DEM,47
+Marshall,A3,State Auditor,,Rene Meyer,LIB,7
+Marshall,A3,State Auditor,,Richard Sattgast,REP,79
+Marshall,A4,State Auditor,,Stephanie Marty,DEM,95
+Marshall,A4,State Auditor,,Rene Meyer,LIB,11
+Marshall,A4,State Auditor,,Richard Sattgast,REP,116
+Marshall,A5,State Auditor,,Stephanie Marty,DEM,61
+Marshall,A5,State Auditor,,Rene Meyer,LIB,10
+Marshall,A5,State Auditor,,Richard Sattgast,REP,76
+Marshall,A6,State Auditor,,Stephanie Marty,DEM,123
+Marshall,A6,State Auditor,,Rene Meyer,LIB,8
+Marshall,A6,State Auditor,,Richard Sattgast,REP,159
+Marshall,A7,State Auditor,,Stephanie Marty,DEM,56
+Marshall,A7,State Auditor,,Rene Meyer,LIB,4
+Marshall,A7,State Auditor,,Richard Sattgast,REP,111
+Marshall,A8,State Auditor,,Stephanie Marty,DEM,57
+Marshall,A8,State Auditor,,Rene Meyer,LIB,7
+Marshall,A8,State Auditor,,Richard Sattgast,REP,126
+Marshall,A9,State Auditor,,Stephanie Marty,DEM,93
+Marshall,A9,State Auditor,,Rene Meyer,LIB,10
+Marshall,A9,State Auditor,,Richard Sattgast,REP,149
+Marshall,A1,State Treasurer,,John Cunningham,DEM,67
+Marshall,A1,State Treasurer,,Josh Haeder,REP,111
+Marshall,A2,State Treasurer,,John Cunningham,DEM,68
+Marshall,A2,State Treasurer,,Josh Haeder,REP,101
+Marshall,A3,State Treasurer,,John Cunningham,DEM,53
+Marshall,A3,State Treasurer,,Josh Haeder,REP,81
+Marshall,A4,State Treasurer,,John Cunningham,DEM,97
+Marshall,A4,State Treasurer,,Josh Haeder,REP,124
+Marshall,A5,State Treasurer,,John Cunningham,DEM,64
+Marshall,A5,State Treasurer,,Josh Haeder,REP,80
+Marshall,A6,State Treasurer,,John Cunningham,DEM,120
+Marshall,A6,State Treasurer,,Josh Haeder,REP,167
+Marshall,A7,State Treasurer,,John Cunningham,DEM,59
+Marshall,A7,State Treasurer,,Josh Haeder,REP,112
+Marshall,A8,State Treasurer,,John Cunningham,DEM,63
+Marshall,A8,State Treasurer,,Josh Haeder,REP,126
+Marshall,A9,State Treasurer,,John Cunningham,DEM,96
+Marshall,A9,State Treasurer,,Josh Haeder,REP,154
+Marshall,A1,Commissioner of School and Public Lands,,Timothy Azure,DEM,64
+Marshall,A1,Commissioner of School and Public Lands,,Brock Greenfield,REP,116
+Marshall,A2,Commissioner of School and Public Lands,,Timothy Azure,DEM,63
+Marshall,A2,Commissioner of School and Public Lands,,Brock Greenfield,REP,99
+Marshall,A3,Commissioner of School and Public Lands,,Timothy Azure,DEM,50
+Marshall,A3,Commissioner of School and Public Lands,,Brock Greenfield,REP,77
+Marshall,A4,Commissioner of School and Public Lands,,Timothy Azure,DEM,86
+Marshall,A4,Commissioner of School and Public Lands,,Brock Greenfield,REP,132
+Marshall,A5,Commissioner of School and Public Lands,,Timothy Azure,DEM,69
+Marshall,A5,Commissioner of School and Public Lands,,Brock Greenfield,REP,79
+Marshall,A6,Commissioner of School and Public Lands,,Timothy Azure,DEM,121
+Marshall,A6,Commissioner of School and Public Lands,,Brock Greenfield,REP,167
+Marshall,A7,Commissioner of School and Public Lands,,Timothy Azure,DEM,60
+Marshall,A7,Commissioner of School and Public Lands,,Brock Greenfield,REP,112
+Marshall,A8,Commissioner of School and Public Lands,,Timothy Azure,DEM,55
+Marshall,A8,Commissioner of School and Public Lands,,Brock Greenfield,REP,133
+Marshall,A9,Commissioner of School and Public Lands,,Timothy Azure,DEM,100
+Marshall,A9,Commissioner of School and Public Lands,,Brock Greenfield,REP,153
+Marshall,A1,Public Utilities Commissioner,,Jeffrey Barth,DEM,59
+Marshall,A1,Public Utilities Commissioner,,Chris Nelson,REP,123
+Marshall,A2,Public Utilities Commissioner,,Jeffrey Barth,DEM,56
+Marshall,A2,Public Utilities Commissioner,,Chris Nelson,REP,111
+Marshall,A3,Public Utilities Commissioner,,Jeffrey Barth,DEM,43
+Marshall,A3,Public Utilities Commissioner,,Chris Nelson,REP,86
+Marshall,A4,Public Utilities Commissioner,,Jeffrey Barth,DEM,83
+Marshall,A4,Public Utilities Commissioner,,Chris Nelson,REP,145
+Marshall,A5,Public Utilities Commissioner,,Jeffrey Barth,DEM,65
+Marshall,A5,Public Utilities Commissioner,,Chris Nelson,REP,83
+Marshall,A6,Public Utilities Commissioner,,Jeffrey Barth,DEM,108
+Marshall,A6,Public Utilities Commissioner,,Chris Nelson,REP,183
+Marshall,A7,Public Utilities Commissioner,,Jeffrey Barth,DEM,54
+Marshall,A7,Public Utilities Commissioner,,Chris Nelson,REP,120
+Marshall,A8,Public Utilities Commissioner,,Jeffrey Barth,DEM,51
+Marshall,A8,Public Utilities Commissioner,,Chris Nelson,REP,140
+Marshall,A9,Public Utilities Commissioner,,Jeffrey Barth,DEM,76
+Marshall,A9,Public Utilities Commissioner,,Chris Nelson,REP,177
+Marshall,A1,State Senate,01,Michael H. Rohl,REP,103
+Marshall,A1,State Senate,01,Susan Wismer,IND,88
+Marshall,A2,State Senate,01,Michael H. Rohl,REP,85
+Marshall,A2,State Senate,01,Susan Wismer,IND,97
+Marshall,A3,State Senate,01,Michael H. Rohl,REP,80
+Marshall,A3,State Senate,01,Susan Wismer,IND,58
+Marshall,A4,State Senate,01,Michael H. Rohl,REP,116
+Marshall,A4,State Senate,01,Susan Wismer,IND,117
+Marshall,A5,State Senate,01,Michael H. Rohl,REP,81
+Marshall,A5,State Senate,01,Susan Wismer,IND,75
+Marshall,A6,State Senate,01,Michael H. Rohl,REP,168
+Marshall,A6,State Senate,01,Susan Wismer,IND,132
+Marshall,A7,State Senate,01,Michael H. Rohl,REP,120
+Marshall,A7,State Senate,01,Susan Wismer,IND,60
+Marshall,A8,State Senate,01,Michael H. Rohl,REP,127
+Marshall,A8,State Senate,01,Susan Wismer,IND,75
+Marshall,A9,State Senate,01,Michael H. Rohl,REP,157
+Marshall,A9,State Senate,01,Susan Wismer,IND,111
+Marshall,A1,State House,01,Steven D. McCleerey,DEM,79
+Marshall,A1,State House,01,Kay F. Nikolas,DEM,58
+Marshall,A1,State House,01,Joe Donnell,REP,88
+Marshall,A1,State House,01,Tamara St John,REP,108
+Marshall,A2,State House,01,Steven D. McCleerey,DEM,68
+Marshall,A2,State House,01,Kay F. Nikolas,DEM,66
+Marshall,A2,State House,01,Joe Donnell,REP,67
+Marshall,A2,State House,01,Tamara St John,REP,96
+Marshall,A3,State House,01,Steven D. McCleerey,DEM,61
+Marshall,A3,State House,01,Kay F. Nikolas,DEM,48
+Marshall,A3,State House,01,Joe Donnell,REP,60
+Marshall,A3,State House,01,Tamara St John,REP,70
+Marshall,A4,State House,01,Steven D. McCleerey,DEM,107
+Marshall,A4,State House,01,Kay F. Nikolas,DEM,75
+Marshall,A4,State House,01,Joe Donnell,REP,92
+Marshall,A4,State House,01,Tamara St John,REP,106
+Marshall,A5,State House,01,Steven D. McCleerey,DEM,65
+Marshall,A5,State House,01,Kay F. Nikolas,DEM,45
+Marshall,A5,State House,01,Joe Donnell,REP,72
+Marshall,A5,State House,01,Tamara St John,REP,72
+Marshall,A6,State House,01,Steven D. McCleerey,DEM,136
+Marshall,A6,State House,01,Kay F. Nikolas,DEM,100
+Marshall,A6,State House,01,Joe Donnell,REP,136
+Marshall,A6,State House,01,Tamara St John,REP,158
+Marshall,A7,State House,01,Steven D. McCleerey,DEM,70
+Marshall,A7,State House,01,Kay F. Nikolas,DEM,43
+Marshall,A7,State House,01,Joe Donnell,REP,80
+Marshall,A7,State House,01,Tamara St John,REP,103
+Marshall,A8,State House,01,Steven D. McCleerey,DEM,71
+Marshall,A8,State House,01,Kay F. Nikolas,DEM,46
+Marshall,A8,State House,01,Joe Donnell,REP,100
+Marshall,A8,State House,01,Tamara St John,REP,121
+Marshall,A9,State House,01,Steven D. McCleerey,DEM,125
+Marshall,A9,State House,01,Kay F. Nikolas,DEM,73
+Marshall,A9,State House,01,Joe Donnell,REP,117
+Marshall,A9,State House,01,Tamara St John,REP,144
+Marshall,A1,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,96
+Marshall,A2,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,83
+Marshall,A3,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,67
+Marshall,A4,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,124
+Marshall,A5,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,59
+Marshall,A6,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,131
+Marshall,A7,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,60
+Marshall,A8,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,91
+Marshall,A9,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,115
+Marshall,A1,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,99
+Marshall,A2,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,86
+Marshall,A3,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,69
+Marshall,A4,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,121
+Marshall,A5,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,60
+Marshall,A6,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,133
+Marshall,A7,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,55
+Marshall,A8,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,102
+Marshall,A9,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,115
+Marshall,A1,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,93
+Marshall,A2,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,77
+Marshall,A3,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,65
+Marshall,A4,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,108
+Marshall,A5,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,54
+Marshall,A6,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,125
+Marshall,A7,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,53
+Marshall,A8,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,89
+Marshall,A9,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,106
+Marshall,A1,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,118
+Marshall,A2,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,108
+Marshall,A3,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,84
+Marshall,A4,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,142
+Marshall,A5,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,88
+Marshall,A6,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,176
+Marshall,A7,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,125
+Marshall,A8,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,134
+Marshall,A9,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,151
+Marshall,A1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,130
+Marshall,A1,Supreme Court Retention,3,Patricia J. DeVaney - No,,33
+Marshall,A2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,127
+Marshall,A2,Supreme Court Retention,3,Patricia J. DeVaney - No,,31
+Marshall,A3,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,98
+Marshall,A3,Supreme Court Retention,3,Patricia J. DeVaney - No,,28
+Marshall,A4,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,163
+Marshall,A4,Supreme Court Retention,3,Patricia J. DeVaney - No,,31
+Marshall,A5,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,100
+Marshall,A5,Supreme Court Retention,3,Patricia J. DeVaney - No,,30
+Marshall,A6,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,228
+Marshall,A6,Supreme Court Retention,3,Patricia J. DeVaney - No,,36
+Marshall,A7,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,118
+Marshall,A7,Supreme Court Retention,3,Patricia J. DeVaney - No,,30
+Marshall,A8,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,136
+Marshall,A8,Supreme Court Retention,3,Patricia J. DeVaney - No,,35
+Marshall,A9,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,175
+Marshall,A9,Supreme Court Retention,3,Patricia J. DeVaney - No,,46
+Marshall,A1,Supreme Court Retention,2,Mark E. Salter - Yes,,132
+Marshall,A1,Supreme Court Retention,2,Mark E. Salter - No,,32
+Marshall,A2,Supreme Court Retention,2,Mark E. Salter - Yes,,128
+Marshall,A2,Supreme Court Retention,2,Mark E. Salter - No,,28
+Marshall,A3,Supreme Court Retention,2,Mark E. Salter - Yes,,105
+Marshall,A3,Supreme Court Retention,2,Mark E. Salter - No,,22
+Marshall,A4,Supreme Court Retention,2,Mark E. Salter - Yes,,161
+Marshall,A4,Supreme Court Retention,2,Mark E. Salter - No,,33
+Marshall,A5,Supreme Court Retention,2,Mark E. Salter - Yes,,100
+Marshall,A5,Supreme Court Retention,2,Mark E. Salter - No,,28
+Marshall,A6,Supreme Court Retention,2,Mark E. Salter - Yes,,227
+Marshall,A6,Supreme Court Retention,2,Mark E. Salter - No,,37
+Marshall,A7,Supreme Court Retention,2,Mark E. Salter - Yes,,114
+Marshall,A7,Supreme Court Retention,2,Mark E. Salter - No,,35
+Marshall,A8,Supreme Court Retention,2,Mark E. Salter - Yes,,134
+Marshall,A8,Supreme Court Retention,2,Mark E. Salter - No,,32
+Marshall,A9,Supreme Court Retention,2,Mark E. Salter - Yes,,173
+Marshall,A9,Supreme Court Retention,2,Mark E. Salter - No,,42
+Marshall,A1,Constitutional Amendment D,,Yes,,105
+Marshall,A1,Constitutional Amendment D,,No,,83
+Marshall,A2,Constitutional Amendment D,,Yes,,115
+Marshall,A2,Constitutional Amendment D,,No,,59
+Marshall,A3,Constitutional Amendment D,,Yes,,80
+Marshall,A3,Constitutional Amendment D,,No,,59
+Marshall,A4,Constitutional Amendment D,,Yes,,138
+Marshall,A4,Constitutional Amendment D,,No,,89
+Marshall,A5,Constitutional Amendment D,,Yes,,100
+Marshall,A5,Constitutional Amendment D,,No,,56
+Marshall,A6,Constitutional Amendment D,,Yes,,187
+Marshall,A6,Constitutional Amendment D,,No,,109
+Marshall,A7,Constitutional Amendment D,,Yes,,95
+Marshall,A7,Constitutional Amendment D,,No,,74
+Marshall,A8,Constitutional Amendment D,,Yes,,101
+Marshall,A8,Constitutional Amendment D,,No,,94
+Marshall,A9,Constitutional Amendment D,,Yes,,159
+Marshall,A9,Constitutional Amendment D,,No,,101
+Marshall,A1,Initiated Measure 27,,Yes,,104
+Marshall,A1,Initiated Measure 27,,No,,89
+Marshall,A2,Initiated Measure 27,,Yes,,98
+Marshall,A2,Initiated Measure 27,,No,,77
+Marshall,A3,Initiated Measure 27,,Yes,,66
+Marshall,A3,Initiated Measure 27,,No,,72
+Marshall,A4,Initiated Measure 27,,Yes,,127
+Marshall,A4,Initiated Measure 27,,No,,103
+Marshall,A5,Initiated Measure 27,,Yes,,71
+Marshall,A5,Initiated Measure 27,,No,,85
+Marshall,A6,Initiated Measure 27,,Yes,,137
+Marshall,A6,Initiated Measure 27,,No,,166
+Marshall,A7,Initiated Measure 27,,Yes,,68
+Marshall,A7,Initiated Measure 27,,No,,104
+Marshall,A8,Initiated Measure 27,,Yes,,76
+Marshall,A8,Initiated Measure 27,,No,,125
+Marshall,A9,Initiated Measure 27,,Yes,,111
+Marshall,A9,Initiated Measure 27,,No,,156

--- a/2022/counties/20221108__sd__general__mccook__precinct.csv
+++ b/2022/counties/20221108__sd__general__mccook__precinct.csv
@@ -1,0 +1,229 @@
+county,precinct,office,district,candidate,party,votes
+McCook,01,U.S. Senate,,Brian L. Bengs,DEM,118
+McCook,01,U.S. Senate,,Tamara J Lesnar,LIB,14
+McCook,01,U.S. Senate,,John R. Thune,REP,389
+McCook,02,U.S. Senate,,Brian L. Bengs,DEM,27
+McCook,02,U.S. Senate,,Tamara J Lesnar,LIB,4
+McCook,02,U.S. Senate,,John R. Thune,REP,116
+McCook,03,U.S. Senate,,Brian L. Bengs,DEM,86
+McCook,03,U.S. Senate,,Tamara J Lesnar,LIB,27
+McCook,03,U.S. Senate,,John R. Thune,REP,440
+McCook,04,U.S. Senate,,Brian L. Bengs,DEM,37
+McCook,04,U.S. Senate,,Tamara J Lesnar,LIB,11
+McCook,04,U.S. Senate,,John R. Thune,REP,387
+McCook,05,U.S. Senate,,Brian L. Bengs,DEM,103
+McCook,05,U.S. Senate,,Tamara J Lesnar,LIB,27
+McCook,05,U.S. Senate,,John R. Thune,REP,439
+McCook,06,U.S. Senate,,Brian L. Bengs,DEM,37
+McCook,06,U.S. Senate,,Tamara J Lesnar,LIB,9
+McCook,06,U.S. Senate,,John R. Thune,REP,262
+McCook,01,U.S. House,1,Collin Duprel,LIB,105
+McCook,01,U.S. House,1,Dusty Johnson,REP,391
+McCook,02,U.S. House,1,Collin Duprel,LIB,25
+McCook,02,U.S. House,1,Dusty Johnson,REP,116
+McCook,03,U.S. House,1,Collin Duprel,LIB,93
+McCook,03,U.S. House,1,Dusty Johnson,REP,438
+McCook,04,U.S. House,1,Collin Duprel,LIB,42
+McCook,04,U.S. House,1,Dusty Johnson,REP,383
+McCook,05,U.S. House,1,Collin Duprel,LIB,83
+McCook,05,U.S. House,1,Dusty Johnson,REP,470
+McCook,06,U.S. House,1,Collin Duprel,LIB,41
+McCook,06,U.S. House,1,Dusty Johnson,REP,256
+McCook,01,Governor,,Jamie Smith and Jennifer Keintz,DEM,163
+McCook,01,Governor,,Tracey Quint and Ashley Strand,LIB,7
+McCook,01,Governor,,Kristi Noem and Larry Rhoden,REP,354
+McCook,02,Governor,,Jamie Smith and Jennifer Keintz,DEM,40
+McCook,02,Governor,,Tracey Quint and Ashley Strand,LIB,7
+McCook,02,Governor,,Kristi Noem and Larry Rhoden,REP,98
+McCook,03,Governor,,Jamie Smith and Jennifer Keintz,DEM,141
+McCook,03,Governor,,Tracey Quint and Ashley Strand,LIB,19
+McCook,03,Governor,,Kristi Noem and Larry Rhoden,REP,396
+McCook,04,Governor,,Jamie Smith and Jennifer Keintz,DEM,67
+McCook,04,Governor,,Tracey Quint and Ashley Strand,LIB,6
+McCook,04,Governor,,Kristi Noem and Larry Rhoden,REP,366
+McCook,05,Governor,,Jamie Smith and Jennifer Keintz,DEM,152
+McCook,05,Governor,,Tracey Quint and Ashley Strand,LIB,28
+McCook,05,Governor,,Kristi Noem and Larry Rhoden,REP,396
+McCook,06,Governor,,Jamie Smith and Jennifer Keintz,DEM,62
+McCook,06,Governor,,Tracey Quint and Ashley Strand,LIB,4
+McCook,06,Governor,,Kristi Noem and Larry Rhoden,REP,241
+McCook,01,Secretary of State,,Thomas A Cool,DEM,159
+McCook,01,Secretary of State,,Monae Johnson,REP,336
+McCook,02,Secretary of State,,Thomas A Cool,DEM,46
+McCook,02,Secretary of State,,Monae Johnson,REP,94
+McCook,03,Secretary of State,,Thomas A Cool,DEM,151
+McCook,03,Secretary of State,,Monae Johnson,REP,367
+McCook,04,Secretary of State,,Thomas A Cool,DEM,66
+McCook,04,Secretary of State,,Monae Johnson,REP,346
+McCook,05,Secretary of State,,Thomas A Cool,DEM,165
+McCook,05,Secretary of State,,Monae Johnson,REP,381
+McCook,06,Secretary of State,,Thomas A Cool,DEM,82
+McCook,06,Secretary of State,,Monae Johnson,REP,211
+McCook,01,Attorney General,,Marty J. Jackley,REP,391
+McCook,02,Attorney General,,Marty J. Jackley,REP,118
+McCook,03,Attorney General,,Marty J. Jackley,REP,441
+McCook,04,Attorney General,,Marty J. Jackley,REP,378
+McCook,05,Attorney General,,Marty J. Jackley,REP,453
+McCook,06,Attorney General,,Marty J. Jackley,REP,255
+McCook,01,State Auditor,,Stephanie Marty,DEM,149
+McCook,01,State Auditor,,Rene Meyer,LIB,23
+McCook,01,State Auditor,,Richard Sattgast,REP,320
+McCook,02,State Auditor,,Stephanie Marty,DEM,37
+McCook,02,State Auditor,,Rene Meyer,LIB,8
+McCook,02,State Auditor,,Richard Sattgast,REP,96
+McCook,03,State Auditor,,Stephanie Marty,DEM,118
+McCook,03,State Auditor,,Rene Meyer,LIB,34
+McCook,03,State Auditor,,Richard Sattgast,REP,364
+McCook,04,State Auditor,,Stephanie Marty,DEM,56
+McCook,04,State Auditor,,Rene Meyer,LIB,13
+McCook,04,State Auditor,,Richard Sattgast,REP,338
+McCook,05,State Auditor,,Stephanie Marty,DEM,145
+McCook,05,State Auditor,,Rene Meyer,LIB,28
+McCook,05,State Auditor,,Richard Sattgast,REP,370
+McCook,06,State Auditor,,Stephanie Marty,DEM,60
+McCook,06,State Auditor,,Rene Meyer,LIB,10
+McCook,06,State Auditor,,Richard Sattgast,REP,219
+McCook,01,State Treasurer,,John Cunningham,DEM,153
+McCook,01,State Treasurer,,Josh Haeder,REP,331
+McCook,02,State Treasurer,,John Cunningham,DEM,46
+McCook,02,State Treasurer,,Josh Haeder,REP,93
+McCook,03,State Treasurer,,John Cunningham,DEM,129
+McCook,03,State Treasurer,,Josh Haeder,REP,376
+McCook,04,State Treasurer,,John Cunningham,DEM,56
+McCook,04,State Treasurer,,Josh Haeder,REP,350
+McCook,05,State Treasurer,,John Cunningham,DEM,147
+McCook,05,State Treasurer,,Josh Haeder,REP,384
+McCook,06,State Treasurer,,John Cunningham,DEM,74
+McCook,06,State Treasurer,,Josh Haeder,REP,218
+McCook,01,Commissioner of School and Public Lands,,Timothy Azure,DEM,148
+McCook,01,Commissioner of School and Public Lands,,Brock Greenfield,REP,320
+McCook,02,Commissioner of School and Public Lands,,Timothy Azure,DEM,38
+McCook,02,Commissioner of School and Public Lands,,Brock Greenfield,REP,100
+McCook,03,Commissioner of School and Public Lands,,Timothy Azure,DEM,116
+McCook,03,Commissioner of School and Public Lands,,Brock Greenfield,REP,377
+McCook,04,Commissioner of School and Public Lands,,Timothy Azure,DEM,49
+McCook,04,Commissioner of School and Public Lands,,Brock Greenfield,REP,347
+McCook,05,Commissioner of School and Public Lands,,Timothy Azure,DEM,146
+McCook,05,Commissioner of School and Public Lands,,Brock Greenfield,REP,380
+McCook,06,Commissioner of School and Public Lands,,Timothy Azure,DEM,61
+McCook,06,Commissioner of School and Public Lands,,Brock Greenfield,REP,226
+McCook,01,Public Utilities Commissioner,,Jeffrey Barth,DEM,137
+McCook,01,Public Utilities Commissioner,,Chris Nelson,REP,352
+McCook,02,Public Utilities Commissioner,,Jeffrey Barth,DEM,33
+McCook,02,Public Utilities Commissioner,,Chris Nelson,REP,110
+McCook,03,Public Utilities Commissioner,,Jeffrey Barth,DEM,121
+McCook,03,Public Utilities Commissioner,,Chris Nelson,REP,399
+McCook,04,Public Utilities Commissioner,,Jeffrey Barth,DEM,47
+McCook,04,Public Utilities Commissioner,,Chris Nelson,REP,370
+McCook,05,Public Utilities Commissioner,,Jeffrey Barth,DEM,131
+McCook,05,Public Utilities Commissioner,,Chris Nelson,REP,425
+McCook,06,Public Utilities Commissioner,,Jeffrey Barth,DEM,54
+McCook,06,Public Utilities Commissioner,,Chris Nelson,REP,242
+McCook,01,State Senate,19,Russell Graeff,DEM,136
+McCook,01,State Senate,19,Kyle Schoenfish,REP,350
+McCook,02,State Senate,19,Russell Graeff,DEM,37
+McCook,02,State Senate,19,Kyle Schoenfish,REP,104
+McCook,03,State Senate,19,Russell Graeff,DEM,113
+McCook,03,State Senate,19,Kyle Schoenfish,REP,399
+McCook,04,State Senate,19,Russell Graeff,DEM,48
+McCook,04,State Senate,19,Kyle Schoenfish,REP,364
+McCook,05,State Senate,19,Russell Graeff,DEM,125
+McCook,05,State Senate,19,Kyle Schoenfish,REP,417
+McCook,06,State Senate,19,Russell Graeff,DEM,51
+McCook,06,State Senate,19,Kyle Schoenfish,REP,236
+McCook,01,State House,19,Jessica Bahmuller,REP,227
+McCook,01,State House,19,Drew Peterson,REP,331
+McCook,02,State House,19,Jessica Bahmuller,REP,79
+McCook,02,State House,19,Drew Peterson,REP,95
+McCook,03,State House,19,Jessica Bahmuller,REP,285
+McCook,03,State House,19,Drew Peterson,REP,336
+McCook,04,State House,19,Jessica Bahmuller,REP,258
+McCook,04,State House,19,Drew Peterson,REP,284
+McCook,05,State House,19,Jessica Bahmuller,REP,280
+McCook,05,State House,19,Drew Peterson,REP,415
+McCook,06,State House,19,Jessica Bahmuller,REP,164
+McCook,06,State House,19,Drew Peterson,REP,220
+McCook,01,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,219
+McCook,02,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,68
+McCook,03,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,264
+McCook,04,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,206
+McCook,05,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,297
+McCook,06,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,141
+McCook,01,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,213
+McCook,02,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,60
+McCook,03,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,239
+McCook,04,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,185
+McCook,05,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,269
+McCook,06,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,133
+McCook,01,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,196
+McCook,02,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,63
+McCook,03,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,239
+McCook,04,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,186
+McCook,05,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,265
+McCook,06,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,137
+McCook,01,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,200
+McCook,02,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,61
+McCook,03,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,243
+McCook,04,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,192
+McCook,05,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,268
+McCook,06,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,133
+McCook,01,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,199
+McCook,02,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,62
+McCook,03,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,238
+McCook,04,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,184
+McCook,05,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,262
+McCook,06,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,134
+McCook,01,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,201
+McCook,02,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,63
+McCook,03,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,236
+McCook,04,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,189
+McCook,05,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,261
+McCook,06,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,135
+McCook,01,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,348
+McCook,01,Supreme Court Retention,3,Patricia J. DeVaney - No,,74
+McCook,02,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,103
+McCook,02,Supreme Court Retention,3,Patricia J. DeVaney - No,,21
+McCook,03,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,409
+McCook,03,Supreme Court Retention,3,Patricia J. DeVaney - No,,72
+McCook,04,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,285
+McCook,04,Supreme Court Retention,3,Patricia J. DeVaney - No,,83
+McCook,05,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,420
+McCook,05,Supreme Court Retention,3,Patricia J. DeVaney - No,,73
+McCook,06,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,228
+McCook,06,Supreme Court Retention,3,Patricia J. DeVaney - No,,41
+McCook,01,Supreme Court Retention,2,Mark E. Salter - Yes,,353
+McCook,01,Supreme Court Retention,2,Mark E. Salter - No,,71
+McCook,02,Supreme Court Retention,2,Mark E. Salter - Yes,,100
+McCook,02,Supreme Court Retention,2,Mark E. Salter - No,,24
+McCook,03,Supreme Court Retention,2,Mark E. Salter - Yes,,411
+McCook,03,Supreme Court Retention,2,Mark E. Salter - No,,71
+McCook,04,Supreme Court Retention,2,Mark E. Salter - Yes,,287
+McCook,04,Supreme Court Retention,2,Mark E. Salter - No,,77
+McCook,05,Supreme Court Retention,2,Mark E. Salter - Yes,,420
+McCook,05,Supreme Court Retention,2,Mark E. Salter - No,,74
+McCook,06,Supreme Court Retention,2,Mark E. Salter - Yes,,228
+McCook,06,Supreme Court Retention,2,Mark E. Salter - No,,42
+McCook,01,Constitutional Amendment D,,Yes,,247
+McCook,01,Constitutional Amendment D,,No,,251
+McCook,02,Constitutional Amendment D,,Yes,,78
+McCook,02,Constitutional Amendment D,,No,,65
+McCook,03,Constitutional Amendment D,,Yes,,249
+McCook,03,Constitutional Amendment D,,No,,291
+McCook,04,Constitutional Amendment D,,Yes,,169
+McCook,04,Constitutional Amendment D,,No,,262
+McCook,05,Constitutional Amendment D,,Yes,,293
+McCook,05,Constitutional Amendment D,,No,,278
+McCook,06,Constitutional Amendment D,,Yes,,123
+McCook,06,Constitutional Amendment D,,No,,179
+McCook,01,Initiated Measure 27,,Yes,,224
+McCook,01,Initiated Measure 27,,No,,292
+McCook,02,Initiated Measure 27,,Yes,,49
+McCook,02,Initiated Measure 27,,No,,95
+McCook,03,Initiated Measure 27,,Yes,,217
+McCook,03,Initiated Measure 27,,No,,329
+McCook,04,Initiated Measure 27,,Yes,,132
+McCook,04,Initiated Measure 27,,No,,305
+McCook,05,Initiated Measure 27,,Yes,,221
+McCook,05,Initiated Measure 27,,No,,353
+McCook,06,Initiated Measure 27,,Yes,,96
+McCook,06,Initiated Measure 27,,No,,210

--- a/2022/counties/20221108__sd__general__mcpherson__precinct.csv
+++ b/2022/counties/20221108__sd__general__mcpherson__precinct.csv
@@ -1,0 +1,141 @@
+county,precinct,office,district,candidate,party,votes
+McPherson,1,U.S. Senate,,Brian L. Bengs,DEM,30
+McPherson,1,U.S. Senate,,Tamara J Lesnar,LIB,7
+McPherson,1,U.S. Senate,,John R. Thune,REP,227
+McPherson,2,U.S. Senate,,Brian L. Bengs,DEM,21
+McPherson,2,U.S. Senate,,Tamara J Lesnar,LIB,10
+McPherson,2,U.S. Senate,,John R. Thune,REP,233
+McPherson,3,U.S. Senate,,Brian L. Bengs,DEM,24
+McPherson,3,U.S. Senate,,Tamara J Lesnar,LIB,12
+McPherson,3,U.S. Senate,,John R. Thune,REP,228
+McPherson,4,U.S. Senate,,Brian L. Bengs,DEM,33
+McPherson,4,U.S. Senate,,Tamara J Lesnar,LIB,11
+McPherson,4,U.S. Senate,,John R. Thune,REP,266
+McPherson,1,U.S. House,1,Collin Duprel,LIB,34
+McPherson,1,U.S. House,1,Dusty Johnson,REP,220
+McPherson,2,U.S. House,1,Collin Duprel,LIB,17
+McPherson,2,U.S. House,1,Dusty Johnson,REP,246
+McPherson,3,U.S. House,1,Collin Duprel,LIB,36
+McPherson,3,U.S. House,1,Dusty Johnson,REP,226
+McPherson,4,U.S. House,1,Collin Duprel,LIB,36
+McPherson,4,U.S. House,1,Dusty Johnson,REP,261
+McPherson,1,Governor,,Jamie Smith and Jennifer Keintz,DEM,48
+McPherson,1,Governor,,Tracey Quint and Ashley Strand,LIB,7
+McPherson,1,Governor,,Kristi Noem and Larry Rhoden,REP,208
+McPherson,2,Governor,,Jamie Smith and Jennifer Keintz,DEM,30
+McPherson,2,Governor,,Tracey Quint and Ashley Strand,LIB,5
+McPherson,2,Governor,,Kristi Noem and Larry Rhoden,REP,229
+McPherson,3,Governor,,Jamie Smith and Jennifer Keintz,DEM,41
+McPherson,3,Governor,,Tracey Quint and Ashley Strand,LIB,5
+McPherson,3,Governor,,Kristi Noem and Larry Rhoden,REP,220
+McPherson,4,Governor,,Jamie Smith and Jennifer Keintz,DEM,48
+McPherson,4,Governor,,Tracey Quint and Ashley Strand,LIB,5
+McPherson,4,Governor,,Kristi Noem and Larry Rhoden,REP,254
+McPherson,1,Secretary of State,,Thomas A Cool,DEM,47
+McPherson,1,Secretary of State,,Monae Johnson,REP,204
+McPherson,2,Secretary of State,,Thomas A Cool,DEM,38
+McPherson,2,Secretary of State,,Monae Johnson,REP,220
+McPherson,3,Secretary of State,,Thomas A Cool,DEM,38
+McPherson,3,Secretary of State,,Monae Johnson,REP,223
+McPherson,4,Secretary of State,,Thomas A Cool,DEM,48
+McPherson,4,Secretary of State,,Monae Johnson,REP,248
+McPherson,1,Attorney General,,Marty J. Jackley,REP,225
+McPherson,2,Attorney General,,Marty J. Jackley,REP,234
+McPherson,3,Attorney General,,Marty J. Jackley,REP,233
+McPherson,4,Attorney General,,Marty J. Jackley,REP,276
+McPherson,1,State Auditor,,Stephanie Marty,DEM,41
+McPherson,1,State Auditor,,Rene Meyer,LIB,11
+McPherson,1,State Auditor,,Richard Sattgast,REP,201
+McPherson,2,State Auditor,,Stephanie Marty,DEM,36
+McPherson,2,State Auditor,,Rene Meyer,LIB,3
+McPherson,2,State Auditor,,Richard Sattgast,REP,214
+McPherson,3,State Auditor,,Stephanie Marty,DEM,34
+McPherson,3,State Auditor,,Rene Meyer,LIB,9
+McPherson,3,State Auditor,,Richard Sattgast,REP,211
+McPherson,4,State Auditor,,Stephanie Marty,DEM,33
+McPherson,4,State Auditor,,Rene Meyer,LIB,15
+McPherson,4,State Auditor,,Richard Sattgast,REP,243
+McPherson,1,State Treasurer,,John Cunningham,DEM,47
+McPherson,1,State Treasurer,,Josh Haeder,REP,207
+McPherson,2,State Treasurer,,John Cunningham,DEM,34
+McPherson,2,State Treasurer,,Josh Haeder,REP,217
+McPherson,3,State Treasurer,,John Cunningham,DEM,34
+McPherson,3,State Treasurer,,Josh Haeder,REP,224
+McPherson,4,State Treasurer,,John Cunningham,DEM,33
+McPherson,4,State Treasurer,,Josh Haeder,REP,258
+McPherson,1,Commissioner of School and Public Lands,,Timothy Azure,DEM,40
+McPherson,1,Commissioner of School and Public Lands,,Brock Greenfield,REP,218
+McPherson,2,Commissioner of School and Public Lands,,Timothy Azure,DEM,27
+McPherson,2,Commissioner of School and Public Lands,,Brock Greenfield,REP,230
+McPherson,3,Commissioner of School and Public Lands,,Timothy Azure,DEM,35
+McPherson,3,Commissioner of School and Public Lands,,Brock Greenfield,REP,219
+McPherson,4,Commissioner of School and Public Lands,,Timothy Azure,DEM,39
+McPherson,4,Commissioner of School and Public Lands,,Brock Greenfield,REP,250
+McPherson,1,Public Utilities Commissioner,,Jeffrey Barth,DEM,66
+McPherson,1,Public Utilities Commissioner,,Chris Nelson,REP,192
+McPherson,2,Public Utilities Commissioner,,Jeffrey Barth,DEM,47
+McPherson,2,Public Utilities Commissioner,,Chris Nelson,REP,210
+McPherson,3,Public Utilities Commissioner,,Jeffrey Barth,DEM,32
+McPherson,3,Public Utilities Commissioner,,Chris Nelson,REP,225
+McPherson,4,Public Utilities Commissioner,,Jeffrey Barth,DEM,41
+McPherson,4,Public Utilities Commissioner,,Chris Nelson,REP,255
+McPherson,1,State Senate,23,Bryan J. Breitling,REP,218
+McPherson,2,State Senate,23,Bryan J. Breitling,REP,227
+McPherson,3,State Senate,23,Bryan J. Breitling,REP,233
+McPherson,4,State Senate,23,Bryan J. Breitling,REP,264
+McPherson,1,State House,23,James D. Wangsness,REP,143
+McPherson,1,State House,23,Scott Moore,REP,209
+McPherson,2,State House,23,James D. Wangsness,REP,91
+McPherson,2,State House,23,Scott Moore,REP,234
+McPherson,3,State House,23,James D. Wangsness,REP,122
+McPherson,3,State House,23,Scott Moore,REP,219
+McPherson,4,State House,23,James D. Wangsness,REP,148
+McPherson,4,State House,23,Scott Moore,REP,251
+McPherson,1,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,170
+McPherson,2,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,169
+McPherson,3,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,157
+McPherson,4,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,181
+McPherson,1,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,166
+McPherson,2,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,157
+McPherson,3,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,149
+McPherson,4,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,179
+McPherson,1,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,164
+McPherson,2,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,156
+McPherson,3,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,149
+McPherson,4,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,168
+McPherson,1,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,171
+McPherson,2,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,162
+McPherson,3,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,154
+McPherson,4,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,171
+McPherson,1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,208
+McPherson,1,Supreme Court Retention,3,Patricia J. DeVaney - No,,34
+McPherson,2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,182
+McPherson,2,Supreme Court Retention,3,Patricia J. DeVaney - No,,30
+McPherson,3,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,190
+McPherson,3,Supreme Court Retention,3,Patricia J. DeVaney - No,,39
+McPherson,4,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,221
+McPherson,4,Supreme Court Retention,3,Patricia J. DeVaney - No,,39
+McPherson,1,Supreme Court Retention,2,Mark E. Salter - Yes,,201
+McPherson,1,Supreme Court Retention,2,Mark E. Salter - No,,38
+McPherson,2,Supreme Court Retention,2,Mark E. Salter - Yes,,181
+McPherson,2,Supreme Court Retention,2,Mark E. Salter - No,,29
+McPherson,3,Supreme Court Retention,2,Mark E. Salter - Yes,,187
+McPherson,3,Supreme Court Retention,2,Mark E. Salter - No,,38
+McPherson,4,Supreme Court Retention,2,Mark E. Salter - Yes,,217
+McPherson,4,Supreme Court Retention,2,Mark E. Salter - No,,42
+McPherson,1,Constitutional Amendment D,,Yes,,130
+McPherson,1,Constitutional Amendment D,,No,,126
+McPherson,2,Constitutional Amendment D,,Yes,,164
+McPherson,2,Constitutional Amendment D,,No,,93
+McPherson,3,Constitutional Amendment D,,Yes,,119
+McPherson,3,Constitutional Amendment D,,No,,140
+McPherson,4,Constitutional Amendment D,,Yes,,142
+McPherson,4,Constitutional Amendment D,,No,,154
+McPherson,1,Initiated Measure 27,,Yes,,74
+McPherson,1,Initiated Measure 27,,No,,187
+McPherson,2,Initiated Measure 27,,Yes,,46
+McPherson,2,Initiated Measure 27,,No,,212
+McPherson,3,Initiated Measure 27,,Yes,,91
+McPherson,3,Initiated Measure 27,,No,,171
+McPherson,4,Initiated Measure 27,,Yes,,93
+McPherson,4,Initiated Measure 27,,No,,214

--- a/2022/counties/20221108__sd__general__meade__precinct.csv
+++ b/2022/counties/20221108__sd__general__meade__precinct.csv
@@ -1,0 +1,1644 @@
+county,precinct,office,district,candidate,party,votes
+Meade,ALKALI #6A,U.S. Senate,,Brian L. Bengs,DEM,15
+Meade,ALKALI #6A,U.S. Senate,,Tamara J Lesnar,LIB,8
+Meade,ALKALI #6A,U.S. Senate,,John R. Thune,REP,121
+Meade,BASE #23,U.S. Senate,,Brian L. Bengs,DEM,89
+Meade,BASE #23,U.S. Senate,,Tamara J Lesnar,LIB,21
+Meade,BASE #23,U.S. Senate,,John R. Thune,REP,174
+Meade,BEAR BUTTE #9,U.S. Senate,,Brian L. Bengs,DEM,19
+Meade,BEAR BUTTE #9,U.S. Senate,,Tamara J Lesnar,LIB,10
+Meade,BEAR BUTTE #9,U.S. Senate,,John R. Thune,REP,122
+Meade,BLACK HAWK #14,U.S. Senate,,Brian L. Bengs,DEM,77
+Meade,BLACK HAWK #14,U.S. Senate,,Tamara J Lesnar,LIB,17
+Meade,BLACK HAWK #14,U.S. Senate,,John R. Thune,REP,220
+Meade,?,U.S. Senate,,Brian L. Bengs,DEM,144
+Meade,?,U.S. Senate,,Tamara J Lesnar,LIB,37
+Meade,?,U.S. Senate,,John R. Thune,REP,562
+Meade,CENTRAL STURGIS #3,U.S. Senate,,Brian L. Bengs,DEM,60
+Meade,CENTRAL STURGIS #3,U.S. Senate,,Tamara J Lesnar,LIB,17
+Meade,CENTRAL STURGIS #3,U.S. Senate,,John R. Thune,REP,153
+Meade,CHALK BUTTE #27,U.S. Senate,,Brian L. Bengs,DEM,12
+Meade,CHALK BUTTE #27,U.S. Senate,,Tamara J Lesnar,LIB,11
+Meade,CHALK BUTTE #27,U.S. Senate,,John R. Thune,REP,82
+Meade,EAST ELK VALE #21A,U.S. Senate,,Brian L. Bengs,DEM,57
+Meade,EAST ELK VALE #21A,U.S. Senate,,Tamara J Lesnar,LIB,34
+Meade,EAST ELK VALE #21A,U.S. Senate,,John R. Thune,REP,369
+Meade,EAST PIEDMONT #12A,U.S. Senate,,Brian L. Bengs,DEM,41
+Meade,EAST PIEDMONT #12A,U.S. Senate,,Tamara J Lesnar,LIB,10
+Meade,EAST PIEDMONT #12A,U.S. Senate,,John R. Thune,REP,235
+Meade,EAST STURGIS #1,U.S. Senate,,Brian L. Bengs,DEM,54
+Meade,EAST STURGIS #1,U.S. Senate,,Tamara J Lesnar,LIB,8
+Meade,EAST STURGIS #1,U.S. Senate,,John R. Thune,REP,155
+Meade,ELK VALE #21,U.S. Senate,,Brian L. Bengs,DEM,3
+Meade,ELK VALE #21,U.S. Senate,,Tamara J Lesnar,LIB,4
+Meade,ELK VALE #21,U.S. Senate,,John R. Thune,REP,53
+Meade,ELM SPRINGS #18,U.S. Senate,,Brian L. Bengs,DEM,8
+Meade,ELM SPRINGS #18,U.S. Senate,,Tamara J Lesnar,LIB,11
+Meade,ELM SPRINGS #18,U.S. Senate,,John R. Thune,REP,68
+Meade,FAIRPOINT #29,U.S. Senate,,Brian L. Bengs,DEM,3
+Meade,FAIRPOINT #29,U.S. Senate,,Tamara J Lesnar,LIB,3
+Meade,FAIRPOINT #29,U.S. Senate,,John R. Thune,REP,25
+Meade,FAITH #31,U.S. Senate,,Brian L. Bengs,DEM,17
+Meade,FAITH #31,U.S. Senate,,Tamara J Lesnar,LIB,11
+Meade,FAITH #31,U.S. Senate,,John R. Thune,REP,185
+Meade,FORT MEADE #1A,U.S. Senate,,Brian L. Bengs,DEM,9
+Meade,FORT MEADE #1A,U.S. Senate,,Tamara J Lesnar,LIB,5
+Meade,FORT MEADE #1A,U.S. Senate,,John R. Thune,REP,20
+Meade,HARMONY #8,U.S. Senate,,Brian L. Bengs,DEM,55
+Meade,HARMONY #8,U.S. Senate,,Tamara J Lesnar,LIB,14
+Meade,HARMONY #8,U.S. Senate,,John R. Thune,REP,250
+Meade,HEREFORD #20,U.S. Senate,,Brian L. Bengs,DEM,3
+Meade,HEREFORD #20,U.S. Senate,,Tamara J Lesnar,LIB,1
+Meade,HEREFORD #20,U.S. Senate,,John R. Thune,REP,48
+Meade,MARCUS #41,U.S. Senate,,Brian L. Bengs,DEM,4
+Meade,MARCUS #41,U.S. Senate,,Tamara J Lesnar,LIB,5
+Meade,MARCUS #41,U.S. Senate,,John R. Thune,REP,32
+Meade,?,U.S. Senate,,Brian L. Bengs,DEM,103
+Meade,?,U.S. Senate,,Tamara J Lesnar,LIB,36
+Meade,?,U.S. Senate,,John R. Thune,REP,536
+Meade,?,U.S. Senate,,Brian L. Bengs,DEM,41
+Meade,?,U.S. Senate,,Tamara J Lesnar,LIB,13
+Meade,?,U.S. Senate,,John R. Thune,REP,79
+Meade,NORTHWEST STURGIS #5,U.S. Senate,,Brian L. Bengs,DEM,86
+Meade,NORTHWEST STURGIS #5,U.S. Senate,,Tamara J Lesnar,LIB,41
+Meade,NORTHWEST STURGIS #5,U.S. Senate,,John R. Thune,REP,286
+Meade,PIEDMONT CENTRAL #11A,U.S. Senate,,Brian L. Bengs,DEM,106
+Meade,PIEDMONT CENTRAL #11A,U.S. Senate,,Tamara J Lesnar,LIB,31
+Meade,PIEDMONT CENTRAL #11A,U.S. Senate,,John R. Thune,REP,506
+Meade,PIEDMONT WEST #11,U.S. Senate,,Brian L. Bengs,DEM,86
+Meade,PIEDMONT WEST #11,U.S. Senate,,Tamara J Lesnar,LIB,25
+Meade,PIEDMONT WEST #11,U.S. Senate,,John R. Thune,REP,352
+Meade,PINE #33,U.S. Senate,,Brian L. Bengs,DEM,8
+Meade,PINE #33,U.S. Senate,,Tamara J Lesnar,LIB,7
+Meade,PINE #33,U.S. Senate,,John R. Thune,REP,57
+Meade,RED OWL #30,U.S. Senate,,Brian L. Bengs,DEM,2
+Meade,RED OWL #30,U.S. Senate,,Tamara J Lesnar,LIB,8
+Meade,RED OWL #30,U.S. Senate,,John R. Thune,REP,66
+Meade,RURAL BLACK HAWK #15,U.S. Senate,,Brian L. Bengs,DEM,65
+Meade,RURAL BLACK HAWK #15,U.S. Senate,,Tamara J Lesnar,LIB,16
+Meade,RURAL BLACK HAWK #15,U.S. Senate,,John R. Thune,REP,323
+Meade,RURAL STURGIS #7,U.S. Senate,,Brian L. Bengs,DEM,74
+Meade,RURAL STURGIS #7,U.S. Senate,,Tamara J Lesnar,LIB,21
+Meade,RURAL STURGIS #7,U.S. Senate,,John R. Thune,REP,344
+Meade,SOUTH STURGIS #2A,U.S. Senate,,Brian L. Bengs,DEM,70
+Meade,SOUTH STURGIS #2A,U.S. Senate,,Tamara J Lesnar,LIB,20
+Meade,SOUTH STURGIS #2A,U.S. Senate,,John R. Thune,REP,251
+Meade,?,U.S. Senate,,Brian L. Bengs,DEM,158
+Meade,?,U.S. Senate,,Tamara J Lesnar,LIB,59
+Meade,?,U.S. Senate,,John R. Thune,REP,591
+Meade,SOUTHEAST STURGIS #2,U.S. Senate,,Brian L. Bengs,DEM,94
+Meade,SOUTHEAST STURGIS #2,U.S. Senate,,Tamara J Lesnar,LIB,26
+Meade,SOUTHEAST STURGIS #2,U.S. Senate,,John R. Thune,REP,354
+Meade,SOUTHWEST STURGIS #4A,U.S. Senate,,Brian L. Bengs,DEM,59
+Meade,SOUTHWEST STURGIS #4A,U.S. Senate,,Tamara J Lesnar,LIB,21
+Meade,SOUTHWEST STURGIS #4A,U.S. Senate,,John R. Thune,REP,191
+Meade,STURGIS #5A,U.S. Senate,,Brian L. Bengs,DEM,43
+Meade,STURGIS #5A,U.S. Senate,,Tamara J Lesnar,LIB,11
+Meade,STURGIS #5A,U.S. Senate,,John R. Thune,REP,156
+Meade,SULPHUR #35,U.S. Senate,,Brian L. Bengs,DEM,1
+Meade,SULPHUR #35,U.S. Senate,,Tamara J Lesnar,LIB,9
+Meade,SULPHUR #35,U.S. Senate,,John R. Thune,REP,33
+Meade,SUMMERSET #10,U.S. Senate,,Brian L. Bengs,DEM,194
+Meade,SUMMERSET #10,U.S. Senate,,Tamara J Lesnar,LIB,49
+Meade,SUMMERSET #10,U.S. Senate,,John R. Thune,REP,750
+Meade,TILFORD #6,U.S. Senate,,Brian L. Bengs,DEM,112
+Meade,TILFORD #6,U.S. Senate,,Tamara J Lesnar,LIB,25
+Meade,TILFORD #6,U.S. Senate,,John R. Thune,REP,546
+Meade,UNION #40,U.S. Senate,,Brian L. Bengs,DEM,3
+Meade,UNION #40,U.S. Senate,,Tamara J Lesnar,LIB,1
+Meade,UNION #40,U.S. Senate,,John R. Thune,REP,28
+Meade,VIEWFIELD #17,U.S. Senate,,Brian L. Bengs,DEM,6
+Meade,VIEWFIELD #17,U.S. Senate,,Tamara J Lesnar,LIB,11
+Meade,VIEWFIELD #17,U.S. Senate,,John R. Thune,REP,76
+Meade,WEST BLACK HAWK #16,U.S. Senate,,Brian L. Bengs,DEM,71
+Meade,WEST BLACK HAWK #16,U.S. Senate,,Tamara J Lesnar,LIB,16
+Meade,WEST BLACK HAWK #16,U.S. Senate,,John R. Thune,REP,239
+Meade,WEST ELK VALE #24,U.S. Senate,,Brian L. Bengs,DEM,32
+Meade,WEST ELK VALE #24,U.S. Senate,,Tamara J Lesnar,LIB,12
+Meade,WEST ELK VALE #24,U.S. Senate,,John R. Thune,REP,139
+Meade,WEST STURGIS #4,U.S. Senate,,Brian L. Bengs,DEM,48
+Meade,WEST STURGIS #4,U.S. Senate,,Tamara J Lesnar,LIB,15
+Meade,WEST STURGIS #4,U.S. Senate,,John R. Thune,REP,123
+Meade,WHITE OWL #25,U.S. Senate,,Brian L. Bengs,DEM,2
+Meade,WHITE OWL #25,U.S. Senate,,Tamara J Lesnar,LIB,2
+Meade,WHITE OWL #25,U.S. Senate,,John R. Thune,REP,34
+Meade,ALKALI #6A,U.S. House,1,Collin Duprel,LIB,50
+Meade,ALKALI #6A,U.S. House,1,Dusty Johnson,REP,94
+Meade,BASE #23,U.S. House,1,Collin Duprel,LIB,98
+Meade,BASE #23,U.S. House,1,Dusty Johnson,REP,171
+Meade,BEAR BUTTE #9,U.S. House,1,Collin Duprel,LIB,64
+Meade,BEAR BUTTE #9,U.S. House,1,Dusty Johnson,REP,86
+Meade,BLACK HAWK #14,U.S. House,1,Collin Duprel,LIB,81
+Meade,BLACK HAWK #14,U.S. House,1,Dusty Johnson,REP,225
+Meade,?,U.S. House,1,Collin Duprel,LIB,178
+Meade,?,U.S. House,1,Dusty Johnson,REP,542
+Meade,CENTRAL STURGIS #3,U.S. House,1,Collin Duprel,LIB,95
+Meade,CENTRAL STURGIS #3,U.S. House,1,Dusty Johnson,REP,127
+Meade,CHALK BUTTE #27,U.S. House,1,Collin Duprel,LIB,42
+Meade,CHALK BUTTE #27,U.S. House,1,Dusty Johnson,REP,67
+Meade,EAST ELK VALE #21A,U.S. House,1,Collin Duprel,LIB,99
+Meade,EAST ELK VALE #21A,U.S. House,1,Dusty Johnson,REP,355
+Meade,EAST PIEDMONT #12A,U.S. House,1,Collin Duprel,LIB,55
+Meade,EAST PIEDMONT #12A,U.S. House,1,Dusty Johnson,REP,229
+Meade,EAST STURGIS #1,U.S. House,1,Collin Duprel,LIB,79
+Meade,EAST STURGIS #1,U.S. House,1,Dusty Johnson,REP,134
+Meade,ELK VALE #21,U.S. House,1,Collin Duprel,LIB,13
+Meade,ELK VALE #21,U.S. House,1,Dusty Johnson,REP,46
+Meade,ELM SPRINGS #18,U.S. House,1,Collin Duprel,LIB,26
+Meade,ELM SPRINGS #18,U.S. House,1,Dusty Johnson,REP,57
+Meade,FAIRPOINT #29,U.S. House,1,Collin Duprel,LIB,11
+Meade,FAIRPOINT #29,U.S. House,1,Dusty Johnson,REP,21
+Meade,FAITH #31,U.S. House,1,Collin Duprel,LIB,51
+Meade,FAITH #31,U.S. House,1,Dusty Johnson,REP,156
+Meade,FORT MEADE #1A,U.S. House,1,Collin Duprel,LIB,19
+Meade,FORT MEADE #1A,U.S. House,1,Dusty Johnson,REP,14
+Meade,HARMONY #8,U.S. House,1,Collin Duprel,LIB,103
+Meade,HARMONY #8,U.S. House,1,Dusty Johnson,REP,210
+Meade,HEREFORD #20,U.S. House,1,Collin Duprel,LIB,21
+Meade,HEREFORD #20,U.S. House,1,Dusty Johnson,REP,31
+Meade,MARCUS #41,U.S. House,1,Collin Duprel,LIB,19
+Meade,MARCUS #41,U.S. House,1,Dusty Johnson,REP,24
+Meade,?,U.S. House,1,Collin Duprel,LIB,125
+Meade,?,U.S. House,1,Dusty Johnson,REP,525
+Meade,?,U.S. House,1,Collin Duprel,LIB,60
+Meade,?,U.S. House,1,Dusty Johnson,REP,66
+Meade,NORTHWEST STURGIS #5,U.S. House,1,Collin Duprel,LIB,181
+Meade,NORTHWEST STURGIS #5,U.S. House,1,Dusty Johnson,REP,224
+Meade,PIEDMONT CENTRAL #11A,U.S. House,1,Collin Duprel,LIB,126
+Meade,PIEDMONT CENTRAL #11A,U.S. House,1,Dusty Johnson,REP,499
+Meade,PIEDMONT WEST #11,U.S. House,1,Collin Duprel,LIB,114
+Meade,PIEDMONT WEST #11,U.S. House,1,Dusty Johnson,REP,333
+Meade,PINE #33,U.S. House,1,Collin Duprel,LIB,28
+Meade,PINE #33,U.S. House,1,Dusty Johnson,REP,43
+Meade,RED OWL #30,U.S. House,1,Collin Duprel,LIB,32
+Meade,RED OWL #30,U.S. House,1,Dusty Johnson,REP,42
+Meade,RURAL BLACK HAWK #15,U.S. House,1,Collin Duprel,LIB,80
+Meade,RURAL BLACK HAWK #15,U.S. House,1,Dusty Johnson,REP,312
+Meade,RURAL STURGIS #7,U.S. House,1,Collin Duprel,LIB,132
+Meade,RURAL STURGIS #7,U.S. House,1,Dusty Johnson,REP,291
+Meade,SOUTH STURGIS #2A,U.S. House,1,Collin Duprel,LIB,122
+Meade,SOUTH STURGIS #2A,U.S. House,1,Dusty Johnson,REP,212
+Meade,?,U.S. House,1,Collin Duprel,LIB,185
+Meade,?,U.S. House,1,Dusty Johnson,REP,586
+Meade,SOUTHEAST STURGIS #2,U.S. House,1,Collin Duprel,LIB,166
+Meade,SOUTHEAST STURGIS #2,U.S. House,1,Dusty Johnson,REP,304
+Meade,SOUTHWEST STURGIS #4A,U.S. House,1,Collin Duprel,LIB,94
+Meade,SOUTHWEST STURGIS #4A,U.S. House,1,Dusty Johnson,REP,175
+Meade,STURGIS #5A,U.S. House,1,Collin Duprel,LIB,70
+Meade,STURGIS #5A,U.S. House,1,Dusty Johnson,REP,139
+Meade,SULPHUR #35,U.S. House,1,Collin Duprel,LIB,13
+Meade,SULPHUR #35,U.S. House,1,Dusty Johnson,REP,29
+Meade,SUMMERSET #10,U.S. House,1,Collin Duprel,LIB,216
+Meade,SUMMERSET #10,U.S. House,1,Dusty Johnson,REP,732
+Meade,TILFORD #6,U.S. House,1,Collin Duprel,LIB,203
+Meade,TILFORD #6,U.S. House,1,Dusty Johnson,REP,471
+Meade,UNION #40,U.S. House,1,Collin Duprel,LIB,9
+Meade,UNION #40,U.S. House,1,Dusty Johnson,REP,22
+Meade,VIEWFIELD #17,U.S. House,1,Collin Duprel,LIB,23
+Meade,VIEWFIELD #17,U.S. House,1,Dusty Johnson,REP,65
+Meade,WEST BLACK HAWK #16,U.S. House,1,Collin Duprel,LIB,75
+Meade,WEST BLACK HAWK #16,U.S. House,1,Dusty Johnson,REP,236
+Meade,WEST ELK VALE #24,U.S. House,1,Collin Duprel,LIB,45
+Meade,WEST ELK VALE #24,U.S. House,1,Dusty Johnson,REP,130
+Meade,WEST STURGIS #4,U.S. House,1,Collin Duprel,LIB,79
+Meade,WEST STURGIS #4,U.S. House,1,Dusty Johnson,REP,102
+Meade,WHITE OWL #25,U.S. House,1,Collin Duprel,LIB,12
+Meade,WHITE OWL #25,U.S. House,1,Dusty Johnson,REP,25
+Meade,ALKALI #6A,Governor,,Jamie Smith and Jennifer Keintz,DEM,17
+Meade,ALKALI #6A,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Meade,ALKALI #6A,Governor,,Kristi Noem and Larry Rhoden,REP,119
+Meade,BASE #23,Governor,,Jamie Smith and Jennifer Keintz,DEM,111
+Meade,BASE #23,Governor,,Tracey Quint and Ashley Strand,LIB,13
+Meade,BASE #23,Governor,,Kristi Noem and Larry Rhoden,REP,166
+Meade,BEAR BUTTE #9,Governor,,Jamie Smith and Jennifer Keintz,DEM,24
+Meade,BEAR BUTTE #9,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Meade,BEAR BUTTE #9,Governor,,Kristi Noem and Larry Rhoden,REP,126
+Meade,BLACK HAWK #14,Governor,,Jamie Smith and Jennifer Keintz,DEM,98
+Meade,BLACK HAWK #14,Governor,,Tracey Quint and Ashley Strand,LIB,13
+Meade,BLACK HAWK #14,Governor,,Kristi Noem and Larry Rhoden,REP,208
+Meade,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,202
+Meade,?,Governor,,Tracey Quint and Ashley Strand,LIB,39
+Meade,?,Governor,,Kristi Noem and Larry Rhoden,REP,506
+Meade,CENTRAL STURGIS #3,Governor,,Jamie Smith and Jennifer Keintz,DEM,84
+Meade,CENTRAL STURGIS #3,Governor,,Tracey Quint and Ashley Strand,LIB,10
+Meade,CENTRAL STURGIS #3,Governor,,Kristi Noem and Larry Rhoden,REP,140
+Meade,CHALK BUTTE #27,Governor,,Jamie Smith and Jennifer Keintz,DEM,10
+Meade,CHALK BUTTE #27,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Meade,CHALK BUTTE #27,Governor,,Kristi Noem and Larry Rhoden,REP,95
+Meade,EAST ELK VALE #21A,Governor,,Jamie Smith and Jennifer Keintz,DEM,71
+Meade,EAST ELK VALE #21A,Governor,,Tracey Quint and Ashley Strand,LIB,31
+Meade,EAST ELK VALE #21A,Governor,,Kristi Noem and Larry Rhoden,REP,363
+Meade,EAST PIEDMONT #12A,Governor,,Jamie Smith and Jennifer Keintz,DEM,50
+Meade,EAST PIEDMONT #12A,Governor,,Tracey Quint and Ashley Strand,LIB,9
+Meade,EAST PIEDMONT #12A,Governor,,Kristi Noem and Larry Rhoden,REP,232
+Meade,EAST STURGIS #1,Governor,,Jamie Smith and Jennifer Keintz,DEM,74
+Meade,EAST STURGIS #1,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Meade,EAST STURGIS #1,Governor,,Kristi Noem and Larry Rhoden,REP,141
+Meade,ELK VALE #21,Governor,,Jamie Smith and Jennifer Keintz,DEM,7
+Meade,ELK VALE #21,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Meade,ELK VALE #21,Governor,,Kristi Noem and Larry Rhoden,REP,52
+Meade,ELM SPRINGS #18,Governor,,Jamie Smith and Jennifer Keintz,DEM,11
+Meade,ELM SPRINGS #18,Governor,,Tracey Quint and Ashley Strand,LIB,8
+Meade,ELM SPRINGS #18,Governor,,Kristi Noem and Larry Rhoden,REP,66
+Meade,FAIRPOINT #29,Governor,,Jamie Smith and Jennifer Keintz,DEM,6
+Meade,FAIRPOINT #29,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Meade,FAIRPOINT #29,Governor,,Kristi Noem and Larry Rhoden,REP,27
+Meade,FAITH #31,Governor,,Jamie Smith and Jennifer Keintz,DEM,18
+Meade,FAITH #31,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Meade,FAITH #31,Governor,,Kristi Noem and Larry Rhoden,REP,192
+Meade,FORT MEADE #1A,Governor,,Jamie Smith and Jennifer Keintz,DEM,13
+Meade,FORT MEADE #1A,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Meade,FORT MEADE #1A,Governor,,Kristi Noem and Larry Rhoden,REP,20
+Meade,HARMONY #8,Governor,,Jamie Smith and Jennifer Keintz,DEM,83
+Meade,HARMONY #8,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Meade,HARMONY #8,Governor,,Kristi Noem and Larry Rhoden,REP,241
+Meade,HEREFORD #20,Governor,,Jamie Smith and Jennifer Keintz,DEM,9
+Meade,HEREFORD #20,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Meade,HEREFORD #20,Governor,,Kristi Noem and Larry Rhoden,REP,40
+Meade,MARCUS #41,Governor,,Jamie Smith and Jennifer Keintz,DEM,2
+Meade,MARCUS #41,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Meade,MARCUS #41,Governor,,Kristi Noem and Larry Rhoden,REP,38
+Meade,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,125
+Meade,?,Governor,,Tracey Quint and Ashley Strand,LIB,22
+Meade,?,Governor,,Kristi Noem and Larry Rhoden,REP,529
+Meade,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,45
+Meade,?,Governor,,Tracey Quint and Ashley Strand,LIB,15
+Meade,?,Governor,,Kristi Noem and Larry Rhoden,REP,74
+Meade,NORTHWEST STURGIS #5,Governor,,Jamie Smith and Jennifer Keintz,DEM,109
+Meade,NORTHWEST STURGIS #5,Governor,,Tracey Quint and Ashley Strand,LIB,40
+Meade,NORTHWEST STURGIS #5,Governor,,Kristi Noem and Larry Rhoden,REP,266
+Meade,PIEDMONT CENTRAL #11A,Governor,,Jamie Smith and Jennifer Keintz,DEM,146
+Meade,PIEDMONT CENTRAL #11A,Governor,,Tracey Quint and Ashley Strand,LIB,21
+Meade,PIEDMONT CENTRAL #11A,Governor,,Kristi Noem and Larry Rhoden,REP,484
+Meade,PIEDMONT WEST #11,Governor,,Jamie Smith and Jennifer Keintz,DEM,106
+Meade,PIEDMONT WEST #11,Governor,,Tracey Quint and Ashley Strand,LIB,16
+Meade,PIEDMONT WEST #11,Governor,,Kristi Noem and Larry Rhoden,REP,343
+Meade,PINE #33,Governor,,Jamie Smith and Jennifer Keintz,DEM,4
+Meade,PINE #33,Governor,,Tracey Quint and Ashley Strand,LIB,6
+Meade,PINE #33,Governor,,Kristi Noem and Larry Rhoden,REP,62
+Meade,RED OWL #30,Governor,,Jamie Smith and Jennifer Keintz,DEM,2
+Meade,RED OWL #30,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Meade,RED OWL #30,Governor,,Kristi Noem and Larry Rhoden,REP,73
+Meade,RURAL BLACK HAWK #15,Governor,,Jamie Smith and Jennifer Keintz,DEM,99
+Meade,RURAL BLACK HAWK #15,Governor,,Tracey Quint and Ashley Strand,LIB,18
+Meade,RURAL BLACK HAWK #15,Governor,,Kristi Noem and Larry Rhoden,REP,288
+Meade,RURAL STURGIS #7,Governor,,Jamie Smith and Jennifer Keintz,DEM,113
+Meade,RURAL STURGIS #7,Governor,,Tracey Quint and Ashley Strand,LIB,16
+Meade,RURAL STURGIS #7,Governor,,Kristi Noem and Larry Rhoden,REP,311
+Meade,SOUTH STURGIS #2A,Governor,,Jamie Smith and Jennifer Keintz,DEM,102
+Meade,SOUTH STURGIS #2A,Governor,,Tracey Quint and Ashley Strand,LIB,10
+Meade,SOUTH STURGIS #2A,Governor,,Kristi Noem and Larry Rhoden,REP,230
+Meade,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,206
+Meade,?,Governor,,Tracey Quint and Ashley Strand,LIB,52
+Meade,?,Governor,,Kristi Noem and Larry Rhoden,REP,555
+Meade,SOUTHEAST STURGIS #2,Governor,,Jamie Smith and Jennifer Keintz,DEM,153
+Meade,SOUTHEAST STURGIS #2,Governor,,Tracey Quint and Ashley Strand,LIB,12
+Meade,SOUTHEAST STURGIS #2,Governor,,Kristi Noem and Larry Rhoden,REP,315
+Meade,SOUTHWEST STURGIS #4A,Governor,,Jamie Smith and Jennifer Keintz,DEM,86
+Meade,SOUTHWEST STURGIS #4A,Governor,,Tracey Quint and Ashley Strand,LIB,14
+Meade,SOUTHWEST STURGIS #4A,Governor,,Kristi Noem and Larry Rhoden,REP,176
+Meade,STURGIS #5A,Governor,,Jamie Smith and Jennifer Keintz,DEM,70
+Meade,STURGIS #5A,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Meade,STURGIS #5A,Governor,,Kristi Noem and Larry Rhoden,REP,137
+Meade,SULPHUR #35,Governor,,Jamie Smith and Jennifer Keintz,DEM,0
+Meade,SULPHUR #35,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Meade,SULPHUR #35,Governor,,Kristi Noem and Larry Rhoden,REP,45
+Meade,SUMMERSET #10,Governor,,Jamie Smith and Jennifer Keintz,DEM,257
+Meade,SUMMERSET #10,Governor,,Tracey Quint and Ashley Strand,LIB,37
+Meade,SUMMERSET #10,Governor,,Kristi Noem and Larry Rhoden,REP,699
+Meade,TILFORD #6,Governor,,Jamie Smith and Jennifer Keintz,DEM,150
+Meade,TILFORD #6,Governor,,Tracey Quint and Ashley Strand,LIB,18
+Meade,TILFORD #6,Governor,,Kristi Noem and Larry Rhoden,REP,517
+Meade,UNION #40,Governor,,Jamie Smith and Jennifer Keintz,DEM,3
+Meade,UNION #40,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Meade,UNION #40,Governor,,Kristi Noem and Larry Rhoden,REP,29
+Meade,VIEWFIELD #17,Governor,,Jamie Smith and Jennifer Keintz,DEM,6
+Meade,VIEWFIELD #17,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Meade,VIEWFIELD #17,Governor,,Kristi Noem and Larry Rhoden,REP,86
+Meade,WEST BLACK HAWK #16,Governor,,Jamie Smith and Jennifer Keintz,DEM,110
+Meade,WEST BLACK HAWK #16,Governor,,Tracey Quint and Ashley Strand,LIB,13
+Meade,WEST BLACK HAWK #16,Governor,,Kristi Noem and Larry Rhoden,REP,201
+Meade,WEST ELK VALE #24,Governor,,Jamie Smith and Jennifer Keintz,DEM,45
+Meade,WEST ELK VALE #24,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Meade,WEST ELK VALE #24,Governor,,Kristi Noem and Larry Rhoden,REP,138
+Meade,WEST STURGIS #4,Governor,,Jamie Smith and Jennifer Keintz,DEM,58
+Meade,WEST STURGIS #4,Governor,,Tracey Quint and Ashley Strand,LIB,15
+Meade,WEST STURGIS #4,Governor,,Kristi Noem and Larry Rhoden,REP,115
+Meade,WHITE OWL #25,Governor,,Jamie Smith and Jennifer Keintz,DEM,2
+Meade,WHITE OWL #25,Governor,,Tracey Quint and Ashley Strand,LIB,0
+Meade,WHITE OWL #25,Governor,,Kristi Noem and Larry Rhoden,REP,37
+Meade,ALKALI #6A,Secretary of State,,Thomas A Cool,DEM,20
+Meade,ALKALI #6A,Secretary of State,,Monae Johnson,REP,119
+Meade,BASE #23,Secretary of State,,Thomas A Cool,DEM,102
+Meade,BASE #23,Secretary of State,,Monae Johnson,REP,170
+Meade,BEAR BUTTE #9,Secretary of State,,Thomas A Cool,DEM,26
+Meade,BEAR BUTTE #9,Secretary of State,,Monae Johnson,REP,114
+Meade,BLACK HAWK #14,Secretary of State,,Thomas A Cool,DEM,81
+Meade,BLACK HAWK #14,Secretary of State,,Monae Johnson,REP,225
+Meade,?,Secretary of State,,Thomas A Cool,DEM,197
+Meade,?,Secretary of State,,Monae Johnson,REP,517
+Meade,CENTRAL STURGIS #3,Secretary of State,,Thomas A Cool,DEM,78
+Meade,CENTRAL STURGIS #3,Secretary of State,,Monae Johnson,REP,143
+Meade,CHALK BUTTE #27,Secretary of State,,Thomas A Cool,DEM,12
+Meade,CHALK BUTTE #27,Secretary of State,,Monae Johnson,REP,92
+Meade,EAST ELK VALE #21A,Secretary of State,,Thomas A Cool,DEM,70
+Meade,EAST ELK VALE #21A,Secretary of State,,Monae Johnson,REP,384
+Meade,EAST PIEDMONT #12A,Secretary of State,,Thomas A Cool,DEM,50
+Meade,EAST PIEDMONT #12A,Secretary of State,,Monae Johnson,REP,232
+Meade,EAST STURGIS #1,Secretary of State,,Thomas A Cool,DEM,65
+Meade,EAST STURGIS #1,Secretary of State,,Monae Johnson,REP,147
+Meade,ELK VALE #21,Secretary of State,,Thomas A Cool,DEM,5
+Meade,ELK VALE #21,Secretary of State,,Monae Johnson,REP,53
+Meade,ELM SPRINGS #18,Secretary of State,,Thomas A Cool,DEM,13
+Meade,ELM SPRINGS #18,Secretary of State,,Monae Johnson,REP,75
+Meade,FAIRPOINT #29,Secretary of State,,Thomas A Cool,DEM,7
+Meade,FAIRPOINT #29,Secretary of State,,Monae Johnson,REP,25
+Meade,FAITH #31,Secretary of State,,Thomas A Cool,DEM,23
+Meade,FAITH #31,Secretary of State,,Monae Johnson,REP,176
+Meade,FORT MEADE #1A,Secretary of State,,Thomas A Cool,DEM,13
+Meade,FORT MEADE #1A,Secretary of State,,Monae Johnson,REP,19
+Meade,HARMONY #8,Secretary of State,,Thomas A Cool,DEM,72
+Meade,HARMONY #8,Secretary of State,,Monae Johnson,REP,245
+Meade,HEREFORD #20,Secretary of State,,Thomas A Cool,DEM,7
+Meade,HEREFORD #20,Secretary of State,,Monae Johnson,REP,41
+Meade,MARCUS #41,Secretary of State,,Thomas A Cool,DEM,2
+Meade,MARCUS #41,Secretary of State,,Monae Johnson,REP,31
+Meade,?,Secretary of State,,Thomas A Cool,DEM,118
+Meade,?,Secretary of State,,Monae Johnson,REP,537
+Meade,?,Secretary of State,,Thomas A Cool,DEM,46
+Meade,?,Secretary of State,,Monae Johnson,REP,81
+Meade,NORTHWEST STURGIS #5,Secretary of State,,Thomas A Cool,DEM,108
+Meade,NORTHWEST STURGIS #5,Secretary of State,,Monae Johnson,REP,282
+Meade,PIEDMONT CENTRAL #11A,Secretary of State,,Thomas A Cool,DEM,136
+Meade,PIEDMONT CENTRAL #11A,Secretary of State,,Monae Johnson,REP,491
+Meade,PIEDMONT WEST #11,Secretary of State,,Thomas A Cool,DEM,113
+Meade,PIEDMONT WEST #11,Secretary of State,,Monae Johnson,REP,340
+Meade,PINE #33,Secretary of State,,Thomas A Cool,DEM,5
+Meade,PINE #33,Secretary of State,,Monae Johnson,REP,63
+Meade,RED OWL #30,Secretary of State,,Thomas A Cool,DEM,2
+Meade,RED OWL #30,Secretary of State,,Monae Johnson,REP,69
+Meade,RURAL BLACK HAWK #15,Secretary of State,,Thomas A Cool,DEM,90
+Meade,RURAL BLACK HAWK #15,Secretary of State,,Monae Johnson,REP,293
+Meade,RURAL STURGIS #7,Secretary of State,,Thomas A Cool,DEM,98
+Meade,RURAL STURGIS #7,Secretary of State,,Monae Johnson,REP,316
+Meade,SOUTH STURGIS #2A,Secretary of State,,Thomas A Cool,DEM,95
+Meade,SOUTH STURGIS #2A,Secretary of State,,Monae Johnson,REP,230
+Meade,?,Secretary of State,,Thomas A Cool,DEM,200
+Meade,?,Secretary of State,,Monae Johnson,REP,576
+Meade,SOUTHEAST STURGIS #2,Secretary of State,,Thomas A Cool,DEM,134
+Meade,SOUTHEAST STURGIS #2,Secretary of State,,Monae Johnson,REP,312
+Meade,SOUTHWEST STURGIS #4A,Secretary of State,,Thomas A Cool,DEM,77
+Meade,SOUTHWEST STURGIS #4A,Secretary of State,,Monae Johnson,REP,184
+Meade,STURGIS #5A,Secretary of State,,Thomas A Cool,DEM,61
+Meade,STURGIS #5A,Secretary of State,,Monae Johnson,REP,138
+Meade,SULPHUR #35,Secretary of State,,Thomas A Cool,DEM,3
+Meade,SULPHUR #35,Secretary of State,,Monae Johnson,REP,42
+Meade,SUMMERSET #10,Secretary of State,,Thomas A Cool,DEM,244
+Meade,SUMMERSET #10,Secretary of State,,Monae Johnson,REP,706
+Meade,TILFORD #6,Secretary of State,,Thomas A Cool,DEM,135
+Meade,TILFORD #6,Secretary of State,,Monae Johnson,REP,529
+Meade,UNION #40,Secretary of State,,Thomas A Cool,DEM,7
+Meade,UNION #40,Secretary of State,,Monae Johnson,REP,23
+Meade,VIEWFIELD #17,Secretary of State,,Thomas A Cool,DEM,5
+Meade,VIEWFIELD #17,Secretary of State,,Monae Johnson,REP,86
+Meade,WEST BLACK HAWK #16,Secretary of State,,Thomas A Cool,DEM,105
+Meade,WEST BLACK HAWK #16,Secretary of State,,Monae Johnson,REP,213
+Meade,WEST ELK VALE #24,Secretary of State,,Thomas A Cool,DEM,40
+Meade,WEST ELK VALE #24,Secretary of State,,Monae Johnson,REP,142
+Meade,WEST STURGIS #4,Secretary of State,,Thomas A Cool,DEM,65
+Meade,WEST STURGIS #4,Secretary of State,,Monae Johnson,REP,114
+Meade,WHITE OWL #25,Secretary of State,,Thomas A Cool,DEM,2
+Meade,WHITE OWL #25,Secretary of State,,Monae Johnson,REP,32
+Meade,ALKALI #6A,Attorney General,,Marty J. Jackley,REP,127
+Meade,BASE #23,Attorney General,,Marty J. Jackley,REP,201
+Meade,BEAR BUTTE #9,Attorney General,,Marty J. Jackley,REP,129
+Meade,BLACK HAWK #14,Attorney General,,Marty J. Jackley,REP,240
+Meade,?,Attorney General,,Marty J. Jackley,REP,593
+Meade,CENTRAL STURGIS #3,Attorney General,,Marty J. Jackley,REP,185
+Meade,CHALK BUTTE #27,Attorney General,,Marty J. Jackley,REP,87
+Meade,EAST ELK VALE #21A,Attorney General,,Marty J. Jackley,REP,378
+Meade,EAST PIEDMONT #12A,Attorney General,,Marty J. Jackley,REP,250
+Meade,EAST STURGIS #1,Attorney General,,Marty J. Jackley,REP,171
+Meade,ELK VALE #21,Attorney General,,Marty J. Jackley,REP,51
+Meade,ELM SPRINGS #18,Attorney General,,Marty J. Jackley,REP,72
+Meade,FAIRPOINT #29,Attorney General,,Marty J. Jackley,REP,29
+Meade,FAITH #31,Attorney General,,Marty J. Jackley,REP,180
+Meade,FORT MEADE #1A,Attorney General,,Marty J. Jackley,REP,19
+Meade,HARMONY #8,Attorney General,,Marty J. Jackley,REP,276
+Meade,HEREFORD #20,Attorney General,,Marty J. Jackley,REP,41
+Meade,MARCUS #41,Attorney General,,Marty J. Jackley,REP,28
+Meade,?,Attorney General,,Marty J. Jackley,REP,561
+Meade,?,Attorney General,,Marty J. Jackley,REP,93
+Meade,NORTHWEST STURGIS #5,Attorney General,,Marty J. Jackley,REP,323
+Meade,PIEDMONT CENTRAL #11A,Attorney General,,Marty J. Jackley,REP,523
+Meade,PIEDMONT WEST #11,Attorney General,,Marty J. Jackley,REP,383
+Meade,PINE #33,Attorney General,,Marty J. Jackley,REP,58
+Meade,RED OWL #30,Attorney General,,Marty J. Jackley,REP,65
+Meade,RURAL BLACK HAWK #15,Attorney General,,Marty J. Jackley,REP,341
+Meade,RURAL STURGIS #7,Attorney General,,Marty J. Jackley,REP,362
+Meade,SOUTH STURGIS #2A,Attorney General,,Marty J. Jackley,REP,288
+Meade,?,Attorney General,,Marty J. Jackley,REP,645
+Meade,SOUTHEAST STURGIS #2,Attorney General,,Marty J. Jackley,REP,389
+Meade,SOUTHWEST STURGIS #4A,Attorney General,,Marty J. Jackley,REP,232
+Meade,STURGIS #5A,Attorney General,,Marty J. Jackley,REP,185
+Meade,SULPHUR #35,Attorney General,,Marty J. Jackley,REP,34
+Meade,SUMMERSET #10,Attorney General,,Marty J. Jackley,REP,817
+Meade,TILFORD #6,Attorney General,,Marty J. Jackley,REP,585
+Meade,UNION #40,Attorney General,,Marty J. Jackley,REP,26
+Meade,VIEWFIELD #17,Attorney General,,Marty J. Jackley,REP,78
+Meade,WEST BLACK HAWK #16,Attorney General,,Marty J. Jackley,REP,255
+Meade,WEST ELK VALE #24,Attorney General,,Marty J. Jackley,REP,154
+Meade,WEST STURGIS #4,Attorney General,,Marty J. Jackley,REP,145
+Meade,WHITE OWL #25,Attorney General,,Marty J. Jackley,REP,34
+Meade,ALKALI #6A,State Auditor,,Stephanie Marty,DEM,19
+Meade,ALKALI #6A,State Auditor,,Rene Meyer,LIB,12
+Meade,ALKALI #6A,State Auditor,,Richard Sattgast,REP,104
+Meade,BASE #23,State Auditor,,Stephanie Marty,DEM,82
+Meade,BASE #23,State Auditor,,Rene Meyer,LIB,41
+Meade,BASE #23,State Auditor,,Richard Sattgast,REP,146
+Meade,BEAR BUTTE #9,State Auditor,,Stephanie Marty,DEM,22
+Meade,BEAR BUTTE #9,State Auditor,,Rene Meyer,LIB,12
+Meade,BEAR BUTTE #9,State Auditor,,Richard Sattgast,REP,108
+Meade,BLACK HAWK #14,State Auditor,,Stephanie Marty,DEM,82
+Meade,BLACK HAWK #14,State Auditor,,Rene Meyer,LIB,20
+Meade,BLACK HAWK #14,State Auditor,,Richard Sattgast,REP,202
+Meade,?,State Auditor,,Stephanie Marty,DEM,171
+Meade,?,State Auditor,,Rene Meyer,LIB,52
+Meade,?,State Auditor,,Richard Sattgast,REP,479
+Meade,CENTRAL STURGIS #3,State Auditor,,Stephanie Marty,DEM,65
+Meade,CENTRAL STURGIS #3,State Auditor,,Rene Meyer,LIB,14
+Meade,CENTRAL STURGIS #3,State Auditor,,Richard Sattgast,REP,140
+Meade,CHALK BUTTE #27,State Auditor,,Stephanie Marty,DEM,13
+Meade,CHALK BUTTE #27,State Auditor,,Rene Meyer,LIB,9
+Meade,CHALK BUTTE #27,State Auditor,,Richard Sattgast,REP,84
+Meade,EAST ELK VALE #21A,State Auditor,,Stephanie Marty,DEM,64
+Meade,EAST ELK VALE #21A,State Auditor,,Rene Meyer,LIB,45
+Meade,EAST ELK VALE #21A,State Auditor,,Richard Sattgast,REP,336
+Meade,EAST PIEDMONT #12A,State Auditor,,Stephanie Marty,DEM,41
+Meade,EAST PIEDMONT #12A,State Auditor,,Rene Meyer,LIB,8
+Meade,EAST PIEDMONT #12A,State Auditor,,Richard Sattgast,REP,222
+Meade,EAST STURGIS #1,State Auditor,,Stephanie Marty,DEM,58
+Meade,EAST STURGIS #1,State Auditor,,Rene Meyer,LIB,15
+Meade,EAST STURGIS #1,State Auditor,,Richard Sattgast,REP,135
+Meade,ELK VALE #21,State Auditor,,Stephanie Marty,DEM,4
+Meade,ELK VALE #21,State Auditor,,Rene Meyer,LIB,5
+Meade,ELK VALE #21,State Auditor,,Richard Sattgast,REP,47
+Meade,ELM SPRINGS #18,State Auditor,,Stephanie Marty,DEM,10
+Meade,ELM SPRINGS #18,State Auditor,,Rene Meyer,LIB,9
+Meade,ELM SPRINGS #18,State Auditor,,Richard Sattgast,REP,66
+Meade,FAIRPOINT #29,State Auditor,,Stephanie Marty,DEM,6
+Meade,FAIRPOINT #29,State Auditor,,Rene Meyer,LIB,2
+Meade,FAIRPOINT #29,State Auditor,,Richard Sattgast,REP,24
+Meade,FAITH #31,State Auditor,,Stephanie Marty,DEM,19
+Meade,FAITH #31,State Auditor,,Rene Meyer,LIB,10
+Meade,FAITH #31,State Auditor,,Richard Sattgast,REP,168
+Meade,FORT MEADE #1A,State Auditor,,Stephanie Marty,DEM,10
+Meade,FORT MEADE #1A,State Auditor,,Rene Meyer,LIB,6
+Meade,FORT MEADE #1A,State Auditor,,Richard Sattgast,REP,17
+Meade,HARMONY #8,State Auditor,,Stephanie Marty,DEM,68
+Meade,HARMONY #8,State Auditor,,Rene Meyer,LIB,22
+Meade,HARMONY #8,State Auditor,,Richard Sattgast,REP,225
+Meade,HEREFORD #20,State Auditor,,Stephanie Marty,DEM,5
+Meade,HEREFORD #20,State Auditor,,Rene Meyer,LIB,3
+Meade,HEREFORD #20,State Auditor,,Richard Sattgast,REP,37
+Meade,MARCUS #41,State Auditor,,Stephanie Marty,DEM,0
+Meade,MARCUS #41,State Auditor,,Rene Meyer,LIB,5
+Meade,MARCUS #41,State Auditor,,Richard Sattgast,REP,27
+Meade,?,State Auditor,,Stephanie Marty,DEM,107
+Meade,?,State Auditor,,Rene Meyer,LIB,43
+Meade,?,State Auditor,,Richard Sattgast,REP,504
+Meade,?,State Auditor,,Stephanie Marty,DEM,36
+Meade,?,State Auditor,,Rene Meyer,LIB,18
+Meade,?,State Auditor,,Richard Sattgast,REP,68
+Meade,NORTHWEST STURGIS #5,State Auditor,,Stephanie Marty,DEM,97
+Meade,NORTHWEST STURGIS #5,State Auditor,,Rene Meyer,LIB,52
+Meade,NORTHWEST STURGIS #5,State Auditor,,Richard Sattgast,REP,239
+Meade,PIEDMONT CENTRAL #11A,State Auditor,,Stephanie Marty,DEM,116
+Meade,PIEDMONT CENTRAL #11A,State Auditor,,Rene Meyer,LIB,47
+Meade,PIEDMONT CENTRAL #11A,State Auditor,,Richard Sattgast,REP,456
+Meade,PIEDMONT WEST #11,State Auditor,,Stephanie Marty,DEM,107
+Meade,PIEDMONT WEST #11,State Auditor,,Rene Meyer,LIB,31
+Meade,PIEDMONT WEST #11,State Auditor,,Richard Sattgast,REP,314
+Meade,PINE #33,State Auditor,,Stephanie Marty,DEM,4
+Meade,PINE #33,State Auditor,,Rene Meyer,LIB,7
+Meade,PINE #33,State Auditor,,Richard Sattgast,REP,56
+Meade,RED OWL #30,State Auditor,,Stephanie Marty,DEM,3
+Meade,RED OWL #30,State Auditor,,Rene Meyer,LIB,7
+Meade,RED OWL #30,State Auditor,,Richard Sattgast,REP,57
+Meade,RURAL BLACK HAWK #15,State Auditor,,Stephanie Marty,DEM,75
+Meade,RURAL BLACK HAWK #15,State Auditor,,Rene Meyer,LIB,26
+Meade,RURAL BLACK HAWK #15,State Auditor,,Richard Sattgast,REP,283
+Meade,RURAL STURGIS #7,State Auditor,,Stephanie Marty,DEM,79
+Meade,RURAL STURGIS #7,State Auditor,,Rene Meyer,LIB,38
+Meade,RURAL STURGIS #7,State Auditor,,Richard Sattgast,REP,300
+Meade,SOUTH STURGIS #2A,State Auditor,,Stephanie Marty,DEM,92
+Meade,SOUTH STURGIS #2A,State Auditor,,Rene Meyer,LIB,24
+Meade,SOUTH STURGIS #2A,State Auditor,,Richard Sattgast,REP,209
+Meade,?,State Auditor,,Stephanie Marty,DEM,175
+Meade,?,State Auditor,,Rene Meyer,LIB,65
+Meade,?,State Auditor,,Richard Sattgast,REP,536
+Meade,SOUTHEAST STURGIS #2,State Auditor,,Stephanie Marty,DEM,104
+Meade,SOUTHEAST STURGIS #2,State Auditor,,Rene Meyer,LIB,33
+Meade,SOUTHEAST STURGIS #2,State Auditor,,Richard Sattgast,REP,313
+Meade,SOUTHWEST STURGIS #4A,State Auditor,,Stephanie Marty,DEM,68
+Meade,SOUTHWEST STURGIS #4A,State Auditor,,Rene Meyer,LIB,25
+Meade,SOUTHWEST STURGIS #4A,State Auditor,,Richard Sattgast,REP,169
+Meade,STURGIS #5A,State Auditor,,Stephanie Marty,DEM,55
+Meade,STURGIS #5A,State Auditor,,Rene Meyer,LIB,20
+Meade,STURGIS #5A,State Auditor,,Richard Sattgast,REP,123
+Meade,SULPHUR #35,State Auditor,,Stephanie Marty,DEM,1
+Meade,SULPHUR #35,State Auditor,,Rene Meyer,LIB,3
+Meade,SULPHUR #35,State Auditor,,Richard Sattgast,REP,40
+Meade,SUMMERSET #10,State Auditor,,Stephanie Marty,DEM,217
+Meade,SUMMERSET #10,State Auditor,,Rene Meyer,LIB,74
+Meade,SUMMERSET #10,State Auditor,,Richard Sattgast,REP,652
+Meade,TILFORD #6,State Auditor,,Stephanie Marty,DEM,123
+Meade,TILFORD #6,State Auditor,,Rene Meyer,LIB,30
+Meade,TILFORD #6,State Auditor,,Richard Sattgast,REP,503
+Meade,UNION #40,State Auditor,,Stephanie Marty,DEM,9
+Meade,UNION #40,State Auditor,,Rene Meyer,LIB,1
+Meade,UNION #40,State Auditor,,Richard Sattgast,REP,20
+Meade,VIEWFIELD #17,State Auditor,,Stephanie Marty,DEM,7
+Meade,VIEWFIELD #17,State Auditor,,Rene Meyer,LIB,10
+Meade,VIEWFIELD #17,State Auditor,,Richard Sattgast,REP,73
+Meade,WEST BLACK HAWK #16,State Auditor,,Stephanie Marty,DEM,85
+Meade,WEST BLACK HAWK #16,State Auditor,,Rene Meyer,LIB,24
+Meade,WEST BLACK HAWK #16,State Auditor,,Richard Sattgast,REP,204
+Meade,WEST ELK VALE #24,State Auditor,,Stephanie Marty,DEM,32
+Meade,WEST ELK VALE #24,State Auditor,,Rene Meyer,LIB,17
+Meade,WEST ELK VALE #24,State Auditor,,Richard Sattgast,REP,124
+Meade,WEST STURGIS #4,State Auditor,,Stephanie Marty,DEM,51
+Meade,WEST STURGIS #4,State Auditor,,Rene Meyer,LIB,16
+Meade,WEST STURGIS #4,State Auditor,,Richard Sattgast,REP,114
+Meade,WHITE OWL #25,State Auditor,,Stephanie Marty,DEM,4
+Meade,WHITE OWL #25,State Auditor,,Rene Meyer,LIB,1
+Meade,WHITE OWL #25,State Auditor,,Richard Sattgast,REP,30
+Meade,ALKALI #6A,State Treasurer,,John Cunningham,DEM,21
+Meade,ALKALI #6A,State Treasurer,,Josh Haeder,REP,114
+Meade,BASE #23,State Treasurer,,John Cunningham,DEM,94
+Meade,BASE #23,State Treasurer,,Josh Haeder,REP,173
+Meade,BEAR BUTTE #9,State Treasurer,,John Cunningham,DEM,25
+Meade,BEAR BUTTE #9,State Treasurer,,Josh Haeder,REP,116
+Meade,BLACK HAWK #14,State Treasurer,,John Cunningham,DEM,87
+Meade,BLACK HAWK #14,State Treasurer,,Josh Haeder,REP,216
+Meade,?,State Treasurer,,John Cunningham,DEM,192
+Meade,?,State Treasurer,,Josh Haeder,REP,506
+Meade,CENTRAL STURGIS #3,State Treasurer,,John Cunningham,DEM,70
+Meade,CENTRAL STURGIS #3,State Treasurer,,Josh Haeder,REP,147
+Meade,CHALK BUTTE #27,State Treasurer,,John Cunningham,DEM,13
+Meade,CHALK BUTTE #27,State Treasurer,,Josh Haeder,REP,93
+Meade,EAST ELK VALE #21A,State Treasurer,,John Cunningham,DEM,71
+Meade,EAST ELK VALE #21A,State Treasurer,,Josh Haeder,REP,372
+Meade,EAST PIEDMONT #12A,State Treasurer,,John Cunningham,DEM,45
+Meade,EAST PIEDMONT #12A,State Treasurer,,Josh Haeder,REP,228
+Meade,EAST STURGIS #1,State Treasurer,,John Cunningham,DEM,67
+Meade,EAST STURGIS #1,State Treasurer,,Josh Haeder,REP,144
+Meade,ELK VALE #21,State Treasurer,,John Cunningham,DEM,5
+Meade,ELK VALE #21,State Treasurer,,Josh Haeder,REP,50
+Meade,ELM SPRINGS #18,State Treasurer,,John Cunningham,DEM,13
+Meade,ELM SPRINGS #18,State Treasurer,,Josh Haeder,REP,71
+Meade,FAIRPOINT #29,State Treasurer,,John Cunningham,DEM,7
+Meade,FAIRPOINT #29,State Treasurer,,Josh Haeder,REP,26
+Meade,FAITH #31,State Treasurer,,John Cunningham,DEM,24
+Meade,FAITH #31,State Treasurer,,Josh Haeder,REP,174
+Meade,FORT MEADE #1A,State Treasurer,,John Cunningham,DEM,12
+Meade,FORT MEADE #1A,State Treasurer,,Josh Haeder,REP,19
+Meade,HARMONY #8,State Treasurer,,John Cunningham,DEM,74
+Meade,HARMONY #8,State Treasurer,,Josh Haeder,REP,237
+Meade,HEREFORD #20,State Treasurer,,John Cunningham,DEM,7
+Meade,HEREFORD #20,State Treasurer,,Josh Haeder,REP,39
+Meade,MARCUS #41,State Treasurer,,John Cunningham,DEM,2
+Meade,MARCUS #41,State Treasurer,,Josh Haeder,REP,29
+Meade,?,State Treasurer,,John Cunningham,DEM,106
+Meade,?,State Treasurer,,Josh Haeder,REP,547
+Meade,?,State Treasurer,,John Cunningham,DEM,44
+Meade,?,State Treasurer,,Josh Haeder,REP,77
+Meade,NORTHWEST STURGIS #5,State Treasurer,,John Cunningham,DEM,106
+Meade,NORTHWEST STURGIS #5,State Treasurer,,Josh Haeder,REP,276
+Meade,PIEDMONT CENTRAL #11A,State Treasurer,,John Cunningham,DEM,124
+Meade,PIEDMONT CENTRAL #11A,State Treasurer,,Josh Haeder,REP,486
+Meade,PIEDMONT WEST #11,State Treasurer,,John Cunningham,DEM,106
+Meade,PIEDMONT WEST #11,State Treasurer,,Josh Haeder,REP,346
+Meade,PINE #33,State Treasurer,,John Cunningham,DEM,8
+Meade,PINE #33,State Treasurer,,Josh Haeder,REP,62
+Meade,RED OWL #30,State Treasurer,,John Cunningham,DEM,2
+Meade,RED OWL #30,State Treasurer,,Josh Haeder,REP,65
+Meade,RURAL BLACK HAWK #15,State Treasurer,,John Cunningham,DEM,76
+Meade,RURAL BLACK HAWK #15,State Treasurer,,Josh Haeder,REP,305
+Meade,RURAL STURGIS #7,State Treasurer,,John Cunningham,DEM,88
+Meade,RURAL STURGIS #7,State Treasurer,,Josh Haeder,REP,328
+Meade,SOUTH STURGIS #2A,State Treasurer,,John Cunningham,DEM,93
+Meade,SOUTH STURGIS #2A,State Treasurer,,Josh Haeder,REP,231
+Meade,?,State Treasurer,,John Cunningham,DEM,185
+Meade,?,State Treasurer,,Josh Haeder,REP,582
+Meade,SOUTHEAST STURGIS #2,State Treasurer,,John Cunningham,DEM,119
+Meade,SOUTHEAST STURGIS #2,State Treasurer,,Josh Haeder,REP,319
+Meade,SOUTHWEST STURGIS #4A,State Treasurer,,John Cunningham,DEM,76
+Meade,SOUTHWEST STURGIS #4A,State Treasurer,,Josh Haeder,REP,184
+Meade,STURGIS #5A,State Treasurer,,John Cunningham,DEM,55
+Meade,STURGIS #5A,State Treasurer,,Josh Haeder,REP,142
+Meade,SULPHUR #35,State Treasurer,,John Cunningham,DEM,2
+Meade,SULPHUR #35,State Treasurer,,Josh Haeder,REP,43
+Meade,SUMMERSET #10,State Treasurer,,John Cunningham,DEM,236
+Meade,SUMMERSET #10,State Treasurer,,Josh Haeder,REP,696
+Meade,TILFORD #6,State Treasurer,,John Cunningham,DEM,128
+Meade,TILFORD #6,State Treasurer,,Josh Haeder,REP,522
+Meade,UNION #40,State Treasurer,,John Cunningham,DEM,7
+Meade,UNION #40,State Treasurer,,Josh Haeder,REP,22
+Meade,VIEWFIELD #17,State Treasurer,,John Cunningham,DEM,7
+Meade,VIEWFIELD #17,State Treasurer,,Josh Haeder,REP,80
+Meade,WEST BLACK HAWK #16,State Treasurer,,John Cunningham,DEM,88
+Meade,WEST BLACK HAWK #16,State Treasurer,,Josh Haeder,REP,219
+Meade,WEST ELK VALE #24,State Treasurer,,John Cunningham,DEM,38
+Meade,WEST ELK VALE #24,State Treasurer,,Josh Haeder,REP,140
+Meade,WEST STURGIS #4,State Treasurer,,John Cunningham,DEM,60
+Meade,WEST STURGIS #4,State Treasurer,,Josh Haeder,REP,117
+Meade,WHITE OWL #25,State Treasurer,,John Cunningham,DEM,3
+Meade,WHITE OWL #25,State Treasurer,,Josh Haeder,REP,33
+Meade,ALKALI #6A,Commissioner of School and Public Lands,,Timothy Azure,DEM,20
+Meade,ALKALI #6A,Commissioner of School and Public Lands,,Brock Greenfield,REP,110
+Meade,BASE #23,Commissioner of School and Public Lands,,Timothy Azure,DEM,96
+Meade,BASE #23,Commissioner of School and Public Lands,,Brock Greenfield,REP,168
+Meade,BEAR BUTTE #9,Commissioner of School and Public Lands,,Timothy Azure,DEM,30
+Meade,BEAR BUTTE #9,Commissioner of School and Public Lands,,Brock Greenfield,REP,111
+Meade,BLACK HAWK #14,Commissioner of School and Public Lands,,Timothy Azure,DEM,81
+Meade,BLACK HAWK #14,Commissioner of School and Public Lands,,Brock Greenfield,REP,218
+Meade,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,177
+Meade,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,503
+Meade,CENTRAL STURGIS #3,Commissioner of School and Public Lands,,Timothy Azure,DEM,73
+Meade,CENTRAL STURGIS #3,Commissioner of School and Public Lands,,Brock Greenfield,REP,143
+Meade,CHALK BUTTE #27,Commissioner of School and Public Lands,,Timothy Azure,DEM,13
+Meade,CHALK BUTTE #27,Commissioner of School and Public Lands,,Brock Greenfield,REP,94
+Meade,EAST ELK VALE #21A,Commissioner of School and Public Lands,,Timothy Azure,DEM,68
+Meade,EAST ELK VALE #21A,Commissioner of School and Public Lands,,Brock Greenfield,REP,368
+Meade,EAST PIEDMONT #12A,Commissioner of School and Public Lands,,Timothy Azure,DEM,41
+Meade,EAST PIEDMONT #12A,Commissioner of School and Public Lands,,Brock Greenfield,REP,230
+Meade,EAST STURGIS #1,Commissioner of School and Public Lands,,Timothy Azure,DEM,58
+Meade,EAST STURGIS #1,Commissioner of School and Public Lands,,Brock Greenfield,REP,147
+Meade,ELK VALE #21,Commissioner of School and Public Lands,,Timothy Azure,DEM,6
+Meade,ELK VALE #21,Commissioner of School and Public Lands,,Brock Greenfield,REP,49
+Meade,ELM SPRINGS #18,Commissioner of School and Public Lands,,Timothy Azure,DEM,12
+Meade,ELM SPRINGS #18,Commissioner of School and Public Lands,,Brock Greenfield,REP,71
+Meade,FAIRPOINT #29,Commissioner of School and Public Lands,,Timothy Azure,DEM,7
+Meade,FAIRPOINT #29,Commissioner of School and Public Lands,,Brock Greenfield,REP,26
+Meade,FAITH #31,Commissioner of School and Public Lands,,Timothy Azure,DEM,14
+Meade,FAITH #31,Commissioner of School and Public Lands,,Brock Greenfield,REP,182
+Meade,FORT MEADE #1A,Commissioner of School and Public Lands,,Timothy Azure,DEM,13
+Meade,FORT MEADE #1A,Commissioner of School and Public Lands,,Brock Greenfield,REP,18
+Meade,HARMONY #8,Commissioner of School and Public Lands,,Timothy Azure,DEM,70
+Meade,HARMONY #8,Commissioner of School and Public Lands,,Brock Greenfield,REP,236
+Meade,HEREFORD #20,Commissioner of School and Public Lands,,Timothy Azure,DEM,7
+Meade,HEREFORD #20,Commissioner of School and Public Lands,,Brock Greenfield,REP,41
+Meade,MARCUS #41,Commissioner of School and Public Lands,,Timothy Azure,DEM,3
+Meade,MARCUS #41,Commissioner of School and Public Lands,,Brock Greenfield,REP,29
+Meade,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,109
+Meade,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,542
+Meade,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,40
+Meade,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,82
+Meade,NORTHWEST STURGIS #5,Commissioner of School and Public Lands,,Timothy Azure,DEM,103
+Meade,NORTHWEST STURGIS #5,Commissioner of School and Public Lands,,Brock Greenfield,REP,274
+Meade,PIEDMONT CENTRAL #11A,Commissioner of School and Public Lands,,Timothy Azure,DEM,135
+Meade,PIEDMONT CENTRAL #11A,Commissioner of School and Public Lands,,Brock Greenfield,REP,479
+Meade,PIEDMONT WEST #11,Commissioner of School and Public Lands,,Timothy Azure,DEM,111
+Meade,PIEDMONT WEST #11,Commissioner of School and Public Lands,,Brock Greenfield,REP,335
+Meade,PINE #33,Commissioner of School and Public Lands,,Timothy Azure,DEM,7
+Meade,PINE #33,Commissioner of School and Public Lands,,Brock Greenfield,REP,63
+Meade,RED OWL #30,Commissioner of School and Public Lands,,Timothy Azure,DEM,3
+Meade,RED OWL #30,Commissioner of School and Public Lands,,Brock Greenfield,REP,67
+Meade,RURAL BLACK HAWK #15,Commissioner of School and Public Lands,,Timothy Azure,DEM,80
+Meade,RURAL BLACK HAWK #15,Commissioner of School and Public Lands,,Brock Greenfield,REP,295
+Meade,RURAL STURGIS #7,Commissioner of School and Public Lands,,Timothy Azure,DEM,91
+Meade,RURAL STURGIS #7,Commissioner of School and Public Lands,,Brock Greenfield,REP,313
+Meade,SOUTH STURGIS #2A,Commissioner of School and Public Lands,,Timothy Azure,DEM,94
+Meade,SOUTH STURGIS #2A,Commissioner of School and Public Lands,,Brock Greenfield,REP,226
+Meade,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,183
+Meade,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,576
+Meade,SOUTHEAST STURGIS #2,Commissioner of School and Public Lands,,Timothy Azure,DEM,123
+Meade,SOUTHEAST STURGIS #2,Commissioner of School and Public Lands,,Brock Greenfield,REP,313
+Meade,SOUTHWEST STURGIS #4A,Commissioner of School and Public Lands,,Timothy Azure,DEM,77
+Meade,SOUTHWEST STURGIS #4A,Commissioner of School and Public Lands,,Brock Greenfield,REP,177
+Meade,STURGIS #5A,Commissioner of School and Public Lands,,Timothy Azure,DEM,55
+Meade,STURGIS #5A,Commissioner of School and Public Lands,,Brock Greenfield,REP,139
+Meade,SULPHUR #35,Commissioner of School and Public Lands,,Timothy Azure,DEM,1
+Meade,SULPHUR #35,Commissioner of School and Public Lands,,Brock Greenfield,REP,44
+Meade,SUMMERSET #10,Commissioner of School and Public Lands,,Timothy Azure,DEM,232
+Meade,SUMMERSET #10,Commissioner of School and Public Lands,,Brock Greenfield,REP,696
+Meade,TILFORD #6,Commissioner of School and Public Lands,,Timothy Azure,DEM,131
+Meade,TILFORD #6,Commissioner of School and Public Lands,,Brock Greenfield,REP,514
+Meade,UNION #40,Commissioner of School and Public Lands,,Timothy Azure,DEM,8
+Meade,UNION #40,Commissioner of School and Public Lands,,Brock Greenfield,REP,23
+Meade,VIEWFIELD #17,Commissioner of School and Public Lands,,Timothy Azure,DEM,5
+Meade,VIEWFIELD #17,Commissioner of School and Public Lands,,Brock Greenfield,REP,81
+Meade,WEST BLACK HAWK #16,Commissioner of School and Public Lands,,Timothy Azure,DEM,92
+Meade,WEST BLACK HAWK #16,Commissioner of School and Public Lands,,Brock Greenfield,REP,218
+Meade,WEST ELK VALE #24,Commissioner of School and Public Lands,,Timothy Azure,DEM,34
+Meade,WEST ELK VALE #24,Commissioner of School and Public Lands,,Brock Greenfield,REP,143
+Meade,WEST STURGIS #4,Commissioner of School and Public Lands,,Timothy Azure,DEM,59
+Meade,WEST STURGIS #4,Commissioner of School and Public Lands,,Brock Greenfield,REP,117
+Meade,WHITE OWL #25,Commissioner of School and Public Lands,,Timothy Azure,DEM,1
+Meade,WHITE OWL #25,Commissioner of School and Public Lands,,Brock Greenfield,REP,34
+Meade,ALKALI #6A,Public Utilities Commissioner,,Jeffrey Barth,DEM,23
+Meade,ALKALI #6A,Public Utilities Commissioner,,Chris Nelson,REP,110
+Meade,BASE #23,Public Utilities Commissioner,,Jeffrey Barth,DEM,87
+Meade,BASE #23,Public Utilities Commissioner,,Chris Nelson,REP,171
+Meade,BEAR BUTTE #9,Public Utilities Commissioner,,Jeffrey Barth,DEM,29
+Meade,BEAR BUTTE #9,Public Utilities Commissioner,,Chris Nelson,REP,113
+Meade,BLACK HAWK #14,Public Utilities Commissioner,,Jeffrey Barth,DEM,71
+Meade,BLACK HAWK #14,Public Utilities Commissioner,,Chris Nelson,REP,226
+Meade,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,170
+Meade,?,Public Utilities Commissioner,,Chris Nelson,REP,528
+Meade,CENTRAL STURGIS #3,Public Utilities Commissioner,,Jeffrey Barth,DEM,59
+Meade,CENTRAL STURGIS #3,Public Utilities Commissioner,,Chris Nelson,REP,156
+Meade,CHALK BUTTE #27,Public Utilities Commissioner,,Jeffrey Barth,DEM,13
+Meade,CHALK BUTTE #27,Public Utilities Commissioner,,Chris Nelson,REP,97
+Meade,EAST ELK VALE #21A,Public Utilities Commissioner,,Jeffrey Barth,DEM,72
+Meade,EAST ELK VALE #21A,Public Utilities Commissioner,,Chris Nelson,REP,369
+Meade,EAST PIEDMONT #12A,Public Utilities Commissioner,,Jeffrey Barth,DEM,42
+Meade,EAST PIEDMONT #12A,Public Utilities Commissioner,,Chris Nelson,REP,235
+Meade,EAST STURGIS #1,Public Utilities Commissioner,,Jeffrey Barth,DEM,60
+Meade,EAST STURGIS #1,Public Utilities Commissioner,,Chris Nelson,REP,148
+Meade,ELK VALE #21,Public Utilities Commissioner,,Jeffrey Barth,DEM,7
+Meade,ELK VALE #21,Public Utilities Commissioner,,Chris Nelson,REP,49
+Meade,ELM SPRINGS #18,Public Utilities Commissioner,,Jeffrey Barth,DEM,14
+Meade,ELM SPRINGS #18,Public Utilities Commissioner,,Chris Nelson,REP,72
+Meade,FAIRPOINT #29,Public Utilities Commissioner,,Jeffrey Barth,DEM,6
+Meade,FAIRPOINT #29,Public Utilities Commissioner,,Chris Nelson,REP,26
+Meade,FAITH #31,Public Utilities Commissioner,,Jeffrey Barth,DEM,18
+Meade,FAITH #31,Public Utilities Commissioner,,Chris Nelson,REP,182
+Meade,FORT MEADE #1A,Public Utilities Commissioner,,Jeffrey Barth,DEM,12
+Meade,FORT MEADE #1A,Public Utilities Commissioner,,Chris Nelson,REP,19
+Meade,HARMONY #8,Public Utilities Commissioner,,Jeffrey Barth,DEM,68
+Meade,HARMONY #8,Public Utilities Commissioner,,Chris Nelson,REP,243
+Meade,HEREFORD #20,Public Utilities Commissioner,,Jeffrey Barth,DEM,7
+Meade,HEREFORD #20,Public Utilities Commissioner,,Chris Nelson,REP,41
+Meade,MARCUS #41,Public Utilities Commissioner,,Jeffrey Barth,DEM,6
+Meade,MARCUS #41,Public Utilities Commissioner,,Chris Nelson,REP,29
+Meade,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,104
+Meade,?,Public Utilities Commissioner,,Chris Nelson,REP,551
+Meade,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,39
+Meade,?,Public Utilities Commissioner,,Chris Nelson,REP,84
+Meade,NORTHWEST STURGIS #5,Public Utilities Commissioner,,Jeffrey Barth,DEM,105
+Meade,NORTHWEST STURGIS #5,Public Utilities Commissioner,,Chris Nelson,REP,277
+Meade,PIEDMONT CENTRAL #11A,Public Utilities Commissioner,,Jeffrey Barth,DEM,124
+Meade,PIEDMONT CENTRAL #11A,Public Utilities Commissioner,,Chris Nelson,REP,501
+Meade,PIEDMONT WEST #11,Public Utilities Commissioner,,Jeffrey Barth,DEM,105
+Meade,PIEDMONT WEST #11,Public Utilities Commissioner,,Chris Nelson,REP,343
+Meade,PINE #33,Public Utilities Commissioner,,Jeffrey Barth,DEM,13
+Meade,PINE #33,Public Utilities Commissioner,,Chris Nelson,REP,56
+Meade,RED OWL #30,Public Utilities Commissioner,,Jeffrey Barth,DEM,4
+Meade,RED OWL #30,Public Utilities Commissioner,,Chris Nelson,REP,66
+Meade,RURAL BLACK HAWK #15,Public Utilities Commissioner,,Jeffrey Barth,DEM,66
+Meade,RURAL BLACK HAWK #15,Public Utilities Commissioner,,Chris Nelson,REP,311
+Meade,RURAL STURGIS #7,Public Utilities Commissioner,,Jeffrey Barth,DEM,82
+Meade,RURAL STURGIS #7,Public Utilities Commissioner,,Chris Nelson,REP,328
+Meade,SOUTH STURGIS #2A,Public Utilities Commissioner,,Jeffrey Barth,DEM,86
+Meade,SOUTH STURGIS #2A,Public Utilities Commissioner,,Chris Nelson,REP,240
+Meade,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,174
+Meade,?,Public Utilities Commissioner,,Chris Nelson,REP,598
+Meade,SOUTHEAST STURGIS #2,Public Utilities Commissioner,,Jeffrey Barth,DEM,120
+Meade,SOUTHEAST STURGIS #2,Public Utilities Commissioner,,Chris Nelson,REP,332
+Meade,SOUTHWEST STURGIS #4A,Public Utilities Commissioner,,Jeffrey Barth,DEM,68
+Meade,SOUTHWEST STURGIS #4A,Public Utilities Commissioner,,Chris Nelson,REP,191
+Meade,STURGIS #5A,Public Utilities Commissioner,,Jeffrey Barth,DEM,49
+Meade,STURGIS #5A,Public Utilities Commissioner,,Chris Nelson,REP,148
+Meade,SULPHUR #35,Public Utilities Commissioner,,Jeffrey Barth,DEM,1
+Meade,SULPHUR #35,Public Utilities Commissioner,,Chris Nelson,REP,44
+Meade,SUMMERSET #10,Public Utilities Commissioner,,Jeffrey Barth,DEM,217
+Meade,SUMMERSET #10,Public Utilities Commissioner,,Chris Nelson,REP,716
+Meade,TILFORD #6,Public Utilities Commissioner,,Jeffrey Barth,DEM,133
+Meade,TILFORD #6,Public Utilities Commissioner,,Chris Nelson,REP,530
+Meade,UNION #40,Public Utilities Commissioner,,Jeffrey Barth,DEM,8
+Meade,UNION #40,Public Utilities Commissioner,,Chris Nelson,REP,23
+Meade,VIEWFIELD #17,Public Utilities Commissioner,,Jeffrey Barth,DEM,9
+Meade,VIEWFIELD #17,Public Utilities Commissioner,,Chris Nelson,REP,79
+Meade,WEST BLACK HAWK #16,Public Utilities Commissioner,,Jeffrey Barth,DEM,83
+Meade,WEST BLACK HAWK #16,Public Utilities Commissioner,,Chris Nelson,REP,229
+Meade,WEST ELK VALE #24,Public Utilities Commissioner,,Jeffrey Barth,DEM,41
+Meade,WEST ELK VALE #24,Public Utilities Commissioner,,Chris Nelson,REP,136
+Meade,WEST STURGIS #4,Public Utilities Commissioner,,Jeffrey Barth,DEM,58
+Meade,WEST STURGIS #4,Public Utilities Commissioner,,Chris Nelson,REP,121
+Meade,WHITE OWL #25,Public Utilities Commissioner,,Jeffrey Barth,DEM,3
+Meade,WHITE OWL #25,Public Utilities Commissioner,,Chris Nelson,REP,33
+Meade,ALKALI #6A,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,77
+Meade,BASE #23,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,131
+Meade,BEAR BUTTE #9,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,63
+Meade,BLACK HAWK #14,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,128
+Meade,?,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,343
+Meade,CENTRAL STURGIS #3,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,98
+Meade,CHALK BUTTE #27,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,42
+Meade,EAST ELK VALE #21A,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,208
+Meade,EAST PIEDMONT #12A,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,137
+Meade,EAST STURGIS #1,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,92
+Meade,ELK VALE #21,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,34
+Meade,ELM SPRINGS #18,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,24
+Meade,FAIRPOINT #29,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,20
+Meade,FAITH #31,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,104
+Meade,FORT MEADE #1A,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,13
+Meade,HARMONY #8,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,157
+Meade,HEREFORD #20,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,13
+Meade,MARCUS #41,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,8
+Meade,?,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,302
+Meade,?,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,63
+Meade,NORTHWEST STURGIS #5,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,193
+Meade,PIEDMONT CENTRAL #11A,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,275
+Meade,PIEDMONT WEST #11,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,219
+Meade,PINE #33,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,21
+Meade,RED OWL #30,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,30
+Meade,RURAL BLACK HAWK #15,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,187
+Meade,RURAL STURGIS #7,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,208
+Meade,SOUTH STURGIS #2A,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,179
+Meade,?,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,354
+Meade,SOUTHEAST STURGIS #2,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,226
+Meade,SOUTHWEST STURGIS #4A,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,140
+Meade,STURGIS #5A,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,107
+Meade,SULPHUR #35,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,11
+Meade,SUMMERSET #10,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,471
+Meade,TILFORD #6,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,324
+Meade,UNION #40,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,15
+Meade,VIEWFIELD #17,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,34
+Meade,WEST BLACK HAWK #16,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,137
+Meade,WEST ELK VALE #24,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,79
+Meade,WEST STURGIS #4,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,88
+Meade,WHITE OWL #25,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,18
+Meade,ALKALI #6A,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,78
+Meade,BASE #23,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,128
+Meade,BEAR BUTTE #9,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,66
+Meade,BLACK HAWK #14,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,115
+Meade,?,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,352
+Meade,CENTRAL STURGIS #3,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,95
+Meade,CHALK BUTTE #27,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,44
+Meade,EAST ELK VALE #21A,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,208
+Meade,EAST PIEDMONT #12A,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,137
+Meade,EAST STURGIS #1,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,84
+Meade,ELK VALE #21,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,35
+Meade,ELM SPRINGS #18,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,19
+Meade,FAIRPOINT #29,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,18
+Meade,FAITH #31,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,105
+Meade,FORT MEADE #1A,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,13
+Meade,HARMONY #8,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,152
+Meade,HEREFORD #20,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,14
+Meade,MARCUS #41,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,8
+Meade,?,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,301
+Meade,?,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,65
+Meade,NORTHWEST STURGIS #5,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,193
+Meade,PIEDMONT CENTRAL #11A,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,269
+Meade,PIEDMONT WEST #11,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,219
+Meade,PINE #33,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,21
+Meade,RED OWL #30,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,27
+Meade,RURAL BLACK HAWK #15,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,190
+Meade,RURAL STURGIS #7,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,207
+Meade,SOUTH STURGIS #2A,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,176
+Meade,?,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,349
+Meade,SOUTHEAST STURGIS #2,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,219
+Meade,SOUTHWEST STURGIS #4A,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,133
+Meade,STURGIS #5A,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,111
+Meade,SULPHUR #35,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,11
+Meade,SUMMERSET #10,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,469
+Meade,TILFORD #6,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,337
+Meade,UNION #40,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,14
+Meade,VIEWFIELD #17,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,31
+Meade,WEST BLACK HAWK #16,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,135
+Meade,WEST ELK VALE #24,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,79
+Meade,WEST STURGIS #4,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,88
+Meade,WHITE OWL #25,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,19
+Meade,ALKALI #6A,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,76
+Meade,BASE #23,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,129
+Meade,BEAR BUTTE #9,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,64
+Meade,BLACK HAWK #14,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,125
+Meade,?,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,341
+Meade,CENTRAL STURGIS #3,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,93
+Meade,CHALK BUTTE #27,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,43
+Meade,EAST ELK VALE #21A,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,212
+Meade,EAST PIEDMONT #12A,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,131
+Meade,EAST STURGIS #1,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,88
+Meade,ELK VALE #21,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,33
+Meade,ELM SPRINGS #18,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,20
+Meade,FAIRPOINT #29,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,19
+Meade,FAITH #31,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,102
+Meade,FORT MEADE #1A,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,13
+Meade,HARMONY #8,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,155
+Meade,HEREFORD #20,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,15
+Meade,MARCUS #41,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,7
+Meade,?,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,306
+Meade,?,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,63
+Meade,NORTHWEST STURGIS #5,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,191
+Meade,PIEDMONT CENTRAL #11A,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,269
+Meade,PIEDMONT WEST #11,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,220
+Meade,PINE #33,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,19
+Meade,RED OWL #30,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,25
+Meade,RURAL BLACK HAWK #15,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,183
+Meade,RURAL STURGIS #7,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,207
+Meade,SOUTH STURGIS #2A,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,178
+Meade,?,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,349
+Meade,SOUTHEAST STURGIS #2,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,221
+Meade,SOUTHWEST STURGIS #4A,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,131
+Meade,STURGIS #5A,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,105
+Meade,SULPHUR #35,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,9
+Meade,SUMMERSET #10,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,470
+Meade,TILFORD #6,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,332
+Meade,UNION #40,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,14
+Meade,VIEWFIELD #17,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,30
+Meade,WEST BLACK HAWK #16,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,138
+Meade,WEST ELK VALE #24,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,77
+Meade,WEST STURGIS #4,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,87
+Meade,WHITE OWL #25,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,17
+Meade,ALKALI #6A,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,18
+Meade,ALKALI #6A,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,22
+Meade,ALKALI #6A,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,8
+Meade,ALKALI #6A,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,36
+Meade,ALKALI #6A,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,19
+Meade,BASE #23,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,20
+Meade,BASE #23,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,30
+Meade,BASE #23,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,45
+Meade,BASE #23,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,42
+Meade,BASE #23,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,5
+Meade,BEAR BUTTE #9,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,16
+Meade,BEAR BUTTE #9,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,35
+Meade,BEAR BUTTE #9,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,12
+Meade,BEAR BUTTE #9,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,33
+Meade,BEAR BUTTE #9,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,29
+Meade,BLACK HAWK #14,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,23
+Meade,BLACK HAWK #14,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,42
+Meade,BLACK HAWK #14,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,29
+Meade,BLACK HAWK #14,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,86
+Meade,BLACK HAWK #14,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,32
+Meade,?,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,56
+Meade,?,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,104
+Meade,?,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,76
+Meade,?,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,153
+Meade,?,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,119
+Meade,CENTRAL STURGIS #3,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,19
+Meade,CENTRAL STURGIS #3,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,52
+Meade,CENTRAL STURGIS #3,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,19
+Meade,CENTRAL STURGIS #3,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,50
+Meade,CENTRAL STURGIS #3,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,17
+Meade,CHALK BUTTE #27,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,6
+Meade,CHALK BUTTE #27,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,18
+Meade,CHALK BUTTE #27,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,6
+Meade,CHALK BUTTE #27,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,30
+Meade,CHALK BUTTE #27,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,9
+Meade,EAST ELK VALE #21A,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,33
+Meade,EAST ELK VALE #21A,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,39
+Meade,EAST ELK VALE #21A,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,66
+Meade,EAST ELK VALE #21A,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,65
+Meade,EAST ELK VALE #21A,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,46
+Meade,EAST PIEDMONT #12A,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,29
+Meade,EAST PIEDMONT #12A,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,27
+Meade,EAST PIEDMONT #12A,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,38
+Meade,EAST PIEDMONT #12A,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,38
+Meade,EAST PIEDMONT #12A,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,27
+Meade,EAST STURGIS #1,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,18
+Meade,EAST STURGIS #1,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,57
+Meade,EAST STURGIS #1,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,18
+Meade,EAST STURGIS #1,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,37
+Meade,EAST STURGIS #1,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,20
+Meade,ELK VALE #21,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,13
+Meade,ELK VALE #21,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,5
+Meade,ELK VALE #21,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,3
+Meade,ELK VALE #21,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,14
+Meade,ELK VALE #21,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,9
+Meade,ELM SPRINGS #18,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,6
+Meade,ELM SPRINGS #18,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,10
+Meade,ELM SPRINGS #18,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,5
+Meade,ELM SPRINGS #18,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,11
+Meade,ELM SPRINGS #18,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,11
+Meade,FAIRPOINT #29,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,3
+Meade,FAIRPOINT #29,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,7
+Meade,FAIRPOINT #29,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,1
+Meade,FAIRPOINT #29,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,6
+Meade,FAIRPOINT #29,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,10
+Meade,FAITH #31,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,3
+Meade,FAITH #31,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,29
+Meade,FAITH #31,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,17
+Meade,FAITH #31,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,43
+Meade,FAITH #31,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,48
+Meade,FORT MEADE #1A,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,3
+Meade,FORT MEADE #1A,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,6
+Meade,FORT MEADE #1A,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,2
+Meade,FORT MEADE #1A,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,5
+Meade,FORT MEADE #1A,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,4
+Meade,HARMONY #8,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,39
+Meade,HARMONY #8,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,58
+Meade,HARMONY #8,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,14
+Meade,HARMONY #8,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,68
+Meade,HARMONY #8,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,47
+Meade,HEREFORD #20,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,3
+Meade,HEREFORD #20,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,7
+Meade,HEREFORD #20,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,2
+Meade,HEREFORD #20,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,11
+Meade,HEREFORD #20,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,1
+Meade,MARCUS #41,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,1
+Meade,MARCUS #41,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,3
+Meade,MARCUS #41,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,2
+Meade,MARCUS #41,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,7
+Meade,MARCUS #41,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,3
+Meade,?,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,38
+Meade,?,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,58
+Meade,?,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,77
+Meade,?,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,139
+Meade,?,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,77
+Meade,?,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,28
+Meade,?,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,21
+Meade,?,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,6
+Meade,?,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,20
+Meade,?,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,11
+Meade,NORTHWEST STURGIS #5,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,60
+Meade,NORTHWEST STURGIS #5,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,61
+Meade,NORTHWEST STURGIS #5,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,27
+Meade,NORTHWEST STURGIS #5,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,74
+Meade,NORTHWEST STURGIS #5,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,60
+Meade,PIEDMONT CENTRAL #11A,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,59
+Meade,PIEDMONT CENTRAL #11A,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,52
+Meade,PIEDMONT CENTRAL #11A,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,63
+Meade,PIEDMONT CENTRAL #11A,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,130
+Meade,PIEDMONT CENTRAL #11A,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,69
+Meade,PIEDMONT WEST #11,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,54
+Meade,PIEDMONT WEST #11,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,43
+Meade,PIEDMONT WEST #11,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,46
+Meade,PIEDMONT WEST #11,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,93
+Meade,PIEDMONT WEST #11,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,59
+Meade,PINE #33,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,0
+Meade,PINE #33,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,9
+Meade,PINE #33,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,6
+Meade,PINE #33,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,13
+Meade,PINE #33,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,23
+Meade,RED OWL #30,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,2
+Meade,RED OWL #30,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,19
+Meade,RED OWL #30,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,4
+Meade,RED OWL #30,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,20
+Meade,RED OWL #30,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,4
+Meade,RURAL BLACK HAWK #15,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,38
+Meade,RURAL BLACK HAWK #15,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,40
+Meade,RURAL BLACK HAWK #15,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,32
+Meade,RURAL BLACK HAWK #15,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,84
+Meade,RURAL BLACK HAWK #15,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,50
+Meade,RURAL STURGIS #7,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,46
+Meade,RURAL STURGIS #7,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,101
+Meade,RURAL STURGIS #7,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,24
+Meade,RURAL STURGIS #7,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,81
+Meade,RURAL STURGIS #7,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,48
+Meade,SOUTH STURGIS #2A,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,38
+Meade,SOUTH STURGIS #2A,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,67
+Meade,SOUTH STURGIS #2A,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,20
+Meade,SOUTH STURGIS #2A,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,83
+Meade,SOUTH STURGIS #2A,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,46
+Meade,?,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,93
+Meade,?,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,74
+Meade,?,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,86
+Meade,?,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,144
+Meade,?,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,84
+Meade,SOUTHEAST STURGIS #2,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,51
+Meade,SOUTHEAST STURGIS #2,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,122
+Meade,SOUTHEAST STURGIS #2,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,30
+Meade,SOUTHEAST STURGIS #2,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,119
+Meade,SOUTHEAST STURGIS #2,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,51
+Meade,SOUTHWEST STURGIS #4A,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,30
+Meade,SOUTHWEST STURGIS #4A,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,59
+Meade,SOUTHWEST STURGIS #4A,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,14
+Meade,SOUTHWEST STURGIS #4A,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,70
+Meade,SOUTHWEST STURGIS #4A,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,31
+Meade,STURGIS #5A,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,27
+Meade,STURGIS #5A,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,53
+Meade,STURGIS #5A,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,11
+Meade,STURGIS #5A,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,29
+Meade,STURGIS #5A,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,30
+Meade,SULPHUR #35,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,0
+Meade,SULPHUR #35,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,4
+Meade,SULPHUR #35,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,2
+Meade,SULPHUR #35,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,15
+Meade,SULPHUR #35,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,11
+Meade,SUMMERSET #10,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,76
+Meade,SUMMERSET #10,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,105
+Meade,SUMMERSET #10,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,98
+Meade,SUMMERSET #10,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,206
+Meade,SUMMERSET #10,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,147
+Meade,TILFORD #6,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,69
+Meade,TILFORD #6,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,113
+Meade,TILFORD #6,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,37
+Meade,TILFORD #6,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,130
+Meade,TILFORD #6,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,88
+Meade,UNION #40,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,4
+Meade,UNION #40,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,3
+Meade,UNION #40,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,2
+Meade,UNION #40,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,5
+Meade,UNION #40,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,5
+Meade,VIEWFIELD #17,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,6
+Meade,VIEWFIELD #17,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,12
+Meade,VIEWFIELD #17,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,9
+Meade,VIEWFIELD #17,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,16
+Meade,VIEWFIELD #17,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,11
+Meade,WEST BLACK HAWK #16,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,39
+Meade,WEST BLACK HAWK #16,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,35
+Meade,WEST BLACK HAWK #16,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,34
+Meade,WEST BLACK HAWK #16,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,51
+Meade,WEST BLACK HAWK #16,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,39
+Meade,WEST ELK VALE #24,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,7
+Meade,WEST ELK VALE #24,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,17
+Meade,WEST ELK VALE #24,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,22
+Meade,WEST ELK VALE #24,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,28
+Meade,WEST ELK VALE #24,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,12
+Meade,WEST STURGIS #4,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,28
+Meade,WEST STURGIS #4,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,35
+Meade,WEST STURGIS #4,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,16
+Meade,WEST STURGIS #4,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,35
+Meade,WEST STURGIS #4,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,16
+Meade,WHITE OWL #25,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,4
+Meade,WHITE OWL #25,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,12
+Meade,WHITE OWL #25,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,4
+Meade,WHITE OWL #25,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,5
+Meade,WHITE OWL #25,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,1
+Meade,ALKALI #6A,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,103
+Meade,ALKALI #6A,Supreme Court Retention,3,Patricia J. DeVaney - No,,16
+Meade,BASE #23,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,169
+Meade,BASE #23,Supreme Court Retention,3,Patricia J. DeVaney - No,,71
+Meade,BEAR BUTTE #9,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,89
+Meade,BEAR BUTTE #9,Supreme Court Retention,3,Patricia J. DeVaney - No,,32
+Meade,BLACK HAWK #14,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,202
+Meade,BLACK HAWK #14,Supreme Court Retention,3,Patricia J. DeVaney - No,,64
+Meade,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,496
+Meade,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,141
+Meade,CENTRAL STURGIS #3,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,144
+Meade,CENTRAL STURGIS #3,Supreme Court Retention,3,Patricia J. DeVaney - No,,47
+Meade,CHALK BUTTE #27,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,61
+Meade,CHALK BUTTE #27,Supreme Court Retention,3,Patricia J. DeVaney - No,,23
+Meade,EAST ELK VALE #21A,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,313
+Meade,EAST ELK VALE #21A,Supreme Court Retention,3,Patricia J. DeVaney - No,,67
+Meade,EAST PIEDMONT #12A,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,193
+Meade,EAST PIEDMONT #12A,Supreme Court Retention,3,Patricia J. DeVaney - No,,41
+Meade,EAST STURGIS #1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,135
+Meade,EAST STURGIS #1,Supreme Court Retention,3,Patricia J. DeVaney - No,,46
+Meade,ELK VALE #21,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,44
+Meade,ELK VALE #21,Supreme Court Retention,3,Patricia J. DeVaney - No,,6
+Meade,ELM SPRINGS #18,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,50
+Meade,ELM SPRINGS #18,Supreme Court Retention,3,Patricia J. DeVaney - No,,16
+Meade,FAIRPOINT #29,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,20
+Meade,FAIRPOINT #29,Supreme Court Retention,3,Patricia J. DeVaney - No,,5
+Meade,FAITH #31,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,142
+Meade,FAITH #31,Supreme Court Retention,3,Patricia J. DeVaney - No,,24
+Meade,FORT MEADE #1A,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,19
+Meade,FORT MEADE #1A,Supreme Court Retention,3,Patricia J. DeVaney - No,,10
+Meade,HARMONY #8,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,215
+Meade,HARMONY #8,Supreme Court Retention,3,Patricia J. DeVaney - No,,62
+Meade,HEREFORD #20,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,25
+Meade,HEREFORD #20,Supreme Court Retention,3,Patricia J. DeVaney - No,,14
+Meade,MARCUS #41,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,22
+Meade,MARCUS #41,Supreme Court Retention,3,Patricia J. DeVaney - No,,4
+Meade,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,449
+Meade,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,112
+Meade,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,75
+Meade,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,39
+Meade,NORTHWEST STURGIS #5,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,278
+Meade,NORTHWEST STURGIS #5,Supreme Court Retention,3,Patricia J. DeVaney - No,,79
+Meade,PIEDMONT CENTRAL #11A,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,438
+Meade,PIEDMONT CENTRAL #11A,Supreme Court Retention,3,Patricia J. DeVaney - No,,100
+Meade,PIEDMONT WEST #11,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,327
+Meade,PIEDMONT WEST #11,Supreme Court Retention,3,Patricia J. DeVaney - No,,74
+Meade,PINE #33,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,45
+Meade,PINE #33,Supreme Court Retention,3,Patricia J. DeVaney - No,,12
+Meade,RED OWL #30,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,39
+Meade,RED OWL #30,Supreme Court Retention,3,Patricia J. DeVaney - No,,16
+Meade,RURAL BLACK HAWK #15,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,283
+Meade,RURAL BLACK HAWK #15,Supreme Court Retention,3,Patricia J. DeVaney - No,,53
+Meade,RURAL STURGIS #7,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,296
+Meade,RURAL STURGIS #7,Supreme Court Retention,3,Patricia J. DeVaney - No,,65
+Meade,SOUTH STURGIS #2A,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,232
+Meade,SOUTH STURGIS #2A,Supreme Court Retention,3,Patricia J. DeVaney - No,,52
+Meade,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,529
+Meade,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,160
+Meade,SOUTHEAST STURGIS #2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,318
+Meade,SOUTHEAST STURGIS #2,Supreme Court Retention,3,Patricia J. DeVaney - No,,83
+Meade,SOUTHWEST STURGIS #4A,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,185
+Meade,SOUTHWEST STURGIS #4A,Supreme Court Retention,3,Patricia J. DeVaney - No,,53
+Meade,STURGIS #5A,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,150
+Meade,STURGIS #5A,Supreme Court Retention,3,Patricia J. DeVaney - No,,32
+Meade,SULPHUR #35,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,21
+Meade,SULPHUR #35,Supreme Court Retention,3,Patricia J. DeVaney - No,,9
+Meade,SUMMERSET #10,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,689
+Meade,SUMMERSET #10,Supreme Court Retention,3,Patricia J. DeVaney - No,,133
+Meade,TILFORD #6,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,459
+Meade,TILFORD #6,Supreme Court Retention,3,Patricia J. DeVaney - No,,121
+Meade,UNION #40,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,25
+Meade,UNION #40,Supreme Court Retention,3,Patricia J. DeVaney - No,,7
+Meade,VIEWFIELD #17,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,51
+Meade,VIEWFIELD #17,Supreme Court Retention,3,Patricia J. DeVaney - No,,20
+Meade,WEST BLACK HAWK #16,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,217
+Meade,WEST BLACK HAWK #16,Supreme Court Retention,3,Patricia J. DeVaney - No,,55
+Meade,WEST ELK VALE #24,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,112
+Meade,WEST ELK VALE #24,Supreme Court Retention,3,Patricia J. DeVaney - No,,36
+Meade,WEST STURGIS #4,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,110
+Meade,WEST STURGIS #4,Supreme Court Retention,3,Patricia J. DeVaney - No,,43
+Meade,WHITE OWL #25,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,24
+Meade,WHITE OWL #25,Supreme Court Retention,3,Patricia J. DeVaney - No,,2
+Meade,ALKALI #6A,Supreme Court Retention,2,Mark E. Salter - Yes,,101
+Meade,ALKALI #6A,Supreme Court Retention,2,Mark E. Salter - No,,18
+Meade,BASE #23,Supreme Court Retention,2,Mark E. Salter - Yes,,162
+Meade,BASE #23,Supreme Court Retention,2,Mark E. Salter - No,,78
+Meade,BEAR BUTTE #9,Supreme Court Retention,2,Mark E. Salter - Yes,,88
+Meade,BEAR BUTTE #9,Supreme Court Retention,2,Mark E. Salter - No,,33
+Meade,BLACK HAWK #14,Supreme Court Retention,2,Mark E. Salter - Yes,,201
+Meade,BLACK HAWK #14,Supreme Court Retention,2,Mark E. Salter - No,,63
+Meade,?,Supreme Court Retention,2,Mark E. Salter - Yes,,487
+Meade,?,Supreme Court Retention,2,Mark E. Salter - No,,145
+Meade,CENTRAL STURGIS #3,Supreme Court Retention,2,Mark E. Salter - Yes,,143
+Meade,CENTRAL STURGIS #3,Supreme Court Retention,2,Mark E. Salter - No,,44
+Meade,CHALK BUTTE #27,Supreme Court Retention,2,Mark E. Salter - Yes,,56
+Meade,CHALK BUTTE #27,Supreme Court Retention,2,Mark E. Salter - No,,27
+Meade,EAST ELK VALE #21A,Supreme Court Retention,2,Mark E. Salter - Yes,,310
+Meade,EAST ELK VALE #21A,Supreme Court Retention,2,Mark E. Salter - No,,72
+Meade,EAST PIEDMONT #12A,Supreme Court Retention,2,Mark E. Salter - Yes,,186
+Meade,EAST PIEDMONT #12A,Supreme Court Retention,2,Mark E. Salter - No,,48
+Meade,EAST STURGIS #1,Supreme Court Retention,2,Mark E. Salter - Yes,,137
+Meade,EAST STURGIS #1,Supreme Court Retention,2,Mark E. Salter - No,,44
+Meade,ELK VALE #21,Supreme Court Retention,2,Mark E. Salter - Yes,,41
+Meade,ELK VALE #21,Supreme Court Retention,2,Mark E. Salter - No,,9
+Meade,ELM SPRINGS #18,Supreme Court Retention,2,Mark E. Salter - Yes,,48
+Meade,ELM SPRINGS #18,Supreme Court Retention,2,Mark E. Salter - No,,16
+Meade,FAIRPOINT #29,Supreme Court Retention,2,Mark E. Salter - Yes,,20
+Meade,FAIRPOINT #29,Supreme Court Retention,2,Mark E. Salter - No,,5
+Meade,FAITH #31,Supreme Court Retention,2,Mark E. Salter - Yes,,141
+Meade,FAITH #31,Supreme Court Retention,2,Mark E. Salter - No,,26
+Meade,FORT MEADE #1A,Supreme Court Retention,2,Mark E. Salter - Yes,,19
+Meade,FORT MEADE #1A,Supreme Court Retention,2,Mark E. Salter - No,,9
+Meade,HARMONY #8,Supreme Court Retention,2,Mark E. Salter - Yes,,211
+Meade,HARMONY #8,Supreme Court Retention,2,Mark E. Salter - No,,63
+Meade,HEREFORD #20,Supreme Court Retention,2,Mark E. Salter - Yes,,26
+Meade,HEREFORD #20,Supreme Court Retention,2,Mark E. Salter - No,,13
+Meade,MARCUS #41,Supreme Court Retention,2,Mark E. Salter - Yes,,21
+Meade,MARCUS #41,Supreme Court Retention,2,Mark E. Salter - No,,3
+Meade,?,Supreme Court Retention,2,Mark E. Salter - Yes,,429
+Meade,?,Supreme Court Retention,2,Mark E. Salter - No,,127
+Meade,?,Supreme Court Retention,2,Mark E. Salter - Yes,,74
+Meade,?,Supreme Court Retention,2,Mark E. Salter - No,,40
+Meade,NORTHWEST STURGIS #5,Supreme Court Retention,2,Mark E. Salter - Yes,,269
+Meade,NORTHWEST STURGIS #5,Supreme Court Retention,2,Mark E. Salter - No,,84
+Meade,PIEDMONT CENTRAL #11A,Supreme Court Retention,2,Mark E. Salter - Yes,,424
+Meade,PIEDMONT CENTRAL #11A,Supreme Court Retention,2,Mark E. Salter - No,,106
+Meade,PIEDMONT WEST #11,Supreme Court Retention,2,Mark E. Salter - Yes,,324
+Meade,PIEDMONT WEST #11,Supreme Court Retention,2,Mark E. Salter - No,,70
+Meade,PINE #33,Supreme Court Retention,2,Mark E. Salter - Yes,,44
+Meade,PINE #33,Supreme Court Retention,2,Mark E. Salter - No,,13
+Meade,RED OWL #30,Supreme Court Retention,2,Mark E. Salter - Yes,,42
+Meade,RED OWL #30,Supreme Court Retention,2,Mark E. Salter - No,,13
+Meade,RURAL BLACK HAWK #15,Supreme Court Retention,2,Mark E. Salter - Yes,,286
+Meade,RURAL BLACK HAWK #15,Supreme Court Retention,2,Mark E. Salter - No,,50
+Meade,RURAL STURGIS #7,Supreme Court Retention,2,Mark E. Salter - Yes,,296
+Meade,RURAL STURGIS #7,Supreme Court Retention,2,Mark E. Salter - No,,61
+Meade,SOUTH STURGIS #2A,Supreme Court Retention,2,Mark E. Salter - Yes,,236
+Meade,SOUTH STURGIS #2A,Supreme Court Retention,2,Mark E. Salter - No,,50
+Meade,?,Supreme Court Retention,2,Mark E. Salter - Yes,,526
+Meade,?,Supreme Court Retention,2,Mark E. Salter - No,,158
+Meade,SOUTHEAST STURGIS #2,Supreme Court Retention,2,Mark E. Salter - Yes,,311
+Meade,SOUTHEAST STURGIS #2,Supreme Court Retention,2,Mark E. Salter - No,,84
+Meade,SOUTHWEST STURGIS #4A,Supreme Court Retention,2,Mark E. Salter - Yes,,186
+Meade,SOUTHWEST STURGIS #4A,Supreme Court Retention,2,Mark E. Salter - No,,49
+Meade,STURGIS #5A,Supreme Court Retention,2,Mark E. Salter - Yes,,143
+Meade,STURGIS #5A,Supreme Court Retention,2,Mark E. Salter - No,,37
+Meade,SULPHUR #35,Supreme Court Retention,2,Mark E. Salter - Yes,,19
+Meade,SULPHUR #35,Supreme Court Retention,2,Mark E. Salter - No,,10
+Meade,SUMMERSET #10,Supreme Court Retention,2,Mark E. Salter - Yes,,680
+Meade,SUMMERSET #10,Supreme Court Retention,2,Mark E. Salter - No,,136
+Meade,TILFORD #6,Supreme Court Retention,2,Mark E. Salter - Yes,,458
+Meade,TILFORD #6,Supreme Court Retention,2,Mark E. Salter - No,,120
+Meade,UNION #40,Supreme Court Retention,2,Mark E. Salter - Yes,,25
+Meade,UNION #40,Supreme Court Retention,2,Mark E. Salter - No,,7
+Meade,VIEWFIELD #17,Supreme Court Retention,2,Mark E. Salter - Yes,,50
+Meade,VIEWFIELD #17,Supreme Court Retention,2,Mark E. Salter - No,,21
+Meade,WEST BLACK HAWK #16,Supreme Court Retention,2,Mark E. Salter - Yes,,215
+Meade,WEST BLACK HAWK #16,Supreme Court Retention,2,Mark E. Salter - No,,49
+Meade,WEST ELK VALE #24,Supreme Court Retention,2,Mark E. Salter - Yes,,116
+Meade,WEST ELK VALE #24,Supreme Court Retention,2,Mark E. Salter - No,,30
+Meade,WEST STURGIS #4,Supreme Court Retention,2,Mark E. Salter - Yes,,116
+Meade,WEST STURGIS #4,Supreme Court Retention,2,Mark E. Salter - No,,36
+Meade,WHITE OWL #25,Supreme Court Retention,2,Mark E. Salter - Yes,,23
+Meade,WHITE OWL #25,Supreme Court Retention,2,Mark E. Salter - No,,3
+Meade,ALKALI #6A,Constitutional Amendment D,,Yes,,58
+Meade,ALKALI #6A,Constitutional Amendment D,,No,,86
+Meade,BASE #23,Constitutional Amendment D,,Yes,,187
+Meade,BASE #23,Constitutional Amendment D,,No,,94
+Meade,BEAR BUTTE #9,Constitutional Amendment D,,Yes,,59
+Meade,BEAR BUTTE #9,Constitutional Amendment D,,No,,94
+Meade,BLACK HAWK #14,Constitutional Amendment D,,Yes,,169
+Meade,BLACK HAWK #14,Constitutional Amendment D,,No,,142
+Meade,?,Constitutional Amendment D,,Yes,,410
+Meade,?,Constitutional Amendment D,,No,,326
+Meade,CENTRAL STURGIS #3,Constitutional Amendment D,,Yes,,131
+Meade,CENTRAL STURGIS #3,Constitutional Amendment D,,No,,93
+Meade,CHALK BUTTE #27,Constitutional Amendment D,,Yes,,29
+Meade,CHALK BUTTE #27,Constitutional Amendment D,,No,,79
+Meade,EAST ELK VALE #21A,Constitutional Amendment D,,Yes,,218
+Meade,EAST ELK VALE #21A,Constitutional Amendment D,,No,,232
+Meade,EAST PIEDMONT #12A,Constitutional Amendment D,,Yes,,102
+Meade,EAST PIEDMONT #12A,Constitutional Amendment D,,No,,184
+Meade,EAST STURGIS #1,Constitutional Amendment D,,Yes,,113
+Meade,EAST STURGIS #1,Constitutional Amendment D,,No,,103
+Meade,ELK VALE #21,Constitutional Amendment D,,Yes,,27
+Meade,ELK VALE #21,Constitutional Amendment D,,No,,34
+Meade,ELM SPRINGS #18,Constitutional Amendment D,,Yes,,30
+Meade,ELM SPRINGS #18,Constitutional Amendment D,,No,,59
+Meade,FAIRPOINT #29,Constitutional Amendment D,,Yes,,10
+Meade,FAIRPOINT #29,Constitutional Amendment D,,No,,24
+Meade,FAITH #31,Constitutional Amendment D,,Yes,,77
+Meade,FAITH #31,Constitutional Amendment D,,No,,137
+Meade,FORT MEADE #1A,Constitutional Amendment D,,Yes,,22
+Meade,FORT MEADE #1A,Constitutional Amendment D,,No,,12
+Meade,HARMONY #8,Constitutional Amendment D,,Yes,,141
+Meade,HARMONY #8,Constitutional Amendment D,,No,,182
+Meade,HEREFORD #20,Constitutional Amendment D,,Yes,,22
+Meade,HEREFORD #20,Constitutional Amendment D,,No,,29
+Meade,MARCUS #41,Constitutional Amendment D,,Yes,,9
+Meade,MARCUS #41,Constitutional Amendment D,,No,,37
+Meade,?,Constitutional Amendment D,,Yes,,271
+Meade,?,Constitutional Amendment D,,No,,394
+Meade,?,Constitutional Amendment D,,Yes,,77
+Meade,?,Constitutional Amendment D,,No,,55
+Meade,NORTHWEST STURGIS #5,Constitutional Amendment D,,Yes,,259
+Meade,NORTHWEST STURGIS #5,Constitutional Amendment D,,No,,150
+Meade,PIEDMONT CENTRAL #11A,Constitutional Amendment D,,Yes,,344
+Meade,PIEDMONT CENTRAL #11A,Constitutional Amendment D,,No,,302
+Meade,PIEDMONT WEST #11,Constitutional Amendment D,,Yes,,204
+Meade,PIEDMONT WEST #11,Constitutional Amendment D,,No,,258
+Meade,PINE #33,Constitutional Amendment D,,Yes,,13
+Meade,PINE #33,Constitutional Amendment D,,No,,59
+Meade,RED OWL #30,Constitutional Amendment D,,Yes,,18
+Meade,RED OWL #30,Constitutional Amendment D,,No,,59
+Meade,RURAL BLACK HAWK #15,Constitutional Amendment D,,Yes,,185
+Meade,RURAL BLACK HAWK #15,Constitutional Amendment D,,No,,213
+Meade,RURAL STURGIS #7,Constitutional Amendment D,,Yes,,217
+Meade,RURAL STURGIS #7,Constitutional Amendment D,,No,,215
+Meade,SOUTH STURGIS #2A,Constitutional Amendment D,,Yes,,186
+Meade,SOUTH STURGIS #2A,Constitutional Amendment D,,No,,151
+Meade,?,Constitutional Amendment D,,Yes,,404
+Meade,?,Constitutional Amendment D,,No,,398
+Meade,SOUTHEAST STURGIS #2,Constitutional Amendment D,,Yes,,234
+Meade,SOUTHEAST STURGIS #2,Constitutional Amendment D,,No,,235
+Meade,SOUTHWEST STURGIS #4A,Constitutional Amendment D,,Yes,,150
+Meade,SOUTHWEST STURGIS #4A,Constitutional Amendment D,,No,,123
+Meade,STURGIS #5A,Constitutional Amendment D,,Yes,,110
+Meade,STURGIS #5A,Constitutional Amendment D,,No,,97
+Meade,SULPHUR #35,Constitutional Amendment D,,Yes,,8
+Meade,SULPHUR #35,Constitutional Amendment D,,No,,37
+Meade,SUMMERSET #10,Constitutional Amendment D,,Yes,,512
+Meade,SUMMERSET #10,Constitutional Amendment D,,No,,474
+Meade,TILFORD #6,Constitutional Amendment D,,Yes,,301
+Meade,TILFORD #6,Constitutional Amendment D,,No,,381
+Meade,UNION #40,Constitutional Amendment D,,Yes,,17
+Meade,UNION #40,Constitutional Amendment D,,No,,18
+Meade,VIEWFIELD #17,Constitutional Amendment D,,Yes,,25
+Meade,VIEWFIELD #17,Constitutional Amendment D,,No,,68
+Meade,WEST BLACK HAWK #16,Constitutional Amendment D,,Yes,,183
+Meade,WEST BLACK HAWK #16,Constitutional Amendment D,,No,,137
+Meade,WEST ELK VALE #24,Constitutional Amendment D,,Yes,,81
+Meade,WEST ELK VALE #24,Constitutional Amendment D,,No,,98
+Meade,WEST STURGIS #4,Constitutional Amendment D,,Yes,,117
+Meade,WEST STURGIS #4,Constitutional Amendment D,,No,,66
+Meade,WHITE OWL #25,Constitutional Amendment D,,Yes,,12
+Meade,WHITE OWL #25,Constitutional Amendment D,,No,,23
+Meade,ALKALI #6A,Initiated Measure 27,,Yes,,26
+Meade,ALKALI #6A,Initiated Measure 27,,No,,117
+Meade,BASE #23,Initiated Measure 27,,Yes,,191
+Meade,BASE #23,Initiated Measure 27,,No,,96
+Meade,BEAR BUTTE #9,Initiated Measure 27,,Yes,,33
+Meade,BEAR BUTTE #9,Initiated Measure 27,,No,,125
+Meade,BLACK HAWK #14,Initiated Measure 27,,Yes,,163
+Meade,BLACK HAWK #14,Initiated Measure 27,,No,,158
+Meade,?,Initiated Measure 27,,Yes,,375
+Meade,?,Initiated Measure 27,,No,,368
+Meade,CENTRAL STURGIS #3,Initiated Measure 27,,Yes,,130
+Meade,CENTRAL STURGIS #3,Initiated Measure 27,,No,,99
+Meade,CHALK BUTTE #27,Initiated Measure 27,,Yes,,17
+Meade,CHALK BUTTE #27,Initiated Measure 27,,No,,92
+Meade,EAST ELK VALE #21A,Initiated Measure 27,,Yes,,216
+Meade,EAST ELK VALE #21A,Initiated Measure 27,,No,,248
+Meade,EAST PIEDMONT #12A,Initiated Measure 27,,Yes,,105
+Meade,EAST PIEDMONT #12A,Initiated Measure 27,,No,,185
+Meade,EAST STURGIS #1,Initiated Measure 27,,Yes,,110
+Meade,EAST STURGIS #1,Initiated Measure 27,,No,,110
+Meade,ELK VALE #21,Initiated Measure 27,,Yes,,27
+Meade,ELK VALE #21,Initiated Measure 27,,No,,35
+Meade,ELM SPRINGS #18,Initiated Measure 27,,Yes,,24
+Meade,ELM SPRINGS #18,Initiated Measure 27,,No,,66
+Meade,FAIRPOINT #29,Initiated Measure 27,,Yes,,3
+Meade,FAIRPOINT #29,Initiated Measure 27,,No,,31
+Meade,FAITH #31,Initiated Measure 27,,Yes,,41
+Meade,FAITH #31,Initiated Measure 27,,No,,174
+Meade,FORT MEADE #1A,Initiated Measure 27,,Yes,,17
+Meade,FORT MEADE #1A,Initiated Measure 27,,No,,18
+Meade,HARMONY #8,Initiated Measure 27,,Yes,,116
+Meade,HARMONY #8,Initiated Measure 27,,No,,210
+Meade,HEREFORD #20,Initiated Measure 27,,Yes,,10
+Meade,HEREFORD #20,Initiated Measure 27,,No,,42
+Meade,MARCUS #41,Initiated Measure 27,,Yes,,14
+Meade,MARCUS #41,Initiated Measure 27,,No,,32
+Meade,?,Initiated Measure 27,,Yes,,262
+Meade,?,Initiated Measure 27,,No,,412
+Meade,?,Initiated Measure 27,,Yes,,89
+Meade,?,Initiated Measure 27,,No,,44
+Meade,NORTHWEST STURGIS #5,Initiated Measure 27,,Yes,,267
+Meade,NORTHWEST STURGIS #5,Initiated Measure 27,,No,,152
+Meade,PIEDMONT CENTRAL #11A,Initiated Measure 27,,Yes,,324
+Meade,PIEDMONT CENTRAL #11A,Initiated Measure 27,,No,,329
+Meade,PIEDMONT WEST #11,Initiated Measure 27,,Yes,,179
+Meade,PIEDMONT WEST #11,Initiated Measure 27,,No,,287
+Meade,PINE #33,Initiated Measure 27,,Yes,,5
+Meade,PINE #33,Initiated Measure 27,,No,,68
+Meade,RED OWL #30,Initiated Measure 27,,Yes,,9
+Meade,RED OWL #30,Initiated Measure 27,,No,,69
+Meade,RURAL BLACK HAWK #15,Initiated Measure 27,,Yes,,162
+Meade,RURAL BLACK HAWK #15,Initiated Measure 27,,No,,245
+Meade,RURAL STURGIS #7,Initiated Measure 27,,Yes,,180
+Meade,RURAL STURGIS #7,Initiated Measure 27,,No,,260
+Meade,SOUTH STURGIS #2A,Initiated Measure 27,,Yes,,166
+Meade,SOUTH STURGIS #2A,Initiated Measure 27,,No,,178
+Meade,?,Initiated Measure 27,,Yes,,374
+Meade,?,Initiated Measure 27,,No,,438
+Meade,SOUTHEAST STURGIS #2,Initiated Measure 27,,Yes,,203
+Meade,SOUTHEAST STURGIS #2,Initiated Measure 27,,No,,274
+Meade,SOUTHWEST STURGIS #4A,Initiated Measure 27,,Yes,,119
+Meade,SOUTHWEST STURGIS #4A,Initiated Measure 27,,No,,158
+Meade,STURGIS #5A,Initiated Measure 27,,Yes,,103
+Meade,STURGIS #5A,Initiated Measure 27,,No,,108
+Meade,SULPHUR #35,Initiated Measure 27,,Yes,,3
+Meade,SULPHUR #35,Initiated Measure 27,,No,,43
+Meade,SUMMERSET #10,Initiated Measure 27,,Yes,,431
+Meade,SUMMERSET #10,Initiated Measure 27,,No,,566
+Meade,TILFORD #6,Initiated Measure 27,,Yes,,275
+Meade,TILFORD #6,Initiated Measure 27,,No,,409
+Meade,UNION #40,Initiated Measure 27,,Yes,,3
+Meade,UNION #40,Initiated Measure 27,,No,,32
+Meade,VIEWFIELD #17,Initiated Measure 27,,Yes,,14
+Meade,VIEWFIELD #17,Initiated Measure 27,,No,,80
+Meade,WEST BLACK HAWK #16,Initiated Measure 27,,Yes,,158
+Meade,WEST BLACK HAWK #16,Initiated Measure 27,,No,,166
+Meade,WEST ELK VALE #24,Initiated Measure 27,,Yes,,82
+Meade,WEST ELK VALE #24,Initiated Measure 27,,No,,103
+Meade,WEST STURGIS #4,Initiated Measure 27,,Yes,,115
+Meade,WEST STURGIS #4,Initiated Measure 27,,No,,72
+Meade,WHITE OWL #25,Initiated Measure 27,,Yes,,6
+Meade,WHITE OWL #25,Initiated Measure 27,,No,,30
+Meade,ALKALI #6A,State Senate,29,Dean Wink,REP,115
+Meade,BASE #23,State Senate,29,Dean Wink,REP,198
+Meade,BEAR BUTTE #9,State Senate,29,Dean Wink,REP,105
+Meade,BLACK HAWK #14,State Senate,29,Dean Wink,REP,221
+Meade,CENTRAL BLACK HAWK #19,State Senate,33,Darren Freidel,LIB,174
+Meade,CENTRAL BLACK HAWK #19,State Senate,33,David Johnson,REP,507
+Meade,CENTRAL STURGIS #3,State Senate,29,Dean Wink,REP,152
+Meade,CHALK BUTTE #27,State Senate,29,Dean Wink,REP,77
+Meade,EAST ELK VALE #21A,State Senate,29,Dean Wink,REP,366
+Meade,EAST PIEDMONT #12A,State Senate,29,Dean Wink,REP,231
+Meade,EAST STURGIS #1,State Senate,29,Dean Wink,REP,150
+Meade,ELK VALE #21,State Senate,29,Dean Wink,REP,45
+Meade,ELM SPRINGS #18,State Senate,29,Dean Wink,REP,63
+Meade,FAIRPOINT #29,State Senate,29,Dean Wink,REP,27
+Meade,FAITH #31,State Senate,29,Dean Wink,REP,178
+Meade,FORT MEADE #1A,State Senate,29,Dean Wink,REP,21
+Meade,HARMONY #8,State Senate,29,Dean Wink,REP,241
+Meade,HEREFORD #20,State Senate,29,Dean Wink,REP,38
+Meade,MARCUS #41,State Senate,29,Dean Wink,REP,21
+Meade,NORTHEAST PIEDMONT #12,State Senate,29,Dean Wink,REP,528
+Meade,NORTHEAST STURGIS #1- A,State Senate,29,Dean Wink,REP,86
+Meade,NORTHWEST STURGIS #5,State Senate,29,Dean Wink,REP,293
+Meade,PIEDMONT CENTRAL #11A,State Senate,29,Dean Wink,REP,489
+Meade,PIEDMONT WEST #11,State Senate,29,Dean Wink,REP,343
+Meade,PINE #33,State Senate,29,Dean Wink,REP,48
+Meade,RED OWL #30,State Senate,29,Dean Wink,REP,60
+Meade,RURAL BLACK HAWK #15,State Senate,29,Dean Wink,REP,313
+Meade,RURAL STURGIS #7,State Senate,29,Dean Wink,REP,330
+Meade,SOUTH STURGIS #2A,State Senate,29,Dean Wink,REP,258
+Meade,SOUTHEAST PIEDMONT #13,State Senate,29,Dean Wink,REP,594
+Meade,SOUTHEAST STURGIS #2,State Senate,29,Dean Wink,REP,345
+Meade,SOUTHWEST STURGIS #4A,State Senate,29,Dean Wink,REP,199
+Meade,STURGIS #5A,State Senate,29,Dean Wink,REP,168
+Meade,SULPHUR #35,State Senate,29,Dean Wink,REP,31
+Meade,SUMMERSET #10,State Senate,33,Darren Freidel,LIB,208
+Meade,SUMMERSET #10,State Senate,33,David Johnson,REP,688
+Meade,TILFORD #6,State Senate,29,Dean Wink,REP,536
+Meade,UNION #40,State Senate,29,Dean Wink,REP,22
+Meade,VIEWFIELD #17,State Senate,29,Dean Wink,REP,71
+Meade,WEST BLACK HAWK #16,State Senate,33,Darren Freidel,LIB,81
+Meade,WEST BLACK HAWK #16,State Senate,33,David Johnson,REP,213
+Meade,WEST ELK VALE #24,State Senate,29,Dean Wink,REP,143
+Meade,WEST STURGIS #4,State Senate,29,Dean Wink,REP,130
+Meade,WHITE OWL #25 10 of 19,State Senate,29,Dean Wink,REP,36
+Meade,ALKALI #6A,State House,29,Sean Natchke,LIB,37
+Meade,ALKALI #6A,State House,29,Gary L Cammack,REP,87
+Meade,ALKALI #6A,State House,29,Kirk Chaffee,REP,97
+Meade,BASE #23,State House,29,Sean Natchke,LIB,94
+Meade,BASE #23,State House,29,Gary L Cammack,REP,93
+Meade,BASE #23,State House,29,Kirk Chaffee,REP,132
+Meade,BEAR BUTTE #9,State House,29,Sean Natchke,LIB,38
+Meade,BEAR BUTTE #9,State House,29,Gary L Cammack,REP,95
+Meade,BEAR BUTTE #9,State House,29,Kirk Chaffee,REP,96
+Meade,BLACK HAWK #14,State House,29,Sean Natchke,LIB,89
+Meade,BLACK HAWK #14,State House,29,Gary L Cammack,REP,121
+Meade,BLACK HAWK #14,State House,29,Kirk Chaffee,REP,171
+Meade,CENTRAL BLACK HAWK #19,State House,33,Vince Vidal,DEM,199
+Meade,CENTRAL BLACK HAWK #19,State House,33,Curt Massie,REP,361
+Meade,CENTRAL BLACK HAWK #19,State House,33,Phil Jensen,REP,450
+Meade,CENTRAL STURGIS #3,State House,29,Sean Natchke,LIB,65
+Meade,CENTRAL STURGIS #3,State House,29,Gary L Cammack,REP,104
+Meade,CENTRAL STURGIS #3,State House,29,Kirk Chaffee,REP,138
+Meade,CHALK BUTTE #27,State House,29,Sean Natchke,LIB,23
+Meade,CHALK BUTTE #27,State House,29,Gary L Cammack,REP,53
+Meade,CHALK BUTTE #27,State House,29,Kirk Chaffee,REP,76
+Meade,EAST ELK VALE #21A,State House,29,Sean Natchke,LIB,103
+Meade,EAST ELK VALE #21A,State House,29,Gary L Cammack,REP,233
+Meade,EAST ELK VALE #21A,State House,29,Kirk Chaffee,REP,284
+Meade,EAST PIEDMONT #12A,State House,29,Sean Natchke,LIB,42
+Meade,EAST PIEDMONT #12A,State House,29,Gary L Cammack,REP,178
+Meade,EAST PIEDMONT #12A,State House,29,Kirk Chaffee,REP,191
+Meade,EAST STURGIS #1,State House,29,Sean Natchke,LIB,51
+Meade,EAST STURGIS #1,State House,29,Gary L Cammack,REP,103
+Meade,EAST STURGIS #1,State House,29,Kirk Chaffee,REP,133
+Meade,ELK VALE #21,State House,29,Sean Natchke,LIB,14
+Meade,ELK VALE #21,State House,29,Gary L Cammack,REP,33
+Meade,ELK VALE #21,State House,29,Kirk Chaffee,REP,41
+Meade,ELM SPRINGS #18,State House,29,Sean Natchke,LIB,20
+Meade,ELM SPRINGS #18,State House,29,Gary L Cammack,REP,39
+Meade,ELM SPRINGS #18,State House,29,Kirk Chaffee,REP,54
+Meade,FAIRPOINT #29,State House,29,Sean Natchke,LIB,8
+Meade,FAIRPOINT #29,State House,29,Gary L Cammack,REP,24
+Meade,FAIRPOINT #29,State House,29,Kirk Chaffee,REP,24
+Meade,FAITH #31,State House,29,Sean Natchke,LIB,40
+Meade,FAITH #31,State House,29,Gary L Cammack,REP,115
+Meade,FAITH #31,State House,29,Kirk Chaffee,REP,143
+Meade,FORT MEADE #1A,State House,29,Sean Natchke,LIB,16
+Meade,FORT MEADE #1A,State House,29,Gary L Cammack,REP,16
+Meade,FORT MEADE #1A,State House,29,Kirk Chaffee,REP,15
+Meade,HARMONY #8,State House,29,Sean Natchke,LIB,84
+Meade,HARMONY #8,State House,29,Gary L Cammack,REP,190
+Meade,HARMONY #8,State House,29,Kirk Chaffee,REP,196
+Meade,HEREFORD #20,State House,29,Sean Natchke,LIB,12
+Meade,HEREFORD #20,State House,29,Gary L Cammack,REP,31
+Meade,HEREFORD #20,State House,29,Kirk Chaffee,REP,38
+Meade,MARCUS #41,State House,29,Sean Natchke,LIB,14
+Meade,MARCUS #41,State House,29,Gary L Cammack,REP,13
+Meade,MARCUS #41,State House,29,Kirk Chaffee,REP,22
+Meade,NORTHEAST PIEDMONT #12,State House,29,Sean Natchke,LIB,113
+Meade,NORTHEAST PIEDMONT #12,State House,29,Gary L Cammack,REP,385
+Meade,NORTHEAST PIEDMONT #12,State House,29,Kirk Chaffee,REP,443
+Meade,NORTHEAST STURGIS #1- A,State House,29,Sean Natchke,LIB,38
+Meade,NORTHEAST STURGIS #1- A,State House,29,Gary L Cammack,REP,63
+Meade,NORTHEAST STURGIS #1- A,State House,29,Kirk Chaffee,REP,70
+Meade,NORTHWEST STURGIS #5,State House,29,Sean Natchke,LIB,131
+Meade,NORTHWEST STURGIS #5,State House,29,Gary L Cammack,REP,200
+Meade,NORTHWEST STURGIS #5,State House,29,Kirk Chaffee,REP,220
+Meade,PIEDMONT CENTRAL #11A,State House,29,Sean Natchke,LIB,110
+Meade,PIEDMONT CENTRAL #11A,State House,29,Gary L Cammack,REP,338
+Meade,PIEDMONT CENTRAL #11A,State House,29,Kirk Chaffee,REP,395
+Meade,PIEDMONT WEST #11,State House,29,Sean Natchke,LIB,104
+Meade,PIEDMONT WEST #11,State House,29,Gary L Cammack,REP,258
+Meade,PIEDMONT WEST #11,State House,29,Kirk Chaffee,REP,290
+Meade,PINE #33,State House,29,Sean Natchke,LIB,23
+Meade,PINE #33,State House,29,Gary L Cammack,REP,31
+Meade,PINE #33,State House,29,Kirk Chaffee,REP,52
+Meade,RED OWL #30,State House,29,Sean Natchke,LIB,18
+Meade,RED OWL #30,State House,29,Gary L Cammack,REP,52
+Meade,RED OWL #30,State House,29,Kirk Chaffee,REP,46
+Meade,RURAL BLACK HAWK #15,State House,29,Sean Natchke,LIB,73
+Meade,RURAL BLACK HAWK #15,State House,29,Gary L Cammack,REP,206
+Meade,RURAL BLACK HAWK #15,State House,29,Kirk Chaffee,REP,261
+Meade,RURAL STURGIS #7,State House,29,Sean Natchke,LIB,107
+Meade,RURAL STURGIS #7,State House,29,Gary L Cammack,REP,241
+Meade,RURAL STURGIS #7,State House,29,Kirk Chaffee,REP,281
+Meade,SOUTH STURGIS #2A,State House,29,Sean Natchke,LIB,95
+Meade,SOUTH STURGIS #2A,State House,29,Gary L Cammack,REP,190
+Meade,SOUTH STURGIS #2A,State House,29,Kirk Chaffee,REP,194
+Meade,SOUTHEAST PIEDMONT #13,State House,29,Sean Natchke,LIB,167
+Meade,SOUTHEAST PIEDMONT #13,State House,29,Gary L Cammack,REP,418
+Meade,SOUTHEAST PIEDMONT #13,State House,29,Kirk Chaffee,REP,472
+Meade,SOUTHEAST STURGIS #2,State House,29,Sean Natchke,LIB,107
+Meade,SOUTHEAST STURGIS #2,State House,29,Gary L Cammack,REP,272
+Meade,SOUTHEAST STURGIS #2,State House,29,Kirk Chaffee,REP,302
+Meade,SOUTHWEST STURGIS #4A,State House,29,Sean Natchke,LIB,66
+Meade,SOUTHWEST STURGIS #4A,State House,29,Gary L Cammack,REP,136
+Meade,SOUTHWEST STURGIS #4A,State House,29,Kirk Chaffee,REP,162
+Meade,STURGIS #5A,State House,29,Sean Natchke,LIB,52
+Meade,STURGIS #5A,State House,29,Gary L Cammack,REP,116
+Meade,STURGIS #5A,State House,29,Kirk Chaffee,REP,132
+Meade,SULPHUR #35,State House,29,Sean Natchke,LIB,9
+Meade,SULPHUR #35,State House,29,Gary L Cammack,REP,23
+Meade,SULPHUR #35,State House,29,Kirk Chaffee,REP,29
+Meade,SUMMERSET #10,State House,33,Vince Vidal,DEM,266
+Meade,SUMMERSET #10,State House,33,Curt Massie,REP,471
+Meade,SUMMERSET #10,State House,33,Phil Jensen,REP,586
+Meade,TILFORD #6,State House,29,Sean Natchke,LIB,145
+Meade,TILFORD #6,State House,29,Gary L Cammack,REP,394
+Meade,TILFORD #6,State House,29,Kirk Chaffee,REP,460
+Meade,UNION #40,State House,29,Sean Natchke,LIB,1
+Meade,UNION #40,State House,29,Gary L Cammack,REP,17
+Meade,UNION #40,State House,29,Kirk Chaffee,REP,24
+Meade,VIEWFIELD #17,State House,29,Sean Natchke,LIB,23
+Meade,VIEWFIELD #17,State House,29,Gary L Cammack,REP,49
+Meade,VIEWFIELD #17,State House,29,Kirk Chaffee,REP,66
+Meade,WEST BLACK HAWK #16,State House,33,Vince Vidal,DEM,102
+Meade,WEST BLACK HAWK #16,State House,33,Curt Massie,REP,157
+Meade,WEST BLACK HAWK #16,State House,33,Phil Jensen,REP,193
+Meade,WEST ELK VALE #24,State House,29,Sean Natchke,LIB,33
+Meade,WEST ELK VALE #24,State House,29,Gary L Cammack,REP,99
+Meade,WEST ELK VALE #24,State House,29,Kirk Chaffee,REP,115
+Meade,WEST STURGIS #4,State House,29,Sean Natchke,LIB,58
+Meade,WEST STURGIS #4,State House,29,Gary L Cammack,REP,90
+Meade,WEST STURGIS #4,State House,29,Kirk Chaffee,REP,101
+Meade,WHITE OWL #25 11 of 19,State House,29,Sean Natchke,LIB,4
+Meade,WHITE OWL #25 11 of 19,State House,29,Gary L Cammack,REP,26
+Meade,WHITE OWL #25 11 of 19,State House,29,Kirk Chaffee,REP,30

--- a/2022/counties/20221108__sd__general__mellette__precinct.csv
+++ b/2022/counties/20221108__sd__general__mellette__precinct.csv
@@ -1,0 +1,145 @@
+county,precinct,office,district,candidate,party,votes
+Mellette,2,U.S. Senate,,Brian L. Bengs,DEM,47
+Mellette,2,U.S. Senate,,Tamara J Lesnar,LIB,15
+Mellette,2,U.S. Senate,,John R. Thune,REP,124
+Mellette,3,U.S. Senate,,Brian L. Bengs,DEM,18
+Mellette,3,U.S. Senate,,Tamara J Lesnar,LIB,6
+Mellette,3,U.S. Senate,,John R. Thune,REP,95
+Mellette,5,U.S. Senate,,Brian L. Bengs,DEM,61
+Mellette,5,U.S. Senate,,Tamara J Lesnar,LIB,11
+Mellette,5,U.S. Senate,,John R. Thune,REP,100
+Mellette,6,U.S. Senate,,Brian L. Bengs,DEM,39
+Mellette,6,U.S. Senate,,Tamara J Lesnar,LIB,12
+Mellette,6,U.S. Senate,,John R. Thune,REP,96
+Mellette,2,U.S. House,1,Collin Duprel,LIB,48
+Mellette,2,U.S. House,1,Dusty Johnson,REP,129
+Mellette,3,U.S. House,1,Collin Duprel,LIB,20
+Mellette,3,U.S. House,1,Dusty Johnson,REP,95
+Mellette,5,U.S. House,1,Collin Duprel,LIB,53
+Mellette,5,U.S. House,1,Dusty Johnson,REP,107
+Mellette,6,U.S. House,1,Collin Duprel,LIB,38
+Mellette,6,U.S. House,1,Dusty Johnson,REP,98
+Mellette,2,Governor,,Jamie Smith and Jennifer Keintz,DEM,63
+Mellette,2,Governor,,Tracey Quint and Ashley Strand,LIB,9
+Mellette,2,Governor,,Kristi Noem and Larry Rhoden,REP,116
+Mellette,3,Governor,,Jamie Smith and Jennifer Keintz,DEM,23
+Mellette,3,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Mellette,3,Governor,,Kristi Noem and Larry Rhoden,REP,94
+Mellette,5,Governor,,Jamie Smith and Jennifer Keintz,DEM,81
+Mellette,5,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Mellette,5,Governor,,Kristi Noem and Larry Rhoden,REP,89
+Mellette,6,Governor,,Jamie Smith and Jennifer Keintz,DEM,47
+Mellette,6,Governor,,Tracey Quint and Ashley Strand,LIB,12
+Mellette,6,Governor,,Kristi Noem and Larry Rhoden,REP,87
+Mellette,2,Secretary of State,,Thomas A Cool,DEM,64
+Mellette,2,Secretary of State,,Monae Johnson,REP,117
+Mellette,3,Secretary of State,,Thomas A Cool,DEM,31
+Mellette,3,Secretary of State,,Monae Johnson,REP,87
+Mellette,5,Secretary of State,,Thomas A Cool,DEM,87
+Mellette,5,Secretary of State,,Monae Johnson,REP,79
+Mellette,6,Secretary of State,,Thomas A Cool,DEM,49
+Mellette,6,Secretary of State,,Monae Johnson,REP,91
+Mellette,2,Attorney General,,Marty J. Jackley,REP,138
+Mellette,3,Attorney General,,Marty J. Jackley,REP,98
+Mellette,5,Attorney General,,Marty J. Jackley,REP,111
+Mellette,6,Attorney General,,Marty J. Jackley,REP,111
+Mellette,2,State Auditor,,Stephanie Marty,DEM,59
+Mellette,2,State Auditor,,Rene Meyer,LIB,13
+Mellette,2,State Auditor,,Richard Sattgast,REP,105
+Mellette,3,State Auditor,,Stephanie Marty,DEM,24
+Mellette,3,State Auditor,,Rene Meyer,LIB,3
+Mellette,3,State Auditor,,Richard Sattgast,REP,90
+Mellette,5,State Auditor,,Stephanie Marty,DEM,76
+Mellette,5,State Auditor,,Rene Meyer,LIB,11
+Mellette,5,State Auditor,,Richard Sattgast,REP,76
+Mellette,6,State Auditor,,Stephanie Marty,DEM,48
+Mellette,6,State Auditor,,Rene Meyer,LIB,11
+Mellette,6,State Auditor,,Richard Sattgast,REP,82
+Mellette,2,State Treasurer,,John Cunningham,DEM,60
+Mellette,2,State Treasurer,,Josh Haeder,REP,117
+Mellette,3,State Treasurer,,John Cunningham,DEM,23
+Mellette,3,State Treasurer,,Josh Haeder,REP,92
+Mellette,5,State Treasurer,,John Cunningham,DEM,82
+Mellette,5,State Treasurer,,Josh Haeder,REP,80
+Mellette,6,State Treasurer,,John Cunningham,DEM,48
+Mellette,6,State Treasurer,,Josh Haeder,REP,94
+Mellette,2,Commissioner of School and Public Lands,,Timothy Azure,DEM,61
+Mellette,2,Commissioner of School and Public Lands,,Brock Greenfield,REP,115
+Mellette,3,Commissioner of School and Public Lands,,Timothy Azure,DEM,20
+Mellette,3,Commissioner of School and Public Lands,,Brock Greenfield,REP,91
+Mellette,5,Commissioner of School and Public Lands,,Timothy Azure,DEM,81
+Mellette,5,Commissioner of School and Public Lands,,Brock Greenfield,REP,79
+Mellette,6,Commissioner of School and Public Lands,,Timothy Azure,DEM,50
+Mellette,6,Commissioner of School and Public Lands,,Brock Greenfield,REP,90
+Mellette,2,Public Utilities Commissioner,,Jeffrey Barth,DEM,57
+Mellette,2,Public Utilities Commissioner,,Chris Nelson,REP,121
+Mellette,3,Public Utilities Commissioner,,Jeffrey Barth,DEM,29
+Mellette,3,Public Utilities Commissioner,,Chris Nelson,REP,91
+Mellette,5,Public Utilities Commissioner,,Jeffrey Barth,DEM,73
+Mellette,5,Public Utilities Commissioner,,Chris Nelson,REP,91
+Mellette,6,Public Utilities Commissioner,,Jeffrey Barth,DEM,44
+Mellette,6,Public Utilities Commissioner,,Chris Nelson,REP,97
+Mellette,2,State Senate,26,Shawn Bordeaux,DEM,86
+Mellette,2,State Senate,26,Joel Koskan,REP,54
+Mellette,3,State Senate,26,Shawn Bordeaux,DEM,39
+Mellette,3,State Senate,26,Joel Koskan,REP,42
+Mellette,5,State Senate,26,Shawn Bordeaux,DEM,101
+Mellette,5,State Senate,26,Joel Koskan,REP,44
+Mellette,6,State Senate,26,Shawn Bordeaux,DEM,71
+Mellette,6,State Senate,26,Joel Koskan,REP,55
+Mellette,2,State House,26A,Eric Emery,DEM,67
+Mellette,2,State House,26A,Joyce Glynn,REP,116
+Mellette,3,State House,26A,Eric Emery,DEM,35
+Mellette,3,State House,26A,Joyce Glynn,REP,80
+Mellette,5,State House,26A,Eric Emery,DEM,92
+Mellette,5,State House,26A,Joyce Glynn,REP,79
+Mellette,6,State House,26A,Eric Emery,DEM,68
+Mellette,6,State House,26A,Joyce Glynn,REP,71
+Mellette,2,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,69
+Mellette,3,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,52
+Mellette,5,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,63
+Mellette,6,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,67
+Mellette,2,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,67
+Mellette,3,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,52
+Mellette,5,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,57
+Mellette,6,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,61
+Mellette,2,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,65
+Mellette,3,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,53
+Mellette,5,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,61
+Mellette,6,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,61
+Mellette,2,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,64
+Mellette,3,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,61
+Mellette,5,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,64
+Mellette,6,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,59
+Mellette,2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,125
+Mellette,2,Supreme Court Retention,3,Patricia J. DeVaney - No,,42
+Mellette,3,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,78
+Mellette,3,Supreme Court Retention,3,Patricia J. DeVaney - No,,26
+Mellette,5,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,109
+Mellette,5,Supreme Court Retention,3,Patricia J. DeVaney - No,,45
+Mellette,6,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,100
+Mellette,6,Supreme Court Retention,3,Patricia J. DeVaney - No,,24
+Mellette,2,Supreme Court Retention,2,Mark E. Salter - Yes,,123
+Mellette,2,Supreme Court Retention,2,Mark E. Salter - No,,41
+Mellette,3,Supreme Court Retention,2,Mark E. Salter - Yes,,77
+Mellette,3,Supreme Court Retention,2,Mark E. Salter - No,,25
+Mellette,5,Supreme Court Retention,2,Mark E. Salter - Yes,,99
+Mellette,5,Supreme Court Retention,2,Mark E. Salter - No,,24
+Mellette,6,Supreme Court Retention,2,Mark E. Salter - Yes,,95
+Mellette,6,Supreme Court Retention,2,Mark E. Salter - No,,31
+Mellette,2,Constitutional Amendment D,,Yes,,102
+Mellette,2,Constitutional Amendment D,,No,,80
+Mellette,3,Constitutional Amendment D,,Yes,,52
+Mellette,3,Constitutional Amendment D,,No,,64
+Mellette,5,Constitutional Amendment D,,Yes,,118
+Mellette,5,Constitutional Amendment D,,No,,51
+Mellette,6,Constitutional Amendment D,,Yes,,78
+Mellette,6,Constitutional Amendment D,,No,,67
+Mellette,2,Initiated Measure 27,,Yes,,89
+Mellette,2,Initiated Measure 27,,No,,95
+Mellette,3,Initiated Measure 27,,Yes,,42
+Mellette,3,Initiated Measure 27,,No,,78
+Mellette,5,Initiated Measure 27,,Yes,,102
+Mellette,5,Initiated Measure 27,,No,,70
+Mellette,6,Initiated Measure 27,,Yes,,62
+Mellette,6,Initiated Measure 27,,No,,83

--- a/2022/counties/20221108__sd__general__miner__precinct.csv
+++ b/2022/counties/20221108__sd__general__miner__precinct.csv
@@ -1,0 +1,305 @@
+county,precinct,office,district,candidate,party,votes
+Miner,1,U.S. Senate,,Brian L. Bengs,DEM,31
+Miner,1,U.S. Senate,,Tamara J Lesnar,LIB,2
+Miner,1,U.S. Senate,,John R. Thune,REP,99
+Miner,2,U.S. Senate,,Brian L. Bengs,DEM,13
+Miner,2,U.S. Senate,,Tamara J Lesnar,LIB,4
+Miner,2,U.S. Senate,,John R. Thune,REP,75
+Miner,3,U.S. Senate,,Brian L. Bengs,DEM,23
+Miner,3,U.S. Senate,,Tamara J Lesnar,LIB,3
+Miner,3,U.S. Senate,,John R. Thune,REP,87
+Miner,4,U.S. Senate,,Brian L. Bengs,DEM,18
+Miner,4,U.S. Senate,,Tamara J Lesnar,LIB,5
+Miner,4,U.S. Senate,,John R. Thune,REP,103
+Miner,5,U.S. Senate,,Brian L. Bengs,DEM,9
+Miner,5,U.S. Senate,,Tamara J Lesnar,LIB,3
+Miner,5,U.S. Senate,,John R. Thune,REP,54
+Miner,6,U.S. Senate,,Brian L. Bengs,DEM,24
+Miner,6,U.S. Senate,,Tamara J Lesnar,LIB,4
+Miner,6,U.S. Senate,,John R. Thune,REP,173
+Miner,7,U.S. Senate,,Brian L. Bengs,DEM,26
+Miner,7,U.S. Senate,,Tamara J Lesnar,LIB,6
+Miner,7,U.S. Senate,,John R. Thune,REP,132
+Miner,8,U.S. Senate,,Brian L. Bengs,DEM,17
+Miner,8,U.S. Senate,,Tamara J Lesnar,LIB,3
+Miner,8,U.S. Senate,,John R. Thune,REP,90
+Miner,1,U.S. House,1,Collin Duprel,LIB,20
+Miner,1,U.S. House,1,Dusty Johnson,REP,101
+Miner,2,U.S. House,1,Collin Duprel,LIB,10
+Miner,2,U.S. House,1,Dusty Johnson,REP,79
+Miner,3,U.S. House,1,Collin Duprel,LIB,9
+Miner,3,U.S. House,1,Dusty Johnson,REP,98
+Miner,4,U.S. House,1,Collin Duprel,LIB,22
+Miner,4,U.S. House,1,Dusty Johnson,REP,100
+Miner,5,U.S. House,1,Collin Duprel,LIB,11
+Miner,5,U.S. House,1,Dusty Johnson,REP,54
+Miner,6,U.S. House,1,Collin Duprel,LIB,20
+Miner,6,U.S. House,1,Dusty Johnson,REP,173
+Miner,7,U.S. House,1,Collin Duprel,LIB,20
+Miner,7,U.S. House,1,Dusty Johnson,REP,136
+Miner,8,U.S. House,1,Collin Duprel,LIB,21
+Miner,8,U.S. House,1,Dusty Johnson,REP,87
+Miner,1,Governor,,Jamie Smith and Jennifer Keintz,DEM,42
+Miner,1,Governor,,Tracey Quint and Ashley Strand,LIB,9
+Miner,1,Governor,,Kristi Noem and Larry Rhoden,REP,79
+Miner,2,Governor,,Jamie Smith and Jennifer Keintz,DEM,25
+Miner,2,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Miner,2,Governor,,Kristi Noem and Larry Rhoden,REP,66
+Miner,3,Governor,,Jamie Smith and Jennifer Keintz,DEM,31
+Miner,3,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Miner,3,Governor,,Kristi Noem and Larry Rhoden,REP,77
+Miner,4,Governor,,Jamie Smith and Jennifer Keintz,DEM,31
+Miner,4,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Miner,4,Governor,,Kristi Noem and Larry Rhoden,REP,91
+Miner,5,Governor,,Jamie Smith and Jennifer Keintz,DEM,15
+Miner,5,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Miner,5,Governor,,Kristi Noem and Larry Rhoden,REP,50
+Miner,6,Governor,,Jamie Smith and Jennifer Keintz,DEM,40
+Miner,6,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Miner,6,Governor,,Kristi Noem and Larry Rhoden,REP,161
+Miner,7,Governor,,Jamie Smith and Jennifer Keintz,DEM,41
+Miner,7,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Miner,7,Governor,,Kristi Noem and Larry Rhoden,REP,122
+Miner,8,Governor,,Jamie Smith and Jennifer Keintz,DEM,23
+Miner,8,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Miner,8,Governor,,Kristi Noem and Larry Rhoden,REP,86
+Miner,1,Secretary of State,,Thomas A Cool,DEM,51
+Miner,1,Secretary of State,,Monae Johnson,REP,70
+Miner,2,Secretary of State,,Thomas A Cool,DEM,27
+Miner,2,Secretary of State,,Monae Johnson,REP,59
+Miner,3,Secretary of State,,Thomas A Cool,DEM,35
+Miner,3,Secretary of State,,Monae Johnson,REP,69
+Miner,4,Secretary of State,,Thomas A Cool,DEM,36
+Miner,4,Secretary of State,,Monae Johnson,REP,72
+Miner,5,Secretary of State,,Thomas A Cool,DEM,22
+Miner,5,Secretary of State,,Monae Johnson,REP,41
+Miner,6,Secretary of State,,Thomas A Cool,DEM,47
+Miner,6,Secretary of State,,Monae Johnson,REP,138
+Miner,7,Secretary of State,,Thomas A Cool,DEM,52
+Miner,7,Secretary of State,,Monae Johnson,REP,103
+Miner,8,Secretary of State,,Thomas A Cool,DEM,26
+Miner,8,Secretary of State,,Monae Johnson,REP,77
+Miner,1,Attorney General,,Marty J. Jackley,REP,91
+Miner,2,Attorney General,,Marty J. Jackley,REP,83
+Miner,3,Attorney General,,Marty J. Jackley,REP,88
+Miner,4,Attorney General,,Marty J. Jackley,REP,91
+Miner,5,Attorney General,,Marty J. Jackley,REP,55
+Miner,6,Attorney General,,Marty J. Jackley,REP,172
+Miner,7,Attorney General,,Marty J. Jackley,REP,129
+Miner,8,Attorney General,,Marty J. Jackley,REP,94
+Miner,1,State Auditor,,Stephanie Marty,DEM,41
+Miner,1,State Auditor,,Rene Meyer,LIB,6
+Miner,1,State Auditor,,Richard Sattgast,REP,73
+Miner,2,State Auditor,,Stephanie Marty,DEM,20
+Miner,2,State Auditor,,Rene Meyer,LIB,3
+Miner,2,State Auditor,,Richard Sattgast,REP,62
+Miner,3,State Auditor,,Stephanie Marty,DEM,30
+Miner,3,State Auditor,,Rene Meyer,LIB,3
+Miner,3,State Auditor,,Richard Sattgast,REP,70
+Miner,4,State Auditor,,Stephanie Marty,DEM,34
+Miner,4,State Auditor,,Rene Meyer,LIB,6
+Miner,4,State Auditor,,Richard Sattgast,REP,71
+Miner,5,State Auditor,,Stephanie Marty,DEM,15
+Miner,5,State Auditor,,Rene Meyer,LIB,2
+Miner,5,State Auditor,,Richard Sattgast,REP,42
+Miner,6,State Auditor,,Stephanie Marty,DEM,34
+Miner,6,State Auditor,,Rene Meyer,LIB,2
+Miner,6,State Auditor,,Richard Sattgast,REP,153
+Miner,7,State Auditor,,Stephanie Marty,DEM,37
+Miner,7,State Auditor,,Rene Meyer,LIB,5
+Miner,7,State Auditor,,Richard Sattgast,REP,105
+Miner,8,State Auditor,,Stephanie Marty,DEM,20
+Miner,8,State Auditor,,Rene Meyer,LIB,10
+Miner,8,State Auditor,,Richard Sattgast,REP,75
+Miner,1,State Treasurer,,John Cunningham,DEM,43
+Miner,1,State Treasurer,,Josh Haeder,REP,76
+Miner,2,State Treasurer,,John Cunningham,DEM,20
+Miner,2,State Treasurer,,Josh Haeder,REP,61
+Miner,3,State Treasurer,,John Cunningham,DEM,30
+Miner,3,State Treasurer,,Josh Haeder,REP,67
+Miner,4,State Treasurer,,John Cunningham,DEM,34
+Miner,4,State Treasurer,,Josh Haeder,REP,71
+Miner,5,State Treasurer,,John Cunningham,DEM,15
+Miner,5,State Treasurer,,Josh Haeder,REP,44
+Miner,6,State Treasurer,,John Cunningham,DEM,38
+Miner,6,State Treasurer,,Josh Haeder,REP,145
+Miner,7,State Treasurer,,John Cunningham,DEM,37
+Miner,7,State Treasurer,,Josh Haeder,REP,109
+Miner,8,State Treasurer,,John Cunningham,DEM,25
+Miner,8,State Treasurer,,Josh Haeder,REP,78
+Miner,1,Commissioner of School and Public Lands,,Timothy Azure,DEM,44
+Miner,1,Commissioner of School and Public Lands,,Brock Greenfield,REP,72
+Miner,2,Commissioner of School and Public Lands,,Timothy Azure,DEM,19
+Miner,2,Commissioner of School and Public Lands,,Brock Greenfield,REP,62
+Miner,3,Commissioner of School and Public Lands,,Timothy Azure,DEM,29
+Miner,3,Commissioner of School and Public Lands,,Brock Greenfield,REP,71
+Miner,4,Commissioner of School and Public Lands,,Timothy Azure,DEM,33
+Miner,4,Commissioner of School and Public Lands,,Brock Greenfield,REP,78
+Miner,5,Commissioner of School and Public Lands,,Timothy Azure,DEM,16
+Miner,5,Commissioner of School and Public Lands,,Brock Greenfield,REP,44
+Miner,6,Commissioner of School and Public Lands,,Timothy Azure,DEM,33
+Miner,6,Commissioner of School and Public Lands,,Brock Greenfield,REP,148
+Miner,7,Commissioner of School and Public Lands,,Timothy Azure,DEM,35
+Miner,7,Commissioner of School and Public Lands,,Brock Greenfield,REP,109
+Miner,8,Commissioner of School and Public Lands,,Timothy Azure,DEM,21
+Miner,8,Commissioner of School and Public Lands,,Brock Greenfield,REP,79
+Miner,1,Public Utilities Commissioner,,Jeffrey Barth,DEM,38
+Miner,1,Public Utilities Commissioner,,Chris Nelson,REP,85
+Miner,2,Public Utilities Commissioner,,Jeffrey Barth,DEM,18
+Miner,2,Public Utilities Commissioner,,Chris Nelson,REP,68
+Miner,3,Public Utilities Commissioner,,Jeffrey Barth,DEM,23
+Miner,3,Public Utilities Commissioner,,Chris Nelson,REP,85
+Miner,4,Public Utilities Commissioner,,Jeffrey Barth,DEM,24
+Miner,4,Public Utilities Commissioner,,Chris Nelson,REP,94
+Miner,5,Public Utilities Commissioner,,Jeffrey Barth,DEM,12
+Miner,5,Public Utilities Commissioner,,Chris Nelson,REP,49
+Miner,6,Public Utilities Commissioner,,Jeffrey Barth,DEM,29
+Miner,6,Public Utilities Commissioner,,Chris Nelson,REP,160
+Miner,7,Public Utilities Commissioner,,Jeffrey Barth,DEM,32
+Miner,7,Public Utilities Commissioner,,Chris Nelson,REP,119
+Miner,8,Public Utilities Commissioner,,Jeffrey Barth,DEM,27
+Miner,8,Public Utilities Commissioner,,Chris Nelson,REP,78
+Miner,1,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,56
+Miner,2,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,42
+Miner,3,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,51
+Miner,4,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,45
+Miner,5,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,25
+Miner,6,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,52
+Miner,7,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,74
+Miner,8,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,44
+Miner,1,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,53
+Miner,2,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,43
+Miner,3,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,51
+Miner,4,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,45
+Miner,5,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,25
+Miner,6,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,53
+Miner,7,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,70
+Miner,8,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,43
+Miner,1,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,53
+Miner,2,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,40
+Miner,3,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,49
+Miner,4,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,43
+Miner,5,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,25
+Miner,6,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,55
+Miner,7,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,72
+Miner,8,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,42
+Miner,1,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,58
+Miner,2,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,46
+Miner,3,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,53
+Miner,4,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,48
+Miner,5,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,28
+Miner,6,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,63
+Miner,7,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,74
+Miner,8,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,42
+Miner,1,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,35
+Miner,1,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,32
+Miner,2,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,27
+Miner,2,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,20
+Miner,3,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,26
+Miner,3,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,35
+Miner,4,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,16
+Miner,4,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,38
+Miner,5,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,11
+Miner,5,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,20
+Miner,6,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,27
+Miner,6,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,39
+Miner,7,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,28
+Miner,7,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,46
+Miner,8,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,17
+Miner,8,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,34
+Miner,1,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,92
+Miner,2,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,73
+Miner,3,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,80
+Miner,4,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,74
+Miner,5,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,41
+Miner,6,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,122
+Miner,7,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,126
+Miner,8,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,61
+Miner,1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,90
+Miner,1,Supreme Court Retention,3,Patricia J. DeVaney - No,,13
+Miner,2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,66
+Miner,2,Supreme Court Retention,3,Patricia J. DeVaney - No,,12
+Miner,3,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,82
+Miner,3,Supreme Court Retention,3,Patricia J. DeVaney - No,,9
+Miner,4,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,79
+Miner,4,Supreme Court Retention,3,Patricia J. DeVaney - No,,13
+Miner,5,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,44
+Miner,5,Supreme Court Retention,3,Patricia J. DeVaney - No,,8
+Miner,6,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,129
+Miner,6,Supreme Court Retention,3,Patricia J. DeVaney - No,,15
+Miner,7,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,106
+Miner,7,Supreme Court Retention,3,Patricia J. DeVaney - No,,23
+Miner,8,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,71
+Miner,8,Supreme Court Retention,3,Patricia J. DeVaney - No,,21
+Miner,1,Supreme Court Retention,2,Mark E. Salter - Yes,,87
+Miner,1,Supreme Court Retention,2,Mark E. Salter - No,,13
+Miner,2,Supreme Court Retention,2,Mark E. Salter - Yes,,67
+Miner,2,Supreme Court Retention,2,Mark E. Salter - No,,10
+Miner,3,Supreme Court Retention,2,Mark E. Salter - Yes,,81
+Miner,3,Supreme Court Retention,2,Mark E. Salter - No,,10
+Miner,4,Supreme Court Retention,2,Mark E. Salter - Yes,,79
+Miner,4,Supreme Court Retention,2,Mark E. Salter - No,,13
+Miner,5,Supreme Court Retention,2,Mark E. Salter - Yes,,46
+Miner,5,Supreme Court Retention,2,Mark E. Salter - No,,6
+Miner,6,Supreme Court Retention,2,Mark E. Salter - Yes,,128
+Miner,6,Supreme Court Retention,2,Mark E. Salter - No,,13
+Miner,7,Supreme Court Retention,2,Mark E. Salter - Yes,,107
+Miner,7,Supreme Court Retention,2,Mark E. Salter - No,,21
+Miner,8,Supreme Court Retention,2,Mark E. Salter - Yes,,72
+Miner,8,Supreme Court Retention,2,Mark E. Salter - No,,19
+Miner,1,Constitutional Amendment D,,Yes,,81
+Miner,1,Constitutional Amendment D,,No,,45
+Miner,2,Constitutional Amendment D,,Yes,,45
+Miner,2,Constitutional Amendment D,,No,,44
+Miner,3,Constitutional Amendment D,,Yes,,64
+Miner,3,Constitutional Amendment D,,No,,45
+Miner,4,Constitutional Amendment D,,Yes,,75
+Miner,4,Constitutional Amendment D,,No,,45
+Miner,5,Constitutional Amendment D,,Yes,,31
+Miner,5,Constitutional Amendment D,,No,,32
+Miner,6,Constitutional Amendment D,,Yes,,83
+Miner,6,Constitutional Amendment D,,No,,100
+Miner,7,Constitutional Amendment D,,Yes,,78
+Miner,7,Constitutional Amendment D,,No,,77
+Miner,8,Constitutional Amendment D,,Yes,,47
+Miner,8,Constitutional Amendment D,,No,,60
+Miner,1,Initiated Measure 27,,Yes,,72
+Miner,1,Initiated Measure 27,,No,,57
+Miner,2,Initiated Measure 27,,Yes,,38
+Miner,2,Initiated Measure 27,,No,,54
+Miner,3,Initiated Measure 27,,Yes,,52
+Miner,3,Initiated Measure 27,,No,,58
+Miner,4,Initiated Measure 27,,Yes,,47
+Miner,4,Initiated Measure 27,,No,,75
+Miner,5,Initiated Measure 27,,Yes,,26
+Miner,5,Initiated Measure 27,,No,,38
+Miner,6,Initiated Measure 27,,Yes,,42
+Miner,6,Initiated Measure 27,,No,,148
+Miner,7,Initiated Measure 27,,Yes,,52
+Miner,7,Initiated Measure 27,,No,,110
+Miner,8,Initiated Measure 27,,Yes,,48
+Miner,8,Initiated Measure 27,,No,,62
+Miner,1,State Senate,08,Casey Crabtree,REP,92
+Miner,2,State Senate,08,Casey Crabtree,REP,77
+Miner,3,State Senate,08,Casey Crabtree,REP,86
+Miner,4,State Senate,08,Casey Crabtree,REP,89
+Miner,5,State Senate,20,Joshua Klumb,REP,48
+Miner,6,State Senate,08,Casey Crabtree,REP,155
+Miner,7,State Senate,08,Casey Crabtree,REP,118
+Miner,8 10 of 22,State Senate,08,Casey Crabtree,REP,81
+Miner,1,State House,08,Tim Reisch,REP,103
+Miner,1,State House,08,John Mills,REP,35
+Miner,2,State House,08,Tim Reisch,REP,77
+Miner,2,State House,08,John Mills,REP,37
+Miner,3,State House,08,Tim Reisch,REP,97
+Miner,3,State House,08,John Mills,REP,31
+Miner,4,State House,08,Tim Reisch,REP,102
+Miner,4,State House,08,John Mills,REP,37
+Miner,5,State House,20,Ben Krohmer,REP,32
+Miner,5,State House,20,Lance Koth,REP,45
+Miner,6,State House,08,Tim Reisch,REP,165
+Miner,6,State House,08,John Mills,REP,82
+Miner,7,State House,08,Tim Reisch,REP,144
+Miner,7,State House,08,John Mills,REP,45
+Miner,8 11 of 22,State House,08,Tim Reisch,REP,89
+Miner,8 11 of 22,State House,08,John Mills,REP,49

--- a/2022/counties/20221108__sd__general__minnehaha__precinct.csv
+++ b/2022/counties/20221108__sd__general__minnehaha__precinct.csv
@@ -1,754 +1,4 @@
 county,precinct,office,district,candidate,party,votes
-Minnehaha,0104,U.S. Senate,,Brian L. Bengs,DEM,335
-Minnehaha,0104,U.S. Senate,,Tamara J Lesnar,LIB,23
-Minnehaha,0104,U.S. Senate,,John R. Thune,REP,375
-Minnehaha,0105,U.S. Senate,,Brian L. Bengs,DEM,190
-Minnehaha,0105,U.S. Senate,,Tamara J Lesnar,LIB,22
-Minnehaha,0105,U.S. Senate,,John R. Thune,REP,248
-Minnehaha,0106,U.S. Senate,,Brian L. Bengs,DEM,410
-Minnehaha,0106,U.S. Senate,,Tamara J Lesnar,LIB,42
-Minnehaha,0106,U.S. Senate,,John R. Thune,REP,649
-Minnehaha,0109,U.S. Senate,,Brian L. Bengs,DEM,364
-Minnehaha,0109,U.S. Senate,,Tamara J Lesnar,LIB,31
-Minnehaha,0109,U.S. Senate,,John R. Thune,REP,686
-Minnehaha,0110,U.S. Senate,,Brian L. Bengs,DEM,416
-Minnehaha,0110,U.S. Senate,,Tamara J Lesnar,LIB,39
-Minnehaha,0110,U.S. Senate,,John R. Thune,REP,731
-Minnehaha,0117,U.S. Senate,,Brian L. Bengs,DEM,421
-Minnehaha,0117,U.S. Senate,,Tamara J Lesnar,LIB,61
-Minnehaha,0117,U.S. Senate,,John R. Thune,REP,863
-Minnehaha,0119,U.S. Senate,,Brian L. Bengs,DEM,237
-Minnehaha,0119,U.S. Senate,,Tamara J Lesnar,LIB,39
-Minnehaha,0119,U.S. Senate,,John R. Thune,REP,349
-Minnehaha,0201,U.S. Senate,,Brian L. Bengs,DEM,405
-Minnehaha,0201,U.S. Senate,,Tamara J Lesnar,LIB,21
-Minnehaha,0201,U.S. Senate,,John R. Thune,REP,679
-Minnehaha,0202,U.S. Senate,,Brian L. Bengs,DEM,517
-Minnehaha,0202,U.S. Senate,,Tamara J Lesnar,LIB,34
-Minnehaha,0202,U.S. Senate,,John R. Thune,REP,906
-Minnehaha,0203,U.S. Senate,,Brian L. Bengs,DEM,397
-Minnehaha,0203,U.S. Senate,,Tamara J Lesnar,LIB,44
-Minnehaha,0203,U.S. Senate,,John R. Thune,REP,663
-Minnehaha,0206,U.S. Senate,,Brian L. Bengs,DEM,406
-Minnehaha,0206,U.S. Senate,,Tamara J Lesnar,LIB,38
-Minnehaha,0206,U.S. Senate,,John R. Thune,REP,706
-Minnehaha,0208,U.S. Senate,,Brian L. Bengs,DEM,387
-Minnehaha,0208,U.S. Senate,,Tamara J Lesnar,LIB,27
-Minnehaha,0208,U.S. Senate,,John R. Thune,REP,771
-Minnehaha,0209,U.S. Senate,,Brian L. Bengs,DEM,413
-Minnehaha,0209,U.S. Senate,,Tamara J Lesnar,LIB,22
-Minnehaha,0209,U.S. Senate,,John R. Thune,REP,627
-Minnehaha,0214,U.S. Senate,,Brian L. Bengs,DEM,930
-Minnehaha,0214,U.S. Senate,,Tamara J Lesnar,LIB,78
-Minnehaha,0214,U.S. Senate,,John R. Thune,REP,1859
-Minnehaha,0301,U.S. Senate,,Brian L. Bengs,DEM,296
-Minnehaha,0301,U.S. Senate,,Tamara J Lesnar,LIB,26
-Minnehaha,0301,U.S. Senate,,John R. Thune,REP,473
-Minnehaha,0305,U.S. Senate,,Brian L. Bengs,DEM,205
-Minnehaha,0305,U.S. Senate,,Tamara J Lesnar,LIB,28
-Minnehaha,0305,U.S. Senate,,John R. Thune,REP,299
-Minnehaha,0309,U.S. Senate,,Brian L. Bengs,DEM,471
-Minnehaha,0309,U.S. Senate,,Tamara J Lesnar,LIB,52
-Minnehaha,0309,U.S. Senate,,John R. Thune,REP,628
-Minnehaha,0310,U.S. Senate,,Brian L. Bengs,DEM,426
-Minnehaha,0310,U.S. Senate,,Tamara J Lesnar,LIB,40
-Minnehaha,0310,U.S. Senate,,John R. Thune,REP,1011
-Minnehaha,0311,U.S. Senate,,Brian L. Bengs,DEM,273
-Minnehaha,0311,U.S. Senate,,Tamara J Lesnar,LIB,30
-Minnehaha,0311,U.S. Senate,,John R. Thune,REP,624
-Minnehaha,0312,U.S. Senate,,Brian L. Bengs,DEM,321
-Minnehaha,0312,U.S. Senate,,Tamara J Lesnar,LIB,46
-Minnehaha,0312,U.S. Senate,,John R. Thune,REP,828
-Minnehaha,0313,U.S. Senate,,Brian L. Bengs,DEM,231
-Minnehaha,0313,U.S. Senate,,Tamara J Lesnar,LIB,36
-Minnehaha,0313,U.S. Senate,,John R. Thune,REP,475
-Minnehaha,0314,U.S. Senate,,Brian L. Bengs,DEM,623
-Minnehaha,0314,U.S. Senate,,Tamara J Lesnar,LIB,77
-Minnehaha,0314,U.S. Senate,,John R. Thune,REP,1099
-Minnehaha,0315,U.S. Senate,,Brian L. Bengs,DEM,384
-Minnehaha,0315,U.S. Senate,,Tamara J Lesnar,LIB,33
-Minnehaha,0315,U.S. Senate,,John R. Thune,REP,696
-Minnehaha,0316,U.S. Senate,,Brian L. Bengs,DEM,510
-Minnehaha,0316,U.S. Senate,,Tamara J Lesnar,LIB,48
-Minnehaha,0316,U.S. Senate,,John R. Thune,REP,1216
-Minnehaha,0317,U.S. Senate,,Brian L. Bengs,DEM,632
-Minnehaha,0317,U.S. Senate,,Tamara J Lesnar,LIB,53
-Minnehaha,0317,U.S. Senate,,John R. Thune,REP,1435
-Minnehaha,0402,U.S. Senate,,Brian L. Bengs,DEM,281
-Minnehaha,0402,U.S. Senate,,Tamara J Lesnar,LIB,44
-Minnehaha,0402,U.S. Senate,,John R. Thune,REP,329
-Minnehaha,0403,U.S. Senate,,Brian L. Bengs,DEM,174
-Minnehaha,0403,U.S. Senate,,Tamara J Lesnar,LIB,19
-Minnehaha,0403,U.S. Senate,,John R. Thune,REP,240
-Minnehaha,0404,U.S. Senate,,Brian L. Bengs,DEM,268
-Minnehaha,0404,U.S. Senate,,Tamara J Lesnar,LIB,43
-Minnehaha,0404,U.S. Senate,,John R. Thune,REP,372
-Minnehaha,0405,U.S. Senate,,Brian L. Bengs,DEM,530
-Minnehaha,0405,U.S. Senate,,Tamara J Lesnar,LIB,63
-Minnehaha,0405,U.S. Senate,,John R. Thune,REP,1005
-Minnehaha,0406,U.S. Senate,,Brian L. Bengs,DEM,129
-Minnehaha,0406,U.S. Senate,,Tamara J Lesnar,LIB,9
-Minnehaha,0406,U.S. Senate,,John R. Thune,REP,157
-Minnehaha,0407,U.S. Senate,,Brian L. Bengs,DEM,499
-Minnehaha,0407,U.S. Senate,,Tamara J Lesnar,LIB,36
-Minnehaha,0407,U.S. Senate,,John R. Thune,REP,751
-Minnehaha,0408,U.S. Senate,,Brian L. Bengs,DEM,152
-Minnehaha,0408,U.S. Senate,,Tamara J Lesnar,LIB,17
-Minnehaha,0408,U.S. Senate,,John R. Thune,REP,153
-Minnehaha,0409,U.S. Senate,,Brian L. Bengs,DEM,286
-Minnehaha,0409,U.S. Senate,,Tamara J Lesnar,LIB,55
-Minnehaha,0409,U.S. Senate,,John R. Thune,REP,369
-Minnehaha,0410,U.S. Senate,,Brian L. Bengs,DEM,265
-Minnehaha,0410,U.S. Senate,,Tamara J Lesnar,LIB,40
-Minnehaha,0410,U.S. Senate,,John R. Thune,REP,477
-Minnehaha,0411,U.S. Senate,,Brian L. Bengs,DEM,623
-Minnehaha,0411,U.S. Senate,,Tamara J Lesnar,LIB,48
-Minnehaha,0411,U.S. Senate,,John R. Thune,REP,1311
-Minnehaha,0412,U.S. Senate,,Brian L. Bengs,DEM,443
-Minnehaha,0412,U.S. Senate,,Tamara J Lesnar,LIB,44
-Minnehaha,0412,U.S. Senate,,John R. Thune,REP,703
-Minnehaha,0413,U.S. Senate,,Brian L. Bengs,DEM,260
-Minnehaha,0413,U.S. Senate,,Tamara J Lesnar,LIB,29
-Minnehaha,0413,U.S. Senate,,John R. Thune,REP,353
-Minnehaha,0415,U.S. Senate,,Brian L. Bengs,DEM,645
-Minnehaha,0415,U.S. Senate,,Tamara J Lesnar,LIB,49
-Minnehaha,0415,U.S. Senate,,John R. Thune,REP,1447
-Minnehaha,0501,U.S. Senate,,Brian L. Bengs,DEM,216
-Minnehaha,0501,U.S. Senate,,Tamara J Lesnar,LIB,34
-Minnehaha,0501,U.S. Senate,,John R. Thune,REP,189
-Minnehaha,0502,U.S. Senate,,Brian L. Bengs,DEM,375
-Minnehaha,0502,U.S. Senate,,Tamara J Lesnar,LIB,29
-Minnehaha,0502,U.S. Senate,,John R. Thune,REP,247
-Minnehaha,0503,U.S. Senate,,Brian L. Bengs,DEM,172
-Minnehaha,0503,U.S. Senate,,Tamara J Lesnar,LIB,22
-Minnehaha,0503,U.S. Senate,,John R. Thune,REP,147
-Minnehaha,0504,U.S. Senate,,Brian L. Bengs,DEM,468
-Minnehaha,0504,U.S. Senate,,Tamara J Lesnar,LIB,37
-Minnehaha,0504,U.S. Senate,,John R. Thune,REP,350
-Minnehaha,0506,U.S. Senate,,Brian L. Bengs,DEM,411
-Minnehaha,0506,U.S. Senate,,Tamara J Lesnar,LIB,51
-Minnehaha,0506,U.S. Senate,,John R. Thune,REP,473
-Minnehaha,0507,U.S. Senate,,Brian L. Bengs,DEM,275
-Minnehaha,0507,U.S. Senate,,Tamara J Lesnar,LIB,19
-Minnehaha,0507,U.S. Senate,,John R. Thune,REP,272
-Minnehaha,0508,U.S. Senate,,Brian L. Bengs,DEM,450
-Minnehaha,0508,U.S. Senate,,Tamara J Lesnar,LIB,24
-Minnehaha,0508,U.S. Senate,,John R. Thune,REP,434
-Minnehaha,0509,U.S. Senate,,Brian L. Bengs,DEM,189
-Minnehaha,0509,U.S. Senate,,Tamara J Lesnar,LIB,31
-Minnehaha,0509,U.S. Senate,,John R. Thune,REP,163
-Minnehaha,0510,U.S. Senate,,Brian L. Bengs,DEM,243
-Minnehaha,0510,U.S. Senate,,Tamara J Lesnar,LIB,29
-Minnehaha,0510,U.S. Senate,,John R. Thune,REP,270
-Minnehaha,0512,U.S. Senate,,Brian L. Bengs,DEM,272
-Minnehaha,0512,U.S. Senate,,Tamara J Lesnar,LIB,31
-Minnehaha,0512,U.S. Senate,,John R. Thune,REP,318
-Minnehaha,0513,U.S. Senate,,Brian L. Bengs,DEM,285
-Minnehaha,0513,U.S. Senate,,Tamara J Lesnar,LIB,16
-Minnehaha,0513,U.S. Senate,,John R. Thune,REP,339
-Minnehaha,0514,U.S. Senate,,Brian L. Bengs,DEM,360
-Minnehaha,0514,U.S. Senate,,Tamara J Lesnar,LIB,50
-Minnehaha,0514,U.S. Senate,,John R. Thune,REP,349
-Minnehaha,0515,U.S. Senate,,Brian L. Bengs,DEM,315
-Minnehaha,0515,U.S. Senate,,Tamara J Lesnar,LIB,32
-Minnehaha,0515,U.S. Senate,,John R. Thune,REP,428
-Minnehaha,0517,U.S. Senate,,Brian L. Bengs,DEM,211
-Minnehaha,0517,U.S. Senate,,Tamara J Lesnar,LIB,20
-Minnehaha,0517,U.S. Senate,,John R. Thune,REP,291
-Minnehaha,0518,U.S. Senate,,Brian L. Bengs,DEM,506
-Minnehaha,0518,U.S. Senate,,Tamara J Lesnar,LIB,63
-Minnehaha,0518,U.S. Senate,,John R. Thune,REP,452
-Minnehaha,0519,U.S. Senate,,Brian L. Bengs,DEM,210
-Minnehaha,0519,U.S. Senate,,Tamara J Lesnar,LIB,14
-Minnehaha,0519,U.S. Senate,,John R. Thune,REP,291
-Minnehaha,0520,U.S. Senate,,Brian L. Bengs,DEM,337
-Minnehaha,0520,U.S. Senate,,Tamara J Lesnar,LIB,56
-Minnehaha,0520,U.S. Senate,,John R. Thune,REP,439
-Minnehaha,0521,U.S. Senate,,Brian L. Bengs,DEM,193
-Minnehaha,0521,U.S. Senate,,Tamara J Lesnar,LIB,10
-Minnehaha,0521,U.S. Senate,,John R. Thune,REP,222
-Minnehaha,0522,U.S. Senate,,Brian L. Bengs,DEM,373
-Minnehaha,0522,U.S. Senate,,Tamara J Lesnar,LIB,61
-Minnehaha,0522,U.S. Senate,,John R. Thune,REP,377
-Minnehaha,0523,U.S. Senate,,Brian L. Bengs,DEM,311
-Minnehaha,0523,U.S. Senate,,Tamara J Lesnar,LIB,44
-Minnehaha,0523,U.S. Senate,,John R. Thune,REP,279
-Minnehaha,VP01,U.S. Senate,,Brian L. Bengs,DEM,128
-Minnehaha,VP01,U.S. Senate,,Tamara J Lesnar,LIB,38
-Minnehaha,VP01,U.S. Senate,,John R. Thune,REP,577
-Minnehaha,VP02,U.S. Senate,,Brian L. Bengs,DEM,370
-Minnehaha,VP02,U.S. Senate,,Tamara J Lesnar,LIB,48
-Minnehaha,VP02,U.S. Senate,,John R. Thune,REP,1281
-Minnehaha,VP03,U.S. Senate,,Brian L. Bengs,DEM,464
-Minnehaha,VP03,U.S. Senate,,Tamara J Lesnar,LIB,81
-Minnehaha,VP03,U.S. Senate,,John R. Thune,REP,1476
-Minnehaha,VP04,U.S. Senate,,Brian L. Bengs,DEM,249
-Minnehaha,VP04,U.S. Senate,,Tamara J Lesnar,LIB,40
-Minnehaha,VP04,U.S. Senate,,John R. Thune,REP,779
-Minnehaha,VP05,U.S. Senate,,Brian L. Bengs,DEM,314
-Minnehaha,VP05,U.S. Senate,,Tamara J Lesnar,LIB,49
-Minnehaha,VP05,U.S. Senate,,John R. Thune,REP,1027
-Minnehaha,VP06,U.S. Senate,,Brian L. Bengs,DEM,93
-Minnehaha,VP06,U.S. Senate,,Tamara J Lesnar,LIB,15
-Minnehaha,VP06,U.S. Senate,,John R. Thune,REP,323
-Minnehaha,VP07,U.S. Senate,,Brian L. Bengs,DEM,344
-Minnehaha,VP07,U.S. Senate,,Tamara J Lesnar,LIB,66
-Minnehaha,VP07,U.S. Senate,,John R. Thune,REP,1252
-Minnehaha,VP08,U.S. Senate,,Brian L. Bengs,DEM,111
-Minnehaha,VP08,U.S. Senate,,Tamara J Lesnar,LIB,30
-Minnehaha,VP08,U.S. Senate,,John R. Thune,REP,497
-Minnehaha,VP09,U.S. Senate,,Brian L. Bengs,DEM,264
-Minnehaha,VP09,U.S. Senate,,Tamara J Lesnar,LIB,48
-Minnehaha,VP09,U.S. Senate,,John R. Thune,REP,950
-Minnehaha,VP10,U.S. Senate,,Brian L. Bengs,DEM,247
-Minnehaha,VP10,U.S. Senate,,Tamara J Lesnar,LIB,41
-Minnehaha,VP10,U.S. Senate,,John R. Thune,REP,848
-Minnehaha,VP11,U.S. Senate,,Brian L. Bengs,DEM,52
-Minnehaha,VP11,U.S. Senate,,Tamara J Lesnar,LIB,10
-Minnehaha,VP11,U.S. Senate,,John R. Thune,REP,237
-Minnehaha,VP12,U.S. Senate,,Brian L. Bengs,DEM,15
-Minnehaha,VP12,U.S. Senate,,Tamara J Lesnar,LIB,4
-Minnehaha,VP12,U.S. Senate,,John R. Thune,REP,106
-Minnehaha,VP13,U.S. Senate,,Brian L. Bengs,DEM,146
-Minnehaha,VP13,U.S. Senate,,Tamara J Lesnar,LIB,46
-Minnehaha,VP13,U.S. Senate,,John R. Thune,REP,699
-Minnehaha,VP15,U.S. Senate,,Brian L. Bengs,DEM,346
-Minnehaha,VP15,U.S. Senate,,Tamara J Lesnar,LIB,40
-Minnehaha,VP15,U.S. Senate,,John R. Thune,REP,1103
-Minnehaha,VP16,U.S. Senate,,Brian L. Bengs,DEM,220
-Minnehaha,VP16,U.S. Senate,,Tamara J Lesnar,LIB,33
-Minnehaha,VP16,U.S. Senate,,John R. Thune,REP,786
-Minnehaha,VP17,U.S. Senate,,Brian L. Bengs,DEM,115
-Minnehaha,VP17,U.S. Senate,,Tamara J Lesnar,LIB,22
-Minnehaha,VP17,U.S. Senate,,John R. Thune,REP,505
-Minnehaha,VP21,U.S. Senate,,Brian L. Bengs,DEM,367
-Minnehaha,VP21,U.S. Senate,,Tamara J Lesnar,LIB,51
-Minnehaha,VP21,U.S. Senate,,John R. Thune,REP,1212
-Minnehaha,0104,U.S. House,1,Collin Duprel,LIB,212
-Minnehaha,0104,U.S. House,1,Dusty Johnson,REP,435
-Minnehaha,0105,U.S. House,1,Collin Duprel,LIB,125
-Minnehaha,0105,U.S. House,1,Dusty Johnson,REP,276
-Minnehaha,0106,U.S. House,1,Collin Duprel,LIB,300
-Minnehaha,0106,U.S. House,1,Dusty Johnson,REP,712
-Minnehaha,0109,U.S. House,1,Collin Duprel,LIB,237
-Minnehaha,0109,U.S. House,1,Dusty Johnson,REP,756
-Minnehaha,0110,U.S. House,1,Collin Duprel,LIB,309
-Minnehaha,0110,U.S. House,1,Dusty Johnson,REP,794
-Minnehaha,0117,U.S. House,1,Collin Duprel,LIB,345
-Minnehaha,0117,U.S. House,1,Dusty Johnson,REP,901
-Minnehaha,0119,U.S. House,1,Collin Duprel,LIB,197
-Minnehaha,0119,U.S. House,1,Dusty Johnson,REP,365
-Minnehaha,0201,U.S. House,1,Collin Duprel,LIB,232
-Minnehaha,0201,U.S. House,1,Dusty Johnson,REP,783
-Minnehaha,0202,U.S. House,1,Collin Duprel,LIB,294
-Minnehaha,0202,U.S. House,1,Dusty Johnson,REP,1028
-Minnehaha,0203,U.S. House,1,Collin Duprel,LIB,275
-Minnehaha,0203,U.S. House,1,Dusty Johnson,REP,733
-Minnehaha,0206,U.S. House,1,Collin Duprel,LIB,269
-Minnehaha,0206,U.S. House,1,Dusty Johnson,REP,788
-Minnehaha,0208,U.S. House,1,Collin Duprel,LIB,232
-Minnehaha,0208,U.S. House,1,Dusty Johnson,REP,841
-Minnehaha,0209,U.S. House,1,Collin Duprel,LIB,247
-Minnehaha,0209,U.S. House,1,Dusty Johnson,REP,720
-Minnehaha,0214,U.S. House,1,Collin Duprel,LIB,629
-Minnehaha,0214,U.S. House,1,Dusty Johnson,REP,2057
-Minnehaha,0301,U.S. House,1,Collin Duprel,LIB,188
-Minnehaha,0301,U.S. House,1,Dusty Johnson,REP,533
-Minnehaha,0305,U.S. House,1,Collin Duprel,LIB,182
-Minnehaha,0305,U.S. House,1,Dusty Johnson,REP,307
-Minnehaha,0309,U.S. House,1,Collin Duprel,LIB,357
-Minnehaha,0309,U.S. House,1,Dusty Johnson,REP,691
-Minnehaha,0310,U.S. House,1,Collin Duprel,LIB,266
-Minnehaha,0310,U.S. House,1,Dusty Johnson,REP,1128
-Minnehaha,0311,U.S. House,1,Collin Duprel,LIB,202
-Minnehaha,0311,U.S. House,1,Dusty Johnson,REP,668
-Minnehaha,0312,U.S. House,1,Collin Duprel,LIB,260
-Minnehaha,0312,U.S. House,1,Dusty Johnson,REP,868
-Minnehaha,0313,U.S. House,1,Collin Duprel,LIB,186
-Minnehaha,0313,U.S. House,1,Dusty Johnson,REP,509
-Minnehaha,0314,U.S. House,1,Collin Duprel,LIB,495
-Minnehaha,0314,U.S. House,1,Dusty Johnson,REP,1173
-Minnehaha,0315,U.S. House,1,Collin Duprel,LIB,293
-Minnehaha,0315,U.S. House,1,Dusty Johnson,REP,748
-Minnehaha,0316,U.S. House,1,Collin Duprel,LIB,354
-Minnehaha,0316,U.S. House,1,Dusty Johnson,REP,1317
-Minnehaha,0317,U.S. House,1,Collin Duprel,LIB,452
-Minnehaha,0317,U.S. House,1,Dusty Johnson,REP,1524
-Minnehaha,0402,U.S. House,1,Collin Duprel,LIB,224
-Minnehaha,0402,U.S. House,1,Dusty Johnson,REP,376
-Minnehaha,0403,U.S. House,1,Collin Duprel,LIB,136
-Minnehaha,0403,U.S. House,1,Dusty Johnson,REP,258
-Minnehaha,0404,U.S. House,1,Collin Duprel,LIB,230
-Minnehaha,0404,U.S. House,1,Dusty Johnson,REP,387
-Minnehaha,0405,U.S. House,1,Collin Duprel,LIB,438
-Minnehaha,0405,U.S. House,1,Dusty Johnson,REP,1030
-Minnehaha,0406,U.S. House,1,Collin Duprel,LIB,93
-Minnehaha,0406,U.S. House,1,Dusty Johnson,REP,178
-Minnehaha,0407,U.S. House,1,Collin Duprel,LIB,305
-Minnehaha,0407,U.S. House,1,Dusty Johnson,REP,867
-Minnehaha,0408,U.S. House,1,Collin Duprel,LIB,111
-Minnehaha,0408,U.S. House,1,Dusty Johnson,REP,177
-Minnehaha,0409,U.S. House,1,Collin Duprel,LIB,239
-Minnehaha,0409,U.S. House,1,Dusty Johnson,REP,412
-Minnehaha,0410,U.S. House,1,Collin Duprel,LIB,210
-Minnehaha,0410,U.S. House,1,Dusty Johnson,REP,518
-Minnehaha,0411,U.S. House,1,Collin Duprel,LIB,397
-Minnehaha,0411,U.S. House,1,Dusty Johnson,REP,1434
-Minnehaha,0412,U.S. House,1,Collin Duprel,LIB,308
-Minnehaha,0412,U.S. House,1,Dusty Johnson,REP,807
-Minnehaha,0413,U.S. House,1,Collin Duprel,LIB,194
-Minnehaha,0413,U.S. House,1,Dusty Johnson,REP,399
-Minnehaha,0415,U.S. House,1,Collin Duprel,LIB,377
-Minnehaha,0415,U.S. House,1,Dusty Johnson,REP,1584
-Minnehaha,0501,U.S. House,1,Collin Duprel,LIB,163
-Minnehaha,0501,U.S. House,1,Dusty Johnson,REP,218
-Minnehaha,0502,U.S. House,1,Collin Duprel,LIB,244
-Minnehaha,0502,U.S. House,1,Dusty Johnson,REP,319
-Minnehaha,0503,U.S. House,1,Collin Duprel,LIB,126
-Minnehaha,0503,U.S. House,1,Dusty Johnson,REP,176
-Minnehaha,0504,U.S. House,1,Collin Duprel,LIB,291
-Minnehaha,0504,U.S. House,1,Dusty Johnson,REP,437
-Minnehaha,0506,U.S. House,1,Collin Duprel,LIB,299
-Minnehaha,0506,U.S. House,1,Dusty Johnson,REP,541
-Minnehaha,0507,U.S. House,1,Collin Duprel,LIB,162
-Minnehaha,0507,U.S. House,1,Dusty Johnson,REP,323
-Minnehaha,0508,U.S. House,1,Collin Duprel,LIB,246
-Minnehaha,0508,U.S. House,1,Dusty Johnson,REP,541
-Minnehaha,0509,U.S. House,1,Collin Duprel,LIB,134
-Minnehaha,0509,U.S. House,1,Dusty Johnson,REP,209
-Minnehaha,0510,U.S. House,1,Collin Duprel,LIB,173
-Minnehaha,0510,U.S. House,1,Dusty Johnson,REP,318
-Minnehaha,0512,U.S. House,1,Collin Duprel,LIB,183
-Minnehaha,0512,U.S. House,1,Dusty Johnson,REP,381
-Minnehaha,0513,U.S. House,1,Collin Duprel,LIB,170
-Minnehaha,0513,U.S. House,1,Dusty Johnson,REP,394
-Minnehaha,0514,U.S. House,1,Collin Duprel,LIB,248
-Minnehaha,0514,U.S. House,1,Dusty Johnson,REP,425
-Minnehaha,0515,U.S. House,1,Collin Duprel,LIB,271
-Minnehaha,0515,U.S. House,1,Dusty Johnson,REP,434
-Minnehaha,0517,U.S. House,1,Collin Duprel,LIB,141
-Minnehaha,0517,U.S. House,1,Dusty Johnson,REP,333
-Minnehaha,0518,U.S. House,1,Collin Duprel,LIB,359
-Minnehaha,0518,U.S. House,1,Dusty Johnson,REP,536
-Minnehaha,0519,U.S. House,1,Collin Duprel,LIB,117
-Minnehaha,0519,U.S. House,1,Dusty Johnson,REP,323
-Minnehaha,0520,U.S. House,1,Collin Duprel,LIB,265
-Minnehaha,0520,U.S. House,1,Dusty Johnson,REP,490
-Minnehaha,0521,U.S. House,1,Collin Duprel,LIB,101
-Minnehaha,0521,U.S. House,1,Dusty Johnson,REP,276
-Minnehaha,0522,U.S. House,1,Collin Duprel,LIB,302
-Minnehaha,0522,U.S. House,1,Dusty Johnson,REP,437
-Minnehaha,0523,U.S. House,1,Collin Duprel,LIB,250
-Minnehaha,0523,U.S. House,1,Dusty Johnson,REP,320
-Minnehaha,VP01,U.S. House,1,Collin Duprel,LIB,137
-Minnehaha,VP01,U.S. House,1,Dusty Johnson,REP,585
-Minnehaha,VP02,U.S. House,1,Collin Duprel,LIB,260
-Minnehaha,VP02,U.S. House,1,Dusty Johnson,REP,1350
-Minnehaha,VP03,U.S. House,1,Collin Duprel,LIB,338
-Minnehaha,VP03,U.S. House,1,Dusty Johnson,REP,1579
-Minnehaha,VP04,U.S. House,1,Collin Duprel,LIB,216
-Minnehaha,VP04,U.S. House,1,Dusty Johnson,REP,797
-Minnehaha,VP05,U.S. House,1,Collin Duprel,LIB,245
-Minnehaha,VP05,U.S. House,1,Dusty Johnson,REP,1076
-Minnehaha,VP06,U.S. House,1,Collin Duprel,LIB,67
-Minnehaha,VP06,U.S. House,1,Dusty Johnson,REP,340
-Minnehaha,VP07,U.S. House,1,Collin Duprel,LIB,287
-Minnehaha,VP07,U.S. House,1,Dusty Johnson,REP,1304
-Minnehaha,VP08,U.S. House,1,Collin Duprel,LIB,109
-Minnehaha,VP08,U.S. House,1,Dusty Johnson,REP,496
-Minnehaha,VP09,U.S. House,1,Collin Duprel,LIB,226
-Minnehaha,VP09,U.S. House,1,Dusty Johnson,REP,994
-Minnehaha,VP10,U.S. House,1,Collin Duprel,LIB,206
-Minnehaha,VP10,U.S. House,1,Dusty Johnson,REP,871
-Minnehaha,VP11,U.S. House,1,Collin Duprel,LIB,42
-Minnehaha,VP11,U.S. House,1,Dusty Johnson,REP,243
-Minnehaha,VP12,U.S. House,1,Collin Duprel,LIB,13
-Minnehaha,VP12,U.S. House,1,Dusty Johnson,REP,108
-Minnehaha,VP13,U.S. House,1,Collin Duprel,LIB,130
-Minnehaha,VP13,U.S. House,1,Dusty Johnson,REP,730
-Minnehaha,VP15,U.S. House,1,Collin Duprel,LIB,280
-Minnehaha,VP15,U.S. House,1,Dusty Johnson,REP,1130
-Minnehaha,VP16,U.S. House,1,Collin Duprel,LIB,181
-Minnehaha,VP16,U.S. House,1,Dusty Johnson,REP,806
-Minnehaha,VP17,U.S. House,1,Collin Duprel,LIB,93
-Minnehaha,VP17,U.S. House,1,Dusty Johnson,REP,518
-Minnehaha,VP21,U.S. House,1,Collin Duprel,LIB,290
-Minnehaha,VP21,U.S. House,1,Dusty Johnson,REP,1253
-Minnehaha,0104,Governor,,Jamie Smith and Jennifer Keintz,DEM,420
-Minnehaha,0104,Governor,,Tracey Quint and Ashley Strand,LIB,15
-Minnehaha,0104,Governor,,Kristi Noem and Larry Rhoden,REP,303
-Minnehaha,0105,Governor,,Jamie Smith and Jennifer Keintz,DEM,242
-Minnehaha,0105,Governor,,Tracey Quint and Ashley Strand,LIB,14
-Minnehaha,0105,Governor,,Kristi Noem and Larry Rhoden,REP,210
-Minnehaha,0106,Governor,,Jamie Smith and Jennifer Keintz,DEM,523
-Minnehaha,0106,Governor,,Tracey Quint and Ashley Strand,LIB,39
-Minnehaha,0106,Governor,,Kristi Noem and Larry Rhoden,REP,545
-Minnehaha,0109,Governor,,Jamie Smith and Jennifer Keintz,DEM,510
-Minnehaha,0109,Governor,,Tracey Quint and Ashley Strand,LIB,30
-Minnehaha,0109,Governor,,Kristi Noem and Larry Rhoden,REP,545
-Minnehaha,0110,Governor,,Jamie Smith and Jennifer Keintz,DEM,542
-Minnehaha,0110,Governor,,Tracey Quint and Ashley Strand,LIB,36
-Minnehaha,0110,Governor,,Kristi Noem and Larry Rhoden,REP,607
-Minnehaha,0117,Governor,,Jamie Smith and Jennifer Keintz,DEM,593
-Minnehaha,0117,Governor,,Tracey Quint and Ashley Strand,LIB,41
-Minnehaha,0117,Governor,,Kristi Noem and Larry Rhoden,REP,715
-Minnehaha,0119,Governor,,Jamie Smith and Jennifer Keintz,DEM,309
-Minnehaha,0119,Governor,,Tracey Quint and Ashley Strand,LIB,32
-Minnehaha,0119,Governor,,Kristi Noem and Larry Rhoden,REP,288
-Minnehaha,0201,Governor,,Jamie Smith and Jennifer Keintz,DEM,561
-Minnehaha,0201,Governor,,Tracey Quint and Ashley Strand,LIB,13
-Minnehaha,0201,Governor,,Kristi Noem and Larry Rhoden,REP,546
-Minnehaha,0202,Governor,,Jamie Smith and Jennifer Keintz,DEM,763
-Minnehaha,0202,Governor,,Tracey Quint and Ashley Strand,LIB,16
-Minnehaha,0202,Governor,,Kristi Noem and Larry Rhoden,REP,687
-Minnehaha,0203,Governor,,Jamie Smith and Jennifer Keintz,DEM,554
-Minnehaha,0203,Governor,,Tracey Quint and Ashley Strand,LIB,37
-Minnehaha,0203,Governor,,Kristi Noem and Larry Rhoden,REP,514
-Minnehaha,0206,Governor,,Jamie Smith and Jennifer Keintz,DEM,559
-Minnehaha,0206,Governor,,Tracey Quint and Ashley Strand,LIB,24
-Minnehaha,0206,Governor,,Kristi Noem and Larry Rhoden,REP,590
-Minnehaha,0208,Governor,,Jamie Smith and Jennifer Keintz,DEM,547
-Minnehaha,0208,Governor,,Tracey Quint and Ashley Strand,LIB,22
-Minnehaha,0208,Governor,,Kristi Noem and Larry Rhoden,REP,620
-Minnehaha,0209,Governor,,Jamie Smith and Jennifer Keintz,DEM,575
-Minnehaha,0209,Governor,,Tracey Quint and Ashley Strand,LIB,14
-Minnehaha,0209,Governor,,Kristi Noem and Larry Rhoden,REP,479
-Minnehaha,0214,Governor,,Jamie Smith and Jennifer Keintz,DEM,1349
-Minnehaha,0214,Governor,,Tracey Quint and Ashley Strand,LIB,54
-Minnehaha,0214,Governor,,Kristi Noem and Larry Rhoden,REP,1502
-Minnehaha,0301,Governor,,Jamie Smith and Jennifer Keintz,DEM,382
-Minnehaha,0301,Governor,,Tracey Quint and Ashley Strand,LIB,15
-Minnehaha,0301,Governor,,Kristi Noem and Larry Rhoden,REP,396
-Minnehaha,0305,Governor,,Jamie Smith and Jennifer Keintz,DEM,253
-Minnehaha,0305,Governor,,Tracey Quint and Ashley Strand,LIB,31
-Minnehaha,0305,Governor,,Kristi Noem and Larry Rhoden,REP,267
-Minnehaha,0309,Governor,,Jamie Smith and Jennifer Keintz,DEM,593
-Minnehaha,0309,Governor,,Tracey Quint and Ashley Strand,LIB,52
-Minnehaha,0309,Governor,,Kristi Noem and Larry Rhoden,REP,516
-Minnehaha,0310,Governor,,Jamie Smith and Jennifer Keintz,DEM,594
-Minnehaha,0310,Governor,,Tracey Quint and Ashley Strand,LIB,26
-Minnehaha,0310,Governor,,Kristi Noem and Larry Rhoden,REP,851
-Minnehaha,0311,Governor,,Jamie Smith and Jennifer Keintz,DEM,396
-Minnehaha,0311,Governor,,Tracey Quint and Ashley Strand,LIB,29
-Minnehaha,0311,Governor,,Kristi Noem and Larry Rhoden,REP,507
-Minnehaha,0312,Governor,,Jamie Smith and Jennifer Keintz,DEM,474
-Minnehaha,0312,Governor,,Tracey Quint and Ashley Strand,LIB,39
-Minnehaha,0312,Governor,,Kristi Noem and Larry Rhoden,REP,704
-Minnehaha,0313,Governor,,Jamie Smith and Jennifer Keintz,DEM,322
-Minnehaha,0313,Governor,,Tracey Quint and Ashley Strand,LIB,28
-Minnehaha,0313,Governor,,Kristi Noem and Larry Rhoden,REP,397
-Minnehaha,0314,Governor,,Jamie Smith and Jennifer Keintz,DEM,826
-Minnehaha,0314,Governor,,Tracey Quint and Ashley Strand,LIB,58
-Minnehaha,0314,Governor,,Kristi Noem and Larry Rhoden,REP,923
-Minnehaha,0315,Governor,,Jamie Smith and Jennifer Keintz,DEM,519
-Minnehaha,0315,Governor,,Tracey Quint and Ashley Strand,LIB,29
-Minnehaha,0315,Governor,,Kristi Noem and Larry Rhoden,REP,578
-Minnehaha,0316,Governor,,Jamie Smith and Jennifer Keintz,DEM,748
-Minnehaha,0316,Governor,,Tracey Quint and Ashley Strand,LIB,40
-Minnehaha,0316,Governor,,Kristi Noem and Larry Rhoden,REP,998
-Minnehaha,0317,Governor,,Jamie Smith and Jennifer Keintz,DEM,911
-Minnehaha,0317,Governor,,Tracey Quint and Ashley Strand,LIB,43
-Minnehaha,0317,Governor,,Kristi Noem and Larry Rhoden,REP,1189
-Minnehaha,0402,Governor,,Jamie Smith and Jennifer Keintz,DEM,368
-Minnehaha,0402,Governor,,Tracey Quint and Ashley Strand,LIB,31
-Minnehaha,0402,Governor,,Kristi Noem and Larry Rhoden,REP,261
-Minnehaha,0403,Governor,,Jamie Smith and Jennifer Keintz,DEM,238
-Minnehaha,0403,Governor,,Tracey Quint and Ashley Strand,LIB,14
-Minnehaha,0403,Governor,,Kristi Noem and Larry Rhoden,REP,185
-Minnehaha,0404,Governor,,Jamie Smith and Jennifer Keintz,DEM,364
-Minnehaha,0404,Governor,,Tracey Quint and Ashley Strand,LIB,43
-Minnehaha,0404,Governor,,Kristi Noem and Larry Rhoden,REP,285
-Minnehaha,0405,Governor,,Jamie Smith and Jennifer Keintz,DEM,613
-Minnehaha,0405,Governor,,Tracey Quint and Ashley Strand,LIB,41
-Minnehaha,0405,Governor,,Kristi Noem and Larry Rhoden,REP,955
-Minnehaha,0406,Governor,,Jamie Smith and Jennifer Keintz,DEM,149
-Minnehaha,0406,Governor,,Tracey Quint and Ashley Strand,LIB,17
-Minnehaha,0406,Governor,,Kristi Noem and Larry Rhoden,REP,129
-Minnehaha,0407,Governor,,Jamie Smith and Jennifer Keintz,DEM,626
-Minnehaha,0407,Governor,,Tracey Quint and Ashley Strand,LIB,32
-Minnehaha,0407,Governor,,Kristi Noem and Larry Rhoden,REP,641
-Minnehaha,0408,Governor,,Jamie Smith and Jennifer Keintz,DEM,183
-Minnehaha,0408,Governor,,Tracey Quint and Ashley Strand,LIB,10
-Minnehaha,0408,Governor,,Kristi Noem and Larry Rhoden,REP,128
-Minnehaha,0409,Governor,,Jamie Smith and Jennifer Keintz,DEM,377
-Minnehaha,0409,Governor,,Tracey Quint and Ashley Strand,LIB,42
-Minnehaha,0409,Governor,,Kristi Noem and Larry Rhoden,REP,299
-Minnehaha,0410,Governor,,Jamie Smith and Jennifer Keintz,DEM,357
-Minnehaha,0410,Governor,,Tracey Quint and Ashley Strand,LIB,27
-Minnehaha,0410,Governor,,Kristi Noem and Larry Rhoden,REP,399
-Minnehaha,0411,Governor,,Jamie Smith and Jennifer Keintz,DEM,805
-Minnehaha,0411,Governor,,Tracey Quint and Ashley Strand,LIB,42
-Minnehaha,0411,Governor,,Kristi Noem and Larry Rhoden,REP,1135
-Minnehaha,0412,Governor,,Jamie Smith and Jennifer Keintz,DEM,599
-Minnehaha,0412,Governor,,Tracey Quint and Ashley Strand,LIB,32
-Minnehaha,0412,Governor,,Kristi Noem and Larry Rhoden,REP,576
-Minnehaha,0413,Governor,,Jamie Smith and Jennifer Keintz,DEM,347
-Minnehaha,0413,Governor,,Tracey Quint and Ashley Strand,LIB,17
-Minnehaha,0413,Governor,,Kristi Noem and Larry Rhoden,REP,283
-Minnehaha,0415,Governor,,Jamie Smith and Jennifer Keintz,DEM,897
-Minnehaha,0415,Governor,,Tracey Quint and Ashley Strand,LIB,30
-Minnehaha,0415,Governor,,Kristi Noem and Larry Rhoden,REP,1228
-Minnehaha,0501,Governor,,Jamie Smith and Jennifer Keintz,DEM,270
-Minnehaha,0501,Governor,,Tracey Quint and Ashley Strand,LIB,19
-Minnehaha,0501,Governor,,Kristi Noem and Larry Rhoden,REP,155
-Minnehaha,0502,Governor,,Jamie Smith and Jennifer Keintz,DEM,445
-Minnehaha,0502,Governor,,Tracey Quint and Ashley Strand,LIB,23
-Minnehaha,0502,Governor,,Kristi Noem and Larry Rhoden,REP,189
-Minnehaha,0503,Governor,,Jamie Smith and Jennifer Keintz,DEM,211
-Minnehaha,0503,Governor,,Tracey Quint and Ashley Strand,LIB,13
-Minnehaha,0503,Governor,,Kristi Noem and Larry Rhoden,REP,119
-Minnehaha,0504,Governor,,Jamie Smith and Jennifer Keintz,DEM,556
-Minnehaha,0504,Governor,,Tracey Quint and Ashley Strand,LIB,30
-Minnehaha,0504,Governor,,Kristi Noem and Larry Rhoden,REP,278
-Minnehaha,0506,Governor,,Jamie Smith and Jennifer Keintz,DEM,547
-Minnehaha,0506,Governor,,Tracey Quint and Ashley Strand,LIB,36
-Minnehaha,0506,Governor,,Kristi Noem and Larry Rhoden,REP,359
-Minnehaha,0507,Governor,,Jamie Smith and Jennifer Keintz,DEM,359
-Minnehaha,0507,Governor,,Tracey Quint and Ashley Strand,LIB,12
-Minnehaha,0507,Governor,,Kristi Noem and Larry Rhoden,REP,203
-Minnehaha,0508,Governor,,Jamie Smith and Jennifer Keintz,DEM,595
-Minnehaha,0508,Governor,,Tracey Quint and Ashley Strand,LIB,16
-Minnehaha,0508,Governor,,Kristi Noem and Larry Rhoden,REP,308
-Minnehaha,0509,Governor,,Jamie Smith and Jennifer Keintz,DEM,260
-Minnehaha,0509,Governor,,Tracey Quint and Ashley Strand,LIB,11
-Minnehaha,0509,Governor,,Kristi Noem and Larry Rhoden,REP,118
-Minnehaha,0510,Governor,,Jamie Smith and Jennifer Keintz,DEM,304
-Minnehaha,0510,Governor,,Tracey Quint and Ashley Strand,LIB,13
-Minnehaha,0510,Governor,,Kristi Noem and Larry Rhoden,REP,226
-Minnehaha,0512,Governor,,Jamie Smith and Jennifer Keintz,DEM,364
-Minnehaha,0512,Governor,,Tracey Quint and Ashley Strand,LIB,19
-Minnehaha,0512,Governor,,Kristi Noem and Larry Rhoden,REP,252
-Minnehaha,0513,Governor,,Jamie Smith and Jennifer Keintz,DEM,390
-Minnehaha,0513,Governor,,Tracey Quint and Ashley Strand,LIB,8
-Minnehaha,0513,Governor,,Kristi Noem and Larry Rhoden,REP,253
-Minnehaha,0514,Governor,,Jamie Smith and Jennifer Keintz,DEM,460
-Minnehaha,0514,Governor,,Tracey Quint and Ashley Strand,LIB,28
-Minnehaha,0514,Governor,,Kristi Noem and Larry Rhoden,REP,281
-Minnehaha,0515,Governor,,Jamie Smith and Jennifer Keintz,DEM,364
-Minnehaha,0515,Governor,,Tracey Quint and Ashley Strand,LIB,27
-Minnehaha,0515,Governor,,Kristi Noem and Larry Rhoden,REP,397
-Minnehaha,0517,Governor,,Jamie Smith and Jennifer Keintz,DEM,262
-Minnehaha,0517,Governor,,Tracey Quint and Ashley Strand,LIB,13
-Minnehaha,0517,Governor,,Kristi Noem and Larry Rhoden,REP,256
-Minnehaha,0518,Governor,,Jamie Smith and Jennifer Keintz,DEM,615
-Minnehaha,0518,Governor,,Tracey Quint and Ashley Strand,LIB,47
-Minnehaha,0518,Governor,,Kristi Noem and Larry Rhoden,REP,364
-Minnehaha,0519,Governor,,Jamie Smith and Jennifer Keintz,DEM,270
-Minnehaha,0519,Governor,,Tracey Quint and Ashley Strand,LIB,7
-Minnehaha,0519,Governor,,Kristi Noem and Larry Rhoden,REP,246
-Minnehaha,0520,Governor,,Jamie Smith and Jennifer Keintz,DEM,432
-Minnehaha,0520,Governor,,Tracey Quint and Ashley Strand,LIB,39
-Minnehaha,0520,Governor,,Kristi Noem and Larry Rhoden,REP,373
-Minnehaha,0521,Governor,,Jamie Smith and Jennifer Keintz,DEM,247
-Minnehaha,0521,Governor,,Tracey Quint and Ashley Strand,LIB,9
-Minnehaha,0521,Governor,,Kristi Noem and Larry Rhoden,REP,169
-Minnehaha,0522,Governor,,Jamie Smith and Jennifer Keintz,DEM,467
-Minnehaha,0522,Governor,,Tracey Quint and Ashley Strand,LIB,40
-Minnehaha,0522,Governor,,Kristi Noem and Larry Rhoden,REP,309
-Minnehaha,0523,Governor,,Jamie Smith and Jennifer Keintz,DEM,391
-Minnehaha,0523,Governor,,Tracey Quint and Ashley Strand,LIB,28
-Minnehaha,0523,Governor,,Kristi Noem and Larry Rhoden,REP,220
-Minnehaha,VP01,Governor,,Jamie Smith and Jennifer Keintz,DEM,171
-Minnehaha,VP01,Governor,,Tracey Quint and Ashley Strand,LIB,29
-Minnehaha,VP01,Governor,,Kristi Noem and Larry Rhoden,REP,546
-Minnehaha,VP02,Governor,,Jamie Smith and Jennifer Keintz,DEM,546
-Minnehaha,VP02,Governor,,Tracey Quint and Ashley Strand,LIB,36
-Minnehaha,VP02,Governor,,Kristi Noem and Larry Rhoden,REP,1124
-Minnehaha,VP03,Governor,,Jamie Smith and Jennifer Keintz,DEM,640
-Minnehaha,VP03,Governor,,Tracey Quint and Ashley Strand,LIB,48
-Minnehaha,VP03,Governor,,Kristi Noem and Larry Rhoden,REP,1349
-Minnehaha,VP04,Governor,,Jamie Smith and Jennifer Keintz,DEM,350
-Minnehaha,VP04,Governor,,Tracey Quint and Ashley Strand,LIB,30
-Minnehaha,VP04,Governor,,Kristi Noem and Larry Rhoden,REP,689
-Minnehaha,VP05,Governor,,Jamie Smith and Jennifer Keintz,DEM,459
-Minnehaha,VP05,Governor,,Tracey Quint and Ashley Strand,LIB,30
-Minnehaha,VP05,Governor,,Kristi Noem and Larry Rhoden,REP,902
-Minnehaha,VP06,Governor,,Jamie Smith and Jennifer Keintz,DEM,138
-Minnehaha,VP06,Governor,,Tracey Quint and Ashley Strand,LIB,11
-Minnehaha,VP06,Governor,,Kristi Noem and Larry Rhoden,REP,283
-Minnehaha,VP07,Governor,,Jamie Smith and Jennifer Keintz,DEM,504
-Minnehaha,VP07,Governor,,Tracey Quint and Ashley Strand,LIB,48
-Minnehaha,VP07,Governor,,Kristi Noem and Larry Rhoden,REP,1111
-Minnehaha,VP08,Governor,,Jamie Smith and Jennifer Keintz,DEM,163
-Minnehaha,VP08,Governor,,Tracey Quint and Ashley Strand,LIB,18
-Minnehaha,VP08,Governor,,Kristi Noem and Larry Rhoden,REP,461
-Minnehaha,VP09,Governor,,Jamie Smith and Jennifer Keintz,DEM,396
-Minnehaha,VP09,Governor,,Tracey Quint and Ashley Strand,LIB,25
-Minnehaha,VP09,Governor,,Kristi Noem and Larry Rhoden,REP,852
-Minnehaha,VP10,Governor,,Jamie Smith and Jennifer Keintz,DEM,380
-Minnehaha,VP10,Governor,,Tracey Quint and Ashley Strand,LIB,34
-Minnehaha,VP10,Governor,,Kristi Noem and Larry Rhoden,REP,730
-Minnehaha,VP11,Governor,,Jamie Smith and Jennifer Keintz,DEM,77
-Minnehaha,VP11,Governor,,Tracey Quint and Ashley Strand,LIB,6
-Minnehaha,VP11,Governor,,Kristi Noem and Larry Rhoden,REP,216
-Minnehaha,VP12,Governor,,Jamie Smith and Jennifer Keintz,DEM,30
-Minnehaha,VP12,Governor,,Tracey Quint and Ashley Strand,LIB,1
-Minnehaha,VP12,Governor,,Kristi Noem and Larry Rhoden,REP,94
-Minnehaha,VP13,Governor,,Jamie Smith and Jennifer Keintz,DEM,204
-Minnehaha,VP13,Governor,,Tracey Quint and Ashley Strand,LIB,42
-Minnehaha,VP13,Governor,,Kristi Noem and Larry Rhoden,REP,647
-Minnehaha,VP15,Governor,,Jamie Smith and Jennifer Keintz,DEM,508
-Minnehaha,VP15,Governor,,Tracey Quint and Ashley Strand,LIB,29
-Minnehaha,VP15,Governor,,Kristi Noem and Larry Rhoden,REP,960
-Minnehaha,VP16,Governor,,Jamie Smith and Jennifer Keintz,DEM,318
-Minnehaha,VP16,Governor,,Tracey Quint and Ashley Strand,LIB,29
-Minnehaha,VP16,Governor,,Kristi Noem and Larry Rhoden,REP,701
-Minnehaha,VP17,Governor,,Jamie Smith and Jennifer Keintz,DEM,173
-Minnehaha,VP17,Governor,,Tracey Quint and Ashley Strand,LIB,20
-Minnehaha,VP17,Governor,,Kristi Noem and Larry Rhoden,REP,447
-Minnehaha,VP21,Governor,,Jamie Smith and Jennifer Keintz,DEM,522
-Minnehaha,VP21,Governor,,Tracey Quint and Ashley Strand,LIB,43
-Minnehaha,VP21,Governor,,Kristi Noem and Larry Rhoden,REP,1066
-Minnehaha,0104,Secretary of State,,Thomas A Cool,DEM,389
-Minnehaha,0104,Secretary of State,,Monae Johnson,REP,296
-Minnehaha,0105,Secretary of State,,Thomas A Cool,DEM,213
-Minnehaha,0105,Secretary of State,,Monae Johnson,REP,218
-Minnehaha,0106,Secretary of State,,Thomas A Cool,DEM,512
-Minnehaha,0106,Secretary of State,,Monae Johnson,REP,527
-Minnehaha,0109,Secretary of State,,Thomas A Cool,DEM,479
-Minnehaha,0109,Secretary of State,,Monae Johnson,REP,536
-Minnehaha,0110,Secretary of State,,Thomas A Cool,DEM,518
-Minnehaha,0110,Secretary of State,,Monae Johnson,REP,604
-Minnehaha,0117,Secretary of State,,Thomas A Cool,DEM,542
-Minnehaha,0117,Secretary of State,,Monae Johnson,REP,732
-Minnehaha,0119,Secretary of State,,Thomas A Cool,DEM,286
-Minnehaha,0119,Secretary of State,,Monae Johnson,REP,306
-Minnehaha,0201,Secretary of State,,Thomas A Cool,DEM,495
-Minnehaha,0201,Secretary of State,,Monae Johnson,REP,569
-Minnehaha,0202,Secretary of State,,Thomas A Cool,DEM,660
-Minnehaha,0202,Secretary of State,,Monae Johnson,REP,730
-Minnehaha,0203,Secretary of State,,Thomas A Cool,DEM,520
-Minnehaha,0203,Secretary of State,,Monae Johnson,REP,539
-Minnehaha,0206,Secretary of State,,Thomas A Cool,DEM,500
-Minnehaha,0206,Secretary of State,,Monae Johnson,REP,590
-Minnehaha,0208,Secretary of State,,Thomas A Cool,DEM,513
-Minnehaha,0208,Secretary of State,,Monae Johnson,REP,611
-Minnehaha,0209,Secretary of State,,Thomas A Cool,DEM,515
-Minnehaha,0209,Secretary of State,,Monae Johnson,REP,492
-Minnehaha,0214,Secretary of State,,Thomas A Cool,DEM,1202
-Minnehaha,0214,Secretary of State,,Monae Johnson,REP,1525
-Minnehaha,0301,Secretary of State,,Thomas A Cool,DEM,364
-Minnehaha,0301,Secretary of State,,Monae Johnson,REP,398
-Minnehaha,0305,Secretary of State,,Thomas A Cool,DEM,260
-Minnehaha,0305,Secretary of State,,Monae Johnson,REP,253
-Minnehaha,0309,Secretary of State,,Thomas A Cool,DEM,571
-Minnehaha,0309,Secretary of State,,Monae Johnson,REP,524
-Minnehaha,0310,Secretary of State,,Thomas A Cool,DEM,583
-Minnehaha,0310,Secretary of State,,Monae Johnson,REP,833
-Minnehaha,0311,Secretary of State,,Thomas A Cool,DEM,388
-Minnehaha,0311,Secretary of State,,Monae Johnson,REP,504
-Minnehaha,0312,Secretary of State,,Thomas A Cool,DEM,437
-Minnehaha,0312,Secretary of State,,Monae Johnson,REP,701
-Minnehaha,0313,Secretary of State,,Thomas A Cool,DEM,311
-Minnehaha,0313,Secretary of State,,Monae Johnson,REP,399
-Minnehaha,0314,Secretary of State,,Thomas A Cool,DEM,781
-Minnehaha,0314,Secretary of State,,Monae Johnson,REP,925
-Minnehaha,0315,Secretary of State,,Thomas A Cool,DEM,493
-Minnehaha,0315,Secretary of State,,Monae Johnson,REP,568
-Minnehaha,0316,Secretary of State,,Thomas A Cool,DEM,681
-Minnehaha,0316,Secretary of State,,Monae Johnson,REP,983
-Minnehaha,0317,Secretary of State,,Thomas A Cool,DEM,845
-Minnehaha,0317,Secretary of State,,Monae Johnson,REP,1155
-Minnehaha,0402,Secretary of State,,Thomas A Cool,DEM,360
-Minnehaha,0402,Secretary of State,,Monae Johnson,REP,264
-Minnehaha,0403,Secretary of State,,Thomas A Cool,DEM,225
-Minnehaha,0403,Secretary of State,,Monae Johnson,REP,191
-Minnehaha,0404,Secretary of State,,Thomas A Cool,DEM,341
-Minnehaha,0404,Secretary of State,,Monae Johnson,REP,294
-Minnehaha,0405,Secretary of State,,Thomas A Cool,DEM,603
-Minnehaha,0405,Secretary of State,,Monae Johnson,REP,936
-Minnehaha,0406,Secretary of State,,Thomas A Cool,DEM,156
-Minnehaha,0406,Secretary of State,,Monae Johnson,REP,121
-Minnehaha,0407,Secretary of State,,Thomas A Cool,DEM,619
-Minnehaha,0407,Secretary of State,,Monae Johnson,REP,607
-Minnehaha,0408,Secretary of State,,Thomas A Cool,DEM,178
-Minnehaha,0408,Secretary of State,,Monae Johnson,REP,122
-Minnehaha,0409,Secretary of State,,Thomas A Cool,DEM,358
-Minnehaha,0409,Secretary of State,,Monae Johnson,REP,312
-Minnehaha,0410,Secretary of State,,Thomas A Cool,DEM,342
-Minnehaha,0410,Secretary of State,,Monae Johnson,REP,390
-Minnehaha,0411,Secretary of State,,Thomas A Cool,DEM,772
-Minnehaha,0411,Secretary of State,,Monae Johnson,REP,1119
-Minnehaha,0412,Secretary of State,,Thomas A Cool,DEM,570
-Minnehaha,0412,Secretary of State,,Monae Johnson,REP,561
-Minnehaha,0413,Secretary of State,,Thomas A Cool,DEM,334
-Minnehaha,0413,Secretary of State,,Monae Johnson,REP,272
-Minnehaha,0415,Secretary of State,,Thomas A Cool,DEM,822
-Minnehaha,0415,Secretary of State,,Monae Johnson,REP,1217
-Minnehaha,0501,Secretary of State,,Thomas A Cool,DEM,256
-Minnehaha,0501,Secretary of State,,Monae Johnson,REP,165
-Minnehaha,0502,Secretary of State,,Thomas A Cool,DEM,431
-Minnehaha,0502,Secretary of State,,Monae Johnson,REP,187
-Minnehaha,0503,Secretary of State,,Thomas A Cool,DEM,199
-Minnehaha,0503,Secretary of State,,Monae Johnson,REP,122
-Minnehaha,0504,Secretary of State,,Thomas A Cool,DEM,535
-Minnehaha,0504,Secretary of State,,Monae Johnson,REP,276
-Minnehaha,0506,Secretary of State,,Thomas A Cool,DEM,520
-Minnehaha,0506,Secretary of State,,Monae Johnson,REP,363
-Minnehaha,0507,Secretary of State,,Thomas A Cool,DEM,333
-Minnehaha,0507,Secretary of State,,Monae Johnson,REP,206
-Minnehaha,0508,Secretary of State,,Thomas A Cool,DEM,548
-Minnehaha,0508,Secretary of State,,Monae Johnson,REP,325
-Minnehaha,0509,Secretary of State,,Thomas A Cool,DEM,235
-Minnehaha,0509,Secretary of State,,Monae Johnson,REP,128
-Minnehaha,0510,Secretary of State,,Thomas A Cool,DEM,285
-Minnehaha,0510,Secretary of State,,Monae Johnson,REP,217
-Minnehaha,0512,Secretary of State,,Thomas A Cool,DEM,326
-Minnehaha,0512,Secretary of State,,Monae Johnson,REP,261
-Minnehaha,0513,Secretary of State,,Thomas A Cool,DEM,356
-Minnehaha,0513,Secretary of State,,Monae Johnson,REP,253
-Minnehaha,0514,Secretary of State,,Thomas A Cool,DEM,441
-Minnehaha,0514,Secretary of State,,Monae Johnson,REP,278
-Minnehaha,0515,Secretary of State,,Thomas A Cool,DEM,352
-Minnehaha,0515,Secretary of State,,Monae Johnson,REP,405
-Minnehaha,0517,Secretary of State,,Thomas A Cool,DEM,264
-Minnehaha,0517,Secretary of State,,Monae Johnson,REP,237
-Minnehaha,0518,Secretary of State,,Thomas A Cool,DEM,584
-Minnehaha,0518,Secretary of State,,Monae Johnson,REP,378
-Minnehaha,0519,Secretary of State,,Thomas A Cool,DEM,242
-Minnehaha,0519,Secretary of State,,Monae Johnson,REP,250
-Minnehaha,0520,Secretary of State,,Thomas A Cool,DEM,429
-Minnehaha,0520,Secretary of State,,Monae Johnson,REP,372
-Minnehaha,0521,Secretary of State,,Thomas A Cool,DEM,231
-Minnehaha,0521,Secretary of State,,Monae Johnson,REP,177
-Minnehaha,0522,Secretary of State,,Thomas A Cool,DEM,455
-Minnehaha,0522,Secretary of State,,Monae Johnson,REP,303
-Minnehaha,0523,Secretary of State,,Thomas A Cool,DEM,375
-Minnehaha,0523,Secretary of State,,Monae Johnson,REP,244
-Minnehaha,VP01,Secretary of State,,Thomas A Cool,DEM,189
-Minnehaha,VP01,Secretary of State,,Monae Johnson,REP,521
-Minnehaha,VP02,Secretary of State,,Thomas A Cool,DEM,515
-Minnehaha,VP02,Secretary of State,,Monae Johnson,REP,1118
-Minnehaha,VP03,Secretary of State,,Thomas A Cool,DEM,600
-Minnehaha,VP03,Secretary of State,,Monae Johnson,REP,1345
-Minnehaha,VP04,Secretary of State,,Thomas A Cool,DEM,333
-Minnehaha,VP04,Secretary of State,,Monae Johnson,REP,681
-Minnehaha,VP05,Secretary of State,,Thomas A Cool,DEM,414
-Minnehaha,VP05,Secretary of State,,Monae Johnson,REP,888
-Minnehaha,VP06,Secretary of State,,Thomas A Cool,DEM,140
-Minnehaha,VP06,Secretary of State,,Monae Johnson,REP,269
-Minnehaha,VP07,Secretary of State,,Thomas A Cool,DEM,505
-Minnehaha,VP07,Secretary of State,,Monae Johnson,REP,1079
-Minnehaha,VP08,Secretary of State,,Thomas A Cool,DEM,170
-Minnehaha,VP08,Secretary of State,,Monae Johnson,REP,426
-Minnehaha,VP09,Secretary of State,,Thomas A Cool,DEM,369
-Minnehaha,VP09,Secretary of State,,Monae Johnson,REP,805
-Minnehaha,VP10,Secretary of State,,Thomas A Cool,DEM,367
-Minnehaha,VP10,Secretary of State,,Monae Johnson,REP,703
-Minnehaha,VP11,Secretary of State,,Thomas A Cool,DEM,73
-Minnehaha,VP11,Secretary of State,,Monae Johnson,REP,215
-Minnehaha,VP12,Secretary of State,,Thomas A Cool,DEM,31
-Minnehaha,VP12,Secretary of State,,Monae Johnson,REP,90
-Minnehaha,VP13,Secretary of State,,Thomas A Cool,DEM,206
-Minnehaha,VP13,Secretary of State,,Monae Johnson,REP,639
-Minnehaha,VP15,Secretary of State,,Thomas A Cool,DEM,489
-Minnehaha,VP15,Secretary of State,,Monae Johnson,REP,930
-Minnehaha,VP16,Secretary of State,,Thomas A Cool,DEM,316
-Minnehaha,VP16,Secretary of State,,Monae Johnson,REP,662
-Minnehaha,VP17,Secretary of State,,Thomas A Cool,DEM,179
-Minnehaha,VP17,Secretary of State,,Monae Johnson,REP,435
-Minnehaha,VP21,Secretary of State,,Thomas A Cool,DEM,503
-Minnehaha,VP21,Secretary of State,,Monae Johnson,REP,1035
 Minnehaha,0104,Attorney General,,Marty J. Jackley,REP,435
 Minnehaha,0105,Attorney General,,Marty J. Jackley,REP,286
 Minnehaha,0106,Attorney General,,Marty J. Jackley,REP,722
@@ -824,681 +74,681 @@ Minnehaha,VP15,Attorney General,,Marty J. Jackley,REP,1172
 Minnehaha,VP16,Attorney General,,Marty J. Jackley,REP,779
 Minnehaha,VP17,Attorney General,,Marty J. Jackley,REP,524
 Minnehaha,VP21,Attorney General,,Marty J. Jackley,REP,1227
-Minnehaha,0104,State Auditor,,Stephanie Marty,DEM,367
-Minnehaha,0104,State Auditor,,Rene Meyer,LIB,24
-Minnehaha,0104,State Auditor,,Richard Sattgast,REP,290
-Minnehaha,0105,State Auditor,,Stephanie Marty,DEM,204
-Minnehaha,0105,State Auditor,,Rene Meyer,LIB,23
-Minnehaha,0105,State Auditor,,Richard Sattgast,REP,207
-Minnehaha,0106,State Auditor,,Stephanie Marty,DEM,451
-Minnehaha,0106,State Auditor,,Rene Meyer,LIB,61
-Minnehaha,0106,State Auditor,,Richard Sattgast,REP,524
-Minnehaha,0109,State Auditor,,Stephanie Marty,DEM,409
-Minnehaha,0109,State Auditor,,Rene Meyer,LIB,47
-Minnehaha,0109,State Auditor,,Richard Sattgast,REP,545
-Minnehaha,0110,State Auditor,,Stephanie Marty,DEM,441
-Minnehaha,0110,State Auditor,,Rene Meyer,LIB,78
-Minnehaha,0110,State Auditor,,Richard Sattgast,REP,573
-Minnehaha,0117,State Auditor,,Stephanie Marty,DEM,476
-Minnehaha,0117,State Auditor,,Rene Meyer,LIB,72
-Minnehaha,0117,State Auditor,,Richard Sattgast,REP,703
-Minnehaha,0119,State Auditor,,Stephanie Marty,DEM,254
-Minnehaha,0119,State Auditor,,Rene Meyer,LIB,49
-Minnehaha,0119,State Auditor,,Richard Sattgast,REP,279
-Minnehaha,0201,State Auditor,,Stephanie Marty,DEM,436
-Minnehaha,0201,State Auditor,,Rene Meyer,LIB,35
-Minnehaha,0201,State Auditor,,Richard Sattgast,REP,571
-Minnehaha,0202,State Auditor,,Stephanie Marty,DEM,586
-Minnehaha,0202,State Auditor,,Rene Meyer,LIB,41
-Minnehaha,0202,State Auditor,,Richard Sattgast,REP,758
-Minnehaha,0203,State Auditor,,Stephanie Marty,DEM,438
-Minnehaha,0203,State Auditor,,Rene Meyer,LIB,62
-Minnehaha,0203,State Auditor,,Richard Sattgast,REP,538
-Minnehaha,0206,State Auditor,,Stephanie Marty,DEM,438
-Minnehaha,0206,State Auditor,,Rene Meyer,LIB,45
-Minnehaha,0206,State Auditor,,Richard Sattgast,REP,577
-Minnehaha,0208,State Auditor,,Stephanie Marty,DEM,431
-Minnehaha,0208,State Auditor,,Rene Meyer,LIB,54
-Minnehaha,0208,State Auditor,,Richard Sattgast,REP,619
-Minnehaha,0209,State Auditor,,Stephanie Marty,DEM,456
-Minnehaha,0209,State Auditor,,Rene Meyer,LIB,30
-Minnehaha,0209,State Auditor,,Richard Sattgast,REP,515
-Minnehaha,0214,State Auditor,,Stephanie Marty,DEM,1038
-Minnehaha,0214,State Auditor,,Rene Meyer,LIB,104
-Minnehaha,0214,State Auditor,,Richard Sattgast,REP,1567
-Minnehaha,0301,State Auditor,,Stephanie Marty,DEM,315
-Minnehaha,0301,State Auditor,,Rene Meyer,LIB,34
-Minnehaha,0301,State Auditor,,Richard Sattgast,REP,406
-Minnehaha,0305,State Auditor,,Stephanie Marty,DEM,217
-Minnehaha,0305,State Auditor,,Rene Meyer,LIB,46
-Minnehaha,0305,State Auditor,,Richard Sattgast,REP,248
-Minnehaha,0309,State Auditor,,Stephanie Marty,DEM,511
-Minnehaha,0309,State Auditor,,Rene Meyer,LIB,72
-Minnehaha,0309,State Auditor,,Richard Sattgast,REP,507
-Minnehaha,0310,State Auditor,,Stephanie Marty,DEM,491
-Minnehaha,0310,State Auditor,,Rene Meyer,LIB,57
-Minnehaha,0310,State Auditor,,Richard Sattgast,REP,835
-Minnehaha,0311,State Auditor,,Stephanie Marty,DEM,311
-Minnehaha,0311,State Auditor,,Rene Meyer,LIB,40
-Minnehaha,0311,State Auditor,,Richard Sattgast,REP,530
-Minnehaha,0312,State Auditor,,Stephanie Marty,DEM,375
-Minnehaha,0312,State Auditor,,Rene Meyer,LIB,76
-Minnehaha,0312,State Auditor,,Richard Sattgast,REP,680
-Minnehaha,0313,State Auditor,,Stephanie Marty,DEM,263
-Minnehaha,0313,State Auditor,,Rene Meyer,LIB,39
-Minnehaha,0313,State Auditor,,Richard Sattgast,REP,395
-Minnehaha,0314,State Auditor,,Stephanie Marty,DEM,676
-Minnehaha,0314,State Auditor,,Rene Meyer,LIB,115
-Minnehaha,0314,State Auditor,,Richard Sattgast,REP,887
-Minnehaha,0315,State Auditor,,Stephanie Marty,DEM,423
-Minnehaha,0315,State Auditor,,Rene Meyer,LIB,45
-Minnehaha,0315,State Auditor,,Richard Sattgast,REP,565
-Minnehaha,0316,State Auditor,,Stephanie Marty,DEM,577
-Minnehaha,0316,State Auditor,,Rene Meyer,LIB,68
-Minnehaha,0316,State Auditor,,Richard Sattgast,REP,988
-Minnehaha,0317,State Auditor,,Stephanie Marty,DEM,721
-Minnehaha,0317,State Auditor,,Rene Meyer,LIB,74
-Minnehaha,0317,State Auditor,,Richard Sattgast,REP,1170
-Minnehaha,0402,State Auditor,,Stephanie Marty,DEM,303
-Minnehaha,0402,State Auditor,,Rene Meyer,LIB,56
-Minnehaha,0402,State Auditor,,Richard Sattgast,REP,263
-Minnehaha,0403,State Auditor,,Stephanie Marty,DEM,195
-Minnehaha,0403,State Auditor,,Rene Meyer,LIB,27
-Minnehaha,0403,State Auditor,,Richard Sattgast,REP,190
-Minnehaha,0404,State Auditor,,Stephanie Marty,DEM,305
-Minnehaha,0404,State Auditor,,Rene Meyer,LIB,71
-Minnehaha,0404,State Auditor,,Richard Sattgast,REP,264
-Minnehaha,0405,State Auditor,,Stephanie Marty,DEM,562
-Minnehaha,0405,State Auditor,,Rene Meyer,LIB,71
-Minnehaha,0405,State Auditor,,Richard Sattgast,REP,911
-Minnehaha,0406,State Auditor,,Stephanie Marty,DEM,138
-Minnehaha,0406,State Auditor,,Rene Meyer,LIB,19
-Minnehaha,0406,State Auditor,,Richard Sattgast,REP,121
-Minnehaha,0407,State Auditor,,Stephanie Marty,DEM,545
-Minnehaha,0407,State Auditor,,Rene Meyer,LIB,36
-Minnehaha,0407,State Auditor,,Richard Sattgast,REP,633
-Minnehaha,0408,State Auditor,,Stephanie Marty,DEM,167
-Minnehaha,0408,State Auditor,,Rene Meyer,LIB,21
-Minnehaha,0408,State Auditor,,Richard Sattgast,REP,119
-Minnehaha,0409,State Auditor,,Stephanie Marty,DEM,329
-Minnehaha,0409,State Auditor,,Rene Meyer,LIB,69
-Minnehaha,0409,State Auditor,,Richard Sattgast,REP,273
-Minnehaha,0410,State Auditor,,Stephanie Marty,DEM,306
-Minnehaha,0410,State Auditor,,Rene Meyer,LIB,49
-Minnehaha,0410,State Auditor,,Richard Sattgast,REP,370
-Minnehaha,0411,State Auditor,,Stephanie Marty,DEM,662
-Minnehaha,0411,State Auditor,,Rene Meyer,LIB,79
-Minnehaha,0411,State Auditor,,Richard Sattgast,REP,1120
-Minnehaha,0412,State Auditor,,Stephanie Marty,DEM,523
-Minnehaha,0412,State Auditor,,Rene Meyer,LIB,45
-Minnehaha,0412,State Auditor,,Richard Sattgast,REP,557
-Minnehaha,0413,State Auditor,,Stephanie Marty,DEM,298
-Minnehaha,0413,State Auditor,,Rene Meyer,LIB,39
-Minnehaha,0413,State Auditor,,Richard Sattgast,REP,263
-Minnehaha,0415,State Auditor,,Stephanie Marty,DEM,724
-Minnehaha,0415,State Auditor,,Rene Meyer,LIB,70
-Minnehaha,0415,State Auditor,,Richard Sattgast,REP,1221
-Minnehaha,0501,State Auditor,,Stephanie Marty,DEM,231
-Minnehaha,0501,State Auditor,,Rene Meyer,LIB,29
-Minnehaha,0501,State Auditor,,Richard Sattgast,REP,160
-Minnehaha,0502,State Auditor,,Stephanie Marty,DEM,386
-Minnehaha,0502,State Auditor,,Rene Meyer,LIB,44
-Minnehaha,0502,State Auditor,,Richard Sattgast,REP,185
-Minnehaha,0503,State Auditor,,Stephanie Marty,DEM,180
-Minnehaha,0503,State Auditor,,Rene Meyer,LIB,32
-Minnehaha,0503,State Auditor,,Richard Sattgast,REP,111
-Minnehaha,0504,State Auditor,,Stephanie Marty,DEM,499
-Minnehaha,0504,State Auditor,,Rene Meyer,LIB,44
-Minnehaha,0504,State Auditor,,Richard Sattgast,REP,266
-Minnehaha,0506,State Auditor,,Stephanie Marty,DEM,453
-Minnehaha,0506,State Auditor,,Rene Meyer,LIB,63
-Minnehaha,0506,State Auditor,,Richard Sattgast,REP,361
-Minnehaha,0507,State Auditor,,Stephanie Marty,DEM,297
-Minnehaha,0507,State Auditor,,Rene Meyer,LIB,25
-Minnehaha,0507,State Auditor,,Richard Sattgast,REP,214
-Minnehaha,0508,State Auditor,,Stephanie Marty,DEM,483
-Minnehaha,0508,State Auditor,,Rene Meyer,LIB,39
-Minnehaha,0508,State Auditor,,Richard Sattgast,REP,328
-Minnehaha,0509,State Auditor,,Stephanie Marty,DEM,208
-Minnehaha,0509,State Auditor,,Rene Meyer,LIB,25
-Minnehaha,0509,State Auditor,,Richard Sattgast,REP,118
-Minnehaha,0510,State Auditor,,Stephanie Marty,DEM,250
-Minnehaha,0510,State Auditor,,Rene Meyer,LIB,30
-Minnehaha,0510,State Auditor,,Richard Sattgast,REP,223
-Minnehaha,0512,State Auditor,,Stephanie Marty,DEM,288
-Minnehaha,0512,State Auditor,,Rene Meyer,LIB,30
-Minnehaha,0512,State Auditor,,Richard Sattgast,REP,266
-Minnehaha,0513,State Auditor,,Stephanie Marty,DEM,309
-Minnehaha,0513,State Auditor,,Rene Meyer,LIB,24
-Minnehaha,0513,State Auditor,,Richard Sattgast,REP,265
-Minnehaha,0514,State Auditor,,Stephanie Marty,DEM,394
-Minnehaha,0514,State Auditor,,Rene Meyer,LIB,51
-Minnehaha,0514,State Auditor,,Richard Sattgast,REP,275
-Minnehaha,0515,State Auditor,,Stephanie Marty,DEM,327
-Minnehaha,0515,State Auditor,,Rene Meyer,LIB,45
-Minnehaha,0515,State Auditor,,Richard Sattgast,REP,374
-Minnehaha,0517,State Auditor,,Stephanie Marty,DEM,228
-Minnehaha,0517,State Auditor,,Rene Meyer,LIB,28
-Minnehaha,0517,State Auditor,,Richard Sattgast,REP,238
-Minnehaha,0518,State Auditor,,Stephanie Marty,DEM,537
-Minnehaha,0518,State Auditor,,Rene Meyer,LIB,71
-Minnehaha,0518,State Auditor,,Richard Sattgast,REP,342
-Minnehaha,0519,State Auditor,,Stephanie Marty,DEM,209
-Minnehaha,0519,State Auditor,,Rene Meyer,LIB,29
-Minnehaha,0519,State Auditor,,Richard Sattgast,REP,246
-Minnehaha,0520,State Auditor,,Stephanie Marty,DEM,372
-Minnehaha,0520,State Auditor,,Rene Meyer,LIB,57
-Minnehaha,0520,State Auditor,,Richard Sattgast,REP,357
-Minnehaha,0521,State Auditor,,Stephanie Marty,DEM,202
-Minnehaha,0521,State Auditor,,Rene Meyer,LIB,16
-Minnehaha,0521,State Auditor,,Richard Sattgast,REP,183
-Minnehaha,0522,State Auditor,,Stephanie Marty,DEM,399
-Minnehaha,0522,State Auditor,,Rene Meyer,LIB,71
-Minnehaha,0522,State Auditor,,Richard Sattgast,REP,296
-Minnehaha,0523,State Auditor,,Stephanie Marty,DEM,333
-Minnehaha,0523,State Auditor,,Rene Meyer,LIB,48
-Minnehaha,0523,State Auditor,,Richard Sattgast,REP,230
-Minnehaha,VP01,State Auditor,,Stephanie Marty,DEM,148
-Minnehaha,VP01,State Auditor,,Rene Meyer,LIB,53
-Minnehaha,VP01,State Auditor,,Richard Sattgast,REP,496
-Minnehaha,VP02,State Auditor,,Stephanie Marty,DEM,441
-Minnehaha,VP02,State Auditor,,Rene Meyer,LIB,68
-Minnehaha,VP02,State Auditor,,Richard Sattgast,REP,1114
-Minnehaha,VP03,State Auditor,,Stephanie Marty,DEM,539
-Minnehaha,VP03,State Auditor,,Rene Meyer,LIB,88
-Minnehaha,VP03,State Auditor,,Richard Sattgast,REP,1310
-Minnehaha,VP04,State Auditor,,Stephanie Marty,DEM,289
-Minnehaha,VP04,State Auditor,,Rene Meyer,LIB,58
-Minnehaha,VP04,State Auditor,,Richard Sattgast,REP,670
-Minnehaha,VP05,State Auditor,,Stephanie Marty,DEM,360
-Minnehaha,VP05,State Auditor,,Rene Meyer,LIB,61
-Minnehaha,VP05,State Auditor,,Richard Sattgast,REP,863
-Minnehaha,VP06,State Auditor,,Stephanie Marty,DEM,121
-Minnehaha,VP06,State Auditor,,Rene Meyer,LIB,21
-Minnehaha,VP06,State Auditor,,Richard Sattgast,REP,267
-Minnehaha,VP07,State Auditor,,Stephanie Marty,DEM,450
-Minnehaha,VP07,State Auditor,,Rene Meyer,LIB,72
-Minnehaha,VP07,State Auditor,,Richard Sattgast,REP,1046
-Minnehaha,VP08,State Auditor,,Stephanie Marty,DEM,140
-Minnehaha,VP08,State Auditor,,Rene Meyer,LIB,36
-Minnehaha,VP08,State Auditor,,Richard Sattgast,REP,409
-Minnehaha,VP09,State Auditor,,Stephanie Marty,DEM,317
-Minnehaha,VP09,State Auditor,,Rene Meyer,LIB,58
-Minnehaha,VP09,State Auditor,,Richard Sattgast,REP,781
-Minnehaha,VP10,State Auditor,,Stephanie Marty,DEM,328
-Minnehaha,VP10,State Auditor,,Rene Meyer,LIB,62
-Minnehaha,VP10,State Auditor,,Richard Sattgast,REP,663
-Minnehaha,VP11,State Auditor,,Stephanie Marty,DEM,69
-Minnehaha,VP11,State Auditor,,Rene Meyer,LIB,9
-Minnehaha,VP11,State Auditor,,Richard Sattgast,REP,204
-Minnehaha,VP12,State Auditor,,Stephanie Marty,DEM,21
-Minnehaha,VP12,State Auditor,,Rene Meyer,LIB,5
-Minnehaha,VP12,State Auditor,,Richard Sattgast,REP,92
-Minnehaha,VP13,State Auditor,,Stephanie Marty,DEM,182
-Minnehaha,VP13,State Auditor,,Rene Meyer,LIB,56
-Minnehaha,VP13,State Auditor,,Richard Sattgast,REP,591
-Minnehaha,VP15,State Auditor,,Stephanie Marty,DEM,413
-Minnehaha,VP15,State Auditor,,Rene Meyer,LIB,62
-Minnehaha,VP15,State Auditor,,Richard Sattgast,REP,909
-Minnehaha,VP16,State Auditor,,Stephanie Marty,DEM,257
-Minnehaha,VP16,State Auditor,,Rene Meyer,LIB,60
-Minnehaha,VP16,State Auditor,,Richard Sattgast,REP,654
-Minnehaha,VP17,State Auditor,,Stephanie Marty,DEM,137
-Minnehaha,VP17,State Auditor,,Rene Meyer,LIB,28
-Minnehaha,VP17,State Auditor,,Richard Sattgast,REP,449
-Minnehaha,VP21,State Auditor,,Stephanie Marty,DEM,456
-Minnehaha,VP21,State Auditor,,Rene Meyer,LIB,73
-Minnehaha,VP21,State Auditor,,Richard Sattgast,REP,991
-Minnehaha,0104,State Treasurer,,John Cunningham,DEM,365
-Minnehaha,0104,State Treasurer,,Josh Haeder,REP,312
-Minnehaha,0105,State Treasurer,,John Cunningham,DEM,203
-Minnehaha,0105,State Treasurer,,Josh Haeder,REP,219
-Minnehaha,0106,State Treasurer,,John Cunningham,DEM,460
-Minnehaha,0106,State Treasurer,,Josh Haeder,REP,551
-Minnehaha,0109,State Treasurer,,John Cunningham,DEM,407
-Minnehaha,0109,State Treasurer,,Josh Haeder,REP,585
-Minnehaha,0110,State Treasurer,,John Cunningham,DEM,459
-Minnehaha,0110,State Treasurer,,Josh Haeder,REP,623
-Minnehaha,0117,State Treasurer,,John Cunningham,DEM,489
-Minnehaha,0117,State Treasurer,,Josh Haeder,REP,736
-Minnehaha,0119,State Treasurer,,John Cunningham,DEM,275
-Minnehaha,0119,State Treasurer,,Josh Haeder,REP,296
-Minnehaha,0201,State Treasurer,,John Cunningham,DEM,435
-Minnehaha,0201,State Treasurer,,Josh Haeder,REP,606
-Minnehaha,0202,State Treasurer,,John Cunningham,DEM,594
-Minnehaha,0202,State Treasurer,,Josh Haeder,REP,777
-Minnehaha,0203,State Treasurer,,John Cunningham,DEM,468
-Minnehaha,0203,State Treasurer,,Josh Haeder,REP,566
-Minnehaha,0206,State Treasurer,,John Cunningham,DEM,446
-Minnehaha,0206,State Treasurer,,Josh Haeder,REP,619
-Minnehaha,0208,State Treasurer,,John Cunningham,DEM,440
-Minnehaha,0208,State Treasurer,,Josh Haeder,REP,658
-Minnehaha,0209,State Treasurer,,John Cunningham,DEM,466
-Minnehaha,0209,State Treasurer,,Josh Haeder,REP,525
-Minnehaha,0214,State Treasurer,,John Cunningham,DEM,1076
-Minnehaha,0214,State Treasurer,,Josh Haeder,REP,1617
-Minnehaha,0301,State Treasurer,,John Cunningham,DEM,331
-Minnehaha,0301,State Treasurer,,Josh Haeder,REP,415
-Minnehaha,0305,State Treasurer,,John Cunningham,DEM,244
-Minnehaha,0305,State Treasurer,,Josh Haeder,REP,263
-Minnehaha,0309,State Treasurer,,John Cunningham,DEM,526
-Minnehaha,0309,State Treasurer,,Josh Haeder,REP,552
-Minnehaha,0310,State Treasurer,,John Cunningham,DEM,494
-Minnehaha,0310,State Treasurer,,Josh Haeder,REP,879
-Minnehaha,0311,State Treasurer,,John Cunningham,DEM,320
-Minnehaha,0311,State Treasurer,,Josh Haeder,REP,532
-Minnehaha,0312,State Treasurer,,John Cunningham,DEM,399
-Minnehaha,0312,State Treasurer,,Josh Haeder,REP,723
-Minnehaha,0313,State Treasurer,,John Cunningham,DEM,260
-Minnehaha,0313,State Treasurer,,Josh Haeder,REP,425
-Minnehaha,0314,State Treasurer,,John Cunningham,DEM,703
-Minnehaha,0314,State Treasurer,,Josh Haeder,REP,958
-Minnehaha,0315,State Treasurer,,John Cunningham,DEM,425
-Minnehaha,0315,State Treasurer,,Josh Haeder,REP,605
-Minnehaha,0316,State Treasurer,,John Cunningham,DEM,581
-Minnehaha,0316,State Treasurer,,Josh Haeder,REP,1037
-Minnehaha,0317,State Treasurer,,John Cunningham,DEM,719
-Minnehaha,0317,State Treasurer,,Josh Haeder,REP,1214
-Minnehaha,0402,State Treasurer,,John Cunningham,DEM,320
-Minnehaha,0402,State Treasurer,,Josh Haeder,REP,283
-Minnehaha,0403,State Treasurer,,John Cunningham,DEM,203
-Minnehaha,0403,State Treasurer,,Josh Haeder,REP,204
-Minnehaha,0404,State Treasurer,,John Cunningham,DEM,329
-Minnehaha,0404,State Treasurer,,Josh Haeder,REP,301
-Minnehaha,0405,State Treasurer,,John Cunningham,DEM,575
-Minnehaha,0405,State Treasurer,,Josh Haeder,REP,953
-Minnehaha,0406,State Treasurer,,John Cunningham,DEM,150
-Minnehaha,0406,State Treasurer,,Josh Haeder,REP,120
-Minnehaha,0407,State Treasurer,,John Cunningham,DEM,558
-Minnehaha,0407,State Treasurer,,Josh Haeder,REP,652
-Minnehaha,0408,State Treasurer,,John Cunningham,DEM,178
-Minnehaha,0408,State Treasurer,,Josh Haeder,REP,125
-Minnehaha,0409,State Treasurer,,John Cunningham,DEM,337
-Minnehaha,0409,State Treasurer,,Josh Haeder,REP,323
-Minnehaha,0410,State Treasurer,,John Cunningham,DEM,321
-Minnehaha,0410,State Treasurer,,Josh Haeder,REP,394
-Minnehaha,0411,State Treasurer,,John Cunningham,DEM,682
-Minnehaha,0411,State Treasurer,,Josh Haeder,REP,1174
-Minnehaha,0412,State Treasurer,,John Cunningham,DEM,525
-Minnehaha,0412,State Treasurer,,Josh Haeder,REP,586
-Minnehaha,0413,State Treasurer,,John Cunningham,DEM,305
-Minnehaha,0413,State Treasurer,,Josh Haeder,REP,283
-Minnehaha,0415,State Treasurer,,John Cunningham,DEM,721
-Minnehaha,0415,State Treasurer,,Josh Haeder,REP,1279
-Minnehaha,0501,State Treasurer,,John Cunningham,DEM,244
-Minnehaha,0501,State Treasurer,,Josh Haeder,REP,172
-Minnehaha,0502,State Treasurer,,John Cunningham,DEM,400
-Minnehaha,0502,State Treasurer,,Josh Haeder,REP,208
-Minnehaha,0503,State Treasurer,,John Cunningham,DEM,182
-Minnehaha,0503,State Treasurer,,Josh Haeder,REP,137
-Minnehaha,0504,State Treasurer,,John Cunningham,DEM,499
-Minnehaha,0504,State Treasurer,,Josh Haeder,REP,298
-Minnehaha,0506,State Treasurer,,John Cunningham,DEM,470
-Minnehaha,0506,State Treasurer,,Josh Haeder,REP,401
-Minnehaha,0507,State Treasurer,,John Cunningham,DEM,299
-Minnehaha,0507,State Treasurer,,Josh Haeder,REP,229
-Minnehaha,0508,State Treasurer,,John Cunningham,DEM,487
-Minnehaha,0508,State Treasurer,,Josh Haeder,REP,356
-Minnehaha,0509,State Treasurer,,John Cunningham,DEM,209
-Minnehaha,0509,State Treasurer,,Josh Haeder,REP,142
-Minnehaha,0510,State Treasurer,,John Cunningham,DEM,251
-Minnehaha,0510,State Treasurer,,Josh Haeder,REP,241
-Minnehaha,0512,State Treasurer,,John Cunningham,DEM,297
-Minnehaha,0512,State Treasurer,,Josh Haeder,REP,271
-Minnehaha,0513,State Treasurer,,John Cunningham,DEM,302
-Minnehaha,0513,State Treasurer,,Josh Haeder,REP,284
-Minnehaha,0514,State Treasurer,,John Cunningham,DEM,410
-Minnehaha,0514,State Treasurer,,Josh Haeder,REP,297
-Minnehaha,0515,State Treasurer,,John Cunningham,DEM,338
-Minnehaha,0515,State Treasurer,,Josh Haeder,REP,405
-Minnehaha,0517,State Treasurer,,John Cunningham,DEM,231
-Minnehaha,0517,State Treasurer,,Josh Haeder,REP,257
-Minnehaha,0518,State Treasurer,,John Cunningham,DEM,562
-Minnehaha,0518,State Treasurer,,Josh Haeder,REP,392
-Minnehaha,0519,State Treasurer,,John Cunningham,DEM,220
-Minnehaha,0519,State Treasurer,,Josh Haeder,REP,257
-Minnehaha,0520,State Treasurer,,John Cunningham,DEM,382
-Minnehaha,0520,State Treasurer,,Josh Haeder,REP,395
-Minnehaha,0521,State Treasurer,,John Cunningham,DEM,209
-Minnehaha,0521,State Treasurer,,Josh Haeder,REP,187
-Minnehaha,0522,State Treasurer,,John Cunningham,DEM,419
-Minnehaha,0522,State Treasurer,,Josh Haeder,REP,328
-Minnehaha,0523,State Treasurer,,John Cunningham,DEM,344
-Minnehaha,0523,State Treasurer,,Josh Haeder,REP,254
-Minnehaha,VP01,State Treasurer,,John Cunningham,DEM,166
-Minnehaha,VP01,State Treasurer,,Josh Haeder,REP,522
-Minnehaha,VP02,State Treasurer,,John Cunningham,DEM,437
-Minnehaha,VP02,State Treasurer,,Josh Haeder,REP,1177
-Minnehaha,VP03,State Treasurer,,John Cunningham,DEM,533
-Minnehaha,VP03,State Treasurer,,Josh Haeder,REP,1371
-Minnehaha,VP04,State Treasurer,,John Cunningham,DEM,301
-Minnehaha,VP04,State Treasurer,,Josh Haeder,REP,695
-Minnehaha,VP05,State Treasurer,,John Cunningham,DEM,360
-Minnehaha,VP05,State Treasurer,,Josh Haeder,REP,905
-Minnehaha,VP06,State Treasurer,,John Cunningham,DEM,120
-Minnehaha,VP06,State Treasurer,,Josh Haeder,REP,283
-Minnehaha,VP07,State Treasurer,,John Cunningham,DEM,444
-Minnehaha,VP07,State Treasurer,,Josh Haeder,REP,1107
-Minnehaha,VP08,State Treasurer,,John Cunningham,DEM,148
-Minnehaha,VP08,State Treasurer,,Josh Haeder,REP,430
-Minnehaha,VP09,State Treasurer,,John Cunningham,DEM,342
-Minnehaha,VP09,State Treasurer,,Josh Haeder,REP,810
-Minnehaha,VP10,State Treasurer,,John Cunningham,DEM,340
-Minnehaha,VP10,State Treasurer,,Josh Haeder,REP,711
-Minnehaha,VP11,State Treasurer,,John Cunningham,DEM,64
-Minnehaha,VP11,State Treasurer,,Josh Haeder,REP,217
-Minnehaha,VP12,State Treasurer,,John Cunningham,DEM,21
-Minnehaha,VP12,State Treasurer,,Josh Haeder,REP,96
-Minnehaha,VP13,State Treasurer,,John Cunningham,DEM,189
-Minnehaha,VP13,State Treasurer,,Josh Haeder,REP,634
-Minnehaha,VP15,State Treasurer,,John Cunningham,DEM,435
-Minnehaha,VP15,State Treasurer,,Josh Haeder,REP,937
-Minnehaha,VP16,State Treasurer,,John Cunningham,DEM,266
-Minnehaha,VP16,State Treasurer,,Josh Haeder,REP,680
-Minnehaha,VP17,State Treasurer,,John Cunningham,DEM,143
-Minnehaha,VP17,State Treasurer,,Josh Haeder,REP,453
-Minnehaha,VP21,State Treasurer,,John Cunningham,DEM,460
-Minnehaha,VP21,State Treasurer,,Josh Haeder,REP,1037
-Minnehaha,0104,Commissioner of School and Public Lands,,Timothy Azure,DEM,353
 Minnehaha,0104,Commissioner of School and Public Lands,,Brock Greenfield,REP,298
-Minnehaha,0105,Commissioner of School and Public Lands,,Timothy Azure,DEM,200
+Minnehaha,0104,Commissioner of School and Public Lands,,Timothy Azure,DEM,353
 Minnehaha,0105,Commissioner of School and Public Lands,,Brock Greenfield,REP,215
-Minnehaha,0106,Commissioner of School and Public Lands,,Timothy Azure,DEM,455
+Minnehaha,0105,Commissioner of School and Public Lands,,Timothy Azure,DEM,200
 Minnehaha,0106,Commissioner of School and Public Lands,,Brock Greenfield,REP,537
-Minnehaha,0109,Commissioner of School and Public Lands,,Timothy Azure,DEM,400
+Minnehaha,0106,Commissioner of School and Public Lands,,Timothy Azure,DEM,455
 Minnehaha,0109,Commissioner of School and Public Lands,,Brock Greenfield,REP,572
-Minnehaha,0110,Commissioner of School and Public Lands,,Timothy Azure,DEM,448
+Minnehaha,0109,Commissioner of School and Public Lands,,Timothy Azure,DEM,400
 Minnehaha,0110,Commissioner of School and Public Lands,,Brock Greenfield,REP,608
-Minnehaha,0117,Commissioner of School and Public Lands,,Timothy Azure,DEM,480
+Minnehaha,0110,Commissioner of School and Public Lands,,Timothy Azure,DEM,448
 Minnehaha,0117,Commissioner of School and Public Lands,,Brock Greenfield,REP,744
-Minnehaha,0119,Commissioner of School and Public Lands,,Timothy Azure,DEM,270
+Minnehaha,0117,Commissioner of School and Public Lands,,Timothy Azure,DEM,480
 Minnehaha,0119,Commissioner of School and Public Lands,,Brock Greenfield,REP,290
-Minnehaha,0201,Commissioner of School and Public Lands,,Timothy Azure,DEM,430
+Minnehaha,0119,Commissioner of School and Public Lands,,Timothy Azure,DEM,270
 Minnehaha,0201,Commissioner of School and Public Lands,,Brock Greenfield,REP,588
-Minnehaha,0202,Commissioner of School and Public Lands,,Timothy Azure,DEM,576
+Minnehaha,0201,Commissioner of School and Public Lands,,Timothy Azure,DEM,430
 Minnehaha,0202,Commissioner of School and Public Lands,,Brock Greenfield,REP,761
-Minnehaha,0203,Commissioner of School and Public Lands,,Timothy Azure,DEM,452
+Minnehaha,0202,Commissioner of School and Public Lands,,Timothy Azure,DEM,576
 Minnehaha,0203,Commissioner of School and Public Lands,,Brock Greenfield,REP,558
-Minnehaha,0206,Commissioner of School and Public Lands,,Timothy Azure,DEM,454
+Minnehaha,0203,Commissioner of School and Public Lands,,Timothy Azure,DEM,452
 Minnehaha,0206,Commissioner of School and Public Lands,,Brock Greenfield,REP,596
-Minnehaha,0208,Commissioner of School and Public Lands,,Timothy Azure,DEM,435
+Minnehaha,0206,Commissioner of School and Public Lands,,Timothy Azure,DEM,454
 Minnehaha,0208,Commissioner of School and Public Lands,,Brock Greenfield,REP,630
-Minnehaha,0209,Commissioner of School and Public Lands,,Timothy Azure,DEM,446
+Minnehaha,0208,Commissioner of School and Public Lands,,Timothy Azure,DEM,435
 Minnehaha,0209,Commissioner of School and Public Lands,,Brock Greenfield,REP,521
-Minnehaha,0214,Commissioner of School and Public Lands,,Timothy Azure,DEM,1047
+Minnehaha,0209,Commissioner of School and Public Lands,,Timothy Azure,DEM,446
 Minnehaha,0214,Commissioner of School and Public Lands,,Brock Greenfield,REP,1589
-Minnehaha,0301,Commissioner of School and Public Lands,,Timothy Azure,DEM,323
+Minnehaha,0214,Commissioner of School and Public Lands,,Timothy Azure,DEM,1047
 Minnehaha,0301,Commissioner of School and Public Lands,,Brock Greenfield,REP,413
-Minnehaha,0305,Commissioner of School and Public Lands,,Timothy Azure,DEM,226
+Minnehaha,0301,Commissioner of School and Public Lands,,Timothy Azure,DEM,323
 Minnehaha,0305,Commissioner of School and Public Lands,,Brock Greenfield,REP,260
-Minnehaha,0309,Commissioner of School and Public Lands,,Timothy Azure,DEM,518
+Minnehaha,0305,Commissioner of School and Public Lands,,Timothy Azure,DEM,226
 Minnehaha,0309,Commissioner of School and Public Lands,,Brock Greenfield,REP,539
-Minnehaha,0310,Commissioner of School and Public Lands,,Timothy Azure,DEM,501
+Minnehaha,0309,Commissioner of School and Public Lands,,Timothy Azure,DEM,518
 Minnehaha,0310,Commissioner of School and Public Lands,,Brock Greenfield,REP,850
-Minnehaha,0311,Commissioner of School and Public Lands,,Timothy Azure,DEM,330
+Minnehaha,0310,Commissioner of School and Public Lands,,Timothy Azure,DEM,501
 Minnehaha,0311,Commissioner of School and Public Lands,,Brock Greenfield,REP,523
-Minnehaha,0312,Commissioner of School and Public Lands,,Timothy Azure,DEM,390
+Minnehaha,0311,Commissioner of School and Public Lands,,Timothy Azure,DEM,330
 Minnehaha,0312,Commissioner of School and Public Lands,,Brock Greenfield,REP,696
-Minnehaha,0313,Commissioner of School and Public Lands,,Timothy Azure,DEM,269
+Minnehaha,0312,Commissioner of School and Public Lands,,Timothy Azure,DEM,390
 Minnehaha,0313,Commissioner of School and Public Lands,,Brock Greenfield,REP,411
-Minnehaha,0314,Commissioner of School and Public Lands,,Timothy Azure,DEM,705
+Minnehaha,0313,Commissioner of School and Public Lands,,Timothy Azure,DEM,269
 Minnehaha,0314,Commissioner of School and Public Lands,,Brock Greenfield,REP,930
-Minnehaha,0315,Commissioner of School and Public Lands,,Timothy Azure,DEM,429
+Minnehaha,0314,Commissioner of School and Public Lands,,Timothy Azure,DEM,705
 Minnehaha,0315,Commissioner of School and Public Lands,,Brock Greenfield,REP,572
-Minnehaha,0316,Commissioner of School and Public Lands,,Timothy Azure,DEM,569
+Minnehaha,0315,Commissioner of School and Public Lands,,Timothy Azure,DEM,429
 Minnehaha,0316,Commissioner of School and Public Lands,,Brock Greenfield,REP,1021
-Minnehaha,0317,Commissioner of School and Public Lands,,Timothy Azure,DEM,731
+Minnehaha,0316,Commissioner of School and Public Lands,,Timothy Azure,DEM,569
 Minnehaha,0317,Commissioner of School and Public Lands,,Brock Greenfield,REP,1174
-Minnehaha,0402,Commissioner of School and Public Lands,,Timothy Azure,DEM,322
+Minnehaha,0317,Commissioner of School and Public Lands,,Timothy Azure,DEM,731
 Minnehaha,0402,Commissioner of School and Public Lands,,Brock Greenfield,REP,277
-Minnehaha,0403,Commissioner of School and Public Lands,,Timothy Azure,DEM,196
+Minnehaha,0402,Commissioner of School and Public Lands,,Timothy Azure,DEM,322
 Minnehaha,0403,Commissioner of School and Public Lands,,Brock Greenfield,REP,199
-Minnehaha,0404,Commissioner of School and Public Lands,,Timothy Azure,DEM,323
+Minnehaha,0403,Commissioner of School and Public Lands,,Timothy Azure,DEM,196
 Minnehaha,0404,Commissioner of School and Public Lands,,Brock Greenfield,REP,300
-Minnehaha,0405,Commissioner of School and Public Lands,,Timothy Azure,DEM,570
+Minnehaha,0404,Commissioner of School and Public Lands,,Timothy Azure,DEM,323
 Minnehaha,0405,Commissioner of School and Public Lands,,Brock Greenfield,REP,955
-Minnehaha,0406,Commissioner of School and Public Lands,,Timothy Azure,DEM,146
+Minnehaha,0405,Commissioner of School and Public Lands,,Timothy Azure,DEM,570
 Minnehaha,0406,Commissioner of School and Public Lands,,Brock Greenfield,REP,124
-Minnehaha,0407,Commissioner of School and Public Lands,,Timothy Azure,DEM,550
+Minnehaha,0406,Commissioner of School and Public Lands,,Timothy Azure,DEM,146
 Minnehaha,0407,Commissioner of School and Public Lands,,Brock Greenfield,REP,630
-Minnehaha,0408,Commissioner of School and Public Lands,,Timothy Azure,DEM,168
+Minnehaha,0407,Commissioner of School and Public Lands,,Timothy Azure,DEM,550
 Minnehaha,0408,Commissioner of School and Public Lands,,Brock Greenfield,REP,126
-Minnehaha,0409,Commissioner of School and Public Lands,,Timothy Azure,DEM,342
+Minnehaha,0408,Commissioner of School and Public Lands,,Timothy Azure,DEM,168
 Minnehaha,0409,Commissioner of School and Public Lands,,Brock Greenfield,REP,308
-Minnehaha,0410,Commissioner of School and Public Lands,,Timothy Azure,DEM,317
+Minnehaha,0409,Commissioner of School and Public Lands,,Timothy Azure,DEM,342
 Minnehaha,0410,Commissioner of School and Public Lands,,Brock Greenfield,REP,401
-Minnehaha,0411,Commissioner of School and Public Lands,,Timothy Azure,DEM,666
+Minnehaha,0410,Commissioner of School and Public Lands,,Timothy Azure,DEM,317
 Minnehaha,0411,Commissioner of School and Public Lands,,Brock Greenfield,REP,1147
-Minnehaha,0412,Commissioner of School and Public Lands,,Timothy Azure,DEM,516
+Minnehaha,0411,Commissioner of School and Public Lands,,Timothy Azure,DEM,666
 Minnehaha,0412,Commissioner of School and Public Lands,,Brock Greenfield,REP,570
-Minnehaha,0413,Commissioner of School and Public Lands,,Timothy Azure,DEM,302
+Minnehaha,0412,Commissioner of School and Public Lands,,Timothy Azure,DEM,516
 Minnehaha,0413,Commissioner of School and Public Lands,,Brock Greenfield,REP,273
-Minnehaha,0415,Commissioner of School and Public Lands,,Timothy Azure,DEM,706
+Minnehaha,0413,Commissioner of School and Public Lands,,Timothy Azure,DEM,302
 Minnehaha,0415,Commissioner of School and Public Lands,,Brock Greenfield,REP,1257
-Minnehaha,0501,Commissioner of School and Public Lands,,Timothy Azure,DEM,247
+Minnehaha,0415,Commissioner of School and Public Lands,,Timothy Azure,DEM,706
 Minnehaha,0501,Commissioner of School and Public Lands,,Brock Greenfield,REP,157
-Minnehaha,0502,Commissioner of School and Public Lands,,Timothy Azure,DEM,389
+Minnehaha,0501,Commissioner of School and Public Lands,,Timothy Azure,DEM,247
 Minnehaha,0502,Commissioner of School and Public Lands,,Brock Greenfield,REP,212
-Minnehaha,0503,Commissioner of School and Public Lands,,Timothy Azure,DEM,186
+Minnehaha,0502,Commissioner of School and Public Lands,,Timothy Azure,DEM,389
 Minnehaha,0503,Commissioner of School and Public Lands,,Brock Greenfield,REP,125
-Minnehaha,0504,Commissioner of School and Public Lands,,Timothy Azure,DEM,501
+Minnehaha,0503,Commissioner of School and Public Lands,,Timothy Azure,DEM,186
 Minnehaha,0504,Commissioner of School and Public Lands,,Brock Greenfield,REP,283
-Minnehaha,0506,Commissioner of School and Public Lands,,Timothy Azure,DEM,467
+Minnehaha,0504,Commissioner of School and Public Lands,,Timothy Azure,DEM,501
 Minnehaha,0506,Commissioner of School and Public Lands,,Brock Greenfield,REP,381
-Minnehaha,0507,Commissioner of School and Public Lands,,Timothy Azure,DEM,306
+Minnehaha,0506,Commissioner of School and Public Lands,,Timothy Azure,DEM,467
 Minnehaha,0507,Commissioner of School and Public Lands,,Brock Greenfield,REP,215
-Minnehaha,0508,Commissioner of School and Public Lands,,Timothy Azure,DEM,491
+Minnehaha,0507,Commissioner of School and Public Lands,,Timothy Azure,DEM,306
 Minnehaha,0508,Commissioner of School and Public Lands,,Brock Greenfield,REP,339
-Minnehaha,0509,Commissioner of School and Public Lands,,Timothy Azure,DEM,213
+Minnehaha,0508,Commissioner of School and Public Lands,,Timothy Azure,DEM,491
 Minnehaha,0509,Commissioner of School and Public Lands,,Brock Greenfield,REP,131
-Minnehaha,0510,Commissioner of School and Public Lands,,Timothy Azure,DEM,253
+Minnehaha,0509,Commissioner of School and Public Lands,,Timothy Azure,DEM,213
 Minnehaha,0510,Commissioner of School and Public Lands,,Brock Greenfield,REP,227
-Minnehaha,0512,Commissioner of School and Public Lands,,Timothy Azure,DEM,303
+Minnehaha,0510,Commissioner of School and Public Lands,,Timothy Azure,DEM,253
 Minnehaha,0512,Commissioner of School and Public Lands,,Brock Greenfield,REP,268
-Minnehaha,0513,Commissioner of School and Public Lands,,Timothy Azure,DEM,300
+Minnehaha,0512,Commissioner of School and Public Lands,,Timothy Azure,DEM,303
 Minnehaha,0513,Commissioner of School and Public Lands,,Brock Greenfield,REP,277
-Minnehaha,0514,Commissioner of School and Public Lands,,Timothy Azure,DEM,406
+Minnehaha,0513,Commissioner of School and Public Lands,,Timothy Azure,DEM,300
 Minnehaha,0514,Commissioner of School and Public Lands,,Brock Greenfield,REP,301
-Minnehaha,0515,Commissioner of School and Public Lands,,Timothy Azure,DEM,337
+Minnehaha,0514,Commissioner of School and Public Lands,,Timothy Azure,DEM,406
 Minnehaha,0515,Commissioner of School and Public Lands,,Brock Greenfield,REP,400
-Minnehaha,0517,Commissioner of School and Public Lands,,Timothy Azure,DEM,231
+Minnehaha,0515,Commissioner of School and Public Lands,,Timothy Azure,DEM,337
 Minnehaha,0517,Commissioner of School and Public Lands,,Brock Greenfield,REP,253
-Minnehaha,0518,Commissioner of School and Public Lands,,Timothy Azure,DEM,552
+Minnehaha,0517,Commissioner of School and Public Lands,,Timothy Azure,DEM,231
 Minnehaha,0518,Commissioner of School and Public Lands,,Brock Greenfield,REP,384
-Minnehaha,0519,Commissioner of School and Public Lands,,Timothy Azure,DEM,223
+Minnehaha,0518,Commissioner of School and Public Lands,,Timothy Azure,DEM,552
 Minnehaha,0519,Commissioner of School and Public Lands,,Brock Greenfield,REP,256
-Minnehaha,0520,Commissioner of School and Public Lands,,Timothy Azure,DEM,394
+Minnehaha,0519,Commissioner of School and Public Lands,,Timothy Azure,DEM,223
 Minnehaha,0520,Commissioner of School and Public Lands,,Brock Greenfield,REP,378
-Minnehaha,0521,Commissioner of School and Public Lands,,Timothy Azure,DEM,198
+Minnehaha,0520,Commissioner of School and Public Lands,,Timothy Azure,DEM,394
 Minnehaha,0521,Commissioner of School and Public Lands,,Brock Greenfield,REP,197
-Minnehaha,0522,Commissioner of School and Public Lands,,Timothy Azure,DEM,421
+Minnehaha,0521,Commissioner of School and Public Lands,,Timothy Azure,DEM,198
 Minnehaha,0522,Commissioner of School and Public Lands,,Brock Greenfield,REP,321
-Minnehaha,0523,Commissioner of School and Public Lands,,Timothy Azure,DEM,351
+Minnehaha,0522,Commissioner of School and Public Lands,,Timothy Azure,DEM,421
 Minnehaha,0523,Commissioner of School and Public Lands,,Brock Greenfield,REP,247
-Minnehaha,VP01,Commissioner of School and Public Lands,,Timothy Azure,DEM,161
+Minnehaha,0523,Commissioner of School and Public Lands,,Timothy Azure,DEM,351
 Minnehaha,VP01,Commissioner of School and Public Lands,,Brock Greenfield,REP,515
-Minnehaha,VP02,Commissioner of School and Public Lands,,Timothy Azure,DEM,443
+Minnehaha,VP01,Commissioner of School and Public Lands,,Timothy Azure,DEM,161
 Minnehaha,VP02,Commissioner of School and Public Lands,,Brock Greenfield,REP,1144
-Minnehaha,VP03,Commissioner of School and Public Lands,,Timothy Azure,DEM,550
+Minnehaha,VP02,Commissioner of School and Public Lands,,Timothy Azure,DEM,443
 Minnehaha,VP03,Commissioner of School and Public Lands,,Brock Greenfield,REP,1339
-Minnehaha,VP04,Commissioner of School and Public Lands,,Timothy Azure,DEM,289
+Minnehaha,VP03,Commissioner of School and Public Lands,,Timothy Azure,DEM,550
 Minnehaha,VP04,Commissioner of School and Public Lands,,Brock Greenfield,REP,685
-Minnehaha,VP05,Commissioner of School and Public Lands,,Timothy Azure,DEM,355
+Minnehaha,VP04,Commissioner of School and Public Lands,,Timothy Azure,DEM,289
 Minnehaha,VP05,Commissioner of School and Public Lands,,Brock Greenfield,REP,885
-Minnehaha,VP06,Commissioner of School and Public Lands,,Timothy Azure,DEM,121
+Minnehaha,VP05,Commissioner of School and Public Lands,,Timothy Azure,DEM,355
 Minnehaha,VP06,Commissioner of School and Public Lands,,Brock Greenfield,REP,273
-Minnehaha,VP07,Commissioner of School and Public Lands,,Timothy Azure,DEM,454
+Minnehaha,VP06,Commissioner of School and Public Lands,,Timothy Azure,DEM,121
 Minnehaha,VP07,Commissioner of School and Public Lands,,Brock Greenfield,REP,1061
-Minnehaha,VP08,Commissioner of School and Public Lands,,Timothy Azure,DEM,145
+Minnehaha,VP07,Commissioner of School and Public Lands,,Timothy Azure,DEM,454
 Minnehaha,VP08,Commissioner of School and Public Lands,,Brock Greenfield,REP,429
-Minnehaha,VP09,Commissioner of School and Public Lands,,Timothy Azure,DEM,326
+Minnehaha,VP08,Commissioner of School and Public Lands,,Timothy Azure,DEM,145
 Minnehaha,VP09,Commissioner of School and Public Lands,,Brock Greenfield,REP,796
-Minnehaha,VP10,Commissioner of School and Public Lands,,Timothy Azure,DEM,326
+Minnehaha,VP09,Commissioner of School and Public Lands,,Timothy Azure,DEM,326
 Minnehaha,VP10,Commissioner of School and Public Lands,,Brock Greenfield,REP,704
-Minnehaha,VP11,Commissioner of School and Public Lands,,Timothy Azure,DEM,63
+Minnehaha,VP10,Commissioner of School and Public Lands,,Timothy Azure,DEM,326
 Minnehaha,VP11,Commissioner of School and Public Lands,,Brock Greenfield,REP,212
-Minnehaha,VP12,Commissioner of School and Public Lands,,Timothy Azure,DEM,22
+Minnehaha,VP11,Commissioner of School and Public Lands,,Timothy Azure,DEM,63
 Minnehaha,VP12,Commissioner of School and Public Lands,,Brock Greenfield,REP,93
-Minnehaha,VP13,Commissioner of School and Public Lands,,Timothy Azure,DEM,169
+Minnehaha,VP12,Commissioner of School and Public Lands,,Timothy Azure,DEM,22
 Minnehaha,VP13,Commissioner of School and Public Lands,,Brock Greenfield,REP,627
-Minnehaha,VP15,Commissioner of School and Public Lands,,Timothy Azure,DEM,429
+Minnehaha,VP13,Commissioner of School and Public Lands,,Timothy Azure,DEM,169
 Minnehaha,VP15,Commissioner of School and Public Lands,,Brock Greenfield,REP,919
-Minnehaha,VP16,Commissioner of School and Public Lands,,Timothy Azure,DEM,268
+Minnehaha,VP15,Commissioner of School and Public Lands,,Timothy Azure,DEM,429
 Minnehaha,VP16,Commissioner of School and Public Lands,,Brock Greenfield,REP,651
-Minnehaha,VP17,Commissioner of School and Public Lands,,Timothy Azure,DEM,137
+Minnehaha,VP16,Commissioner of School and Public Lands,,Timothy Azure,DEM,268
 Minnehaha,VP17,Commissioner of School and Public Lands,,Brock Greenfield,REP,445
-Minnehaha,VP21,Commissioner of School and Public Lands,,Timothy Azure,DEM,452
+Minnehaha,VP17,Commissioner of School and Public Lands,,Timothy Azure,DEM,137
 Minnehaha,VP21,Commissioner of School and Public Lands,,Brock Greenfield,REP,1014
-Minnehaha,0104,Public Utilities Commissioner,,Jeffrey Barth,DEM,352
-Minnehaha,0104,Public Utilities Commissioner,,Chris Nelson,REP,320
-Minnehaha,0105,Public Utilities Commissioner,,Jeffrey Barth,DEM,213
-Minnehaha,0105,Public Utilities Commissioner,,Chris Nelson,REP,223
-Minnehaha,0106,Public Utilities Commissioner,,Jeffrey Barth,DEM,454
-Minnehaha,0106,Public Utilities Commissioner,,Chris Nelson,REP,581
-Minnehaha,0109,Public Utilities Commissioner,,Jeffrey Barth,DEM,416
-Minnehaha,0109,Public Utilities Commissioner,,Chris Nelson,REP,596
-Minnehaha,0110,Public Utilities Commissioner,,Jeffrey Barth,DEM,457
-Minnehaha,0110,Public Utilities Commissioner,,Chris Nelson,REP,630
-Minnehaha,0117,Public Utilities Commissioner,,Jeffrey Barth,DEM,469
-Minnehaha,0117,Public Utilities Commissioner,,Chris Nelson,REP,782
-Minnehaha,0119,Public Utilities Commissioner,,Jeffrey Barth,DEM,266
-Minnehaha,0119,Public Utilities Commissioner,,Chris Nelson,REP,311
-Minnehaha,0201,Public Utilities Commissioner,,Jeffrey Barth,DEM,415
-Minnehaha,0201,Public Utilities Commissioner,,Chris Nelson,REP,632
-Minnehaha,0202,Public Utilities Commissioner,,Jeffrey Barth,DEM,576
-Minnehaha,0202,Public Utilities Commissioner,,Chris Nelson,REP,814
-Minnehaha,0203,Public Utilities Commissioner,,Jeffrey Barth,DEM,461
-Minnehaha,0203,Public Utilities Commissioner,,Chris Nelson,REP,582
-Minnehaha,0206,Public Utilities Commissioner,,Jeffrey Barth,DEM,455
-Minnehaha,0206,Public Utilities Commissioner,,Chris Nelson,REP,622
-Minnehaha,0208,Public Utilities Commissioner,,Jeffrey Barth,DEM,439
-Minnehaha,0208,Public Utilities Commissioner,,Chris Nelson,REP,672
-Minnehaha,0209,Public Utilities Commissioner,,Jeffrey Barth,DEM,476
-Minnehaha,0209,Public Utilities Commissioner,,Chris Nelson,REP,520
-Minnehaha,0214,Public Utilities Commissioner,,Jeffrey Barth,DEM,1042
-Minnehaha,0214,Public Utilities Commissioner,,Chris Nelson,REP,1672
-Minnehaha,0301,Public Utilities Commissioner,,Jeffrey Barth,DEM,313
-Minnehaha,0301,Public Utilities Commissioner,,Chris Nelson,REP,443
-Minnehaha,0305,Public Utilities Commissioner,,Jeffrey Barth,DEM,231
-Minnehaha,0305,Public Utilities Commissioner,,Chris Nelson,REP,273
-Minnehaha,0309,Public Utilities Commissioner,,Jeffrey Barth,DEM,501
-Minnehaha,0309,Public Utilities Commissioner,,Chris Nelson,REP,571
-Minnehaha,0310,Public Utilities Commissioner,,Jeffrey Barth,DEM,497
-Minnehaha,0310,Public Utilities Commissioner,,Chris Nelson,REP,890
-Minnehaha,0311,Public Utilities Commissioner,,Jeffrey Barth,DEM,313
-Minnehaha,0311,Public Utilities Commissioner,,Chris Nelson,REP,562
-Minnehaha,0312,Public Utilities Commissioner,,Jeffrey Barth,DEM,398
-Minnehaha,0312,Public Utilities Commissioner,,Chris Nelson,REP,742
-Minnehaha,0313,Public Utilities Commissioner,,Jeffrey Barth,DEM,266
-Minnehaha,0313,Public Utilities Commissioner,,Chris Nelson,REP,433
-Minnehaha,0314,Public Utilities Commissioner,,Jeffrey Barth,DEM,687
-Minnehaha,0314,Public Utilities Commissioner,,Chris Nelson,REP,994
-Minnehaha,0315,Public Utilities Commissioner,,Jeffrey Barth,DEM,432
-Minnehaha,0315,Public Utilities Commissioner,,Chris Nelson,REP,605
-Minnehaha,0316,Public Utilities Commissioner,,Jeffrey Barth,DEM,579
-Minnehaha,0316,Public Utilities Commissioner,,Chris Nelson,REP,1060
-Minnehaha,0317,Public Utilities Commissioner,,Jeffrey Barth,DEM,723
-Minnehaha,0317,Public Utilities Commissioner,,Chris Nelson,REP,1243
-Minnehaha,0402,Public Utilities Commissioner,,Jeffrey Barth,DEM,318
-Minnehaha,0402,Public Utilities Commissioner,,Chris Nelson,REP,296
-Minnehaha,0403,Public Utilities Commissioner,,Jeffrey Barth,DEM,207
-Minnehaha,0403,Public Utilities Commissioner,,Chris Nelson,REP,205
-Minnehaha,0404,Public Utilities Commissioner,,Jeffrey Barth,DEM,322
-Minnehaha,0404,Public Utilities Commissioner,,Chris Nelson,REP,313
-Minnehaha,0405,Public Utilities Commissioner,,Jeffrey Barth,DEM,578
-Minnehaha,0405,Public Utilities Commissioner,,Chris Nelson,REP,963
-Minnehaha,0406,Public Utilities Commissioner,,Jeffrey Barth,DEM,144
-Minnehaha,0406,Public Utilities Commissioner,,Chris Nelson,REP,136
-Minnehaha,0407,Public Utilities Commissioner,,Jeffrey Barth,DEM,542
-Minnehaha,0407,Public Utilities Commissioner,,Chris Nelson,REP,665
-Minnehaha,0408,Public Utilities Commissioner,,Jeffrey Barth,DEM,174
-Minnehaha,0408,Public Utilities Commissioner,,Chris Nelson,REP,133
-Minnehaha,0409,Public Utilities Commissioner,,Jeffrey Barth,DEM,340
-Minnehaha,0409,Public Utilities Commissioner,,Chris Nelson,REP,326
-Minnehaha,0410,Public Utilities Commissioner,,Jeffrey Barth,DEM,326
-Minnehaha,0410,Public Utilities Commissioner,,Chris Nelson,REP,402
-Minnehaha,0411,Public Utilities Commissioner,,Jeffrey Barth,DEM,673
-Minnehaha,0411,Public Utilities Commissioner,,Chris Nelson,REP,1208
-Minnehaha,0412,Public Utilities Commissioner,,Jeffrey Barth,DEM,534
-Minnehaha,0412,Public Utilities Commissioner,,Chris Nelson,REP,602
-Minnehaha,0413,Public Utilities Commissioner,,Jeffrey Barth,DEM,303
-Minnehaha,0413,Public Utilities Commissioner,,Chris Nelson,REP,293
-Minnehaha,0415,Public Utilities Commissioner,,Jeffrey Barth,DEM,768
-Minnehaha,0415,Public Utilities Commissioner,,Chris Nelson,REP,1247
-Minnehaha,0501,Public Utilities Commissioner,,Jeffrey Barth,DEM,245
-Minnehaha,0501,Public Utilities Commissioner,,Chris Nelson,REP,164
-Minnehaha,0502,Public Utilities Commissioner,,Jeffrey Barth,DEM,384
-Minnehaha,0502,Public Utilities Commissioner,,Chris Nelson,REP,227
-Minnehaha,0503,Public Utilities Commissioner,,Jeffrey Barth,DEM,182
-Minnehaha,0503,Public Utilities Commissioner,,Chris Nelson,REP,135
-Minnehaha,0504,Public Utilities Commissioner,,Jeffrey Barth,DEM,509
-Minnehaha,0504,Public Utilities Commissioner,,Chris Nelson,REP,303
-Minnehaha,0506,Public Utilities Commissioner,,Jeffrey Barth,DEM,472
-Minnehaha,0506,Public Utilities Commissioner,,Chris Nelson,REP,410
-Minnehaha,0507,Public Utilities Commissioner,,Jeffrey Barth,DEM,307
-Minnehaha,0507,Public Utilities Commissioner,,Chris Nelson,REP,237
-Minnehaha,0508,Public Utilities Commissioner,,Jeffrey Barth,DEM,500
-Minnehaha,0508,Public Utilities Commissioner,,Chris Nelson,REP,363
-Minnehaha,0509,Public Utilities Commissioner,,Jeffrey Barth,DEM,202
-Minnehaha,0509,Public Utilities Commissioner,,Chris Nelson,REP,147
-Minnehaha,0510,Public Utilities Commissioner,,Jeffrey Barth,DEM,252
-Minnehaha,0510,Public Utilities Commissioner,,Chris Nelson,REP,256
-Minnehaha,0512,Public Utilities Commissioner,,Jeffrey Barth,DEM,296
-Minnehaha,0512,Public Utilities Commissioner,,Chris Nelson,REP,288
-Minnehaha,0513,Public Utilities Commissioner,,Jeffrey Barth,DEM,318
-Minnehaha,0513,Public Utilities Commissioner,,Chris Nelson,REP,279
-Minnehaha,0514,Public Utilities Commissioner,,Jeffrey Barth,DEM,405
-Minnehaha,0514,Public Utilities Commissioner,,Chris Nelson,REP,315
-Minnehaha,0515,Public Utilities Commissioner,,Jeffrey Barth,DEM,329
-Minnehaha,0515,Public Utilities Commissioner,,Chris Nelson,REP,415
-Minnehaha,0517,Public Utilities Commissioner,,Jeffrey Barth,DEM,238
-Minnehaha,0517,Public Utilities Commissioner,,Chris Nelson,REP,262
-Minnehaha,0518,Public Utilities Commissioner,,Jeffrey Barth,DEM,551
-Minnehaha,0518,Public Utilities Commissioner,,Chris Nelson,REP,409
-Minnehaha,0519,Public Utilities Commissioner,,Jeffrey Barth,DEM,224
-Minnehaha,0519,Public Utilities Commissioner,,Chris Nelson,REP,265
-Minnehaha,0520,Public Utilities Commissioner,,Jeffrey Barth,DEM,380
-Minnehaha,0520,Public Utilities Commissioner,,Chris Nelson,REP,398
-Minnehaha,0521,Public Utilities Commissioner,,Jeffrey Barth,DEM,196
-Minnehaha,0521,Public Utilities Commissioner,,Chris Nelson,REP,205
-Minnehaha,0522,Public Utilities Commissioner,,Jeffrey Barth,DEM,417
-Minnehaha,0522,Public Utilities Commissioner,,Chris Nelson,REP,343
-Minnehaha,0523,Public Utilities Commissioner,,Jeffrey Barth,DEM,345
-Minnehaha,0523,Public Utilities Commissioner,,Chris Nelson,REP,261
-Minnehaha,VP01,Public Utilities Commissioner,,Jeffrey Barth,DEM,213
-Minnehaha,VP01,Public Utilities Commissioner,,Chris Nelson,REP,495
-Minnehaha,VP02,Public Utilities Commissioner,,Jeffrey Barth,DEM,486
-Minnehaha,VP02,Public Utilities Commissioner,,Chris Nelson,REP,1160
-Minnehaha,VP03,Public Utilities Commissioner,,Jeffrey Barth,DEM,563
-Minnehaha,VP03,Public Utilities Commissioner,,Chris Nelson,REP,1378
-Minnehaha,VP04,Public Utilities Commissioner,,Jeffrey Barth,DEM,304
-Minnehaha,VP04,Public Utilities Commissioner,,Chris Nelson,REP,719
-Minnehaha,VP05,Public Utilities Commissioner,,Jeffrey Barth,DEM,357
-Minnehaha,VP05,Public Utilities Commissioner,,Chris Nelson,REP,935
-Minnehaha,VP06,Public Utilities Commissioner,,Jeffrey Barth,DEM,118
-Minnehaha,VP06,Public Utilities Commissioner,,Chris Nelson,REP,294
-Minnehaha,VP07,Public Utilities Commissioner,,Jeffrey Barth,DEM,472
-Minnehaha,VP07,Public Utilities Commissioner,,Chris Nelson,REP,1109
-Minnehaha,VP08,Public Utilities Commissioner,,Jeffrey Barth,DEM,188
-Minnehaha,VP08,Public Utilities Commissioner,,Chris Nelson,REP,411
-Minnehaha,VP09,Public Utilities Commissioner,,Jeffrey Barth,DEM,344
-Minnehaha,VP09,Public Utilities Commissioner,,Chris Nelson,REP,845
-Minnehaha,VP10,Public Utilities Commissioner,,Jeffrey Barth,DEM,398
-Minnehaha,VP10,Public Utilities Commissioner,,Chris Nelson,REP,694
-Minnehaha,VP11,Public Utilities Commissioner,,Jeffrey Barth,DEM,80
-Minnehaha,VP11,Public Utilities Commissioner,,Chris Nelson,REP,210
-Minnehaha,VP12,Public Utilities Commissioner,,Jeffrey Barth,DEM,47
-Minnehaha,VP12,Public Utilities Commissioner,,Chris Nelson,REP,74
-Minnehaha,VP13,Public Utilities Commissioner,,Jeffrey Barth,DEM,206
-Minnehaha,VP13,Public Utilities Commissioner,,Chris Nelson,REP,639
-Minnehaha,VP15,Public Utilities Commissioner,,Jeffrey Barth,DEM,440
-Minnehaha,VP15,Public Utilities Commissioner,,Chris Nelson,REP,958
-Minnehaha,VP16,Public Utilities Commissioner,,Jeffrey Barth,DEM,292
-Minnehaha,VP16,Public Utilities Commissioner,,Chris Nelson,REP,685
-Minnehaha,VP17,Public Utilities Commissioner,,Jeffrey Barth,DEM,185
-Minnehaha,VP17,Public Utilities Commissioner,,Chris Nelson,REP,427
-Minnehaha,VP21,Public Utilities Commissioner,,Jeffrey Barth,DEM,467
-Minnehaha,VP21,Public Utilities Commissioner,,Chris Nelson,REP,1087
+Minnehaha,VP21,Commissioner of School and Public Lands,,Timothy Azure,DEM,452
+Minnehaha,0104,Constitutional Amendment D,,No,,170
+Minnehaha,0104,Constitutional Amendment D,,Yes,,547
+Minnehaha,0105,Constitutional Amendment D,,No,,111
+Minnehaha,0105,Constitutional Amendment D,,Yes,,345
+Minnehaha,0106,Constitutional Amendment D,,No,,357
+Minnehaha,0106,Constitutional Amendment D,,Yes,,719
+Minnehaha,0109,Constitutional Amendment D,,No,,341
+Minnehaha,0109,Constitutional Amendment D,,Yes,,720
+Minnehaha,0110,Constitutional Amendment D,,No,,375
+Minnehaha,0110,Constitutional Amendment D,,Yes,,779
+Minnehaha,0117,Constitutional Amendment D,,No,,528
+Minnehaha,0117,Constitutional Amendment D,,Yes,,789
+Minnehaha,0119,Constitutional Amendment D,,No,,198
+Minnehaha,0119,Constitutional Amendment D,,Yes,,411
+Minnehaha,0201,Constitutional Amendment D,,No,,376
+Minnehaha,0201,Constitutional Amendment D,,Yes,,722
+Minnehaha,0202,Constitutional Amendment D,,No,,504
+Minnehaha,0202,Constitutional Amendment D,,Yes,,940
+Minnehaha,0203,Constitutional Amendment D,,No,,362
+Minnehaha,0203,Constitutional Amendment D,,Yes,,731
+Minnehaha,0206,Constitutional Amendment D,,No,,374
+Minnehaha,0206,Constitutional Amendment D,,Yes,,766
+Minnehaha,0208,Constitutional Amendment D,,No,,426
+Minnehaha,0208,Constitutional Amendment D,,Yes,,739
+Minnehaha,0209,Constitutional Amendment D,,No,,352
+Minnehaha,0209,Constitutional Amendment D,,Yes,,704
+Minnehaha,0214,Constitutional Amendment D,,No,,1085
+Minnehaha,0214,Constitutional Amendment D,,Yes,,1760
+Minnehaha,0301,Constitutional Amendment D,,No,,261
+Minnehaha,0301,Constitutional Amendment D,,Yes,,517
+Minnehaha,0305,Constitutional Amendment D,,No,,169
+Minnehaha,0305,Constitutional Amendment D,,Yes,,368
+Minnehaha,0309,Constitutional Amendment D,,No,,312
+Minnehaha,0309,Constitutional Amendment D,,Yes,,809
+Minnehaha,0310,Constitutional Amendment D,,No,,597
+Minnehaha,0310,Constitutional Amendment D,,Yes,,856
+Minnehaha,0311,Constitutional Amendment D,,No,,369
+Minnehaha,0311,Constitutional Amendment D,,Yes,,548
+Minnehaha,0312,Constitutional Amendment D,,No,,437
+Minnehaha,0312,Constitutional Amendment D,,Yes,,755
+Minnehaha,0313,Constitutional Amendment D,,No,,287
+Minnehaha,0313,Constitutional Amendment D,,Yes,,453
+Minnehaha,0314,Constitutional Amendment D,,No,,658
+Minnehaha,0314,Constitutional Amendment D,,Yes,,1115
+Minnehaha,0315,Constitutional Amendment D,,No,,358
+Minnehaha,0315,Constitutional Amendment D,,Yes,,750
+Minnehaha,0316,Constitutional Amendment D,,No,,658
+Minnehaha,0316,Constitutional Amendment D,,Yes,,1084
+Minnehaha,0317,Constitutional Amendment D,,No,,807
+Minnehaha,0317,Constitutional Amendment D,,Yes,,1280
+Minnehaha,0402,Constitutional Amendment D,,No,,177
+Minnehaha,0402,Constitutional Amendment D,,Yes,,476
+Minnehaha,0403,Constitutional Amendment D,,No,,116
+Minnehaha,0403,Constitutional Amendment D,,Yes,,312
+Minnehaha,0404,Constitutional Amendment D,,No,,170
+Minnehaha,0404,Constitutional Amendment D,,Yes,,507
+Minnehaha,0405,Constitutional Amendment D,,No,,652
+Minnehaha,0405,Constitutional Amendment D,,Yes,,891
+Minnehaha,0406,Constitutional Amendment D,,No,,75
+Minnehaha,0406,Constitutional Amendment D,,Yes,,211
+Minnehaha,0407,Constitutional Amendment D,,No,,445
+Minnehaha,0407,Constitutional Amendment D,,Yes,,807
+Minnehaha,0408,Constitutional Amendment D,,No,,95
+Minnehaha,0408,Constitutional Amendment D,,Yes,,218
+Minnehaha,0409,Constitutional Amendment D,,No,,205
+Minnehaha,0409,Constitutional Amendment D,,Yes,,500
+Minnehaha,0410,Constitutional Amendment D,,No,,265
+Minnehaha,0410,Constitutional Amendment D,,Yes,,509
+Minnehaha,0411,Constitutional Amendment D,,No,,777
+Minnehaha,0411,Constitutional Amendment D,,Yes,,1175
+Minnehaha,0412,Constitutional Amendment D,,No,,385
+Minnehaha,0412,Constitutional Amendment D,,Yes,,796
+Minnehaha,0413,Constitutional Amendment D,,No,,180
+Minnehaha,0413,Constitutional Amendment D,,Yes,,450
+Minnehaha,0415,Constitutional Amendment D,,No,,839
+Minnehaha,0415,Constitutional Amendment D,,Yes,,1261
+Minnehaha,0501,Constitutional Amendment D,,No,,102
+Minnehaha,0501,Constitutional Amendment D,,Yes,,336
+Minnehaha,0502,Constitutional Amendment D,,No,,123
+Minnehaha,0502,Constitutional Amendment D,,Yes,,520
+Minnehaha,0503,Constitutional Amendment D,,No,,64
+Minnehaha,0503,Constitutional Amendment D,,Yes,,279
+Minnehaha,0504,Constitutional Amendment D,,No,,181
+Minnehaha,0504,Constitutional Amendment D,,Yes,,661
+Minnehaha,0506,Constitutional Amendment D,,No,,247
+Minnehaha,0506,Constitutional Amendment D,,Yes,,678
+Minnehaha,0507,Constitutional Amendment D,,No,,131
+Minnehaha,0507,Constitutional Amendment D,,Yes,,429
+Minnehaha,0508,Constitutional Amendment D,,No,,237
+Minnehaha,0508,Constitutional Amendment D,,Yes,,662
+Minnehaha,0509,Constitutional Amendment D,,No,,68
+Minnehaha,0509,Constitutional Amendment D,,Yes,,308
+Minnehaha,0510,Constitutional Amendment D,,No,,137
+Minnehaha,0510,Constitutional Amendment D,,Yes,,397
+Minnehaha,0512,Constitutional Amendment D,,No,,168
+Minnehaha,0512,Constitutional Amendment D,,Yes,,458
+Minnehaha,0513,Constitutional Amendment D,,No,,161
+Minnehaha,0513,Constitutional Amendment D,,Yes,,469
+Minnehaha,0514,Constitutional Amendment D,,No,,197
+Minnehaha,0514,Constitutional Amendment D,,Yes,,551
+Minnehaha,0515,Constitutional Amendment D,,No,,292
+Minnehaha,0515,Constitutional Amendment D,,Yes,,467
+Minnehaha,0517,Constitutional Amendment D,,No,,158
+Minnehaha,0517,Constitutional Amendment D,,Yes,,359
+Minnehaha,0518,Constitutional Amendment D,,No,,243
+Minnehaha,0518,Constitutional Amendment D,,Yes,,757
+Minnehaha,0519,Constitutional Amendment D,,No,,169
+Minnehaha,0519,Constitutional Amendment D,,Yes,,340
+Minnehaha,0520,Constitutional Amendment D,,No,,239
+Minnehaha,0520,Constitutional Amendment D,,Yes,,591
+Minnehaha,0521,Constitutional Amendment D,,No,,127
+Minnehaha,0521,Constitutional Amendment D,,Yes,,290
+Minnehaha,0522,Constitutional Amendment D,,No,,202
+Minnehaha,0522,Constitutional Amendment D,,Yes,,605
+Minnehaha,0523,Constitutional Amendment D,,No,,153
+Minnehaha,0523,Constitutional Amendment D,,Yes,,474
+Minnehaha,VP01,Constitutional Amendment D,,No,,371
+Minnehaha,VP01,Constitutional Amendment D,,Yes,,367
+Minnehaha,VP02,Constitutional Amendment D,,No,,829
+Minnehaha,VP02,Constitutional Amendment D,,Yes,,863
+Minnehaha,VP03,Constitutional Amendment D,,No,,972
+Minnehaha,VP03,Constitutional Amendment D,,Yes,,1019
+Minnehaha,VP04,Constitutional Amendment D,,No,,504
+Minnehaha,VP04,Constitutional Amendment D,,Yes,,540
+Minnehaha,VP05,Constitutional Amendment D,,No,,615
+Minnehaha,VP05,Constitutional Amendment D,,Yes,,767
+Minnehaha,VP06,Constitutional Amendment D,,No,,196
+Minnehaha,VP06,Constitutional Amendment D,,Yes,,239
+Minnehaha,VP07,Constitutional Amendment D,,No,,750
+Minnehaha,VP07,Constitutional Amendment D,,Yes,,887
+Minnehaha,VP08,Constitutional Amendment D,,No,,318
+Minnehaha,VP08,Constitutional Amendment D,,Yes,,310
+Minnehaha,VP09,Constitutional Amendment D,,No,,605
+Minnehaha,VP09,Constitutional Amendment D,,Yes,,633
+Minnehaha,VP10,Constitutional Amendment D,,No,,480
+Minnehaha,VP10,Constitutional Amendment D,,Yes,,635
+Minnehaha,VP11,Constitutional Amendment D,,No,,175
+Minnehaha,VP11,Constitutional Amendment D,,Yes,,123
+Minnehaha,VP12,Constitutional Amendment D,,No,,72
+Minnehaha,VP12,Constitutional Amendment D,,Yes,,52
+Minnehaha,VP13,Constitutional Amendment D,,No,,459
+Minnehaha,VP13,Constitutional Amendment D,,Yes,,418
+Minnehaha,VP15,Constitutional Amendment D,,No,,652
+Minnehaha,VP15,Constitutional Amendment D,,Yes,,820
+Minnehaha,VP16,Constitutional Amendment D,,No,,487
+Minnehaha,VP16,Constitutional Amendment D,,Yes,,539
+Minnehaha,VP17,Constitutional Amendment D,,No,,316
+Minnehaha,VP17,Constitutional Amendment D,,Yes,,309
+Minnehaha,VP21,Constitutional Amendment D,,No,,729
+Minnehaha,VP21,Constitutional Amendment D,,Yes,,880
+Minnehaha,0104,Governor,,Jamie Smith and Jennifer Keintz,DEM,420
+Minnehaha,0104,Governor,,Kristi Noem and Larry Rhoden,REP,303
+Minnehaha,0104,Governor,,Tracey Quint and Ashley Strand,LIB,15
+Minnehaha,0105,Governor,,Jamie Smith and Jennifer Keintz,DEM,242
+Minnehaha,0105,Governor,,Kristi Noem and Larry Rhoden,REP,210
+Minnehaha,0105,Governor,,Tracey Quint and Ashley Strand,LIB,14
+Minnehaha,0106,Governor,,Jamie Smith and Jennifer Keintz,DEM,523
+Minnehaha,0106,Governor,,Kristi Noem and Larry Rhoden,REP,545
+Minnehaha,0106,Governor,,Tracey Quint and Ashley Strand,LIB,39
+Minnehaha,0109,Governor,,Jamie Smith and Jennifer Keintz,DEM,510
+Minnehaha,0109,Governor,,Kristi Noem and Larry Rhoden,REP,545
+Minnehaha,0109,Governor,,Tracey Quint and Ashley Strand,LIB,30
+Minnehaha,0110,Governor,,Jamie Smith and Jennifer Keintz,DEM,542
+Minnehaha,0110,Governor,,Kristi Noem and Larry Rhoden,REP,607
+Minnehaha,0110,Governor,,Tracey Quint and Ashley Strand,LIB,36
+Minnehaha,0117,Governor,,Jamie Smith and Jennifer Keintz,DEM,593
+Minnehaha,0117,Governor,,Kristi Noem and Larry Rhoden,REP,715
+Minnehaha,0117,Governor,,Tracey Quint and Ashley Strand,LIB,41
+Minnehaha,0119,Governor,,Jamie Smith and Jennifer Keintz,DEM,309
+Minnehaha,0119,Governor,,Kristi Noem and Larry Rhoden,REP,288
+Minnehaha,0119,Governor,,Tracey Quint and Ashley Strand,LIB,32
+Minnehaha,0201,Governor,,Jamie Smith and Jennifer Keintz,DEM,561
+Minnehaha,0201,Governor,,Kristi Noem and Larry Rhoden,REP,546
+Minnehaha,0201,Governor,,Tracey Quint and Ashley Strand,LIB,13
+Minnehaha,0202,Governor,,Jamie Smith and Jennifer Keintz,DEM,763
+Minnehaha,0202,Governor,,Kristi Noem and Larry Rhoden,REP,687
+Minnehaha,0202,Governor,,Tracey Quint and Ashley Strand,LIB,16
+Minnehaha,0203,Governor,,Jamie Smith and Jennifer Keintz,DEM,554
+Minnehaha,0203,Governor,,Kristi Noem and Larry Rhoden,REP,514
+Minnehaha,0203,Governor,,Tracey Quint and Ashley Strand,LIB,37
+Minnehaha,0206,Governor,,Jamie Smith and Jennifer Keintz,DEM,559
+Minnehaha,0206,Governor,,Kristi Noem and Larry Rhoden,REP,590
+Minnehaha,0206,Governor,,Tracey Quint and Ashley Strand,LIB,24
+Minnehaha,0208,Governor,,Jamie Smith and Jennifer Keintz,DEM,547
+Minnehaha,0208,Governor,,Kristi Noem and Larry Rhoden,REP,620
+Minnehaha,0208,Governor,,Tracey Quint and Ashley Strand,LIB,22
+Minnehaha,0209,Governor,,Jamie Smith and Jennifer Keintz,DEM,575
+Minnehaha,0209,Governor,,Kristi Noem and Larry Rhoden,REP,479
+Minnehaha,0209,Governor,,Tracey Quint and Ashley Strand,LIB,14
+Minnehaha,0214,Governor,,Jamie Smith and Jennifer Keintz,DEM,1349
+Minnehaha,0214,Governor,,Kristi Noem and Larry Rhoden,REP,1502
+Minnehaha,0214,Governor,,Tracey Quint and Ashley Strand,LIB,54
+Minnehaha,0301,Governor,,Jamie Smith and Jennifer Keintz,DEM,382
+Minnehaha,0301,Governor,,Kristi Noem and Larry Rhoden,REP,396
+Minnehaha,0301,Governor,,Tracey Quint and Ashley Strand,LIB,15
+Minnehaha,0305,Governor,,Jamie Smith and Jennifer Keintz,DEM,253
+Minnehaha,0305,Governor,,Kristi Noem and Larry Rhoden,REP,267
+Minnehaha,0305,Governor,,Tracey Quint and Ashley Strand,LIB,31
+Minnehaha,0309,Governor,,Jamie Smith and Jennifer Keintz,DEM,593
+Minnehaha,0309,Governor,,Kristi Noem and Larry Rhoden,REP,516
+Minnehaha,0309,Governor,,Tracey Quint and Ashley Strand,LIB,52
+Minnehaha,0310,Governor,,Jamie Smith and Jennifer Keintz,DEM,594
+Minnehaha,0310,Governor,,Kristi Noem and Larry Rhoden,REP,851
+Minnehaha,0310,Governor,,Tracey Quint and Ashley Strand,LIB,26
+Minnehaha,0311,Governor,,Jamie Smith and Jennifer Keintz,DEM,396
+Minnehaha,0311,Governor,,Kristi Noem and Larry Rhoden,REP,507
+Minnehaha,0311,Governor,,Tracey Quint and Ashley Strand,LIB,29
+Minnehaha,0312,Governor,,Jamie Smith and Jennifer Keintz,DEM,474
+Minnehaha,0312,Governor,,Kristi Noem and Larry Rhoden,REP,704
+Minnehaha,0312,Governor,,Tracey Quint and Ashley Strand,LIB,39
+Minnehaha,0313,Governor,,Jamie Smith and Jennifer Keintz,DEM,322
+Minnehaha,0313,Governor,,Kristi Noem and Larry Rhoden,REP,397
+Minnehaha,0313,Governor,,Tracey Quint and Ashley Strand,LIB,28
+Minnehaha,0314,Governor,,Jamie Smith and Jennifer Keintz,DEM,826
+Minnehaha,0314,Governor,,Kristi Noem and Larry Rhoden,REP,923
+Minnehaha,0314,Governor,,Tracey Quint and Ashley Strand,LIB,58
+Minnehaha,0315,Governor,,Jamie Smith and Jennifer Keintz,DEM,519
+Minnehaha,0315,Governor,,Kristi Noem and Larry Rhoden,REP,578
+Minnehaha,0315,Governor,,Tracey Quint and Ashley Strand,LIB,29
+Minnehaha,0316,Governor,,Jamie Smith and Jennifer Keintz,DEM,748
+Minnehaha,0316,Governor,,Kristi Noem and Larry Rhoden,REP,998
+Minnehaha,0316,Governor,,Tracey Quint and Ashley Strand,LIB,40
+Minnehaha,0317,Governor,,Jamie Smith and Jennifer Keintz,DEM,911
+Minnehaha,0317,Governor,,Kristi Noem and Larry Rhoden,REP,1189
+Minnehaha,0317,Governor,,Tracey Quint and Ashley Strand,LIB,43
+Minnehaha,0402,Governor,,Jamie Smith and Jennifer Keintz,DEM,368
+Minnehaha,0402,Governor,,Kristi Noem and Larry Rhoden,REP,261
+Minnehaha,0402,Governor,,Tracey Quint and Ashley Strand,LIB,31
+Minnehaha,0403,Governor,,Jamie Smith and Jennifer Keintz,DEM,238
+Minnehaha,0403,Governor,,Kristi Noem and Larry Rhoden,REP,185
+Minnehaha,0403,Governor,,Tracey Quint and Ashley Strand,LIB,14
+Minnehaha,0404,Governor,,Jamie Smith and Jennifer Keintz,DEM,364
+Minnehaha,0404,Governor,,Kristi Noem and Larry Rhoden,REP,285
+Minnehaha,0404,Governor,,Tracey Quint and Ashley Strand,LIB,43
+Minnehaha,0405,Governor,,Jamie Smith and Jennifer Keintz,DEM,613
+Minnehaha,0405,Governor,,Kristi Noem and Larry Rhoden,REP,955
+Minnehaha,0405,Governor,,Tracey Quint and Ashley Strand,LIB,41
+Minnehaha,0406,Governor,,Jamie Smith and Jennifer Keintz,DEM,149
+Minnehaha,0406,Governor,,Kristi Noem and Larry Rhoden,REP,129
+Minnehaha,0406,Governor,,Tracey Quint and Ashley Strand,LIB,17
+Minnehaha,0407,Governor,,Jamie Smith and Jennifer Keintz,DEM,626
+Minnehaha,0407,Governor,,Kristi Noem and Larry Rhoden,REP,641
+Minnehaha,0407,Governor,,Tracey Quint and Ashley Strand,LIB,32
+Minnehaha,0408,Governor,,Jamie Smith and Jennifer Keintz,DEM,183
+Minnehaha,0408,Governor,,Kristi Noem and Larry Rhoden,REP,128
+Minnehaha,0408,Governor,,Tracey Quint and Ashley Strand,LIB,10
+Minnehaha,0409,Governor,,Jamie Smith and Jennifer Keintz,DEM,377
+Minnehaha,0409,Governor,,Kristi Noem and Larry Rhoden,REP,299
+Minnehaha,0409,Governor,,Tracey Quint and Ashley Strand,LIB,42
+Minnehaha,0410,Governor,,Jamie Smith and Jennifer Keintz,DEM,357
+Minnehaha,0410,Governor,,Kristi Noem and Larry Rhoden,REP,399
+Minnehaha,0410,Governor,,Tracey Quint and Ashley Strand,LIB,27
+Minnehaha,0411,Governor,,Jamie Smith and Jennifer Keintz,DEM,805
+Minnehaha,0411,Governor,,Kristi Noem and Larry Rhoden,REP,1135
+Minnehaha,0411,Governor,,Tracey Quint and Ashley Strand,LIB,42
+Minnehaha,0412,Governor,,Jamie Smith and Jennifer Keintz,DEM,599
+Minnehaha,0412,Governor,,Kristi Noem and Larry Rhoden,REP,576
+Minnehaha,0412,Governor,,Tracey Quint and Ashley Strand,LIB,32
+Minnehaha,0413,Governor,,Jamie Smith and Jennifer Keintz,DEM,347
+Minnehaha,0413,Governor,,Kristi Noem and Larry Rhoden,REP,283
+Minnehaha,0413,Governor,,Tracey Quint and Ashley Strand,LIB,17
+Minnehaha,0415,Governor,,Jamie Smith and Jennifer Keintz,DEM,897
+Minnehaha,0415,Governor,,Kristi Noem and Larry Rhoden,REP,1228
+Minnehaha,0415,Governor,,Tracey Quint and Ashley Strand,LIB,30
+Minnehaha,0501,Governor,,Jamie Smith and Jennifer Keintz,DEM,270
+Minnehaha,0501,Governor,,Kristi Noem and Larry Rhoden,REP,155
+Minnehaha,0501,Governor,,Tracey Quint and Ashley Strand,LIB,19
+Minnehaha,0502,Governor,,Jamie Smith and Jennifer Keintz,DEM,445
+Minnehaha,0502,Governor,,Kristi Noem and Larry Rhoden,REP,189
+Minnehaha,0502,Governor,,Tracey Quint and Ashley Strand,LIB,23
+Minnehaha,0503,Governor,,Jamie Smith and Jennifer Keintz,DEM,211
+Minnehaha,0503,Governor,,Kristi Noem and Larry Rhoden,REP,119
+Minnehaha,0503,Governor,,Tracey Quint and Ashley Strand,LIB,13
+Minnehaha,0504,Governor,,Jamie Smith and Jennifer Keintz,DEM,556
+Minnehaha,0504,Governor,,Kristi Noem and Larry Rhoden,REP,278
+Minnehaha,0504,Governor,,Tracey Quint and Ashley Strand,LIB,30
+Minnehaha,0506,Governor,,Jamie Smith and Jennifer Keintz,DEM,547
+Minnehaha,0506,Governor,,Kristi Noem and Larry Rhoden,REP,359
+Minnehaha,0506,Governor,,Tracey Quint and Ashley Strand,LIB,36
+Minnehaha,0507,Governor,,Jamie Smith and Jennifer Keintz,DEM,359
+Minnehaha,0507,Governor,,Kristi Noem and Larry Rhoden,REP,203
+Minnehaha,0507,Governor,,Tracey Quint and Ashley Strand,LIB,12
+Minnehaha,0508,Governor,,Jamie Smith and Jennifer Keintz,DEM,595
+Minnehaha,0508,Governor,,Kristi Noem and Larry Rhoden,REP,308
+Minnehaha,0508,Governor,,Tracey Quint and Ashley Strand,LIB,16
+Minnehaha,0509,Governor,,Jamie Smith and Jennifer Keintz,DEM,260
+Minnehaha,0509,Governor,,Kristi Noem and Larry Rhoden,REP,118
+Minnehaha,0509,Governor,,Tracey Quint and Ashley Strand,LIB,11
+Minnehaha,0510,Governor,,Jamie Smith and Jennifer Keintz,DEM,304
+Minnehaha,0510,Governor,,Kristi Noem and Larry Rhoden,REP,226
+Minnehaha,0510,Governor,,Tracey Quint and Ashley Strand,LIB,13
+Minnehaha,0512,Governor,,Jamie Smith and Jennifer Keintz,DEM,364
+Minnehaha,0512,Governor,,Kristi Noem and Larry Rhoden,REP,252
+Minnehaha,0512,Governor,,Tracey Quint and Ashley Strand,LIB,19
+Minnehaha,0513,Governor,,Jamie Smith and Jennifer Keintz,DEM,390
+Minnehaha,0513,Governor,,Kristi Noem and Larry Rhoden,REP,253
+Minnehaha,0513,Governor,,Tracey Quint and Ashley Strand,LIB,8
+Minnehaha,0514,Governor,,Jamie Smith and Jennifer Keintz,DEM,460
+Minnehaha,0514,Governor,,Kristi Noem and Larry Rhoden,REP,281
+Minnehaha,0514,Governor,,Tracey Quint and Ashley Strand,LIB,28
+Minnehaha,0515,Governor,,Jamie Smith and Jennifer Keintz,DEM,364
+Minnehaha,0515,Governor,,Kristi Noem and Larry Rhoden,REP,397
+Minnehaha,0515,Governor,,Tracey Quint and Ashley Strand,LIB,27
+Minnehaha,0517,Governor,,Jamie Smith and Jennifer Keintz,DEM,262
+Minnehaha,0517,Governor,,Kristi Noem and Larry Rhoden,REP,256
+Minnehaha,0517,Governor,,Tracey Quint and Ashley Strand,LIB,13
+Minnehaha,0518,Governor,,Jamie Smith and Jennifer Keintz,DEM,615
+Minnehaha,0518,Governor,,Kristi Noem and Larry Rhoden,REP,364
+Minnehaha,0518,Governor,,Tracey Quint and Ashley Strand,LIB,47
+Minnehaha,0519,Governor,,Jamie Smith and Jennifer Keintz,DEM,270
+Minnehaha,0519,Governor,,Kristi Noem and Larry Rhoden,REP,246
+Minnehaha,0519,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Minnehaha,0520,Governor,,Jamie Smith and Jennifer Keintz,DEM,432
+Minnehaha,0520,Governor,,Kristi Noem and Larry Rhoden,REP,373
+Minnehaha,0520,Governor,,Tracey Quint and Ashley Strand,LIB,39
+Minnehaha,0521,Governor,,Jamie Smith and Jennifer Keintz,DEM,247
+Minnehaha,0521,Governor,,Kristi Noem and Larry Rhoden,REP,169
+Minnehaha,0521,Governor,,Tracey Quint and Ashley Strand,LIB,9
+Minnehaha,0522,Governor,,Jamie Smith and Jennifer Keintz,DEM,467
+Minnehaha,0522,Governor,,Kristi Noem and Larry Rhoden,REP,309
+Minnehaha,0522,Governor,,Tracey Quint and Ashley Strand,LIB,40
+Minnehaha,0523,Governor,,Jamie Smith and Jennifer Keintz,DEM,391
+Minnehaha,0523,Governor,,Kristi Noem and Larry Rhoden,REP,220
+Minnehaha,0523,Governor,,Tracey Quint and Ashley Strand,LIB,28
+Minnehaha,VP01,Governor,,Jamie Smith and Jennifer Keintz,DEM,171
+Minnehaha,VP01,Governor,,Kristi Noem and Larry Rhoden,REP,546
+Minnehaha,VP01,Governor,,Tracey Quint and Ashley Strand,LIB,29
+Minnehaha,VP02,Governor,,Jamie Smith and Jennifer Keintz,DEM,546
+Minnehaha,VP02,Governor,,Kristi Noem and Larry Rhoden,REP,1124
+Minnehaha,VP02,Governor,,Tracey Quint and Ashley Strand,LIB,36
+Minnehaha,VP03,Governor,,Jamie Smith and Jennifer Keintz,DEM,640
+Minnehaha,VP03,Governor,,Kristi Noem and Larry Rhoden,REP,1349
+Minnehaha,VP03,Governor,,Tracey Quint and Ashley Strand,LIB,48
+Minnehaha,VP04,Governor,,Jamie Smith and Jennifer Keintz,DEM,350
+Minnehaha,VP04,Governor,,Kristi Noem and Larry Rhoden,REP,689
+Minnehaha,VP04,Governor,,Tracey Quint and Ashley Strand,LIB,30
+Minnehaha,VP05,Governor,,Jamie Smith and Jennifer Keintz,DEM,459
+Minnehaha,VP05,Governor,,Kristi Noem and Larry Rhoden,REP,902
+Minnehaha,VP05,Governor,,Tracey Quint and Ashley Strand,LIB,30
+Minnehaha,VP06,Governor,,Jamie Smith and Jennifer Keintz,DEM,138
+Minnehaha,VP06,Governor,,Kristi Noem and Larry Rhoden,REP,283
+Minnehaha,VP06,Governor,,Tracey Quint and Ashley Strand,LIB,11
+Minnehaha,VP07,Governor,,Jamie Smith and Jennifer Keintz,DEM,504
+Minnehaha,VP07,Governor,,Kristi Noem and Larry Rhoden,REP,1111
+Minnehaha,VP07,Governor,,Tracey Quint and Ashley Strand,LIB,48
+Minnehaha,VP08,Governor,,Jamie Smith and Jennifer Keintz,DEM,163
+Minnehaha,VP08,Governor,,Kristi Noem and Larry Rhoden,REP,461
+Minnehaha,VP08,Governor,,Tracey Quint and Ashley Strand,LIB,18
+Minnehaha,VP09,Governor,,Jamie Smith and Jennifer Keintz,DEM,396
+Minnehaha,VP09,Governor,,Kristi Noem and Larry Rhoden,REP,852
+Minnehaha,VP09,Governor,,Tracey Quint and Ashley Strand,LIB,25
+Minnehaha,VP10,Governor,,Jamie Smith and Jennifer Keintz,DEM,380
+Minnehaha,VP10,Governor,,Kristi Noem and Larry Rhoden,REP,730
+Minnehaha,VP10,Governor,,Tracey Quint and Ashley Strand,LIB,34
+Minnehaha,VP11,Governor,,Jamie Smith and Jennifer Keintz,DEM,77
+Minnehaha,VP11,Governor,,Kristi Noem and Larry Rhoden,REP,216
+Minnehaha,VP11,Governor,,Tracey Quint and Ashley Strand,LIB,6
+Minnehaha,VP12,Governor,,Jamie Smith and Jennifer Keintz,DEM,30
+Minnehaha,VP12,Governor,,Kristi Noem and Larry Rhoden,REP,94
+Minnehaha,VP12,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Minnehaha,VP13,Governor,,Jamie Smith and Jennifer Keintz,DEM,204
+Minnehaha,VP13,Governor,,Kristi Noem and Larry Rhoden,REP,647
+Minnehaha,VP13,Governor,,Tracey Quint and Ashley Strand,LIB,42
+Minnehaha,VP15,Governor,,Jamie Smith and Jennifer Keintz,DEM,508
+Minnehaha,VP15,Governor,,Kristi Noem and Larry Rhoden,REP,960
+Minnehaha,VP15,Governor,,Tracey Quint and Ashley Strand,LIB,29
+Minnehaha,VP16,Governor,,Jamie Smith and Jennifer Keintz,DEM,318
+Minnehaha,VP16,Governor,,Kristi Noem and Larry Rhoden,REP,701
+Minnehaha,VP16,Governor,,Tracey Quint and Ashley Strand,LIB,29
+Minnehaha,VP17,Governor,,Jamie Smith and Jennifer Keintz,DEM,173
+Minnehaha,VP17,Governor,,Kristi Noem and Larry Rhoden,REP,447
+Minnehaha,VP17,Governor,,Tracey Quint and Ashley Strand,LIB,20
+Minnehaha,VP21,Governor,,Jamie Smith and Jennifer Keintz,DEM,522
+Minnehaha,VP21,Governor,,Kristi Noem and Larry Rhoden,REP,1066
+Minnehaha,VP21,Governor,,Tracey Quint and Ashley Strand,LIB,43
+Minnehaha,0104,Initiated Measure 27,,No,,306
+Minnehaha,0104,Initiated Measure 27,,Yes,,421
+Minnehaha,0105,Initiated Measure 27,,No,,210
+Minnehaha,0105,Initiated Measure 27,,Yes,,247
+Minnehaha,0106,Initiated Measure 27,,No,,519
+Minnehaha,0106,Initiated Measure 27,,Yes,,577
+Minnehaha,0109,Initiated Measure 27,,No,,498
+Minnehaha,0109,Initiated Measure 27,,Yes,,579
+Minnehaha,0110,Initiated Measure 27,,No,,490
+Minnehaha,0110,Initiated Measure 27,,Yes,,696
+Minnehaha,0117,Initiated Measure 27,,No,,589
+Minnehaha,0117,Initiated Measure 27,,Yes,,754
+Minnehaha,0119,Initiated Measure 27,,No,,204
+Minnehaha,0119,Initiated Measure 27,,Yes,,415
+Minnehaha,0201,Initiated Measure 27,,No,,558
+Minnehaha,0201,Initiated Measure 27,,Yes,,557
+Minnehaha,0202,Initiated Measure 27,,No,,711
+Minnehaha,0202,Initiated Measure 27,,Yes,,750
+Minnehaha,0203,Initiated Measure 27,,No,,508
+Minnehaha,0203,Initiated Measure 27,,Yes,,606
+Minnehaha,0206,Initiated Measure 27,,No,,542
+Minnehaha,0206,Initiated Measure 27,,Yes,,620
+Minnehaha,0208,Initiated Measure 27,,No,,636
+Minnehaha,0208,Initiated Measure 27,,Yes,,540
+Minnehaha,0209,Initiated Measure 27,,No,,494
+Minnehaha,0209,Initiated Measure 27,,Yes,,580
+Minnehaha,0214,Initiated Measure 27,,No,,1425
+Minnehaha,0214,Initiated Measure 27,,Yes,,1471
+Minnehaha,0301,Initiated Measure 27,,No,,379
+Minnehaha,0301,Initiated Measure 27,,Yes,,410
+Minnehaha,0305,Initiated Measure 27,,No,,186
+Minnehaha,0305,Initiated Measure 27,,Yes,,353
+Minnehaha,0309,Initiated Measure 27,,No,,384
+Minnehaha,0309,Initiated Measure 27,,Yes,,758
+Minnehaha,0310,Initiated Measure 27,,No,,770
+Minnehaha,0310,Initiated Measure 27,,Yes,,693
+Minnehaha,0311,Initiated Measure 27,,No,,500
+Minnehaha,0311,Initiated Measure 27,,Yes,,435
+Minnehaha,0312,Initiated Measure 27,,No,,525
+Minnehaha,0312,Initiated Measure 27,,Yes,,694
+Minnehaha,0313,Initiated Measure 27,,No,,349
+Minnehaha,0313,Initiated Measure 27,,Yes,,395
+Minnehaha,0314,Initiated Measure 27,,No,,718
+Minnehaha,0314,Initiated Measure 27,,Yes,,1088
+Minnehaha,0315,Initiated Measure 27,,No,,510
+Minnehaha,0315,Initiated Measure 27,,Yes,,608
+Minnehaha,0316,Initiated Measure 27,,No,,816
+Minnehaha,0316,Initiated Measure 27,,Yes,,971
+Minnehaha,0317,Initiated Measure 27,,No,,946
+Minnehaha,0317,Initiated Measure 27,,Yes,,1179
+Minnehaha,0402,Initiated Measure 27,,No,,219
+Minnehaha,0402,Initiated Measure 27,,Yes,,443
+Minnehaha,0403,Initiated Measure 27,,No,,134
+Minnehaha,0403,Initiated Measure 27,,Yes,,304
+Minnehaha,0404,Initiated Measure 27,,No,,197
+Minnehaha,0404,Initiated Measure 27,,Yes,,499
+Minnehaha,0405,Initiated Measure 27,,No,,610
+Minnehaha,0405,Initiated Measure 27,,Yes,,946
+Minnehaha,0406,Initiated Measure 27,,No,,101
+Minnehaha,0406,Initiated Measure 27,,Yes,,189
+Minnehaha,0407,Initiated Measure 27,,No,,589
+Minnehaha,0407,Initiated Measure 27,,Yes,,691
+Minnehaha,0408,Initiated Measure 27,,No,,107
+Minnehaha,0408,Initiated Measure 27,,Yes,,211
+Minnehaha,0409,Initiated Measure 27,,No,,224
+Minnehaha,0409,Initiated Measure 27,,Yes,,497
+Minnehaha,0410,Initiated Measure 27,,No,,341
+Minnehaha,0410,Initiated Measure 27,,Yes,,443
+Minnehaha,0411,Initiated Measure 27,,No,,976
+Minnehaha,0411,Initiated Measure 27,,Yes,,1015
+Minnehaha,0412,Initiated Measure 27,,No,,502
+Minnehaha,0412,Initiated Measure 27,,Yes,,704
+Minnehaha,0413,Initiated Measure 27,,No,,249
+Minnehaha,0413,Initiated Measure 27,,Yes,,389
+Minnehaha,0415,Initiated Measure 27,,No,,1115
+Minnehaha,0415,Initiated Measure 27,,Yes,,1030
+Minnehaha,0501,Initiated Measure 27,,No,,114
+Minnehaha,0501,Initiated Measure 27,,Yes,,327
+Minnehaha,0502,Initiated Measure 27,,No,,169
+Minnehaha,0502,Initiated Measure 27,,Yes,,484
+Minnehaha,0503,Initiated Measure 27,,No,,89
+Minnehaha,0503,Initiated Measure 27,,Yes,,256
+Minnehaha,0504,Initiated Measure 27,,No,,259
+Minnehaha,0504,Initiated Measure 27,,Yes,,597
+Minnehaha,0506,Initiated Measure 27,,No,,330
+Minnehaha,0506,Initiated Measure 27,,Yes,,602
+Minnehaha,0507,Initiated Measure 27,,No,,200
+Minnehaha,0507,Initiated Measure 27,,Yes,,372
+Minnehaha,0508,Initiated Measure 27,,No,,330
+Minnehaha,0508,Initiated Measure 27,,Yes,,589
+Minnehaha,0509,Initiated Measure 27,,No,,96
+Minnehaha,0509,Initiated Measure 27,,Yes,,291
+Minnehaha,0510,Initiated Measure 27,,No,,189
+Minnehaha,0510,Initiated Measure 27,,Yes,,355
+Minnehaha,0512,Initiated Measure 27,,No,,225
+Minnehaha,0512,Initiated Measure 27,,Yes,,408
+Minnehaha,0513,Initiated Measure 27,,No,,227
+Minnehaha,0513,Initiated Measure 27,,Yes,,419
+Minnehaha,0514,Initiated Measure 27,,No,,245
+Minnehaha,0514,Initiated Measure 27,,Yes,,519
+Minnehaha,0515,Initiated Measure 27,,No,,267
+Minnehaha,0515,Initiated Measure 27,,Yes,,508
+Minnehaha,0517,Initiated Measure 27,,No,,248
+Minnehaha,0517,Initiated Measure 27,,Yes,,282
+Minnehaha,0518,Initiated Measure 27,,No,,348
+Minnehaha,0518,Initiated Measure 27,,Yes,,673
+Minnehaha,0519,Initiated Measure 27,,No,,226
+Minnehaha,0519,Initiated Measure 27,,Yes,,292
+Minnehaha,0520,Initiated Measure 27,,No,,310
+Minnehaha,0520,Initiated Measure 27,,Yes,,534
+Minnehaha,0521,Initiated Measure 27,,No,,150
+Minnehaha,0521,Initiated Measure 27,,Yes,,269
+Minnehaha,0522,Initiated Measure 27,,No,,215
+Minnehaha,0522,Initiated Measure 27,,Yes,,598
+Minnehaha,0523,Initiated Measure 27,,No,,174
+Minnehaha,0523,Initiated Measure 27,,Yes,,462
+Minnehaha,VP01,Initiated Measure 27,,No,,417
+Minnehaha,VP01,Initiated Measure 27,,Yes,,327
+Minnehaha,VP02,Initiated Measure 27,,No,,1046
+Minnehaha,VP02,Initiated Measure 27,,Yes,,662
+Minnehaha,VP03,Initiated Measure 27,,No,,1079
+Minnehaha,VP03,Initiated Measure 27,,Yes,,953
+Minnehaha,VP04,Initiated Measure 27,,No,,560
+Minnehaha,VP04,Initiated Measure 27,,Yes,,507
+Minnehaha,VP05,Initiated Measure 27,,No,,733
+Minnehaha,VP05,Initiated Measure 27,,Yes,,668
+Minnehaha,VP06,Initiated Measure 27,,No,,239
+Minnehaha,VP06,Initiated Measure 27,,Yes,,199
+Minnehaha,VP07,Initiated Measure 27,,No,,932
+Minnehaha,VP07,Initiated Measure 27,,Yes,,732
+Minnehaha,VP08,Initiated Measure 27,,No,,376
+Minnehaha,VP08,Initiated Measure 27,,Yes,,264
+Minnehaha,VP09,Initiated Measure 27,,No,,648
+Minnehaha,VP09,Initiated Measure 27,,Yes,,615
+Minnehaha,VP10,Initiated Measure 27,,No,,595
+Minnehaha,VP10,Initiated Measure 27,,Yes,,540
+Minnehaha,VP11,Initiated Measure 27,,No,,196
+Minnehaha,VP11,Initiated Measure 27,,Yes,,101
+Minnehaha,VP12,Initiated Measure 27,,No,,79
+Minnehaha,VP12,Initiated Measure 27,,Yes,,45
+Minnehaha,VP13,Initiated Measure 27,,No,,554
+Minnehaha,VP13,Initiated Measure 27,,Yes,,335
+Minnehaha,VP15,Initiated Measure 27,,No,,793
+Minnehaha,VP15,Initiated Measure 27,,Yes,,700
+Minnehaha,VP16,Initiated Measure 27,,No,,558
+Minnehaha,VP16,Initiated Measure 27,,Yes,,489
+Minnehaha,VP17,Initiated Measure 27,,No,,397
+Minnehaha,VP17,Initiated Measure 27,,Yes,,236
+Minnehaha,VP21,Initiated Measure 27,,No,,898
+Minnehaha,VP21,Initiated Measure 27,,Yes,,728
 Minnehaha,0104,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,365
 Minnehaha,0105,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,226
 Minnehaha,0106,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,583
@@ -2474,612 +1724,903 @@ Minnehaha,VP15,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Ra
 Minnehaha,VP16,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,385
 Minnehaha,VP17,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,262
 Minnehaha,VP21,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,659
-Minnehaha,0104,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,427
-Minnehaha,0104,Supreme Court Retention,3,Patricia J. DeVaney - No,,150
-Minnehaha,0105,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,289
-Minnehaha,0105,Supreme Court Retention,3,Patricia J. DeVaney - No,,93
-Minnehaha,0106,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,670
-Minnehaha,0106,Supreme Court Retention,3,Patricia J. DeVaney - No,,207
-Minnehaha,0109,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,707
-Minnehaha,0109,Supreme Court Retention,3,Patricia J. DeVaney - No,,167
-Minnehaha,0110,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,730
-Minnehaha,0110,Supreme Court Retention,3,Patricia J. DeVaney - No,,209
-Minnehaha,0117,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,796
-Minnehaha,0117,Supreme Court Retention,3,Patricia J. DeVaney - No,,246
-Minnehaha,0119,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,359
-Minnehaha,0119,Supreme Court Retention,3,Patricia J. DeVaney - No,,131
-Minnehaha,0201,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,736
-Minnehaha,0201,Supreme Court Retention,3,Patricia J. DeVaney - No,,164
-Minnehaha,0202,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1010
-Minnehaha,0202,Supreme Court Retention,3,Patricia J. DeVaney - No,,175
-Minnehaha,0203,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,715
-Minnehaha,0203,Supreme Court Retention,3,Patricia J. DeVaney - No,,202
-Minnehaha,0206,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,744
-Minnehaha,0206,Supreme Court Retention,3,Patricia J. DeVaney - No,,152
-Minnehaha,0208,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,785
-Minnehaha,0208,Supreme Court Retention,3,Patricia J. DeVaney - No,,150
-Minnehaha,0209,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,686
-Minnehaha,0209,Supreme Court Retention,3,Patricia J. DeVaney - No,,181
-Minnehaha,0214,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1926
-Minnehaha,0214,Supreme Court Retention,3,Patricia J. DeVaney - No,,389
-Minnehaha,0301,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,536
-Minnehaha,0301,Supreme Court Retention,3,Patricia J. DeVaney - No,,119
-Minnehaha,0305,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,331
-Minnehaha,0305,Supreme Court Retention,3,Patricia J. DeVaney - No,,97
-Minnehaha,0309,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,688
-Minnehaha,0309,Supreme Court Retention,3,Patricia J. DeVaney - No,,255
-Minnehaha,0310,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1007
-Minnehaha,0310,Supreme Court Retention,3,Patricia J. DeVaney - No,,201
-Minnehaha,0311,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,606
-Minnehaha,0311,Supreme Court Retention,3,Patricia J. DeVaney - No,,137
-Minnehaha,0312,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,783
-Minnehaha,0312,Supreme Court Retention,3,Patricia J. DeVaney - No,,203
-Minnehaha,0313,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,469
-Minnehaha,0313,Supreme Court Retention,3,Patricia J. DeVaney - No,,138
-Minnehaha,0314,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1103
-Minnehaha,0314,Supreme Court Retention,3,Patricia J. DeVaney - No,,372
-Minnehaha,0315,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,721
-Minnehaha,0315,Supreme Court Retention,3,Patricia J. DeVaney - No,,176
-Minnehaha,0316,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1129
-Minnehaha,0316,Supreme Court Retention,3,Patricia J. DeVaney - No,,283
-Minnehaha,0317,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1365
-Minnehaha,0317,Supreme Court Retention,3,Patricia J. DeVaney - No,,332
-Minnehaha,0402,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,382
-Minnehaha,0402,Supreme Court Retention,3,Patricia J. DeVaney - No,,150
-Minnehaha,0403,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,244
-Minnehaha,0403,Supreme Court Retention,3,Patricia J. DeVaney - No,,114
-Minnehaha,0404,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,411
-Minnehaha,0404,Supreme Court Retention,3,Patricia J. DeVaney - No,,164
-Minnehaha,0405,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,899
-Minnehaha,0405,Supreme Court Retention,3,Patricia J. DeVaney - No,,357
-Minnehaha,0406,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,183
-Minnehaha,0406,Supreme Court Retention,3,Patricia J. DeVaney - No,,73
-Minnehaha,0407,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,828
-Minnehaha,0407,Supreme Court Retention,3,Patricia J. DeVaney - No,,195
-Minnehaha,0408,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,200
-Minnehaha,0408,Supreme Court Retention,3,Patricia J. DeVaney - No,,68
-Minnehaha,0409,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,435
-Minnehaha,0409,Supreme Court Retention,3,Patricia J. DeVaney - No,,143
-Minnehaha,0410,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,495
-Minnehaha,0410,Supreme Court Retention,3,Patricia J. DeVaney - No,,149
-Minnehaha,0411,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1301
-Minnehaha,0411,Supreme Court Retention,3,Patricia J. DeVaney - No,,280
-Minnehaha,0412,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,738
-Minnehaha,0412,Supreme Court Retention,3,Patricia J. DeVaney - No,,234
-Minnehaha,0413,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,393
-Minnehaha,0413,Supreme Court Retention,3,Patricia J. DeVaney - No,,128
-Minnehaha,0415,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1397
-Minnehaha,0415,Supreme Court Retention,3,Patricia J. DeVaney - No,,325
-Minnehaha,0501,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,241
-Minnehaha,0501,Supreme Court Retention,3,Patricia J. DeVaney - No,,118
-Minnehaha,0502,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,359
-Minnehaha,0502,Supreme Court Retention,3,Patricia J. DeVaney - No,,148
-Minnehaha,0503,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,181
-Minnehaha,0503,Supreme Court Retention,3,Patricia J. DeVaney - No,,96
-Minnehaha,0504,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,512
-Minnehaha,0504,Supreme Court Retention,3,Patricia J. DeVaney - No,,159
-Minnehaha,0506,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,545
-Minnehaha,0506,Supreme Court Retention,3,Patricia J. DeVaney - No,,215
-Minnehaha,0507,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,351
-Minnehaha,0507,Supreme Court Retention,3,Patricia J. DeVaney - No,,93
-Minnehaha,0508,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,558
-Minnehaha,0508,Supreme Court Retention,3,Patricia J. DeVaney - No,,163
-Minnehaha,0509,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,217
-Minnehaha,0509,Supreme Court Retention,3,Patricia J. DeVaney - No,,87
-Minnehaha,0510,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,333
-Minnehaha,0510,Supreme Court Retention,3,Patricia J. DeVaney - No,,103
-Minnehaha,0512,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,392
-Minnehaha,0512,Supreme Court Retention,3,Patricia J. DeVaney - No,,101
-Minnehaha,0513,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,392
-Minnehaha,0513,Supreme Court Retention,3,Patricia J. DeVaney - No,,106
-Minnehaha,0514,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,428
-Minnehaha,0514,Supreme Court Retention,3,Patricia J. DeVaney - No,,169
-Minnehaha,0515,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,439
-Minnehaha,0515,Supreme Court Retention,3,Patricia J. DeVaney - No,,189
-Minnehaha,0517,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,362
-Minnehaha,0517,Supreme Court Retention,3,Patricia J. DeVaney - No,,79
-Minnehaha,0518,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,586
-Minnehaha,0518,Supreme Court Retention,3,Patricia J. DeVaney - No,,231
-Minnehaha,0519,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,310
-Minnehaha,0519,Supreme Court Retention,3,Patricia J. DeVaney - No,,74
-Minnehaha,0520,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,486
-Minnehaha,0520,Supreme Court Retention,3,Patricia J. DeVaney - No,,181
-Minnehaha,0521,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,267
-Minnehaha,0521,Supreme Court Retention,3,Patricia J. DeVaney - No,,69
-Minnehaha,0522,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,442
-Minnehaha,0522,Supreme Court Retention,3,Patricia J. DeVaney - No,,222
-Minnehaha,0523,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,383
-Minnehaha,0523,Supreme Court Retention,3,Patricia J. DeVaney - No,,145
-Minnehaha,VP01,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,495
-Minnehaha,VP01,Supreme Court Retention,3,Patricia J. DeVaney - No,,112
-Minnehaha,VP02,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1154
-Minnehaha,VP02,Supreme Court Retention,3,Patricia J. DeVaney - No,,221
-Minnehaha,VP03,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1379
-Minnehaha,VP03,Supreme Court Retention,3,Patricia J. DeVaney - No,,291
-Minnehaha,VP04,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,703
-Minnehaha,VP04,Supreme Court Retention,3,Patricia J. DeVaney - No,,176
-Minnehaha,VP05,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,923
-Minnehaha,VP05,Supreme Court Retention,3,Patricia J. DeVaney - No,,197
-Minnehaha,VP06,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,282
-Minnehaha,VP06,Supreme Court Retention,3,Patricia J. DeVaney - No,,58
-Minnehaha,VP07,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1167
-Minnehaha,VP07,Supreme Court Retention,3,Patricia J. DeVaney - No,,226
-Minnehaha,VP08,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,420
-Minnehaha,VP08,Supreme Court Retention,3,Patricia J. DeVaney - No,,82
-Minnehaha,VP09,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,847
-Minnehaha,VP09,Supreme Court Retention,3,Patricia J. DeVaney - No,,174
-Minnehaha,VP10,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,766
-Minnehaha,VP10,Supreme Court Retention,3,Patricia J. DeVaney - No,,167
-Minnehaha,VP11,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,201
-Minnehaha,VP11,Supreme Court Retention,3,Patricia J. DeVaney - No,,43
-Minnehaha,VP12,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,101
-Minnehaha,VP12,Supreme Court Retention,3,Patricia J. DeVaney - No,,6
-Minnehaha,VP13,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,586
-Minnehaha,VP13,Supreme Court Retention,3,Patricia J. DeVaney - No,,135
-Minnehaha,VP15,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1017
-Minnehaha,VP15,Supreme Court Retention,3,Patricia J. DeVaney - No,,194
-Minnehaha,VP16,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,666
-Minnehaha,VP16,Supreme Court Retention,3,Patricia J. DeVaney - No,,142
-Minnehaha,VP17,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,428
-Minnehaha,VP17,Supreme Court Retention,3,Patricia J. DeVaney - No,,85
-Minnehaha,VP21,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1156
-Minnehaha,VP21,Supreme Court Retention,3,Patricia J. DeVaney - No,,212
-Minnehaha,0104,Supreme Court Retention,2,Mark E. Salter - Yes,,423
-Minnehaha,0104,Supreme Court Retention,2,Mark E. Salter - No,,148
-Minnehaha,0105,Supreme Court Retention,2,Mark E. Salter - Yes,,289
-Minnehaha,0105,Supreme Court Retention,2,Mark E. Salter - No,,88
-Minnehaha,0106,Supreme Court Retention,2,Mark E. Salter - Yes,,653
-Minnehaha,0106,Supreme Court Retention,2,Mark E. Salter - No,,217
-Minnehaha,0109,Supreme Court Retention,2,Mark E. Salter - Yes,,703
-Minnehaha,0109,Supreme Court Retention,2,Mark E. Salter - No,,174
-Minnehaha,0110,Supreme Court Retention,2,Mark E. Salter - Yes,,723
-Minnehaha,0110,Supreme Court Retention,2,Mark E. Salter - No,,216
-Minnehaha,0117,Supreme Court Retention,2,Mark E. Salter - Yes,,793
-Minnehaha,0117,Supreme Court Retention,2,Mark E. Salter - No,,241
-Minnehaha,0119,Supreme Court Retention,2,Mark E. Salter - Yes,,349
-Minnehaha,0119,Supreme Court Retention,2,Mark E. Salter - No,,140
-Minnehaha,0201,Supreme Court Retention,2,Mark E. Salter - Yes,,743
-Minnehaha,0201,Supreme Court Retention,2,Mark E. Salter - No,,162
-Minnehaha,0202,Supreme Court Retention,2,Mark E. Salter - Yes,,1037
-Minnehaha,0202,Supreme Court Retention,2,Mark E. Salter - No,,159
-Minnehaha,0203,Supreme Court Retention,2,Mark E. Salter - Yes,,733
-Minnehaha,0203,Supreme Court Retention,2,Mark E. Salter - No,,192
-Minnehaha,0206,Supreme Court Retention,2,Mark E. Salter - Yes,,732
-Minnehaha,0206,Supreme Court Retention,2,Mark E. Salter - No,,162
-Minnehaha,0208,Supreme Court Retention,2,Mark E. Salter - Yes,,794
-Minnehaha,0208,Supreme Court Retention,2,Mark E. Salter - No,,142
-Minnehaha,0209,Supreme Court Retention,2,Mark E. Salter - Yes,,687
-Minnehaha,0209,Supreme Court Retention,2,Mark E. Salter - No,,178
-Minnehaha,0214,Supreme Court Retention,2,Mark E. Salter - Yes,,1931
-Minnehaha,0214,Supreme Court Retention,2,Mark E. Salter - No,,387
-Minnehaha,0301,Supreme Court Retention,2,Mark E. Salter - Yes,,541
-Minnehaha,0301,Supreme Court Retention,2,Mark E. Salter - No,,111
-Minnehaha,0305,Supreme Court Retention,2,Mark E. Salter - Yes,,326
-Minnehaha,0305,Supreme Court Retention,2,Mark E. Salter - No,,105
-Minnehaha,0309,Supreme Court Retention,2,Mark E. Salter - Yes,,664
-Minnehaha,0309,Supreme Court Retention,2,Mark E. Salter - No,,264
-Minnehaha,0310,Supreme Court Retention,2,Mark E. Salter - Yes,,1016
-Minnehaha,0310,Supreme Court Retention,2,Mark E. Salter - No,,200
-Minnehaha,0311,Supreme Court Retention,2,Mark E. Salter - Yes,,606
-Minnehaha,0311,Supreme Court Retention,2,Mark E. Salter - No,,138
-Minnehaha,0312,Supreme Court Retention,2,Mark E. Salter - Yes,,773
-Minnehaha,0312,Supreme Court Retention,2,Mark E. Salter - No,,210
-Minnehaha,0313,Supreme Court Retention,2,Mark E. Salter - Yes,,471
-Minnehaha,0313,Supreme Court Retention,2,Mark E. Salter - No,,136
-Minnehaha,0314,Supreme Court Retention,2,Mark E. Salter - Yes,,1093
-Minnehaha,0314,Supreme Court Retention,2,Mark E. Salter - No,,373
-Minnehaha,0315,Supreme Court Retention,2,Mark E. Salter - Yes,,722
-Minnehaha,0315,Supreme Court Retention,2,Mark E. Salter - No,,181
-Minnehaha,0316,Supreme Court Retention,2,Mark E. Salter - Yes,,1124
-Minnehaha,0316,Supreme Court Retention,2,Mark E. Salter - No,,288
-Minnehaha,0317,Supreme Court Retention,2,Mark E. Salter - Yes,,1376
-Minnehaha,0317,Supreme Court Retention,2,Mark E. Salter - No,,331
-Minnehaha,0402,Supreme Court Retention,2,Mark E. Salter - Yes,,383
-Minnehaha,0402,Supreme Court Retention,2,Mark E. Salter - No,,153
-Minnehaha,0403,Supreme Court Retention,2,Mark E. Salter - Yes,,241
-Minnehaha,0403,Supreme Court Retention,2,Mark E. Salter - No,,113
-Minnehaha,0404,Supreme Court Retention,2,Mark E. Salter - Yes,,393
-Minnehaha,0404,Supreme Court Retention,2,Mark E. Salter - No,,169
-Minnehaha,0405,Supreme Court Retention,2,Mark E. Salter - Yes,,928
-Minnehaha,0405,Supreme Court Retention,2,Mark E. Salter - No,,319
-Minnehaha,0406,Supreme Court Retention,2,Mark E. Salter - Yes,,174
-Minnehaha,0406,Supreme Court Retention,2,Mark E. Salter - No,,78
-Minnehaha,0407,Supreme Court Retention,2,Mark E. Salter - Yes,,816
-Minnehaha,0407,Supreme Court Retention,2,Mark E. Salter - No,,210
-Minnehaha,0408,Supreme Court Retention,2,Mark E. Salter - Yes,,201
-Minnehaha,0408,Supreme Court Retention,2,Mark E. Salter - No,,63
-Minnehaha,0409,Supreme Court Retention,2,Mark E. Salter - Yes,,423
-Minnehaha,0409,Supreme Court Retention,2,Mark E. Salter - No,,156
-Minnehaha,0410,Supreme Court Retention,2,Mark E. Salter - Yes,,476
-Minnehaha,0410,Supreme Court Retention,2,Mark E. Salter - No,,158
-Minnehaha,0411,Supreme Court Retention,2,Mark E. Salter - Yes,,1295
-Minnehaha,0411,Supreme Court Retention,2,Mark E. Salter - No,,275
-Minnehaha,0412,Supreme Court Retention,2,Mark E. Salter - Yes,,721
-Minnehaha,0412,Supreme Court Retention,2,Mark E. Salter - No,,236
-Minnehaha,0413,Supreme Court Retention,2,Mark E. Salter - Yes,,389
-Minnehaha,0413,Supreme Court Retention,2,Mark E. Salter - No,,128
-Minnehaha,0415,Supreme Court Retention,2,Mark E. Salter - Yes,,1409
-Minnehaha,0415,Supreme Court Retention,2,Mark E. Salter - No,,315
-Minnehaha,0501,Supreme Court Retention,2,Mark E. Salter - Yes,,237
-Minnehaha,0501,Supreme Court Retention,2,Mark E. Salter - No,,123
-Minnehaha,0502,Supreme Court Retention,2,Mark E. Salter - Yes,,342
-Minnehaha,0502,Supreme Court Retention,2,Mark E. Salter - No,,159
-Minnehaha,0503,Supreme Court Retention,2,Mark E. Salter - Yes,,175
-Minnehaha,0503,Supreme Court Retention,2,Mark E. Salter - No,,100
-Minnehaha,0504,Supreme Court Retention,2,Mark E. Salter - Yes,,490
-Minnehaha,0504,Supreme Court Retention,2,Mark E. Salter - No,,175
-Minnehaha,0506,Supreme Court Retention,2,Mark E. Salter - Yes,,552
-Minnehaha,0506,Supreme Court Retention,2,Mark E. Salter - No,,202
-Minnehaha,0507,Supreme Court Retention,2,Mark E. Salter - Yes,,349
-Minnehaha,0507,Supreme Court Retention,2,Mark E. Salter - No,,96
-Minnehaha,0508,Supreme Court Retention,2,Mark E. Salter - Yes,,550
-Minnehaha,0508,Supreme Court Retention,2,Mark E. Salter - No,,158
-Minnehaha,0509,Supreme Court Retention,2,Mark E. Salter - Yes,,207
-Minnehaha,0509,Supreme Court Retention,2,Mark E. Salter - No,,94
-Minnehaha,0510,Supreme Court Retention,2,Mark E. Salter - Yes,,315
-Minnehaha,0510,Supreme Court Retention,2,Mark E. Salter - No,,119
-Minnehaha,0512,Supreme Court Retention,2,Mark E. Salter - Yes,,390
-Minnehaha,0512,Supreme Court Retention,2,Mark E. Salter - No,,100
-Minnehaha,0513,Supreme Court Retention,2,Mark E. Salter - Yes,,399
-Minnehaha,0513,Supreme Court Retention,2,Mark E. Salter - No,,102
-Minnehaha,0514,Supreme Court Retention,2,Mark E. Salter - Yes,,425
-Minnehaha,0514,Supreme Court Retention,2,Mark E. Salter - No,,174
-Minnehaha,0515,Supreme Court Retention,2,Mark E. Salter - Yes,,443
-Minnehaha,0515,Supreme Court Retention,2,Mark E. Salter - No,,178
-Minnehaha,0517,Supreme Court Retention,2,Mark E. Salter - Yes,,357
-Minnehaha,0517,Supreme Court Retention,2,Mark E. Salter - No,,84
-Minnehaha,0518,Supreme Court Retention,2,Mark E. Salter - Yes,,577
-Minnehaha,0518,Supreme Court Retention,2,Mark E. Salter - No,,235
-Minnehaha,0519,Supreme Court Retention,2,Mark E. Salter - Yes,,315
-Minnehaha,0519,Supreme Court Retention,2,Mark E. Salter - No,,77
-Minnehaha,0520,Supreme Court Retention,2,Mark E. Salter - Yes,,486
-Minnehaha,0520,Supreme Court Retention,2,Mark E. Salter - No,,185
-Minnehaha,0521,Supreme Court Retention,2,Mark E. Salter - Yes,,264
-Minnehaha,0521,Supreme Court Retention,2,Mark E. Salter - No,,75
-Minnehaha,0522,Supreme Court Retention,2,Mark E. Salter - Yes,,428
-Minnehaha,0522,Supreme Court Retention,2,Mark E. Salter - No,,224
-Minnehaha,0523,Supreme Court Retention,2,Mark E. Salter - Yes,,367
-Minnehaha,0523,Supreme Court Retention,2,Mark E. Salter - No,,157
-Minnehaha,VP01,Supreme Court Retention,2,Mark E. Salter - Yes,,506
-Minnehaha,VP01,Supreme Court Retention,2,Mark E. Salter - No,,98
-Minnehaha,VP02,Supreme Court Retention,2,Mark E. Salter - Yes,,1171
-Minnehaha,VP02,Supreme Court Retention,2,Mark E. Salter - No,,214
-Minnehaha,VP03,Supreme Court Retention,2,Mark E. Salter - Yes,,1389
-Minnehaha,VP03,Supreme Court Retention,2,Mark E. Salter - No,,285
-Minnehaha,VP04,Supreme Court Retention,2,Mark E. Salter - Yes,,706
-Minnehaha,VP04,Supreme Court Retention,2,Mark E. Salter - No,,163
-Minnehaha,VP05,Supreme Court Retention,2,Mark E. Salter - Yes,,941
-Minnehaha,VP05,Supreme Court Retention,2,Mark E. Salter - No,,183
-Minnehaha,VP06,Supreme Court Retention,2,Mark E. Salter - Yes,,288
-Minnehaha,VP06,Supreme Court Retention,2,Mark E. Salter - No,,58
-Minnehaha,VP07,Supreme Court Retention,2,Mark E. Salter - Yes,,1149
-Minnehaha,VP07,Supreme Court Retention,2,Mark E. Salter - No,,234
-Minnehaha,VP08,Supreme Court Retention,2,Mark E. Salter - Yes,,414
-Minnehaha,VP08,Supreme Court Retention,2,Mark E. Salter - No,,84
-Minnehaha,VP09,Supreme Court Retention,2,Mark E. Salter - Yes,,844
-Minnehaha,VP09,Supreme Court Retention,2,Mark E. Salter - No,,169
-Minnehaha,VP10,Supreme Court Retention,2,Mark E. Salter - Yes,,761
-Minnehaha,VP10,Supreme Court Retention,2,Mark E. Salter - No,,167
-Minnehaha,VP11,Supreme Court Retention,2,Mark E. Salter - Yes,,199
-Minnehaha,VP11,Supreme Court Retention,2,Mark E. Salter - No,,41
-Minnehaha,VP12,Supreme Court Retention,2,Mark E. Salter - Yes,,97
-Minnehaha,VP12,Supreme Court Retention,2,Mark E. Salter - No,,8
-Minnehaha,VP13,Supreme Court Retention,2,Mark E. Salter - Yes,,582
-Minnehaha,VP13,Supreme Court Retention,2,Mark E. Salter - No,,133
-Minnehaha,VP15,Supreme Court Retention,2,Mark E. Salter - Yes,,1013
-Minnehaha,VP15,Supreme Court Retention,2,Mark E. Salter - No,,197
-Minnehaha,VP16,Supreme Court Retention,2,Mark E. Salter - Yes,,673
-Minnehaha,VP16,Supreme Court Retention,2,Mark E. Salter - No,,134
-Minnehaha,VP17,Supreme Court Retention,2,Mark E. Salter - Yes,,427
-Minnehaha,VP17,Supreme Court Retention,2,Mark E. Salter - No,,80
-Minnehaha,VP21,Supreme Court Retention,2,Mark E. Salter - Yes,,1140
-Minnehaha,VP21,Supreme Court Retention,2,Mark E. Salter - No,,209
-Minnehaha,0104,Constitutional Amendment D,,Yes,,547
-Minnehaha,0104,Constitutional Amendment D,,No,,170
-Minnehaha,0105,Constitutional Amendment D,,Yes,,345
-Minnehaha,0105,Constitutional Amendment D,,No,,111
-Minnehaha,0106,Constitutional Amendment D,,Yes,,719
-Minnehaha,0106,Constitutional Amendment D,,No,,357
-Minnehaha,0109,Constitutional Amendment D,,Yes,,720
-Minnehaha,0109,Constitutional Amendment D,,No,,341
-Minnehaha,0110,Constitutional Amendment D,,Yes,,779
-Minnehaha,0110,Constitutional Amendment D,,No,,375
-Minnehaha,0117,Constitutional Amendment D,,Yes,,789
-Minnehaha,0117,Constitutional Amendment D,,No,,528
-Minnehaha,0119,Constitutional Amendment D,,Yes,,411
-Minnehaha,0119,Constitutional Amendment D,,No,,198
-Minnehaha,0201,Constitutional Amendment D,,Yes,,722
-Minnehaha,0201,Constitutional Amendment D,,No,,376
-Minnehaha,0202,Constitutional Amendment D,,Yes,,940
-Minnehaha,0202,Constitutional Amendment D,,No,,504
-Minnehaha,0203,Constitutional Amendment D,,Yes,,731
-Minnehaha,0203,Constitutional Amendment D,,No,,362
-Minnehaha,0206,Constitutional Amendment D,,Yes,,766
-Minnehaha,0206,Constitutional Amendment D,,No,,374
-Minnehaha,0208,Constitutional Amendment D,,Yes,,739
-Minnehaha,0208,Constitutional Amendment D,,No,,426
-Minnehaha,0209,Constitutional Amendment D,,Yes,,704
-Minnehaha,0209,Constitutional Amendment D,,No,,352
-Minnehaha,0214,Constitutional Amendment D,,Yes,,1760
-Minnehaha,0214,Constitutional Amendment D,,No,,1085
-Minnehaha,0301,Constitutional Amendment D,,Yes,,517
-Minnehaha,0301,Constitutional Amendment D,,No,,261
-Minnehaha,0305,Constitutional Amendment D,,Yes,,368
-Minnehaha,0305,Constitutional Amendment D,,No,,169
-Minnehaha,0309,Constitutional Amendment D,,Yes,,809
-Minnehaha,0309,Constitutional Amendment D,,No,,312
-Minnehaha,0310,Constitutional Amendment D,,Yes,,856
-Minnehaha,0310,Constitutional Amendment D,,No,,597
-Minnehaha,0311,Constitutional Amendment D,,Yes,,548
-Minnehaha,0311,Constitutional Amendment D,,No,,369
-Minnehaha,0312,Constitutional Amendment D,,Yes,,755
-Minnehaha,0312,Constitutional Amendment D,,No,,437
-Minnehaha,0313,Constitutional Amendment D,,Yes,,453
-Minnehaha,0313,Constitutional Amendment D,,No,,287
-Minnehaha,0314,Constitutional Amendment D,,Yes,,1115
-Minnehaha,0314,Constitutional Amendment D,,No,,658
-Minnehaha,0315,Constitutional Amendment D,,Yes,,750
-Minnehaha,0315,Constitutional Amendment D,,No,,358
-Minnehaha,0316,Constitutional Amendment D,,Yes,,1084
-Minnehaha,0316,Constitutional Amendment D,,No,,658
-Minnehaha,0317,Constitutional Amendment D,,Yes,,1280
-Minnehaha,0317,Constitutional Amendment D,,No,,807
-Minnehaha,0402,Constitutional Amendment D,,Yes,,476
-Minnehaha,0402,Constitutional Amendment D,,No,,177
-Minnehaha,0403,Constitutional Amendment D,,Yes,,312
-Minnehaha,0403,Constitutional Amendment D,,No,,116
-Minnehaha,0404,Constitutional Amendment D,,Yes,,507
-Minnehaha,0404,Constitutional Amendment D,,No,,170
-Minnehaha,0405,Constitutional Amendment D,,Yes,,891
-Minnehaha,0405,Constitutional Amendment D,,No,,652
-Minnehaha,0406,Constitutional Amendment D,,Yes,,211
-Minnehaha,0406,Constitutional Amendment D,,No,,75
-Minnehaha,0407,Constitutional Amendment D,,Yes,,807
-Minnehaha,0407,Constitutional Amendment D,,No,,445
-Minnehaha,0408,Constitutional Amendment D,,Yes,,218
-Minnehaha,0408,Constitutional Amendment D,,No,,95
-Minnehaha,0409,Constitutional Amendment D,,Yes,,500
-Minnehaha,0409,Constitutional Amendment D,,No,,205
-Minnehaha,0410,Constitutional Amendment D,,Yes,,509
-Minnehaha,0410,Constitutional Amendment D,,No,,265
-Minnehaha,0411,Constitutional Amendment D,,Yes,,1175
-Minnehaha,0411,Constitutional Amendment D,,No,,777
-Minnehaha,0412,Constitutional Amendment D,,Yes,,796
-Minnehaha,0412,Constitutional Amendment D,,No,,385
-Minnehaha,0413,Constitutional Amendment D,,Yes,,450
-Minnehaha,0413,Constitutional Amendment D,,No,,180
-Minnehaha,0415,Constitutional Amendment D,,Yes,,1261
-Minnehaha,0415,Constitutional Amendment D,,No,,839
-Minnehaha,0501,Constitutional Amendment D,,Yes,,336
-Minnehaha,0501,Constitutional Amendment D,,No,,102
-Minnehaha,0502,Constitutional Amendment D,,Yes,,520
-Minnehaha,0502,Constitutional Amendment D,,No,,123
-Minnehaha,0503,Constitutional Amendment D,,Yes,,279
-Minnehaha,0503,Constitutional Amendment D,,No,,64
-Minnehaha,0504,Constitutional Amendment D,,Yes,,661
-Minnehaha,0504,Constitutional Amendment D,,No,,181
-Minnehaha,0506,Constitutional Amendment D,,Yes,,678
-Minnehaha,0506,Constitutional Amendment D,,No,,247
-Minnehaha,0507,Constitutional Amendment D,,Yes,,429
-Minnehaha,0507,Constitutional Amendment D,,No,,131
-Minnehaha,0508,Constitutional Amendment D,,Yes,,662
-Minnehaha,0508,Constitutional Amendment D,,No,,237
-Minnehaha,0509,Constitutional Amendment D,,Yes,,308
-Minnehaha,0509,Constitutional Amendment D,,No,,68
-Minnehaha,0510,Constitutional Amendment D,,Yes,,397
-Minnehaha,0510,Constitutional Amendment D,,No,,137
-Minnehaha,0512,Constitutional Amendment D,,Yes,,458
-Minnehaha,0512,Constitutional Amendment D,,No,,168
-Minnehaha,0513,Constitutional Amendment D,,Yes,,469
-Minnehaha,0513,Constitutional Amendment D,,No,,161
-Minnehaha,0514,Constitutional Amendment D,,Yes,,551
-Minnehaha,0514,Constitutional Amendment D,,No,,197
-Minnehaha,0515,Constitutional Amendment D,,Yes,,467
-Minnehaha,0515,Constitutional Amendment D,,No,,292
-Minnehaha,0517,Constitutional Amendment D,,Yes,,359
-Minnehaha,0517,Constitutional Amendment D,,No,,158
-Minnehaha,0518,Constitutional Amendment D,,Yes,,757
-Minnehaha,0518,Constitutional Amendment D,,No,,243
-Minnehaha,0519,Constitutional Amendment D,,Yes,,340
-Minnehaha,0519,Constitutional Amendment D,,No,,169
-Minnehaha,0520,Constitutional Amendment D,,Yes,,591
-Minnehaha,0520,Constitutional Amendment D,,No,,239
-Minnehaha,0521,Constitutional Amendment D,,Yes,,290
-Minnehaha,0521,Constitutional Amendment D,,No,,127
-Minnehaha,0522,Constitutional Amendment D,,Yes,,605
-Minnehaha,0522,Constitutional Amendment D,,No,,202
-Minnehaha,0523,Constitutional Amendment D,,Yes,,474
-Minnehaha,0523,Constitutional Amendment D,,No,,153
-Minnehaha,VP01,Constitutional Amendment D,,Yes,,367
-Minnehaha,VP01,Constitutional Amendment D,,No,,371
-Minnehaha,VP02,Constitutional Amendment D,,Yes,,863
-Minnehaha,VP02,Constitutional Amendment D,,No,,829
-Minnehaha,VP03,Constitutional Amendment D,,Yes,,1019
-Minnehaha,VP03,Constitutional Amendment D,,No,,972
-Minnehaha,VP04,Constitutional Amendment D,,Yes,,540
-Minnehaha,VP04,Constitutional Amendment D,,No,,504
-Minnehaha,VP05,Constitutional Amendment D,,Yes,,767
-Minnehaha,VP05,Constitutional Amendment D,,No,,615
-Minnehaha,VP06,Constitutional Amendment D,,Yes,,239
-Minnehaha,VP06,Constitutional Amendment D,,No,,196
-Minnehaha,VP07,Constitutional Amendment D,,Yes,,887
-Minnehaha,VP07,Constitutional Amendment D,,No,,750
-Minnehaha,VP08,Constitutional Amendment D,,Yes,,310
-Minnehaha,VP08,Constitutional Amendment D,,No,,318
-Minnehaha,VP09,Constitutional Amendment D,,Yes,,633
-Minnehaha,VP09,Constitutional Amendment D,,No,,605
-Minnehaha,VP10,Constitutional Amendment D,,Yes,,635
-Minnehaha,VP10,Constitutional Amendment D,,No,,480
-Minnehaha,VP11,Constitutional Amendment D,,Yes,,123
-Minnehaha,VP11,Constitutional Amendment D,,No,,175
-Minnehaha,VP12,Constitutional Amendment D,,Yes,,52
-Minnehaha,VP12,Constitutional Amendment D,,No,,72
-Minnehaha,VP13,Constitutional Amendment D,,Yes,,418
-Minnehaha,VP13,Constitutional Amendment D,,No,,459
-Minnehaha,VP15,Constitutional Amendment D,,Yes,,820
-Minnehaha,VP15,Constitutional Amendment D,,No,,652
-Minnehaha,VP16,Constitutional Amendment D,,Yes,,539
-Minnehaha,VP16,Constitutional Amendment D,,No,,487
-Minnehaha,VP17,Constitutional Amendment D,,Yes,,309
-Minnehaha,VP17,Constitutional Amendment D,,No,,316
-Minnehaha,VP21,Constitutional Amendment D,,Yes,,880
-Minnehaha,VP21,Constitutional Amendment D,,No,,729
-Minnehaha,0104,Initiated Measure 27,,Yes,,421
-Minnehaha,0104,Initiated Measure 27,,No,,306
-Minnehaha,0105,Initiated Measure 27,,Yes,,247
-Minnehaha,0105,Initiated Measure 27,,No,,210
-Minnehaha,0106,Initiated Measure 27,,Yes,,577
-Minnehaha,0106,Initiated Measure 27,,No,,519
-Minnehaha,0109,Initiated Measure 27,,Yes,,579
-Minnehaha,0109,Initiated Measure 27,,No,,498
-Minnehaha,0110,Initiated Measure 27,,Yes,,696
-Minnehaha,0110,Initiated Measure 27,,No,,490
-Minnehaha,0117,Initiated Measure 27,,Yes,,754
-Minnehaha,0117,Initiated Measure 27,,No,,589
-Minnehaha,0119,Initiated Measure 27,,Yes,,415
-Minnehaha,0119,Initiated Measure 27,,No,,204
-Minnehaha,0201,Initiated Measure 27,,Yes,,557
-Minnehaha,0201,Initiated Measure 27,,No,,558
-Minnehaha,0202,Initiated Measure 27,,Yes,,750
-Minnehaha,0202,Initiated Measure 27,,No,,711
-Minnehaha,0203,Initiated Measure 27,,Yes,,606
-Minnehaha,0203,Initiated Measure 27,,No,,508
-Minnehaha,0206,Initiated Measure 27,,Yes,,620
-Minnehaha,0206,Initiated Measure 27,,No,,542
-Minnehaha,0208,Initiated Measure 27,,Yes,,540
-Minnehaha,0208,Initiated Measure 27,,No,,636
-Minnehaha,0209,Initiated Measure 27,,Yes,,580
-Minnehaha,0209,Initiated Measure 27,,No,,494
-Minnehaha,0214,Initiated Measure 27,,Yes,,1471
-Minnehaha,0214,Initiated Measure 27,,No,,1425
-Minnehaha,0301,Initiated Measure 27,,Yes,,410
-Minnehaha,0301,Initiated Measure 27,,No,,379
-Minnehaha,0305,Initiated Measure 27,,Yes,,353
-Minnehaha,0305,Initiated Measure 27,,No,,186
-Minnehaha,0309,Initiated Measure 27,,Yes,,758
-Minnehaha,0309,Initiated Measure 27,,No,,384
-Minnehaha,0310,Initiated Measure 27,,Yes,,693
-Minnehaha,0310,Initiated Measure 27,,No,,770
-Minnehaha,0311,Initiated Measure 27,,Yes,,435
-Minnehaha,0311,Initiated Measure 27,,No,,500
-Minnehaha,0312,Initiated Measure 27,,Yes,,694
-Minnehaha,0312,Initiated Measure 27,,No,,525
-Minnehaha,0313,Initiated Measure 27,,Yes,,395
-Minnehaha,0313,Initiated Measure 27,,No,,349
-Minnehaha,0314,Initiated Measure 27,,Yes,,1088
-Minnehaha,0314,Initiated Measure 27,,No,,718
-Minnehaha,0315,Initiated Measure 27,,Yes,,608
-Minnehaha,0315,Initiated Measure 27,,No,,510
-Minnehaha,0316,Initiated Measure 27,,Yes,,971
-Minnehaha,0316,Initiated Measure 27,,No,,816
-Minnehaha,0317,Initiated Measure 27,,Yes,,1179
-Minnehaha,0317,Initiated Measure 27,,No,,946
-Minnehaha,0402,Initiated Measure 27,,Yes,,443
-Minnehaha,0402,Initiated Measure 27,,No,,219
-Minnehaha,0403,Initiated Measure 27,,Yes,,304
-Minnehaha,0403,Initiated Measure 27,,No,,134
-Minnehaha,0404,Initiated Measure 27,,Yes,,499
-Minnehaha,0404,Initiated Measure 27,,No,,197
-Minnehaha,0405,Initiated Measure 27,,Yes,,946
-Minnehaha,0405,Initiated Measure 27,,No,,610
-Minnehaha,0406,Initiated Measure 27,,Yes,,189
-Minnehaha,0406,Initiated Measure 27,,No,,101
-Minnehaha,0407,Initiated Measure 27,,Yes,,691
-Minnehaha,0407,Initiated Measure 27,,No,,589
-Minnehaha,0408,Initiated Measure 27,,Yes,,211
-Minnehaha,0408,Initiated Measure 27,,No,,107
-Minnehaha,0409,Initiated Measure 27,,Yes,,497
-Minnehaha,0409,Initiated Measure 27,,No,,224
-Minnehaha,0410,Initiated Measure 27,,Yes,,443
-Minnehaha,0410,Initiated Measure 27,,No,,341
-Minnehaha,0411,Initiated Measure 27,,Yes,,1015
-Minnehaha,0411,Initiated Measure 27,,No,,976
-Minnehaha,0412,Initiated Measure 27,,Yes,,704
-Minnehaha,0412,Initiated Measure 27,,No,,502
-Minnehaha,0413,Initiated Measure 27,,Yes,,389
-Minnehaha,0413,Initiated Measure 27,,No,,249
-Minnehaha,0415,Initiated Measure 27,,Yes,,1030
-Minnehaha,0415,Initiated Measure 27,,No,,1115
-Minnehaha,0501,Initiated Measure 27,,Yes,,327
-Minnehaha,0501,Initiated Measure 27,,No,,114
-Minnehaha,0502,Initiated Measure 27,,Yes,,484
-Minnehaha,0502,Initiated Measure 27,,No,,169
-Minnehaha,0503,Initiated Measure 27,,Yes,,256
-Minnehaha,0503,Initiated Measure 27,,No,,89
-Minnehaha,0504,Initiated Measure 27,,Yes,,597
-Minnehaha,0504,Initiated Measure 27,,No,,259
-Minnehaha,0506,Initiated Measure 27,,Yes,,602
-Minnehaha,0506,Initiated Measure 27,,No,,330
-Minnehaha,0507,Initiated Measure 27,,Yes,,372
-Minnehaha,0507,Initiated Measure 27,,No,,200
-Minnehaha,0508,Initiated Measure 27,,Yes,,589
-Minnehaha,0508,Initiated Measure 27,,No,,330
-Minnehaha,0509,Initiated Measure 27,,Yes,,291
-Minnehaha,0509,Initiated Measure 27,,No,,96
-Minnehaha,0510,Initiated Measure 27,,Yes,,355
-Minnehaha,0510,Initiated Measure 27,,No,,189
-Minnehaha,0512,Initiated Measure 27,,Yes,,408
-Minnehaha,0512,Initiated Measure 27,,No,,225
-Minnehaha,0513,Initiated Measure 27,,Yes,,419
-Minnehaha,0513,Initiated Measure 27,,No,,227
-Minnehaha,0514,Initiated Measure 27,,Yes,,519
-Minnehaha,0514,Initiated Measure 27,,No,,245
-Minnehaha,0515,Initiated Measure 27,,Yes,,508
-Minnehaha,0515,Initiated Measure 27,,No,,267
-Minnehaha,0517,Initiated Measure 27,,Yes,,282
-Minnehaha,0517,Initiated Measure 27,,No,,248
-Minnehaha,0518,Initiated Measure 27,,Yes,,673
-Minnehaha,0518,Initiated Measure 27,,No,,348
-Minnehaha,0519,Initiated Measure 27,,Yes,,292
-Minnehaha,0519,Initiated Measure 27,,No,,226
-Minnehaha,0520,Initiated Measure 27,,Yes,,534
-Minnehaha,0520,Initiated Measure 27,,No,,310
-Minnehaha,0521,Initiated Measure 27,,Yes,,269
-Minnehaha,0521,Initiated Measure 27,,No,,150
-Minnehaha,0522,Initiated Measure 27,,Yes,,598
-Minnehaha,0522,Initiated Measure 27,,No,,215
-Minnehaha,0523,Initiated Measure 27,,Yes,,462
-Minnehaha,0523,Initiated Measure 27,,No,,174
-Minnehaha,VP01,Initiated Measure 27,,Yes,,327
-Minnehaha,VP01,Initiated Measure 27,,No,,417
-Minnehaha,VP02,Initiated Measure 27,,Yes,,662
-Minnehaha,VP02,Initiated Measure 27,,No,,1046
-Minnehaha,VP03,Initiated Measure 27,,Yes,,953
-Minnehaha,VP03,Initiated Measure 27,,No,,1079
-Minnehaha,VP04,Initiated Measure 27,,Yes,,507
-Minnehaha,VP04,Initiated Measure 27,,No,,560
-Minnehaha,VP05,Initiated Measure 27,,Yes,,668
-Minnehaha,VP05,Initiated Measure 27,,No,,733
-Minnehaha,VP06,Initiated Measure 27,,Yes,,199
-Minnehaha,VP06,Initiated Measure 27,,No,,239
-Minnehaha,VP07,Initiated Measure 27,,Yes,,732
-Minnehaha,VP07,Initiated Measure 27,,No,,932
-Minnehaha,VP08,Initiated Measure 27,,Yes,,264
-Minnehaha,VP08,Initiated Measure 27,,No,,376
-Minnehaha,VP09,Initiated Measure 27,,Yes,,615
-Minnehaha,VP09,Initiated Measure 27,,No,,648
-Minnehaha,VP10,Initiated Measure 27,,Yes,,540
-Minnehaha,VP10,Initiated Measure 27,,No,,595
-Minnehaha,VP11,Initiated Measure 27,,Yes,,101
-Minnehaha,VP11,Initiated Measure 27,,No,,196
-Minnehaha,VP12,Initiated Measure 27,,Yes,,45
-Minnehaha,VP12,Initiated Measure 27,,No,,79
-Minnehaha,VP13,Initiated Measure 27,,Yes,,335
-Minnehaha,VP13,Initiated Measure 27,,No,,554
-Minnehaha,VP15,Initiated Measure 27,,Yes,,700
-Minnehaha,VP15,Initiated Measure 27,,No,,793
-Minnehaha,VP16,Initiated Measure 27,,Yes,,489
-Minnehaha,VP16,Initiated Measure 27,,No,,558
-Minnehaha,VP17,Initiated Measure 27,,Yes,,236
-Minnehaha,VP17,Initiated Measure 27,,No,,397
-Minnehaha,VP21,Initiated Measure 27,,Yes,,728
-Minnehaha,VP21,Initiated Measure 27,,No,,898
-Minnehaha,0104,State Senate,12,Jessica Meyers,DEM,386
-Minnehaha,0104,State Senate,12,Arch Beal,REP,301
-Minnehaha,0105,State Senate,12,Jessica Meyers,DEM,216
-Minnehaha,0105,State Senate,12,Arch Beal,REP,219
-Minnehaha,0301 Precinct-0305,State Senate,12,Jessica Meyers,DEM,344
-Minnehaha,0301 Precinct-0305,State Senate,12,Arch Beal,REP,422
+Minnehaha,0104,Public Utilities Commissioner,,Chris Nelson,REP,320
+Minnehaha,0104,Public Utilities Commissioner,,Jeffrey Barth,DEM,352
+Minnehaha,0105,Public Utilities Commissioner,,Chris Nelson,REP,223
+Minnehaha,0105,Public Utilities Commissioner,,Jeffrey Barth,DEM,213
+Minnehaha,0106,Public Utilities Commissioner,,Chris Nelson,REP,581
+Minnehaha,0106,Public Utilities Commissioner,,Jeffrey Barth,DEM,454
+Minnehaha,0109,Public Utilities Commissioner,,Chris Nelson,REP,596
+Minnehaha,0109,Public Utilities Commissioner,,Jeffrey Barth,DEM,416
+Minnehaha,0110,Public Utilities Commissioner,,Chris Nelson,REP,630
+Minnehaha,0110,Public Utilities Commissioner,,Jeffrey Barth,DEM,457
+Minnehaha,0117,Public Utilities Commissioner,,Chris Nelson,REP,782
+Minnehaha,0117,Public Utilities Commissioner,,Jeffrey Barth,DEM,469
+Minnehaha,0119,Public Utilities Commissioner,,Chris Nelson,REP,311
+Minnehaha,0119,Public Utilities Commissioner,,Jeffrey Barth,DEM,266
+Minnehaha,0201,Public Utilities Commissioner,,Chris Nelson,REP,632
+Minnehaha,0201,Public Utilities Commissioner,,Jeffrey Barth,DEM,415
+Minnehaha,0202,Public Utilities Commissioner,,Chris Nelson,REP,814
+Minnehaha,0202,Public Utilities Commissioner,,Jeffrey Barth,DEM,576
+Minnehaha,0203,Public Utilities Commissioner,,Chris Nelson,REP,582
+Minnehaha,0203,Public Utilities Commissioner,,Jeffrey Barth,DEM,461
+Minnehaha,0206,Public Utilities Commissioner,,Chris Nelson,REP,622
+Minnehaha,0206,Public Utilities Commissioner,,Jeffrey Barth,DEM,455
+Minnehaha,0208,Public Utilities Commissioner,,Chris Nelson,REP,672
+Minnehaha,0208,Public Utilities Commissioner,,Jeffrey Barth,DEM,439
+Minnehaha,0209,Public Utilities Commissioner,,Chris Nelson,REP,520
+Minnehaha,0209,Public Utilities Commissioner,,Jeffrey Barth,DEM,476
+Minnehaha,0214,Public Utilities Commissioner,,Chris Nelson,REP,1672
+Minnehaha,0214,Public Utilities Commissioner,,Jeffrey Barth,DEM,1042
+Minnehaha,0301,Public Utilities Commissioner,,Chris Nelson,REP,443
+Minnehaha,0301,Public Utilities Commissioner,,Jeffrey Barth,DEM,313
+Minnehaha,0305,Public Utilities Commissioner,,Chris Nelson,REP,273
+Minnehaha,0305,Public Utilities Commissioner,,Jeffrey Barth,DEM,231
+Minnehaha,0309,Public Utilities Commissioner,,Chris Nelson,REP,571
+Minnehaha,0309,Public Utilities Commissioner,,Jeffrey Barth,DEM,501
+Minnehaha,0310,Public Utilities Commissioner,,Chris Nelson,REP,890
+Minnehaha,0310,Public Utilities Commissioner,,Jeffrey Barth,DEM,497
+Minnehaha,0311,Public Utilities Commissioner,,Chris Nelson,REP,562
+Minnehaha,0311,Public Utilities Commissioner,,Jeffrey Barth,DEM,313
+Minnehaha,0312,Public Utilities Commissioner,,Chris Nelson,REP,742
+Minnehaha,0312,Public Utilities Commissioner,,Jeffrey Barth,DEM,398
+Minnehaha,0313,Public Utilities Commissioner,,Chris Nelson,REP,433
+Minnehaha,0313,Public Utilities Commissioner,,Jeffrey Barth,DEM,266
+Minnehaha,0314,Public Utilities Commissioner,,Chris Nelson,REP,994
+Minnehaha,0314,Public Utilities Commissioner,,Jeffrey Barth,DEM,687
+Minnehaha,0315,Public Utilities Commissioner,,Chris Nelson,REP,605
+Minnehaha,0315,Public Utilities Commissioner,,Jeffrey Barth,DEM,432
+Minnehaha,0316,Public Utilities Commissioner,,Chris Nelson,REP,1060
+Minnehaha,0316,Public Utilities Commissioner,,Jeffrey Barth,DEM,579
+Minnehaha,0317,Public Utilities Commissioner,,Chris Nelson,REP,1243
+Minnehaha,0317,Public Utilities Commissioner,,Jeffrey Barth,DEM,723
+Minnehaha,0402,Public Utilities Commissioner,,Chris Nelson,REP,296
+Minnehaha,0402,Public Utilities Commissioner,,Jeffrey Barth,DEM,318
+Minnehaha,0403,Public Utilities Commissioner,,Chris Nelson,REP,205
+Minnehaha,0403,Public Utilities Commissioner,,Jeffrey Barth,DEM,207
+Minnehaha,0404,Public Utilities Commissioner,,Chris Nelson,REP,313
+Minnehaha,0404,Public Utilities Commissioner,,Jeffrey Barth,DEM,322
+Minnehaha,0405,Public Utilities Commissioner,,Chris Nelson,REP,963
+Minnehaha,0405,Public Utilities Commissioner,,Jeffrey Barth,DEM,578
+Minnehaha,0406,Public Utilities Commissioner,,Chris Nelson,REP,136
+Minnehaha,0406,Public Utilities Commissioner,,Jeffrey Barth,DEM,144
+Minnehaha,0407,Public Utilities Commissioner,,Chris Nelson,REP,665
+Minnehaha,0407,Public Utilities Commissioner,,Jeffrey Barth,DEM,542
+Minnehaha,0408,Public Utilities Commissioner,,Chris Nelson,REP,133
+Minnehaha,0408,Public Utilities Commissioner,,Jeffrey Barth,DEM,174
+Minnehaha,0409,Public Utilities Commissioner,,Chris Nelson,REP,326
+Minnehaha,0409,Public Utilities Commissioner,,Jeffrey Barth,DEM,340
+Minnehaha,0410,Public Utilities Commissioner,,Chris Nelson,REP,402
+Minnehaha,0410,Public Utilities Commissioner,,Jeffrey Barth,DEM,326
+Minnehaha,0411,Public Utilities Commissioner,,Chris Nelson,REP,1208
+Minnehaha,0411,Public Utilities Commissioner,,Jeffrey Barth,DEM,673
+Minnehaha,0412,Public Utilities Commissioner,,Chris Nelson,REP,602
+Minnehaha,0412,Public Utilities Commissioner,,Jeffrey Barth,DEM,534
+Minnehaha,0413,Public Utilities Commissioner,,Chris Nelson,REP,293
+Minnehaha,0413,Public Utilities Commissioner,,Jeffrey Barth,DEM,303
+Minnehaha,0415,Public Utilities Commissioner,,Chris Nelson,REP,1247
+Minnehaha,0415,Public Utilities Commissioner,,Jeffrey Barth,DEM,768
+Minnehaha,0501,Public Utilities Commissioner,,Chris Nelson,REP,164
+Minnehaha,0501,Public Utilities Commissioner,,Jeffrey Barth,DEM,245
+Minnehaha,0502,Public Utilities Commissioner,,Chris Nelson,REP,227
+Minnehaha,0502,Public Utilities Commissioner,,Jeffrey Barth,DEM,384
+Minnehaha,0503,Public Utilities Commissioner,,Chris Nelson,REP,135
+Minnehaha,0503,Public Utilities Commissioner,,Jeffrey Barth,DEM,182
+Minnehaha,0504,Public Utilities Commissioner,,Chris Nelson,REP,303
+Minnehaha,0504,Public Utilities Commissioner,,Jeffrey Barth,DEM,509
+Minnehaha,0506,Public Utilities Commissioner,,Chris Nelson,REP,410
+Minnehaha,0506,Public Utilities Commissioner,,Jeffrey Barth,DEM,472
+Minnehaha,0507,Public Utilities Commissioner,,Chris Nelson,REP,237
+Minnehaha,0507,Public Utilities Commissioner,,Jeffrey Barth,DEM,307
+Minnehaha,0508,Public Utilities Commissioner,,Chris Nelson,REP,363
+Minnehaha,0508,Public Utilities Commissioner,,Jeffrey Barth,DEM,500
+Minnehaha,0509,Public Utilities Commissioner,,Chris Nelson,REP,147
+Minnehaha,0509,Public Utilities Commissioner,,Jeffrey Barth,DEM,202
+Minnehaha,0510,Public Utilities Commissioner,,Chris Nelson,REP,256
+Minnehaha,0510,Public Utilities Commissioner,,Jeffrey Barth,DEM,252
+Minnehaha,0512,Public Utilities Commissioner,,Chris Nelson,REP,288
+Minnehaha,0512,Public Utilities Commissioner,,Jeffrey Barth,DEM,296
+Minnehaha,0513,Public Utilities Commissioner,,Chris Nelson,REP,279
+Minnehaha,0513,Public Utilities Commissioner,,Jeffrey Barth,DEM,318
+Minnehaha,0514,Public Utilities Commissioner,,Chris Nelson,REP,315
+Minnehaha,0514,Public Utilities Commissioner,,Jeffrey Barth,DEM,405
+Minnehaha,0515,Public Utilities Commissioner,,Chris Nelson,REP,415
+Minnehaha,0515,Public Utilities Commissioner,,Jeffrey Barth,DEM,329
+Minnehaha,0517,Public Utilities Commissioner,,Chris Nelson,REP,262
+Minnehaha,0517,Public Utilities Commissioner,,Jeffrey Barth,DEM,238
+Minnehaha,0518,Public Utilities Commissioner,,Chris Nelson,REP,409
+Minnehaha,0518,Public Utilities Commissioner,,Jeffrey Barth,DEM,551
+Minnehaha,0519,Public Utilities Commissioner,,Chris Nelson,REP,265
+Minnehaha,0519,Public Utilities Commissioner,,Jeffrey Barth,DEM,224
+Minnehaha,0520,Public Utilities Commissioner,,Chris Nelson,REP,398
+Minnehaha,0520,Public Utilities Commissioner,,Jeffrey Barth,DEM,380
+Minnehaha,0521,Public Utilities Commissioner,,Chris Nelson,REP,205
+Minnehaha,0521,Public Utilities Commissioner,,Jeffrey Barth,DEM,196
+Minnehaha,0522,Public Utilities Commissioner,,Chris Nelson,REP,343
+Minnehaha,0522,Public Utilities Commissioner,,Jeffrey Barth,DEM,417
+Minnehaha,0523,Public Utilities Commissioner,,Chris Nelson,REP,261
+Minnehaha,0523,Public Utilities Commissioner,,Jeffrey Barth,DEM,345
+Minnehaha,VP01,Public Utilities Commissioner,,Chris Nelson,REP,495
+Minnehaha,VP01,Public Utilities Commissioner,,Jeffrey Barth,DEM,213
+Minnehaha,VP02,Public Utilities Commissioner,,Chris Nelson,REP,1160
+Minnehaha,VP02,Public Utilities Commissioner,,Jeffrey Barth,DEM,486
+Minnehaha,VP03,Public Utilities Commissioner,,Chris Nelson,REP,1378
+Minnehaha,VP03,Public Utilities Commissioner,,Jeffrey Barth,DEM,563
+Minnehaha,VP04,Public Utilities Commissioner,,Chris Nelson,REP,719
+Minnehaha,VP04,Public Utilities Commissioner,,Jeffrey Barth,DEM,304
+Minnehaha,VP05,Public Utilities Commissioner,,Chris Nelson,REP,935
+Minnehaha,VP05,Public Utilities Commissioner,,Jeffrey Barth,DEM,357
+Minnehaha,VP06,Public Utilities Commissioner,,Chris Nelson,REP,294
+Minnehaha,VP06,Public Utilities Commissioner,,Jeffrey Barth,DEM,118
+Minnehaha,VP07,Public Utilities Commissioner,,Chris Nelson,REP,1109
+Minnehaha,VP07,Public Utilities Commissioner,,Jeffrey Barth,DEM,472
+Minnehaha,VP08,Public Utilities Commissioner,,Chris Nelson,REP,411
+Minnehaha,VP08,Public Utilities Commissioner,,Jeffrey Barth,DEM,188
+Minnehaha,VP09,Public Utilities Commissioner,,Chris Nelson,REP,845
+Minnehaha,VP09,Public Utilities Commissioner,,Jeffrey Barth,DEM,344
+Minnehaha,VP10,Public Utilities Commissioner,,Chris Nelson,REP,694
+Minnehaha,VP10,Public Utilities Commissioner,,Jeffrey Barth,DEM,398
+Minnehaha,VP11,Public Utilities Commissioner,,Chris Nelson,REP,210
+Minnehaha,VP11,Public Utilities Commissioner,,Jeffrey Barth,DEM,80
+Minnehaha,VP12,Public Utilities Commissioner,,Chris Nelson,REP,74
+Minnehaha,VP12,Public Utilities Commissioner,,Jeffrey Barth,DEM,47
+Minnehaha,VP13,Public Utilities Commissioner,,Chris Nelson,REP,639
+Minnehaha,VP13,Public Utilities Commissioner,,Jeffrey Barth,DEM,206
+Minnehaha,VP15,Public Utilities Commissioner,,Chris Nelson,REP,958
+Minnehaha,VP15,Public Utilities Commissioner,,Jeffrey Barth,DEM,440
+Minnehaha,VP16,Public Utilities Commissioner,,Chris Nelson,REP,685
+Minnehaha,VP16,Public Utilities Commissioner,,Jeffrey Barth,DEM,292
+Minnehaha,VP17,Public Utilities Commissioner,,Chris Nelson,REP,427
+Minnehaha,VP17,Public Utilities Commissioner,,Jeffrey Barth,DEM,185
+Minnehaha,VP21,Public Utilities Commissioner,,Chris Nelson,REP,1087
+Minnehaha,VP21,Public Utilities Commissioner,,Jeffrey Barth,DEM,467
+Minnehaha,0104,Secretary of State,,Monae Johnson,REP,296
+Minnehaha,0104,Secretary of State,,Thomas A Cool,DEM,389
+Minnehaha,0105,Secretary of State,,Monae Johnson,REP,218
+Minnehaha,0105,Secretary of State,,Thomas A Cool,DEM,213
+Minnehaha,0106,Secretary of State,,Monae Johnson,REP,527
+Minnehaha,0106,Secretary of State,,Thomas A Cool,DEM,512
+Minnehaha,0109,Secretary of State,,Monae Johnson,REP,536
+Minnehaha,0109,Secretary of State,,Thomas A Cool,DEM,479
+Minnehaha,0110,Secretary of State,,Monae Johnson,REP,604
+Minnehaha,0110,Secretary of State,,Thomas A Cool,DEM,518
+Minnehaha,0117,Secretary of State,,Monae Johnson,REP,732
+Minnehaha,0117,Secretary of State,,Thomas A Cool,DEM,542
+Minnehaha,0119,Secretary of State,,Monae Johnson,REP,306
+Minnehaha,0119,Secretary of State,,Thomas A Cool,DEM,286
+Minnehaha,0201,Secretary of State,,Monae Johnson,REP,569
+Minnehaha,0201,Secretary of State,,Thomas A Cool,DEM,495
+Minnehaha,0202,Secretary of State,,Monae Johnson,REP,730
+Minnehaha,0202,Secretary of State,,Thomas A Cool,DEM,660
+Minnehaha,0203,Secretary of State,,Monae Johnson,REP,539
+Minnehaha,0203,Secretary of State,,Thomas A Cool,DEM,520
+Minnehaha,0206,Secretary of State,,Monae Johnson,REP,590
+Minnehaha,0206,Secretary of State,,Thomas A Cool,DEM,500
+Minnehaha,0208,Secretary of State,,Monae Johnson,REP,611
+Minnehaha,0208,Secretary of State,,Thomas A Cool,DEM,513
+Minnehaha,0209,Secretary of State,,Monae Johnson,REP,492
+Minnehaha,0209,Secretary of State,,Thomas A Cool,DEM,515
+Minnehaha,0214,Secretary of State,,Monae Johnson,REP,1525
+Minnehaha,0214,Secretary of State,,Thomas A Cool,DEM,1202
+Minnehaha,0301,Secretary of State,,Monae Johnson,REP,398
+Minnehaha,0301,Secretary of State,,Thomas A Cool,DEM,364
+Minnehaha,0305,Secretary of State,,Monae Johnson,REP,253
+Minnehaha,0305,Secretary of State,,Thomas A Cool,DEM,260
+Minnehaha,0309,Secretary of State,,Monae Johnson,REP,524
+Minnehaha,0309,Secretary of State,,Thomas A Cool,DEM,571
+Minnehaha,0310,Secretary of State,,Monae Johnson,REP,833
+Minnehaha,0310,Secretary of State,,Thomas A Cool,DEM,583
+Minnehaha,0311,Secretary of State,,Monae Johnson,REP,504
+Minnehaha,0311,Secretary of State,,Thomas A Cool,DEM,388
+Minnehaha,0312,Secretary of State,,Monae Johnson,REP,701
+Minnehaha,0312,Secretary of State,,Thomas A Cool,DEM,437
+Minnehaha,0313,Secretary of State,,Monae Johnson,REP,399
+Minnehaha,0313,Secretary of State,,Thomas A Cool,DEM,311
+Minnehaha,0314,Secretary of State,,Monae Johnson,REP,925
+Minnehaha,0314,Secretary of State,,Thomas A Cool,DEM,781
+Minnehaha,0315,Secretary of State,,Monae Johnson,REP,568
+Minnehaha,0315,Secretary of State,,Thomas A Cool,DEM,493
+Minnehaha,0316,Secretary of State,,Monae Johnson,REP,983
+Minnehaha,0316,Secretary of State,,Thomas A Cool,DEM,681
+Minnehaha,0317,Secretary of State,,Monae Johnson,REP,1155
+Minnehaha,0317,Secretary of State,,Thomas A Cool,DEM,845
+Minnehaha,0402,Secretary of State,,Monae Johnson,REP,264
+Minnehaha,0402,Secretary of State,,Thomas A Cool,DEM,360
+Minnehaha,0403,Secretary of State,,Monae Johnson,REP,191
+Minnehaha,0403,Secretary of State,,Thomas A Cool,DEM,225
+Minnehaha,0404,Secretary of State,,Monae Johnson,REP,294
+Minnehaha,0404,Secretary of State,,Thomas A Cool,DEM,341
+Minnehaha,0405,Secretary of State,,Monae Johnson,REP,936
+Minnehaha,0405,Secretary of State,,Thomas A Cool,DEM,603
+Minnehaha,0406,Secretary of State,,Monae Johnson,REP,121
+Minnehaha,0406,Secretary of State,,Thomas A Cool,DEM,156
+Minnehaha,0407,Secretary of State,,Monae Johnson,REP,607
+Minnehaha,0407,Secretary of State,,Thomas A Cool,DEM,619
+Minnehaha,0408,Secretary of State,,Monae Johnson,REP,122
+Minnehaha,0408,Secretary of State,,Thomas A Cool,DEM,178
+Minnehaha,0409,Secretary of State,,Monae Johnson,REP,312
+Minnehaha,0409,Secretary of State,,Thomas A Cool,DEM,358
+Minnehaha,0410,Secretary of State,,Monae Johnson,REP,390
+Minnehaha,0410,Secretary of State,,Thomas A Cool,DEM,342
+Minnehaha,0411,Secretary of State,,Monae Johnson,REP,1119
+Minnehaha,0411,Secretary of State,,Thomas A Cool,DEM,772
+Minnehaha,0412,Secretary of State,,Monae Johnson,REP,561
+Minnehaha,0412,Secretary of State,,Thomas A Cool,DEM,570
+Minnehaha,0413,Secretary of State,,Monae Johnson,REP,272
+Minnehaha,0413,Secretary of State,,Thomas A Cool,DEM,334
+Minnehaha,0415,Secretary of State,,Monae Johnson,REP,1217
+Minnehaha,0415,Secretary of State,,Thomas A Cool,DEM,822
+Minnehaha,0501,Secretary of State,,Monae Johnson,REP,165
+Minnehaha,0501,Secretary of State,,Thomas A Cool,DEM,256
+Minnehaha,0502,Secretary of State,,Monae Johnson,REP,187
+Minnehaha,0502,Secretary of State,,Thomas A Cool,DEM,431
+Minnehaha,0503,Secretary of State,,Monae Johnson,REP,122
+Minnehaha,0503,Secretary of State,,Thomas A Cool,DEM,199
+Minnehaha,0504,Secretary of State,,Monae Johnson,REP,276
+Minnehaha,0504,Secretary of State,,Thomas A Cool,DEM,535
+Minnehaha,0506,Secretary of State,,Monae Johnson,REP,363
+Minnehaha,0506,Secretary of State,,Thomas A Cool,DEM,520
+Minnehaha,0507,Secretary of State,,Monae Johnson,REP,206
+Minnehaha,0507,Secretary of State,,Thomas A Cool,DEM,333
+Minnehaha,0508,Secretary of State,,Monae Johnson,REP,325
+Minnehaha,0508,Secretary of State,,Thomas A Cool,DEM,548
+Minnehaha,0509,Secretary of State,,Monae Johnson,REP,128
+Minnehaha,0509,Secretary of State,,Thomas A Cool,DEM,235
+Minnehaha,0510,Secretary of State,,Monae Johnson,REP,217
+Minnehaha,0510,Secretary of State,,Thomas A Cool,DEM,285
+Minnehaha,0512,Secretary of State,,Monae Johnson,REP,261
+Minnehaha,0512,Secretary of State,,Thomas A Cool,DEM,326
+Minnehaha,0513,Secretary of State,,Monae Johnson,REP,253
+Minnehaha,0513,Secretary of State,,Thomas A Cool,DEM,356
+Minnehaha,0514,Secretary of State,,Monae Johnson,REP,278
+Minnehaha,0514,Secretary of State,,Thomas A Cool,DEM,441
+Minnehaha,0515,Secretary of State,,Monae Johnson,REP,405
+Minnehaha,0515,Secretary of State,,Thomas A Cool,DEM,352
+Minnehaha,0517,Secretary of State,,Monae Johnson,REP,237
+Minnehaha,0517,Secretary of State,,Thomas A Cool,DEM,264
+Minnehaha,0518,Secretary of State,,Monae Johnson,REP,378
+Minnehaha,0518,Secretary of State,,Thomas A Cool,DEM,584
+Minnehaha,0519,Secretary of State,,Monae Johnson,REP,250
+Minnehaha,0519,Secretary of State,,Thomas A Cool,DEM,242
+Minnehaha,0520,Secretary of State,,Monae Johnson,REP,372
+Minnehaha,0520,Secretary of State,,Thomas A Cool,DEM,429
+Minnehaha,0521,Secretary of State,,Monae Johnson,REP,177
+Minnehaha,0521,Secretary of State,,Thomas A Cool,DEM,231
+Minnehaha,0522,Secretary of State,,Monae Johnson,REP,303
+Minnehaha,0522,Secretary of State,,Thomas A Cool,DEM,455
+Minnehaha,0523,Secretary of State,,Monae Johnson,REP,244
+Minnehaha,0523,Secretary of State,,Thomas A Cool,DEM,375
+Minnehaha,VP01,Secretary of State,,Monae Johnson,REP,521
+Minnehaha,VP01,Secretary of State,,Thomas A Cool,DEM,189
+Minnehaha,VP02,Secretary of State,,Monae Johnson,REP,1118
+Minnehaha,VP02,Secretary of State,,Thomas A Cool,DEM,515
+Minnehaha,VP03,Secretary of State,,Monae Johnson,REP,1345
+Minnehaha,VP03,Secretary of State,,Thomas A Cool,DEM,600
+Minnehaha,VP04,Secretary of State,,Monae Johnson,REP,681
+Minnehaha,VP04,Secretary of State,,Thomas A Cool,DEM,333
+Minnehaha,VP05,Secretary of State,,Monae Johnson,REP,888
+Minnehaha,VP05,Secretary of State,,Thomas A Cool,DEM,414
+Minnehaha,VP06,Secretary of State,,Monae Johnson,REP,269
+Minnehaha,VP06,Secretary of State,,Thomas A Cool,DEM,140
+Minnehaha,VP07,Secretary of State,,Monae Johnson,REP,1079
+Minnehaha,VP07,Secretary of State,,Thomas A Cool,DEM,505
+Minnehaha,VP08,Secretary of State,,Monae Johnson,REP,426
+Minnehaha,VP08,Secretary of State,,Thomas A Cool,DEM,170
+Minnehaha,VP09,Secretary of State,,Monae Johnson,REP,805
+Minnehaha,VP09,Secretary of State,,Thomas A Cool,DEM,369
+Minnehaha,VP10,Secretary of State,,Monae Johnson,REP,703
+Minnehaha,VP10,Secretary of State,,Thomas A Cool,DEM,367
+Minnehaha,VP11,Secretary of State,,Monae Johnson,REP,215
+Minnehaha,VP11,Secretary of State,,Thomas A Cool,DEM,73
+Minnehaha,VP12,Secretary of State,,Monae Johnson,REP,90
+Minnehaha,VP12,Secretary of State,,Thomas A Cool,DEM,31
+Minnehaha,VP13,Secretary of State,,Monae Johnson,REP,639
+Minnehaha,VP13,Secretary of State,,Thomas A Cool,DEM,206
+Minnehaha,VP15,Secretary of State,,Monae Johnson,REP,930
+Minnehaha,VP15,Secretary of State,,Thomas A Cool,DEM,489
+Minnehaha,VP16,Secretary of State,,Monae Johnson,REP,662
+Minnehaha,VP16,Secretary of State,,Thomas A Cool,DEM,316
+Minnehaha,VP17,Secretary of State,,Monae Johnson,REP,435
+Minnehaha,VP17,Secretary of State,,Thomas A Cool,DEM,179
+Minnehaha,VP21,Secretary of State,,Monae Johnson,REP,1035
+Minnehaha,VP21,Secretary of State,,Thomas A Cool,DEM,503
+Minnehaha,0104,State Auditor,,Rene Meyer,LIB,24
+Minnehaha,0104,State Auditor,,Richard Sattgast,REP,290
+Minnehaha,0104,State Auditor,,Stephanie Marty,DEM,367
+Minnehaha,0105,State Auditor,,Rene Meyer,LIB,23
+Minnehaha,0105,State Auditor,,Richard Sattgast,REP,207
+Minnehaha,0105,State Auditor,,Stephanie Marty,DEM,204
+Minnehaha,0106,State Auditor,,Rene Meyer,LIB,61
+Minnehaha,0106,State Auditor,,Richard Sattgast,REP,524
+Minnehaha,0106,State Auditor,,Stephanie Marty,DEM,451
+Minnehaha,0109,State Auditor,,Rene Meyer,LIB,47
+Minnehaha,0109,State Auditor,,Richard Sattgast,REP,545
+Minnehaha,0109,State Auditor,,Stephanie Marty,DEM,409
+Minnehaha,0110,State Auditor,,Rene Meyer,LIB,78
+Minnehaha,0110,State Auditor,,Richard Sattgast,REP,573
+Minnehaha,0110,State Auditor,,Stephanie Marty,DEM,441
+Minnehaha,0117,State Auditor,,Rene Meyer,LIB,72
+Minnehaha,0117,State Auditor,,Richard Sattgast,REP,703
+Minnehaha,0117,State Auditor,,Stephanie Marty,DEM,476
+Minnehaha,0119,State Auditor,,Rene Meyer,LIB,49
+Minnehaha,0119,State Auditor,,Richard Sattgast,REP,279
+Minnehaha,0119,State Auditor,,Stephanie Marty,DEM,254
+Minnehaha,0201,State Auditor,,Rene Meyer,LIB,35
+Minnehaha,0201,State Auditor,,Richard Sattgast,REP,571
+Minnehaha,0201,State Auditor,,Stephanie Marty,DEM,436
+Minnehaha,0202,State Auditor,,Rene Meyer,LIB,41
+Minnehaha,0202,State Auditor,,Richard Sattgast,REP,758
+Minnehaha,0202,State Auditor,,Stephanie Marty,DEM,586
+Minnehaha,0203,State Auditor,,Rene Meyer,LIB,62
+Minnehaha,0203,State Auditor,,Richard Sattgast,REP,538
+Minnehaha,0203,State Auditor,,Stephanie Marty,DEM,438
+Minnehaha,0206,State Auditor,,Rene Meyer,LIB,45
+Minnehaha,0206,State Auditor,,Richard Sattgast,REP,577
+Minnehaha,0206,State Auditor,,Stephanie Marty,DEM,438
+Minnehaha,0208,State Auditor,,Rene Meyer,LIB,54
+Minnehaha,0208,State Auditor,,Richard Sattgast,REP,619
+Minnehaha,0208,State Auditor,,Stephanie Marty,DEM,431
+Minnehaha,0209,State Auditor,,Rene Meyer,LIB,30
+Minnehaha,0209,State Auditor,,Richard Sattgast,REP,515
+Minnehaha,0209,State Auditor,,Stephanie Marty,DEM,456
+Minnehaha,0214,State Auditor,,Rene Meyer,LIB,104
+Minnehaha,0214,State Auditor,,Richard Sattgast,REP,1567
+Minnehaha,0214,State Auditor,,Stephanie Marty,DEM,1038
+Minnehaha,0301,State Auditor,,Rene Meyer,LIB,34
+Minnehaha,0301,State Auditor,,Richard Sattgast,REP,406
+Minnehaha,0301,State Auditor,,Stephanie Marty,DEM,315
+Minnehaha,0305,State Auditor,,Rene Meyer,LIB,46
+Minnehaha,0305,State Auditor,,Richard Sattgast,REP,248
+Minnehaha,0305,State Auditor,,Stephanie Marty,DEM,217
+Minnehaha,0309,State Auditor,,Rene Meyer,LIB,72
+Minnehaha,0309,State Auditor,,Richard Sattgast,REP,507
+Minnehaha,0309,State Auditor,,Stephanie Marty,DEM,511
+Minnehaha,0310,State Auditor,,Rene Meyer,LIB,57
+Minnehaha,0310,State Auditor,,Richard Sattgast,REP,835
+Minnehaha,0310,State Auditor,,Stephanie Marty,DEM,491
+Minnehaha,0311,State Auditor,,Rene Meyer,LIB,40
+Minnehaha,0311,State Auditor,,Richard Sattgast,REP,530
+Minnehaha,0311,State Auditor,,Stephanie Marty,DEM,311
+Minnehaha,0312,State Auditor,,Rene Meyer,LIB,76
+Minnehaha,0312,State Auditor,,Richard Sattgast,REP,680
+Minnehaha,0312,State Auditor,,Stephanie Marty,DEM,375
+Minnehaha,0313,State Auditor,,Rene Meyer,LIB,39
+Minnehaha,0313,State Auditor,,Richard Sattgast,REP,395
+Minnehaha,0313,State Auditor,,Stephanie Marty,DEM,263
+Minnehaha,0314,State Auditor,,Rene Meyer,LIB,115
+Minnehaha,0314,State Auditor,,Richard Sattgast,REP,887
+Minnehaha,0314,State Auditor,,Stephanie Marty,DEM,676
+Minnehaha,0315,State Auditor,,Rene Meyer,LIB,45
+Minnehaha,0315,State Auditor,,Richard Sattgast,REP,565
+Minnehaha,0315,State Auditor,,Stephanie Marty,DEM,423
+Minnehaha,0316,State Auditor,,Rene Meyer,LIB,68
+Minnehaha,0316,State Auditor,,Richard Sattgast,REP,988
+Minnehaha,0316,State Auditor,,Stephanie Marty,DEM,577
+Minnehaha,0317,State Auditor,,Rene Meyer,LIB,74
+Minnehaha,0317,State Auditor,,Richard Sattgast,REP,1170
+Minnehaha,0317,State Auditor,,Stephanie Marty,DEM,721
+Minnehaha,0402,State Auditor,,Rene Meyer,LIB,56
+Minnehaha,0402,State Auditor,,Richard Sattgast,REP,263
+Minnehaha,0402,State Auditor,,Stephanie Marty,DEM,303
+Minnehaha,0403,State Auditor,,Rene Meyer,LIB,27
+Minnehaha,0403,State Auditor,,Richard Sattgast,REP,190
+Minnehaha,0403,State Auditor,,Stephanie Marty,DEM,195
+Minnehaha,0404,State Auditor,,Rene Meyer,LIB,71
+Minnehaha,0404,State Auditor,,Richard Sattgast,REP,264
+Minnehaha,0404,State Auditor,,Stephanie Marty,DEM,305
+Minnehaha,0405,State Auditor,,Rene Meyer,LIB,71
+Minnehaha,0405,State Auditor,,Richard Sattgast,REP,911
+Minnehaha,0405,State Auditor,,Stephanie Marty,DEM,562
+Minnehaha,0406,State Auditor,,Rene Meyer,LIB,19
+Minnehaha,0406,State Auditor,,Richard Sattgast,REP,121
+Minnehaha,0406,State Auditor,,Stephanie Marty,DEM,138
+Minnehaha,0407,State Auditor,,Rene Meyer,LIB,36
+Minnehaha,0407,State Auditor,,Richard Sattgast,REP,633
+Minnehaha,0407,State Auditor,,Stephanie Marty,DEM,545
+Minnehaha,0408,State Auditor,,Rene Meyer,LIB,21
+Minnehaha,0408,State Auditor,,Richard Sattgast,REP,119
+Minnehaha,0408,State Auditor,,Stephanie Marty,DEM,167
+Minnehaha,0409,State Auditor,,Rene Meyer,LIB,69
+Minnehaha,0409,State Auditor,,Richard Sattgast,REP,273
+Minnehaha,0409,State Auditor,,Stephanie Marty,DEM,329
+Minnehaha,0410,State Auditor,,Rene Meyer,LIB,49
+Minnehaha,0410,State Auditor,,Richard Sattgast,REP,370
+Minnehaha,0410,State Auditor,,Stephanie Marty,DEM,306
+Minnehaha,0411,State Auditor,,Rene Meyer,LIB,79
+Minnehaha,0411,State Auditor,,Richard Sattgast,REP,1120
+Minnehaha,0411,State Auditor,,Stephanie Marty,DEM,662
+Minnehaha,0412,State Auditor,,Rene Meyer,LIB,45
+Minnehaha,0412,State Auditor,,Richard Sattgast,REP,557
+Minnehaha,0412,State Auditor,,Stephanie Marty,DEM,523
+Minnehaha,0413,State Auditor,,Rene Meyer,LIB,39
+Minnehaha,0413,State Auditor,,Richard Sattgast,REP,263
+Minnehaha,0413,State Auditor,,Stephanie Marty,DEM,298
+Minnehaha,0415,State Auditor,,Rene Meyer,LIB,70
+Minnehaha,0415,State Auditor,,Richard Sattgast,REP,1221
+Minnehaha,0415,State Auditor,,Stephanie Marty,DEM,724
+Minnehaha,0501,State Auditor,,Rene Meyer,LIB,29
+Minnehaha,0501,State Auditor,,Richard Sattgast,REP,160
+Minnehaha,0501,State Auditor,,Stephanie Marty,DEM,231
+Minnehaha,0502,State Auditor,,Rene Meyer,LIB,44
+Minnehaha,0502,State Auditor,,Richard Sattgast,REP,185
+Minnehaha,0502,State Auditor,,Stephanie Marty,DEM,386
+Minnehaha,0503,State Auditor,,Rene Meyer,LIB,32
+Minnehaha,0503,State Auditor,,Richard Sattgast,REP,111
+Minnehaha,0503,State Auditor,,Stephanie Marty,DEM,180
+Minnehaha,0504,State Auditor,,Rene Meyer,LIB,44
+Minnehaha,0504,State Auditor,,Richard Sattgast,REP,266
+Minnehaha,0504,State Auditor,,Stephanie Marty,DEM,499
+Minnehaha,0506,State Auditor,,Rene Meyer,LIB,63
+Minnehaha,0506,State Auditor,,Richard Sattgast,REP,361
+Minnehaha,0506,State Auditor,,Stephanie Marty,DEM,453
+Minnehaha,0507,State Auditor,,Rene Meyer,LIB,25
+Minnehaha,0507,State Auditor,,Richard Sattgast,REP,214
+Minnehaha,0507,State Auditor,,Stephanie Marty,DEM,297
+Minnehaha,0508,State Auditor,,Rene Meyer,LIB,39
+Minnehaha,0508,State Auditor,,Richard Sattgast,REP,328
+Minnehaha,0508,State Auditor,,Stephanie Marty,DEM,483
+Minnehaha,0509,State Auditor,,Rene Meyer,LIB,25
+Minnehaha,0509,State Auditor,,Richard Sattgast,REP,118
+Minnehaha,0509,State Auditor,,Stephanie Marty,DEM,208
+Minnehaha,0510,State Auditor,,Rene Meyer,LIB,30
+Minnehaha,0510,State Auditor,,Richard Sattgast,REP,223
+Minnehaha,0510,State Auditor,,Stephanie Marty,DEM,250
+Minnehaha,0512,State Auditor,,Rene Meyer,LIB,30
+Minnehaha,0512,State Auditor,,Richard Sattgast,REP,266
+Minnehaha,0512,State Auditor,,Stephanie Marty,DEM,288
+Minnehaha,0513,State Auditor,,Rene Meyer,LIB,24
+Minnehaha,0513,State Auditor,,Richard Sattgast,REP,265
+Minnehaha,0513,State Auditor,,Stephanie Marty,DEM,309
+Minnehaha,0514,State Auditor,,Rene Meyer,LIB,51
+Minnehaha,0514,State Auditor,,Richard Sattgast,REP,275
+Minnehaha,0514,State Auditor,,Stephanie Marty,DEM,394
+Minnehaha,0515,State Auditor,,Rene Meyer,LIB,45
+Minnehaha,0515,State Auditor,,Richard Sattgast,REP,374
+Minnehaha,0515,State Auditor,,Stephanie Marty,DEM,327
+Minnehaha,0517,State Auditor,,Rene Meyer,LIB,28
+Minnehaha,0517,State Auditor,,Richard Sattgast,REP,238
+Minnehaha,0517,State Auditor,,Stephanie Marty,DEM,228
+Minnehaha,0518,State Auditor,,Rene Meyer,LIB,71
+Minnehaha,0518,State Auditor,,Richard Sattgast,REP,342
+Minnehaha,0518,State Auditor,,Stephanie Marty,DEM,537
+Minnehaha,0519,State Auditor,,Rene Meyer,LIB,29
+Minnehaha,0519,State Auditor,,Richard Sattgast,REP,246
+Minnehaha,0519,State Auditor,,Stephanie Marty,DEM,209
+Minnehaha,0520,State Auditor,,Rene Meyer,LIB,57
+Minnehaha,0520,State Auditor,,Richard Sattgast,REP,357
+Minnehaha,0520,State Auditor,,Stephanie Marty,DEM,372
+Minnehaha,0521,State Auditor,,Rene Meyer,LIB,16
+Minnehaha,0521,State Auditor,,Richard Sattgast,REP,183
+Minnehaha,0521,State Auditor,,Stephanie Marty,DEM,202
+Minnehaha,0522,State Auditor,,Rene Meyer,LIB,71
+Minnehaha,0522,State Auditor,,Richard Sattgast,REP,296
+Minnehaha,0522,State Auditor,,Stephanie Marty,DEM,399
+Minnehaha,0523,State Auditor,,Rene Meyer,LIB,48
+Minnehaha,0523,State Auditor,,Richard Sattgast,REP,230
+Minnehaha,0523,State Auditor,,Stephanie Marty,DEM,333
+Minnehaha,VP01,State Auditor,,Rene Meyer,LIB,53
+Minnehaha,VP01,State Auditor,,Richard Sattgast,REP,496
+Minnehaha,VP01,State Auditor,,Stephanie Marty,DEM,148
+Minnehaha,VP02,State Auditor,,Rene Meyer,LIB,68
+Minnehaha,VP02,State Auditor,,Richard Sattgast,REP,1114
+Minnehaha,VP02,State Auditor,,Stephanie Marty,DEM,441
+Minnehaha,VP03,State Auditor,,Rene Meyer,LIB,88
+Minnehaha,VP03,State Auditor,,Richard Sattgast,REP,1310
+Minnehaha,VP03,State Auditor,,Stephanie Marty,DEM,539
+Minnehaha,VP04,State Auditor,,Rene Meyer,LIB,58
+Minnehaha,VP04,State Auditor,,Richard Sattgast,REP,670
+Minnehaha,VP04,State Auditor,,Stephanie Marty,DEM,289
+Minnehaha,VP05,State Auditor,,Rene Meyer,LIB,61
+Minnehaha,VP05,State Auditor,,Richard Sattgast,REP,863
+Minnehaha,VP05,State Auditor,,Stephanie Marty,DEM,360
+Minnehaha,VP06,State Auditor,,Rene Meyer,LIB,21
+Minnehaha,VP06,State Auditor,,Richard Sattgast,REP,267
+Minnehaha,VP06,State Auditor,,Stephanie Marty,DEM,121
+Minnehaha,VP07,State Auditor,,Rene Meyer,LIB,72
+Minnehaha,VP07,State Auditor,,Richard Sattgast,REP,1046
+Minnehaha,VP07,State Auditor,,Stephanie Marty,DEM,450
+Minnehaha,VP08,State Auditor,,Rene Meyer,LIB,36
+Minnehaha,VP08,State Auditor,,Richard Sattgast,REP,409
+Minnehaha,VP08,State Auditor,,Stephanie Marty,DEM,140
+Minnehaha,VP09,State Auditor,,Rene Meyer,LIB,58
+Minnehaha,VP09,State Auditor,,Richard Sattgast,REP,781
+Minnehaha,VP09,State Auditor,,Stephanie Marty,DEM,317
+Minnehaha,VP10,State Auditor,,Rene Meyer,LIB,62
+Minnehaha,VP10,State Auditor,,Richard Sattgast,REP,663
+Minnehaha,VP10,State Auditor,,Stephanie Marty,DEM,328
+Minnehaha,VP11,State Auditor,,Rene Meyer,LIB,9
+Minnehaha,VP11,State Auditor,,Richard Sattgast,REP,204
+Minnehaha,VP11,State Auditor,,Stephanie Marty,DEM,69
+Minnehaha,VP12,State Auditor,,Rene Meyer,LIB,5
+Minnehaha,VP12,State Auditor,,Richard Sattgast,REP,92
+Minnehaha,VP12,State Auditor,,Stephanie Marty,DEM,21
+Minnehaha,VP13,State Auditor,,Rene Meyer,LIB,56
+Minnehaha,VP13,State Auditor,,Richard Sattgast,REP,591
+Minnehaha,VP13,State Auditor,,Stephanie Marty,DEM,182
+Minnehaha,VP15,State Auditor,,Rene Meyer,LIB,62
+Minnehaha,VP15,State Auditor,,Richard Sattgast,REP,909
+Minnehaha,VP15,State Auditor,,Stephanie Marty,DEM,413
+Minnehaha,VP16,State Auditor,,Rene Meyer,LIB,60
+Minnehaha,VP16,State Auditor,,Richard Sattgast,REP,654
+Minnehaha,VP16,State Auditor,,Stephanie Marty,DEM,257
+Minnehaha,VP17,State Auditor,,Rene Meyer,LIB,28
+Minnehaha,VP17,State Auditor,,Richard Sattgast,REP,449
+Minnehaha,VP17,State Auditor,,Stephanie Marty,DEM,137
+Minnehaha,VP21,State Auditor,,Rene Meyer,LIB,73
+Minnehaha,VP21,State Auditor,,Richard Sattgast,REP,991
+Minnehaha,VP21,State Auditor,,Stephanie Marty,DEM,456
+Minnehaha,0206 Precinct-0208 Precinct-0209 Precinct-0214 Precinct-0301 Precinct-0305 Precinct-0309,State House,02,David Kull,REP,363
+Minnehaha,0206 Precinct-0208 Precinct-0209 Precinct-0214 Precinct-0301 Precinct-0305 Precinct-0309,State House,02,Gary Leighton,DEM,287
+Minnehaha,0206 Precinct-0208 Precinct-0209 Precinct-0214 Precinct-0301 Precinct-0305 Precinct-0309,State House,02,John Sjaarda,REP,332
+Minnehaha,0405 Precinct-0406 Precinct-0407 Precinct-0408,State House,02,David Kull,REP,0
+Minnehaha,0405 Precinct-0406 Precinct-0407 Precinct-0408,State House,02,Gary Leighton,DEM,0
+Minnehaha,0405 Precinct-0406 Precinct-0407 Precinct-0408,State House,02,John Sjaarda,REP,0
+Minnehaha,0409 Precinct-0410,State House,02,David Kull,REP,151
+Minnehaha,0409 Precinct-0410,State House,02,Gary Leighton,DEM,129
+Minnehaha,0409 Precinct-0410,State House,02,John Sjaarda,REP,152
+Minnehaha,0411,State House,02,David Kull,REP,997
+Minnehaha,0411,State House,02,Gary Leighton,DEM,730
+Minnehaha,0411,State House,02,John Sjaarda,REP,943
+Minnehaha,0412 Precinct-0413,State House,02,David Kull,REP,0
+Minnehaha,0412 Precinct-0413,State House,02,Gary Leighton,DEM,0
+Minnehaha,0412 Precinct-0413,State House,02,John Sjaarda,REP,0
+Minnehaha,0415 Precinct-0501 Precinct-0502 Precinct-0503 Precinct-0504 Precinct-0506 Precinct-0507 Precinct-0508 Precinct-0509 Precinct-0510 Precinct-0512,State House,02,David Kull,REP,383
+Minnehaha,0415 Precinct-0501 Precinct-0502 Precinct-0503 Precinct-0504 Precinct-0506 Precinct-0507 Precinct-0508 Precinct-0509 Precinct-0510 Precinct-0512,State House,02,Gary Leighton,DEM,237
+Minnehaha,0415 Precinct-0501 Precinct-0502 Precinct-0503 Precinct-0504 Precinct-0506 Precinct-0507 Precinct-0508 Precinct-0509 Precinct-0510 Precinct-0512,State House,02,John Sjaarda,REP,384
+Minnehaha,0513 Precinct-0514 Precinct-0515 Precinct-0517 Precinct-0518 Precinct-0519 Precinct-0520 Precinct-0521 Precinct-0522 Precinct-0523 Precinct-VP01,State House,02,David Kull,REP,357
+Minnehaha,0513 Precinct-0514 Precinct-0515 Precinct-0517 Precinct-0518 Precinct-0519 Precinct-0520 Precinct-0521 Precinct-0522 Precinct-0523 Precinct-VP01,State House,02,Gary Leighton,DEM,142
+Minnehaha,0513 Precinct-0514 Precinct-0515 Precinct-0517 Precinct-0518 Precinct-0519 Precinct-0520 Precinct-0521 Precinct-0522 Precinct-0523 Precinct-VP01,State House,02,John Sjaarda,REP,502
+Minnehaha,VP02,State House,02,David Kull,REP,957
+Minnehaha,VP02,State House,02,Gary Leighton,DEM,445
+Minnehaha,VP02,State House,02,John Sjaarda,REP,947
+Minnehaha,VP03,State House,02,David Kull,REP,1178
+Minnehaha,VP03,State House,02,Gary Leighton,DEM,528
+Minnehaha,VP03,State House,02,John Sjaarda,REP,1029
+Minnehaha,VP04 Precinct-VP05 23 of 65,State House,02,David Kull,REP,827
+Minnehaha,VP04 Precinct-VP05 23 of 65,State House,02,Gary Leighton,DEM,382
+Minnehaha,VP04 Precinct-VP05 23 of 65,State House,02,John Sjaarda,REP,681
+Minnehaha,VP11 Precinct-VP12 Precinct-VP13 Precinct-VP15 Precinct-VP16,State House,02,David Kull,REP,908
+Minnehaha,VP11 Precinct-VP12 Precinct-VP13 Precinct-VP15 Precinct-VP16,State House,02,Gary Leighton,DEM,443
+Minnehaha,VP11 Precinct-VP12 Precinct-VP13 Precinct-VP15 Precinct-VP16,State House,02,John Sjaarda,REP,723
+Minnehaha,0104 Precinct-0105 Precinct-0106 Precinct-0109 Precinct-0110 Precinct-0117 Precinct-0119 Precinct-0201 Precinct-0202 Precinct-0203,State House,09,Bethany Soye,REP,2
+Minnehaha,0104 Precinct-0105 Precinct-0106 Precinct-0109 Precinct-0110 Precinct-0117 Precinct-0119 Precinct-0201 Precinct-0202 Precinct-0203,State House,09,Kenneth Teunissen,REP,2
+Minnehaha,0104 Precinct-0105 Precinct-0106 Precinct-0109 Precinct-0110 Precinct-0117 Precinct-0119 Precinct-0201 Precinct-0202 Precinct-0203,State House,09,Nick Winkler,DEM,2
+Minnehaha,0310 Precinct-0311 Precinct-0312,State House,09,Bethany Soye,REP,649
+Minnehaha,0310 Precinct-0311 Precinct-0312,State House,09,Kenneth Teunissen,REP,514
+Minnehaha,0310 Precinct-0311 Precinct-0312,State House,09,Nick Winkler,DEM,401
+Minnehaha,0313 Precinct-0314 Precinct-0315,State House,09,Bethany Soye,REP,773
+Minnehaha,0313 Precinct-0314 Precinct-0315,State House,09,Kenneth Teunissen,REP,603
+Minnehaha,0313 Precinct-0314 Precinct-0315,State House,09,Nick Winkler,DEM,642
+Minnehaha,0316,State House,09,Bethany Soye,REP,926
+Minnehaha,0316,State House,09,Kenneth Teunissen,REP,806
+Minnehaha,0316,State House,09,Nick Winkler,DEM,627
+Minnehaha,0317 Precinct-0402 Precinct-0403 Precinct-0404,State House,09,Bethany Soye,REP,1054
+Minnehaha,0317 Precinct-0402 Precinct-0403 Precinct-0404,State House,09,Kenneth Teunissen,REP,928
+Minnehaha,0317 Precinct-0402 Precinct-0403 Precinct-0404,State House,09,Nick Winkler,DEM,785
+Minnehaha,VP06,State House,09,Bethany Soye,REP,230
+Minnehaha,VP06,State House,09,Kenneth Teunissen,REP,208
+Minnehaha,VP06,State House,09,Nick Winkler,DEM,131
+Minnehaha,VP07 Precinct-VP08 Precinct-VP09 Precinct-VP10,State House,09,Bethany Soye,REP,969
+Minnehaha,VP07 Precinct-VP08 Precinct-VP09 Precinct-VP10,State House,09,Kenneth Teunissen,REP,733
+Minnehaha,VP07 Precinct-VP08 Precinct-VP09 Precinct-VP10,State House,09,Nick Winkler,DEM,440
+Minnehaha,VP17 Precinct-VP21 26 of 65,State House,09,Bethany Soye,REP,431
+Minnehaha,VP17 Precinct-VP21 26 of 65,State House,09,Kenneth Teunissen,REP,348
+Minnehaha,VP17 Precinct-VP21 26 of 65,State House,09,Nick Winkler,DEM,155
+Minnehaha,0317 Precinct-0402,State House,10,Erin Healy,DEM,363
+Minnehaha,0317 Precinct-0402,State House,10,John G. Mogen,REP,242
+Minnehaha,0317 Precinct-0402,State House,10,Kameron Nelson,DEM,254
+Minnehaha,0317 Precinct-0402,State House,10,Tom E Sutton,REP,234
+Minnehaha,0403,State House,10,Erin Healy,DEM,219
+Minnehaha,0403,State House,10,John G. Mogen,REP,161
+Minnehaha,0403,State House,10,Kameron Nelson,DEM,175
+Minnehaha,0403,State House,10,Tom E Sutton,REP,171
+Minnehaha,0404 Precinct-0405,State House,10,Erin Healy,DEM,345
+Minnehaha,0404 Precinct-0405,State House,10,John G. Mogen,REP,255
+Minnehaha,0404 Precinct-0405,State House,10,Kameron Nelson,DEM,258
+Minnehaha,0404 Precinct-0405,State House,10,Tom E Sutton,REP,256
+Minnehaha,0406,State House,10,Erin Healy,DEM,129
+Minnehaha,0406,State House,10,John G. Mogen,REP,90
+Minnehaha,0406,State House,10,Kameron Nelson,DEM,105
+Minnehaha,0406,State House,10,Tom E Sutton,REP,99
+Minnehaha,0407,State House,10,Erin Healy,DEM,607
+Minnehaha,0407,State House,10,John G. Mogen,REP,562
+Minnehaha,0407,State House,10,Kameron Nelson,DEM,475
+Minnehaha,0407,State House,10,Tom E Sutton,REP,547
+Minnehaha,0408,State House,10,Erin Healy,DEM,181
+Minnehaha,0408,State House,10,John G. Mogen,REP,104
+Minnehaha,0408,State House,10,Kameron Nelson,DEM,141
+Minnehaha,0408,State House,10,Tom E Sutton,REP,116
+Minnehaha,0409,State House,10,Erin Healy,DEM,403
+Minnehaha,0409,State House,10,John G. Mogen,REP,242
+Minnehaha,0409,State House,10,Kameron Nelson,DEM,282
+Minnehaha,0409,State House,10,Tom E Sutton,REP,278
+Minnehaha,0410 Precinct-0411 Precinct-0412 Precinct-0413,State House,10,Erin Healy,DEM,203
+Minnehaha,0410 Precinct-0411 Precinct-0412 Precinct-0413,State House,10,John G. Mogen,REP,186
+Minnehaha,0410 Precinct-0411 Precinct-0412 Precinct-0413,State House,10,Kameron Nelson,DEM,155
+Minnehaha,0410 Precinct-0411 Precinct-0412 Precinct-0413,State House,10,Tom E Sutton,REP,199
+Minnehaha,0415 Precinct-0501 Precinct-0502 Precinct-0503,State House,10,Erin Healy,DEM,127
+Minnehaha,0415 Precinct-0501 Precinct-0502 Precinct-0503,State House,10,John G. Mogen,REP,44
+Minnehaha,0415 Precinct-0501 Precinct-0502 Precinct-0503,State House,10,Kameron Nelson,DEM,106
+Minnehaha,0415 Precinct-0501 Precinct-0502 Precinct-0503,State House,10,Tom E Sutton,REP,46
+Minnehaha,0504,State House,10,Erin Healy,DEM,547
+Minnehaha,0504,State House,10,John G. Mogen,REP,278
+Minnehaha,0504,State House,10,Kameron Nelson,DEM,432
+Minnehaha,0504,State House,10,Tom E Sutton,REP,233
+Minnehaha,0506,State House,10,Erin Healy,DEM,527
+Minnehaha,0506,State House,10,John G. Mogen,REP,363
+Minnehaha,0506,State House,10,Kameron Nelson,DEM,399
+Minnehaha,0506,State House,10,Tom E Sutton,REP,322
+Minnehaha,0507,State House,10,Erin Healy,DEM,362
+Minnehaha,0507,State House,10,John G. Mogen,REP,211
+Minnehaha,0507,State House,10,Kameron Nelson,DEM,256
+Minnehaha,0507,State House,10,Tom E Sutton,REP,175
+Minnehaha,0508 Precinct-0509 Precinct-0510 Precinct-0512 Precinct-0513 Precinct-0514 Precinct-0515 Precinct-0517,State House,10,Erin Healy,DEM,573
+Minnehaha,0508 Precinct-0509 Precinct-0510 Precinct-0512 Precinct-0513 Precinct-0514 Precinct-0515 Precinct-0517,State House,10,John G. Mogen,REP,339
+Minnehaha,0508 Precinct-0509 Precinct-0510 Precinct-0512 Precinct-0513 Precinct-0514 Precinct-0515 Precinct-0517,State House,10,Kameron Nelson,DEM,447
+Minnehaha,0508 Precinct-0509 Precinct-0510 Precinct-0512 Precinct-0513 Precinct-0514 Precinct-0515 Precinct-0517,State House,10,Tom E Sutton,REP,270
+Minnehaha,0518 Precinct-0519 Precinct-0520 Precinct-0521 Precinct-0522 Precinct-0523 Precinct-VP01 Precinct-VP02 Precinct-VP03 Precinct-VP04 Precinct-VP05 24 of 65,State House,10,Erin Healy,DEM,27
+Minnehaha,0518 Precinct-0519 Precinct-0520 Precinct-0521 Precinct-0522 Precinct-0523 Precinct-VP01 Precinct-VP02 Precinct-VP03 Precinct-VP04 Precinct-VP05 24 of 65,State House,10,John G. Mogen,REP,37
+Minnehaha,0518 Precinct-0519 Precinct-0520 Precinct-0521 Precinct-0522 Precinct-0523 Precinct-VP01 Precinct-VP02 Precinct-VP03 Precinct-VP04 Precinct-VP05 24 of 65,State House,10,Kameron Nelson,DEM,25
+Minnehaha,0518 Precinct-0519 Precinct-0520 Precinct-0521 Precinct-0522 Precinct-0523 Precinct-VP01 Precinct-VP02 Precinct-VP03 Precinct-VP04 Precinct-VP05 24 of 65,State House,10,Tom E Sutton,REP,34
+Minnehaha,0106,State House,11,Brian K. Mulder,REP,511
+Minnehaha,0106,State House,11,Chris Karr,REP,471
+Minnehaha,0106,State House,11,Kim Parke,DEM,419
+Minnehaha,0106,State House,11,Margaret Kuipers,DEM,425
+Minnehaha,0109,State House,11,Brian K. Mulder,REP,525
+Minnehaha,0109,State House,11,Chris Karr,REP,519
+Minnehaha,0109,State House,11,Kim Parke,DEM,401
+Minnehaha,0109,State House,11,Margaret Kuipers,DEM,402
+Minnehaha,0110,State House,11,Brian K. Mulder,REP,553
+Minnehaha,0110,State House,11,Chris Karr,REP,541
+Minnehaha,0110,State House,11,Kim Parke,DEM,409
+Minnehaha,0110,State House,11,Margaret Kuipers,DEM,447
+Minnehaha,0117,State House,11,Brian K. Mulder,REP,670
+Minnehaha,0117,State House,11,Chris Karr,REP,654
+Minnehaha,0117,State House,11,Kim Parke,DEM,430
+Minnehaha,0117,State House,11,Margaret Kuipers,DEM,487
+Minnehaha,0309,State House,11,Brian K. Mulder,REP,493
+Minnehaha,0309,State House,11,Chris Karr,REP,474
+Minnehaha,0309,State House,11,Kim Parke,DEM,461
+Minnehaha,0309,State House,11,Margaret Kuipers,DEM,504
+Minnehaha,0310,State House,11,Brian K. Mulder,REP,818
+Minnehaha,0310,State House,11,Chris Karr,REP,794
+Minnehaha,0310,State House,11,Kim Parke,DEM,471
+Minnehaha,0310,State House,11,Margaret Kuipers,DEM,502
+Minnehaha,0311,State House,11,Brian K. Mulder,REP,494
+Minnehaha,0311,State House,11,Chris Karr,REP,500
+Minnehaha,0311,State House,11,Kim Parke,DEM,321
+Minnehaha,0311,State House,11,Margaret Kuipers,DEM,313
+Minnehaha,0313,State House,11,Brian K. Mulder,REP,384
+Minnehaha,0313,State House,11,Chris Karr,REP,370
+Minnehaha,0313,State House,11,Kim Parke,DEM,243
+Minnehaha,0313,State House,11,Margaret Kuipers,DEM,265
+Minnehaha,0315,State House,11,Brian K. Mulder,REP,531
+Minnehaha,0315,State House,11,Chris Karr,REP,548
+Minnehaha,0315,State House,11,Kim Parke,DEM,396
+Minnehaha,0315,State House,11,Margaret Kuipers,DEM,429
+Minnehaha,VP06,State House,11,Brian K. Mulder,REP,9
+Minnehaha,VP06,State House,11,Chris Karr,REP,8
+Minnehaha,VP06,State House,11,Kim Parke,DEM,2
+Minnehaha,VP06,State House,11,Margaret Kuipers,DEM,1
+Minnehaha,0104,State House,12,Amber Arlint,REP,288
+Minnehaha,0104,State House,12,Erin Royer,DEM,318
+Minnehaha,0104,State House,12,Greg Jamison,REP,298
+Minnehaha,0104,State House,12,Kristin Hayward,DEM,328
+Minnehaha,0105 Precinct-0106 Precinct-0109,State House,12,Amber Arlint,REP,199
+Minnehaha,0105 Precinct-0106 Precinct-0109,State House,12,Erin Royer,DEM,174
+Minnehaha,0105 Precinct-0106 Precinct-0109,State House,12,Greg Jamison,REP,209
+Minnehaha,0105 Precinct-0106 Precinct-0109,State House,12,Kristin Hayward,DEM,190
+Minnehaha,0208 Precinct-0209 Precinct-0214 Precinct-0301 Precinct-0305 Precinct-0309 Precinct-0310 Precinct-0311 Precinct-0312 Precinct-0313 Precinct-0314 Precinct-0315 Precinct-0316 Precinct-0317 Precinct-0402 Precinct-0403 Precinct-0404,State House,12,Amber Arlint,REP,389
+Minnehaha,0208 Precinct-0209 Precinct-0214 Precinct-0301 Precinct-0305 Precinct-0309 Precinct-0310 Precinct-0311 Precinct-0312 Precinct-0313 Precinct-0314 Precinct-0315 Precinct-0316 Precinct-0317 Precinct-0402 Precinct-0403 Precinct-0404,State House,12,Erin Royer,DEM,292
+Minnehaha,0208 Precinct-0209 Precinct-0214 Precinct-0301 Precinct-0305 Precinct-0309 Precinct-0310 Precinct-0311 Precinct-0312 Precinct-0313 Precinct-0314 Precinct-0315 Precinct-0316 Precinct-0317 Precinct-0402 Precinct-0403 Precinct-0404,State House,12,Greg Jamison,REP,412
+Minnehaha,0208 Precinct-0209 Precinct-0214 Precinct-0301 Precinct-0305 Precinct-0309 Precinct-0310 Precinct-0311 Precinct-0312 Precinct-0313 Precinct-0314 Precinct-0315 Precinct-0316 Precinct-0317 Precinct-0402 Precinct-0403 Precinct-0404,State House,12,Kristin Hayward,DEM,294
+Minnehaha,0405 Precinct-0406 Precinct-0407 Precinct-0408 Precinct-0409 Precinct-0410 Precinct-0411 Precinct-0412 Precinct-0413 Precinct-0415 Precinct-0501 Precinct-0502 Precinct-0503 Precinct-0504 Precinct-0506,State House,12,Amber Arlint,REP,103
+Minnehaha,0405 Precinct-0406 Precinct-0407 Precinct-0408 Precinct-0409 Precinct-0410 Precinct-0411 Precinct-0412 Precinct-0413 Precinct-0415 Precinct-0501 Precinct-0502 Precinct-0503 Precinct-0504 Precinct-0506,State House,12,Erin Royer,DEM,136
+Minnehaha,0405 Precinct-0406 Precinct-0407 Precinct-0408 Precinct-0409 Precinct-0410 Precinct-0411 Precinct-0412 Precinct-0413 Precinct-0415 Precinct-0501 Precinct-0502 Precinct-0503 Precinct-0504 Precinct-0506,State House,12,Greg Jamison,REP,102
+Minnehaha,0405 Precinct-0406 Precinct-0407 Precinct-0408 Precinct-0409 Precinct-0410 Precinct-0411 Precinct-0412 Precinct-0413 Precinct-0415 Precinct-0501 Precinct-0502 Precinct-0503 Precinct-0504 Precinct-0506,State House,12,Kristin Hayward,DEM,136
+Minnehaha,0507 Precinct-0508 Precinct-0509,State House,12,Amber Arlint,REP,113
+Minnehaha,0507 Precinct-0508 Precinct-0509,State House,12,Erin Royer,DEM,207
+Minnehaha,0507 Precinct-0508 Precinct-0509,State House,12,Greg Jamison,REP,124
+Minnehaha,0507 Precinct-0508 Precinct-0509,State House,12,Kristin Hayward,DEM,199
+Minnehaha,0510,State House,12,Amber Arlint,REP,203
+Minnehaha,0510,State House,12,Erin Royer,DEM,236
+Minnehaha,0510,State House,12,Greg Jamison,REP,236
+Minnehaha,0510,State House,12,Kristin Hayward,DEM,230
+Minnehaha,0514 Precinct-0515,State House,12,Amber Arlint,REP,137
+Minnehaha,0514 Precinct-0515,State House,12,Erin Royer,DEM,175
+Minnehaha,0514 Precinct-0515,State House,12,Greg Jamison,REP,153
+Minnehaha,0514 Precinct-0515,State House,12,Kristin Hayward,DEM,170
+Minnehaha,0517,State House,12,Amber Arlint,REP,235
+Minnehaha,0517,State House,12,Erin Royer,DEM,211
+Minnehaha,0517,State House,12,Greg Jamison,REP,247
+Minnehaha,0517,State House,12,Kristin Hayward,DEM,225
+Minnehaha,0518 Precinct-0519 Precinct-0520,State House,12,Amber Arlint,REP,244
+Minnehaha,0518 Precinct-0519 Precinct-0520,State House,12,Erin Royer,DEM,215
+Minnehaha,0518 Precinct-0519 Precinct-0520,State House,12,Greg Jamison,REP,258
+Minnehaha,0518 Precinct-0519 Precinct-0520,State House,12,Kristin Hayward,DEM,211
+Minnehaha,0521 Precinct-0522 Precinct-0523 Precinct-VP01 Precinct-VP02 Precinct-VP03 Precinct-VP04 Precinct-VP05 25 of 65,State House,12,Amber Arlint,REP,176
+Minnehaha,0521 Precinct-0522 Precinct-0523 Precinct-VP01 Precinct-VP02 Precinct-VP03 Precinct-VP04 Precinct-VP05 25 of 65,State House,12,Erin Royer,DEM,215
+Minnehaha,0521 Precinct-0522 Precinct-0523 Precinct-VP01 Precinct-VP02 Precinct-VP03 Precinct-VP04 Precinct-VP05 25 of 65,State House,12,Greg Jamison,REP,185
+Minnehaha,0521 Precinct-0522 Precinct-0523 Precinct-VP01 Precinct-VP02 Precinct-VP03 Precinct-VP04 Precinct-VP05 25 of 65,State House,12,Kristin Hayward,DEM,173
+Minnehaha,0110 Precinct-0117 Precinct-0119,State House,13,Sue Peterson,REP,313
+Minnehaha,0110 Precinct-0117 Precinct-0119,State House,13,Tony Venhuizen,REP,227
+Minnehaha,0201 Precinct-0202 Precinct-0203 Precinct-0206,State House,13,Sue Peterson,REP,561
+Minnehaha,0201 Precinct-0202 Precinct-0203 Precinct-0206,State House,13,Tony Venhuizen,REP,514
+Minnehaha,0512,State House,13,Sue Peterson,REP,270
+Minnehaha,0512,State House,13,Tony Venhuizen,REP,244
+Minnehaha,0513,State House,13,Sue Peterson,REP,279
+Minnehaha,0513,State House,13,Tony Venhuizen,REP,278
+Minnehaha,0202,State House,14,Mike Huber,DEM,571
+Minnehaha,0202,State House,14,Taylor Rae Rehfeldt,REP,822
+Minnehaha,0202,State House,14,Tyler Tordsen,REP,686
+Minnehaha,0202,State House,14,Wendy Mamer,DEM,552
+Minnehaha,0203,State House,14,Mike Huber,DEM,453
+Minnehaha,0203,State House,14,Taylor Rae Rehfeldt,REP,599
+Minnehaha,0203,State House,14,Tyler Tordsen,REP,491
+Minnehaha,0203,State House,14,Wendy Mamer,DEM,430
+Minnehaha,0206,State House,14,Mike Huber,DEM,473
+Minnehaha,0206,State House,14,Taylor Rae Rehfeldt,REP,633
+Minnehaha,0206,State House,14,Tyler Tordsen,REP,502
+Minnehaha,0206,State House,14,Wendy Mamer,DEM,429
+Minnehaha,0208,State House,14,Mike Huber,DEM,441
+Minnehaha,0208,State House,14,Taylor Rae Rehfeldt,REP,684
+Minnehaha,0208,State House,14,Tyler Tordsen,REP,557
+Minnehaha,0208,State House,14,Wendy Mamer,DEM,385
+Minnehaha,0209,State House,14,Mike Huber,DEM,480
+Minnehaha,0209,State House,14,Taylor Rae Rehfeldt,REP,532
+Minnehaha,0209,State House,14,Tyler Tordsen,REP,436
+Minnehaha,0209,State House,14,Wendy Mamer,DEM,439
+Minnehaha,0214,State House,14,Mike Huber,DEM,802
+Minnehaha,0214,State House,14,Taylor Rae Rehfeldt,REP,1241
+Minnehaha,0214,State House,14,Tyler Tordsen,REP,1018
+Minnehaha,0214,State House,14,Wendy Mamer,DEM,730
+Minnehaha,0412,State House,14,Mike Huber,DEM,518
+Minnehaha,0412,State House,14,Taylor Rae Rehfeldt,REP,557
+Minnehaha,0412,State House,14,Tyler Tordsen,REP,489
+Minnehaha,0412,State House,14,Wendy Mamer,DEM,456
+Minnehaha,0413,State House,14,Mike Huber,DEM,304
+Minnehaha,0413,State House,14,Taylor Rae Rehfeldt,REP,270
+Minnehaha,0413,State House,14,Tyler Tordsen,REP,225
+Minnehaha,0413,State House,14,Wendy Mamer,DEM,272
+Minnehaha,0415,State House,14,Mike Huber,DEM,525
+Minnehaha,0415,State House,14,Taylor Rae Rehfeldt,REP,782
+Minnehaha,0415,State House,14,Tyler Tordsen,REP,702
+Minnehaha,0415,State House,14,Wendy Mamer,DEM,466
+Minnehaha,VP02,State House,14,Mike Huber,DEM,3
+Minnehaha,VP02,State House,14,Taylor Rae Rehfeldt,REP,7
+Minnehaha,VP02,State House,14,Tyler Tordsen,REP,5
+Minnehaha,VP02,State House,14,Wendy Mamer,DEM,2
+Minnehaha,0305,State House,15,Joni Tschetter,REP,237
+Minnehaha,0305,State House,15,Kadyn Wittman,DEM,179
+Minnehaha,0305,State House,15,Linda Duba,DEM,228
+Minnehaha,0305,State House,15,Matt Rosburg,REP,210
+Minnehaha,0405,State House,15,Joni Tschetter,REP,787
+Minnehaha,0405,State House,15,Kadyn Wittman,DEM,446
+Minnehaha,0405,State House,15,Linda Duba,DEM,510
+Minnehaha,0405,State House,15,Matt Rosburg,REP,706
+Minnehaha,0501,State House,15,Joni Tschetter,REP,145
+Minnehaha,0501,State House,15,Kadyn Wittman,DEM,204
+Minnehaha,0501,State House,15,Linda Duba,DEM,228
+Minnehaha,0501,State House,15,Matt Rosburg,REP,140
+Minnehaha,0502,State House,15,Joni Tschetter,REP,143
+Minnehaha,0502,State House,15,Kadyn Wittman,DEM,269
+Minnehaha,0502,State House,15,Linda Duba,DEM,269
+Minnehaha,0502,State House,15,Matt Rosburg,REP,132
+Minnehaha,0503,State House,15,Joni Tschetter,REP,17
+Minnehaha,0503,State House,15,Kadyn Wittman,DEM,41
+Minnehaha,0503,State House,15,Linda Duba,DEM,39
+Minnehaha,0503,State House,15,Matt Rosburg,REP,17
+Minnehaha,0514,State House,15,Joni Tschetter,REP,136
+Minnehaha,0514,State House,15,Kadyn Wittman,DEM,199
+Minnehaha,0514,State House,15,Linda Duba,DEM,223
+Minnehaha,0514,State House,15,Matt Rosburg,REP,102
+Minnehaha,0515,State House,15,Joni Tschetter,REP,381
+Minnehaha,0515,State House,15,Kadyn Wittman,DEM,305
+Minnehaha,0515,State House,15,Linda Duba,DEM,319
+Minnehaha,0515,State House,15,Matt Rosburg,REP,338
+Minnehaha,0518,State House,15,Joni Tschetter,REP,363
+Minnehaha,0518,State House,15,Kadyn Wittman,DEM,490
+Minnehaha,0518,State House,15,Linda Duba,DEM,548
+Minnehaha,0518,State House,15,Matt Rosburg,REP,334
+Minnehaha,0520,State House,15,Joni Tschetter,REP,361
+Minnehaha,0520,State House,15,Kadyn Wittman,DEM,364
+Minnehaha,0520,State House,15,Linda Duba,DEM,399
+Minnehaha,0520,State House,15,Matt Rosburg,REP,296
+Minnehaha,0522,State House,15,Joni Tschetter,REP,291
+Minnehaha,0522,State House,15,Kadyn Wittman,DEM,364
+Minnehaha,0522,State House,15,Linda Duba,DEM,430
+Minnehaha,0522,State House,15,Matt Rosburg,REP,263
+Minnehaha,0523,State House,15,Joni Tschetter,REP,212
+Minnehaha,0523,State House,15,Kadyn Wittman,DEM,326
+Minnehaha,0523,State House,15,Linda Duba,DEM,344
+Minnehaha,0523,State House,15,Matt Rosburg,REP,200
+Minnehaha,VP04,State House,15,Joni Tschetter,REP,24
+Minnehaha,VP04,State House,15,Kadyn Wittman,DEM,7
+Minnehaha,VP04,State House,15,Linda Duba,DEM,8
+Minnehaha,VP04,State House,15,Matt Rosburg,REP,23
+Minnehaha,0305,State House,25,Dan Ahlers,DEM,5
+Minnehaha,0305,State House,25,David Kills A Hundred,DEM,7
+Minnehaha,0305,State House,25,Jon Hansen,REP,5
+Minnehaha,0305,State House,25,Randy Gross,REP,6
+Minnehaha,0314,State House,25,Dan Ahlers,DEM,111
+Minnehaha,0314,State House,25,David Kills A Hundred,DEM,70
+Minnehaha,0314,State House,25,Jon Hansen,REP,135
+Minnehaha,0314,State House,25,Randy Gross,REP,135
+Minnehaha,0405,State House,25,Dan Ahlers,DEM,82
+Minnehaha,0405,State House,25,David Kills A Hundred,DEM,45
+Minnehaha,0405,State House,25,Jon Hansen,REP,93
+Minnehaha,0405,State House,25,Randy Gross,REP,93
+Minnehaha,0406,State House,25,Dan Ahlers,DEM,16
+Minnehaha,0406,State House,25,David Kills A Hundred,DEM,11
+Minnehaha,0406,State House,25,Jon Hansen,REP,12
+Minnehaha,0406,State House,25,Randy Gross,REP,12
+Minnehaha,VP01,State House,25,Dan Ahlers,DEM,12
+Minnehaha,VP01,State House,25,David Kills A Hundred,DEM,3
+Minnehaha,VP01,State House,25,Jon Hansen,REP,41
+Minnehaha,VP01,State House,25,Randy Gross,REP,35
+Minnehaha,VP03,State House,25,Dan Ahlers,DEM,46
+Minnehaha,VP03,State House,25,David Kills A Hundred,DEM,27
+Minnehaha,VP03,State House,25,Jon Hansen,REP,79
+Minnehaha,VP03,State House,25,Randy Gross,REP,75
+Minnehaha,VP04,State House,25,Dan Ahlers,DEM,356
+Minnehaha,VP04,State House,25,David Kills A Hundred,DEM,205
+Minnehaha,VP04,State House,25,Jon Hansen,REP,601
+Minnehaha,VP04,State House,25,Randy Gross,REP,605
+Minnehaha,VP07,State House,25,Dan Ahlers,DEM,40
+Minnehaha,VP07,State House,25,David Kills A Hundred,DEM,27
+Minnehaha,VP07,State House,25,Jon Hansen,REP,84
+Minnehaha,VP07,State House,25,Randy Gross,REP,80
+Minnehaha,VP08,State House,25,Dan Ahlers,DEM,206
+Minnehaha,VP08,State House,25,David Kills A Hundred,DEM,104
+Minnehaha,VP08,State House,25,Jon Hansen,REP,406
+Minnehaha,VP08,State House,25,Randy Gross,REP,385
+Minnehaha,VP09,State House,25,Dan Ahlers,DEM,558
+Minnehaha,VP09,State House,25,David Kills A Hundred,DEM,226
+Minnehaha,VP09,State House,25,Jon Hansen,REP,751
+Minnehaha,VP09,State House,25,Randy Gross,REP,636
+Minnehaha,VP10,State House,25,Dan Ahlers,DEM,472
+Minnehaha,VP10,State House,25,David Kills A Hundred,DEM,232
+Minnehaha,VP10,State House,25,Jon Hansen,REP,673
+Minnehaha,VP10,State House,25,Randy Gross,REP,593
+Minnehaha,VP11,State House,25,Dan Ahlers,DEM,125
+Minnehaha,VP11,State House,25,David Kills A Hundred,DEM,47
+Minnehaha,VP11,State House,25,Jon Hansen,REP,208
+Minnehaha,VP11,State House,25,Randy Gross,REP,159
+Minnehaha,VP12,State House,25,Dan Ahlers,DEM,50
+Minnehaha,VP12,State House,25,David Kills A Hundred,DEM,11
+Minnehaha,VP12,State House,25,Jon Hansen,REP,81
+Minnehaha,VP12,State House,25,Randy Gross,REP,70
+Minnehaha,VP13,State House,25,Dan Ahlers,DEM,300
+Minnehaha,VP13,State House,25,David Kills A Hundred,DEM,124
+Minnehaha,VP13,State House,25,Jon Hansen,REP,607
+Minnehaha,VP13,State House,25,Randy Gross,REP,516
+Minnehaha,VP16,State House,25,Dan Ahlers,DEM,358
+Minnehaha,VP16,State House,25,David Kills A Hundred,DEM,198
+Minnehaha,VP16,State House,25,Jon Hansen,REP,631
+Minnehaha,VP16,State House,25,Randy Gross,REP,585
+Minnehaha,VP21,State House,25,Dan Ahlers,DEM,797
+Minnehaha,VP21,State House,25,David Kills A Hundred,DEM,281
+Minnehaha,VP21,State House,25,Jon Hansen,REP,1012
+Minnehaha,VP21,State House,25,Randy Gross,REP,797
+Minnehaha,0214,State Senate,02,Steve Kolbeck,REP,492
+Minnehaha,0407,State Senate,02,Steve Kolbeck,REP,0
+Minnehaha,0410,State Senate,02,Steve Kolbeck,REP,206
+Minnehaha,0411,State Senate,02,Steve Kolbeck,REP,1290
+Minnehaha,0412,State Senate,02,Steve Kolbeck,REP,0
+Minnehaha,0415,State Senate,02,Steve Kolbeck,REP,518
+Minnehaha,VP01,State Senate,02,Steve Kolbeck,REP,521
+Minnehaha,VP02,State Senate,02,Steve Kolbeck,REP,1210
+Minnehaha,VP03,State Senate,02,Steve Kolbeck,REP,1441
+Minnehaha,VP05,State Senate,02,Steve Kolbeck,REP,1031
+Minnehaha,VP15,State Senate,02,Steve Kolbeck,REP,1101
+Minnehaha,0117,State Senate,09,Brent Hoffman,REP,3
+Minnehaha,0312,State Senate,09,Brent Hoffman,REP,773
+Minnehaha,0314,State Senate,09,Brent Hoffman,REP,926
+Minnehaha,0316,State Senate,09,Brent Hoffman,REP,1134
+Minnehaha,0317,State Senate,09,Brent Hoffman,REP,1338
+Minnehaha,VP06,State Senate,09,Brent Hoffman,REP,285
+Minnehaha,VP07,State Senate,09,Brent Hoffman,REP,1086
+Minnehaha,VP17,State Senate,09,Brent Hoffman,REP,479
 Minnehaha,0402,State Senate,10,Liz Larson,DEM,353
 Minnehaha,0402,State Senate,10,Maggie Sutton,REP,268
 Minnehaha,0403,State Senate,10,Liz Larson,DEM,218
@@ -3098,8 +2639,6 @@ Minnehaha,0410,State Senate,10,Liz Larson,DEM,204
 Minnehaha,0410,State Senate,10,Maggie Sutton,REP,212
 Minnehaha,0502,State Senate,10,Liz Larson,DEM,125
 Minnehaha,0502,State Senate,10,Maggie Sutton,REP,47
-Minnehaha,0503,State Senate,12,Jessica Meyers,DEM,159
-Minnehaha,0503,State Senate,12,Arch Beal,REP,111
 Minnehaha,0504,State Senate,10,Liz Larson,DEM,541
 Minnehaha,0504,State Senate,10,Maggie Sutton,REP,274
 Minnehaha,0506,State Senate,10,Liz Larson,DEM,505
@@ -3108,230 +2647,938 @@ Minnehaha,0507,State Senate,10,Liz Larson,DEM,342
 Minnehaha,0507,State Senate,10,Maggie Sutton,REP,206
 Minnehaha,0508,State Senate,10,Liz Larson,DEM,546
 Minnehaha,0508,State Senate,10,Maggie Sutton,REP,326
-Minnehaha,0509,State Senate,12,Jessica Meyers,DEM,235
-Minnehaha,0509,State Senate,12,Arch Beal,REP,119
-Minnehaha,0510 Precinct-0512,State Senate,12,Jessica Meyers,DEM,274
-Minnehaha,0510 Precinct-0512,State Senate,12,Arch Beal,REP,239
-Minnehaha,0513 Precinct-0514 Precinct-0515,State Senate,12,Jessica Meyers,DEM,206
-Minnehaha,0513 Precinct-0514 Precinct-0515,State Senate,12,Arch Beal,REP,159
-Minnehaha,0517 Precinct-0518,State Senate,12,Jessica Meyers,DEM,245
-Minnehaha,0517 Precinct-0518,State Senate,12,Arch Beal,REP,259
-Minnehaha,0519,State Senate,12,Jessica Meyers,DEM,256
-Minnehaha,0519,State Senate,12,Arch Beal,REP,250
-Minnehaha,0520 Precinct-0521 Precinct-0522,State Senate,12,Jessica Meyers,DEM,223
-Minnehaha,0520 Precinct-0521 Precinct-0522,State Senate,12,Arch Beal,REP,185
 Minnehaha,VP02,State Senate,10,Liz Larson,DEM,27
 Minnehaha,VP02,State Senate,10,Maggie Sutton,REP,40
+Minnehaha,0106,State Senate,11,Jim Stalzer,REP,531
+Minnehaha,0106,State Senate,11,Sheryl L. Johnson,DEM,499
+Minnehaha,0109,State Senate,11,Jim Stalzer,REP,564
+Minnehaha,0109,State Senate,11,Sheryl L. Johnson,DEM,459
+Minnehaha,0110,State Senate,11,Jim Stalzer,REP,601
+Minnehaha,0110,State Senate,11,Sheryl L. Johnson,DEM,509
+Minnehaha,0117,State Senate,11,Jim Stalzer,REP,733
+Minnehaha,0117,State Senate,11,Sheryl L. Johnson,DEM,529
+Minnehaha,0309,State Senate,11,Jim Stalzer,REP,525
+Minnehaha,0309,State Senate,11,Sheryl L. Johnson,DEM,556
+Minnehaha,0310,State Senate,11,Jim Stalzer,REP,829
+Minnehaha,0310,State Senate,11,Sheryl L. Johnson,DEM,573
+Minnehaha,0311,State Senate,11,Jim Stalzer,REP,517
+Minnehaha,0311,State Senate,11,Sheryl L. Johnson,DEM,379
+Minnehaha,0313,State Senate,11,Jim Stalzer,REP,405
+Minnehaha,0313,State Senate,11,Sheryl L. Johnson,DEM,301
+Minnehaha,0315,State Senate,11,Jim Stalzer,REP,574
+Minnehaha,0315,State Senate,11,Sheryl L. Johnson,DEM,479
+Minnehaha,VP06,State Senate,11,Jim Stalzer,REP,10
+Minnehaha,VP06,State Senate,11,Sheryl L. Johnson,DEM,2
+Minnehaha,0104,State Senate,12,Arch Beal,REP,301
+Minnehaha,0104,State Senate,12,Jessica Meyers,DEM,386
+Minnehaha,0105,State Senate,12,Arch Beal,REP,219
+Minnehaha,0105,State Senate,12,Jessica Meyers,DEM,216
+Minnehaha,0301 Precinct-0305,State Senate,12,Arch Beal,REP,422
+Minnehaha,0301 Precinct-0305,State Senate,12,Jessica Meyers,DEM,344
+Minnehaha,0503,State Senate,12,Arch Beal,REP,111
+Minnehaha,0503,State Senate,12,Jessica Meyers,DEM,159
+Minnehaha,0509,State Senate,12,Arch Beal,REP,119
+Minnehaha,0509,State Senate,12,Jessica Meyers,DEM,235
+Minnehaha,0510 Precinct-0512,State Senate,12,Arch Beal,REP,239
+Minnehaha,0510 Precinct-0512,State Senate,12,Jessica Meyers,DEM,274
+Minnehaha,0513 Precinct-0514 Precinct-0515,State Senate,12,Arch Beal,REP,159
+Minnehaha,0513 Precinct-0514 Precinct-0515,State Senate,12,Jessica Meyers,DEM,206
+Minnehaha,0517 Precinct-0518,State Senate,12,Arch Beal,REP,259
+Minnehaha,0517 Precinct-0518,State Senate,12,Jessica Meyers,DEM,245
+Minnehaha,0519,State Senate,12,Arch Beal,REP,250
+Minnehaha,0519,State Senate,12,Jessica Meyers,DEM,256
+Minnehaha,0520 Precinct-0521 Precinct-0522,State Senate,12,Arch Beal,REP,185
+Minnehaha,0520 Precinct-0521 Precinct-0522,State Senate,12,Jessica Meyers,DEM,223
 Minnehaha,0104 Precinct-0105 Precinct-0106 Precinct-0109 Precinct-0110 Precinct-0117 Precinct-0119,State Senate,13,Jack Kolbeck,REP,292
 Minnehaha,0104 Precinct-0105 Precinct-0106 Precinct-0109 Precinct-0110 Precinct-0117 Precinct-0119,State Senate,13,Lora Hubbel,IND,249
 Minnehaha,0201,State Senate,13,Jack Kolbeck,REP,679
 Minnehaha,0201,State Senate,13,Lora Hubbel,IND,300
-Minnehaha,0202,State Senate,14,Matthew Tysdal,DEM,658
-Minnehaha,0202,State Senate,14,Larry P. Zikmund,REP,752
-Minnehaha,0203,State Senate,14,Matthew Tysdal,DEM,497
-Minnehaha,0203,State Senate,14,Larry P. Zikmund,REP,564
-Minnehaha,0206,State Senate,14,Matthew Tysdal,DEM,509
-Minnehaha,0206,State Senate,14,Larry P. Zikmund,REP,596
-Minnehaha,0208,State Senate,14,Matthew Tysdal,DEM,500
-Minnehaha,0208,State Senate,14,Larry P. Zikmund,REP,626
-Minnehaha,0209,State Senate,14,Matthew Tysdal,DEM,486
-Minnehaha,0209,State Senate,14,Larry P. Zikmund,REP,537
-Minnehaha,0214 Precinct-0301,State Senate,14,Matthew Tysdal,DEM,894
-Minnehaha,0214 Precinct-0301,State Senate,14,Larry P. Zikmund,REP,1146
-Minnehaha,0305 Precinct-0309 Precinct-0310 Precinct-0311,State Senate,15,Reynold F. Nesiba,DEM,232
-Minnehaha,0305 Precinct-0309 Precinct-0310 Precinct-0311,State Senate,15,Brenda Lawrence,REP,252
-Minnehaha,0402 Precinct-0403 Precinct-0404 Precinct-0405,State Senate,15,Reynold F. Nesiba,DEM,520
-Minnehaha,0402 Precinct-0403 Precinct-0404 Precinct-0405,State Senate,15,Brenda Lawrence,REP,833
-Minnehaha,0410 Precinct-0411 Precinct-0412,State Senate,14,Matthew Tysdal,DEM,571
-Minnehaha,0410 Precinct-0411 Precinct-0412,State Senate,14,Larry P. Zikmund,REP,560
-Minnehaha,0413,State Senate,14,Matthew Tysdal,DEM,319
-Minnehaha,0413,State Senate,14,Larry P. Zikmund,REP,291
-Minnehaha,0415,State Senate,14,Matthew Tysdal,DEM,566
-Minnehaha,0415,State Senate,14,Larry P. Zikmund,REP,775
-Minnehaha,0501,State Senate,15,Reynold F. Nesiba,DEM,245
-Minnehaha,0501,State Senate,15,Brenda Lawrence,REP,169
-Minnehaha,0502,State Senate,15,Reynold F. Nesiba,DEM,301
-Minnehaha,0502,State Senate,15,Brenda Lawrence,REP,151
-Minnehaha,0503 Precinct-0504 Precinct-0506 Precinct-0507,State Senate,15,Reynold F. Nesiba,DEM,40
-Minnehaha,0503 Precinct-0504 Precinct-0506 Precinct-0507,State Senate,15,Brenda Lawrence,REP,18
 Minnehaha,0508 Precinct-0509 Precinct-0510 Precinct-0512,State Senate,13,Jack Kolbeck,REP,312
 Minnehaha,0508 Precinct-0509 Precinct-0510 Precinct-0512,State Senate,13,Lora Hubbel,IND,215
 Minnehaha,0513,State Senate,13,Jack Kolbeck,REP,352
 Minnehaha,0513,State Senate,13,Lora Hubbel,IND,190
-Minnehaha,0514,State Senate,15,Reynold F. Nesiba,DEM,231
-Minnehaha,0514,State Senate,15,Brenda Lawrence,REP,132
-Minnehaha,0515,State Senate,15,Reynold F. Nesiba,DEM,333
-Minnehaha,0515,State Senate,15,Brenda Lawrence,REP,405
-Minnehaha,0517 Precinct-0518 Precinct-0519,State Senate,15,Reynold F. Nesiba,DEM,570
-Minnehaha,0517 Precinct-0518 Precinct-0519,State Senate,15,Brenda Lawrence,REP,388
-Minnehaha,0520 Precinct-0521,State Senate,15,Reynold F. Nesiba,DEM,415
-Minnehaha,0520 Precinct-0521,State Senate,15,Brenda Lawrence,REP,378
-Minnehaha,0522,State Senate,15,Reynold F. Nesiba,DEM,440
-Minnehaha,0522,State Senate,15,Brenda Lawrence,REP,317
-Minnehaha,0523,State Senate,15,Reynold F. Nesiba,DEM,364
-Minnehaha,0523,State Senate,15,Brenda Lawrence,REP,239
-Minnehaha,VP02,State Senate,14,Matthew Tysdal,DEM,1
+Minnehaha,0202,State Senate,14,Larry P. Zikmund,REP,752
+Minnehaha,0202,State Senate,14,Matthew Tysdal,DEM,658
+Minnehaha,0203,State Senate,14,Larry P. Zikmund,REP,564
+Minnehaha,0203,State Senate,14,Matthew Tysdal,DEM,497
+Minnehaha,0206,State Senate,14,Larry P. Zikmund,REP,596
+Minnehaha,0206,State Senate,14,Matthew Tysdal,DEM,509
+Minnehaha,0208,State Senate,14,Larry P. Zikmund,REP,626
+Minnehaha,0208,State Senate,14,Matthew Tysdal,DEM,500
+Minnehaha,0209,State Senate,14,Larry P. Zikmund,REP,537
+Minnehaha,0209,State Senate,14,Matthew Tysdal,DEM,486
+Minnehaha,0214 Precinct-0301,State Senate,14,Larry P. Zikmund,REP,1146
+Minnehaha,0214 Precinct-0301,State Senate,14,Matthew Tysdal,DEM,894
+Minnehaha,0410 Precinct-0411 Precinct-0412,State Senate,14,Larry P. Zikmund,REP,560
+Minnehaha,0410 Precinct-0411 Precinct-0412,State Senate,14,Matthew Tysdal,DEM,571
+Minnehaha,0413,State Senate,14,Larry P. Zikmund,REP,291
+Minnehaha,0413,State Senate,14,Matthew Tysdal,DEM,319
+Minnehaha,0415,State Senate,14,Larry P. Zikmund,REP,775
+Minnehaha,0415,State Senate,14,Matthew Tysdal,DEM,566
 Minnehaha,VP02,State Senate,14,Larry P. Zikmund,REP,7
-Minnehaha,VP04 20 of 65,State Senate,15,Reynold F. Nesiba,DEM,6
+Minnehaha,VP02,State Senate,14,Matthew Tysdal,DEM,1
+Minnehaha,0305 Precinct-0309 Precinct-0310 Precinct-0311,State Senate,15,Brenda Lawrence,REP,252
+Minnehaha,0305 Precinct-0309 Precinct-0310 Precinct-0311,State Senate,15,Reynold F. Nesiba,DEM,232
+Minnehaha,0402 Precinct-0403 Precinct-0404 Precinct-0405,State Senate,15,Brenda Lawrence,REP,833
+Minnehaha,0402 Precinct-0403 Precinct-0404 Precinct-0405,State Senate,15,Reynold F. Nesiba,DEM,520
+Minnehaha,0501,State Senate,15,Brenda Lawrence,REP,169
+Minnehaha,0501,State Senate,15,Reynold F. Nesiba,DEM,245
+Minnehaha,0502,State Senate,15,Brenda Lawrence,REP,151
+Minnehaha,0502,State Senate,15,Reynold F. Nesiba,DEM,301
+Minnehaha,0503 Precinct-0504 Precinct-0506 Precinct-0507,State Senate,15,Brenda Lawrence,REP,18
+Minnehaha,0503 Precinct-0504 Precinct-0506 Precinct-0507,State Senate,15,Reynold F. Nesiba,DEM,40
+Minnehaha,0514,State Senate,15,Brenda Lawrence,REP,132
+Minnehaha,0514,State Senate,15,Reynold F. Nesiba,DEM,231
+Minnehaha,0515,State Senate,15,Brenda Lawrence,REP,405
+Minnehaha,0515,State Senate,15,Reynold F. Nesiba,DEM,333
+Minnehaha,0517 Precinct-0518 Precinct-0519,State Senate,15,Brenda Lawrence,REP,388
+Minnehaha,0517 Precinct-0518 Precinct-0519,State Senate,15,Reynold F. Nesiba,DEM,570
+Minnehaha,0520 Precinct-0521,State Senate,15,Brenda Lawrence,REP,378
+Minnehaha,0520 Precinct-0521,State Senate,15,Reynold F. Nesiba,DEM,415
+Minnehaha,0522,State Senate,15,Brenda Lawrence,REP,317
+Minnehaha,0522,State Senate,15,Reynold F. Nesiba,DEM,440
+Minnehaha,0523,State Senate,15,Brenda Lawrence,REP,239
+Minnehaha,0523,State Senate,15,Reynold F. Nesiba,DEM,364
 Minnehaha,VP04 20 of 65,State Senate,15,Brenda Lawrence,REP,28
-Minnehaha,0104 Precinct-0105 Precinct-0106 Precinct-0109 Precinct-0110 Precinct-0117 Precinct-0119 Precinct-0201 Precinct-0202 Precinct-0203,State House,09,Nick Winkler,DEM,2
-Minnehaha,0104 Precinct-0105 Precinct-0106 Precinct-0109 Precinct-0110 Precinct-0117 Precinct-0119 Precinct-0201 Precinct-0202 Precinct-0203,State House,09,Kenneth Teunissen,REP,2
-Minnehaha,0104 Precinct-0105 Precinct-0106 Precinct-0109 Precinct-0110 Precinct-0117 Precinct-0119 Precinct-0201 Precinct-0202 Precinct-0203,State House,09,Bethany Soye,REP,2
-Minnehaha,0206 Precinct-0208 Precinct-0209 Precinct-0214 Precinct-0301 Precinct-0305 Precinct-0309,State House,02,Gary Leighton,DEM,287
-Minnehaha,0206 Precinct-0208 Precinct-0209 Precinct-0214 Precinct-0301 Precinct-0305 Precinct-0309,State House,02,John Sjaarda,REP,332
-Minnehaha,0206 Precinct-0208 Precinct-0209 Precinct-0214 Precinct-0301 Precinct-0305 Precinct-0309,State House,02,David Kull,REP,363
-Minnehaha,0310 Precinct-0311 Precinct-0312,State House,09,Nick Winkler,DEM,401
-Minnehaha,0310 Precinct-0311 Precinct-0312,State House,09,Kenneth Teunissen,REP,514
-Minnehaha,0310 Precinct-0311 Precinct-0312,State House,09,Bethany Soye,REP,649
-Minnehaha,0313 Precinct-0314 Precinct-0315,State House,09,Nick Winkler,DEM,642
-Minnehaha,0313 Precinct-0314 Precinct-0315,State House,09,Kenneth Teunissen,REP,603
-Minnehaha,0313 Precinct-0314 Precinct-0315,State House,09,Bethany Soye,REP,773
-Minnehaha,0316,State House,09,Nick Winkler,DEM,627
-Minnehaha,0316,State House,09,Kenneth Teunissen,REP,806
-Minnehaha,0316,State House,09,Bethany Soye,REP,926
-Minnehaha,0317 Precinct-0402 Precinct-0403 Precinct-0404,State House,09,Nick Winkler,DEM,785
-Minnehaha,0317 Precinct-0402 Precinct-0403 Precinct-0404,State House,09,Kenneth Teunissen,REP,928
-Minnehaha,0317 Precinct-0402 Precinct-0403 Precinct-0404,State House,09,Bethany Soye,REP,1054
-Minnehaha,0405 Precinct-0406 Precinct-0407 Precinct-0408,State House,02,Gary Leighton,DEM,0
-Minnehaha,0405 Precinct-0406 Precinct-0407 Precinct-0408,State House,02,John Sjaarda,REP,0
-Minnehaha,0405 Precinct-0406 Precinct-0407 Precinct-0408,State House,02,David Kull,REP,0
-Minnehaha,0409 Precinct-0410,State House,02,Gary Leighton,DEM,129
-Minnehaha,0409 Precinct-0410,State House,02,John Sjaarda,REP,152
-Minnehaha,0409 Precinct-0410,State House,02,David Kull,REP,151
-Minnehaha,0411,State House,02,Gary Leighton,DEM,730
-Minnehaha,0411,State House,02,John Sjaarda,REP,943
-Minnehaha,0411,State House,02,David Kull,REP,997
-Minnehaha,0412 Precinct-0413,State House,02,Gary Leighton,DEM,0
-Minnehaha,0412 Precinct-0413,State House,02,John Sjaarda,REP,0
-Minnehaha,0412 Precinct-0413,State House,02,David Kull,REP,0
-Minnehaha,0415 Precinct-0501 Precinct-0502 Precinct-0503 Precinct-0504 Precinct-0506 Precinct-0507 Precinct-0508 Precinct-0509 Precinct-0510 Precinct-0512,State House,02,Gary Leighton,DEM,237
-Minnehaha,0415 Precinct-0501 Precinct-0502 Precinct-0503 Precinct-0504 Precinct-0506 Precinct-0507 Precinct-0508 Precinct-0509 Precinct-0510 Precinct-0512,State House,02,John Sjaarda,REP,384
-Minnehaha,0415 Precinct-0501 Precinct-0502 Precinct-0503 Precinct-0504 Precinct-0506 Precinct-0507 Precinct-0508 Precinct-0509 Precinct-0510 Precinct-0512,State House,02,David Kull,REP,383
-Minnehaha,0513 Precinct-0514 Precinct-0515 Precinct-0517 Precinct-0518 Precinct-0519 Precinct-0520 Precinct-0521 Precinct-0522 Precinct-0523 Precinct-VP01,State House,02,Gary Leighton,DEM,142
-Minnehaha,0513 Precinct-0514 Precinct-0515 Precinct-0517 Precinct-0518 Precinct-0519 Precinct-0520 Precinct-0521 Precinct-0522 Precinct-0523 Precinct-VP01,State House,02,John Sjaarda,REP,502
-Minnehaha,0513 Precinct-0514 Precinct-0515 Precinct-0517 Precinct-0518 Precinct-0519 Precinct-0520 Precinct-0521 Precinct-0522 Precinct-0523 Precinct-VP01,State House,02,David Kull,REP,357
-Minnehaha,VP02,State House,02,Gary Leighton,DEM,445
-Minnehaha,VP02,State House,02,John Sjaarda,REP,947
-Minnehaha,VP02,State House,02,David Kull,REP,957
-Minnehaha,VP03,State House,02,Gary Leighton,DEM,528
-Minnehaha,VP03,State House,02,John Sjaarda,REP,1029
-Minnehaha,VP03,State House,02,David Kull,REP,1178
-Minnehaha,VP04 Precinct-VP05 23 of 65,State House,02,Gary Leighton,DEM,382
-Minnehaha,VP04 Precinct-VP05 23 of 65,State House,02,John Sjaarda,REP,681
-Minnehaha,VP04 Precinct-VP05 23 of 65,State House,02,David Kull,REP,827
-Minnehaha,0317 Precinct-0402,State House,10,Erin Healy,DEM,363
-Minnehaha,0317 Precinct-0402,State House,10,Kameron Nelson,DEM,254
-Minnehaha,0317 Precinct-0402,State House,10,Tom E Sutton,REP,234
-Minnehaha,0317 Precinct-0402,State House,10,John G. Mogen,REP,242
-Minnehaha,0403,State House,10,Erin Healy,DEM,219
-Minnehaha,0403,State House,10,Kameron Nelson,DEM,175
-Minnehaha,0403,State House,10,Tom E Sutton,REP,171
-Minnehaha,0403,State House,10,John G. Mogen,REP,161
-Minnehaha,0404 Precinct-0405,State House,10,Erin Healy,DEM,345
-Minnehaha,0404 Precinct-0405,State House,10,Kameron Nelson,DEM,258
-Minnehaha,0404 Precinct-0405,State House,10,Tom E Sutton,REP,256
-Minnehaha,0404 Precinct-0405,State House,10,John G. Mogen,REP,255
-Minnehaha,0406,State House,10,Erin Healy,DEM,129
-Minnehaha,0406,State House,10,Kameron Nelson,DEM,105
-Minnehaha,0406,State House,10,Tom E Sutton,REP,99
-Minnehaha,0406,State House,10,John G. Mogen,REP,90
-Minnehaha,0407,State House,10,Erin Healy,DEM,607
-Minnehaha,0407,State House,10,Kameron Nelson,DEM,475
-Minnehaha,0407,State House,10,Tom E Sutton,REP,547
-Minnehaha,0407,State House,10,John G. Mogen,REP,562
-Minnehaha,0408,State House,10,Erin Healy,DEM,181
-Minnehaha,0408,State House,10,Kameron Nelson,DEM,141
-Minnehaha,0408,State House,10,Tom E Sutton,REP,116
-Minnehaha,0408,State House,10,John G. Mogen,REP,104
-Minnehaha,0409,State House,10,Erin Healy,DEM,403
-Minnehaha,0409,State House,10,Kameron Nelson,DEM,282
-Minnehaha,0409,State House,10,Tom E Sutton,REP,278
-Minnehaha,0409,State House,10,John G. Mogen,REP,242
-Minnehaha,0410 Precinct-0411 Precinct-0412 Precinct-0413,State House,10,Erin Healy,DEM,203
-Minnehaha,0410 Precinct-0411 Precinct-0412 Precinct-0413,State House,10,Kameron Nelson,DEM,155
-Minnehaha,0410 Precinct-0411 Precinct-0412 Precinct-0413,State House,10,Tom E Sutton,REP,199
-Minnehaha,0410 Precinct-0411 Precinct-0412 Precinct-0413,State House,10,John G. Mogen,REP,186
-Minnehaha,0415 Precinct-0501 Precinct-0502 Precinct-0503,State House,10,Erin Healy,DEM,127
-Minnehaha,0415 Precinct-0501 Precinct-0502 Precinct-0503,State House,10,Kameron Nelson,DEM,106
-Minnehaha,0415 Precinct-0501 Precinct-0502 Precinct-0503,State House,10,Tom E Sutton,REP,46
-Minnehaha,0415 Precinct-0501 Precinct-0502 Precinct-0503,State House,10,John G. Mogen,REP,44
-Minnehaha,0504,State House,10,Erin Healy,DEM,547
-Minnehaha,0504,State House,10,Kameron Nelson,DEM,432
-Minnehaha,0504,State House,10,Tom E Sutton,REP,233
-Minnehaha,0504,State House,10,John G. Mogen,REP,278
-Minnehaha,0506,State House,10,Erin Healy,DEM,527
-Minnehaha,0506,State House,10,Kameron Nelson,DEM,399
-Minnehaha,0506,State House,10,Tom E Sutton,REP,322
-Minnehaha,0506,State House,10,John G. Mogen,REP,363
-Minnehaha,0507,State House,10,Erin Healy,DEM,362
-Minnehaha,0507,State House,10,Kameron Nelson,DEM,256
-Minnehaha,0507,State House,10,Tom E Sutton,REP,175
-Minnehaha,0507,State House,10,John G. Mogen,REP,211
-Minnehaha,0508 Precinct-0509 Precinct-0510 Precinct-0512 Precinct-0513 Precinct-0514 Precinct-0515 Precinct-0517,State House,10,Erin Healy,DEM,573
-Minnehaha,0508 Precinct-0509 Precinct-0510 Precinct-0512 Precinct-0513 Precinct-0514 Precinct-0515 Precinct-0517,State House,10,Kameron Nelson,DEM,447
-Minnehaha,0508 Precinct-0509 Precinct-0510 Precinct-0512 Precinct-0513 Precinct-0514 Precinct-0515 Precinct-0517,State House,10,Tom E Sutton,REP,270
-Minnehaha,0508 Precinct-0509 Precinct-0510 Precinct-0512 Precinct-0513 Precinct-0514 Precinct-0515 Precinct-0517,State House,10,John G. Mogen,REP,339
-Minnehaha,0518 Precinct-0519 Precinct-0520 Precinct-0521 Precinct-0522 Precinct-0523 Precinct-VP01 Precinct-VP02 Precinct-VP03 Precinct-VP04 Precinct-VP05 24 of 65,State House,10,Erin Healy,DEM,27
-Minnehaha,0518 Precinct-0519 Precinct-0520 Precinct-0521 Precinct-0522 Precinct-0523 Precinct-VP01 Precinct-VP02 Precinct-VP03 Precinct-VP04 Precinct-VP05 24 of 65,State House,10,Kameron Nelson,DEM,25
-Minnehaha,0518 Precinct-0519 Precinct-0520 Precinct-0521 Precinct-0522 Precinct-0523 Precinct-VP01 Precinct-VP02 Precinct-VP03 Precinct-VP04 Precinct-VP05 24 of 65,State House,10,Tom E Sutton,REP,34
-Minnehaha,0518 Precinct-0519 Precinct-0520 Precinct-0521 Precinct-0522 Precinct-0523 Precinct-VP01 Precinct-VP02 Precinct-VP03 Precinct-VP04 Precinct-VP05 24 of 65,State House,10,John G. Mogen,REP,37
-Minnehaha,0104,State House,12,Kristin Hayward,DEM,328
-Minnehaha,0104,State House,12,Erin Royer,DEM,318
-Minnehaha,0104,State House,12,Greg Jamison,REP,298
-Minnehaha,0104,State House,12,Amber Arlint,REP,288
-Minnehaha,0105 Precinct-0106 Precinct-0109,State House,12,Kristin Hayward,DEM,190
-Minnehaha,0105 Precinct-0106 Precinct-0109,State House,12,Erin Royer,DEM,174
-Minnehaha,0105 Precinct-0106 Precinct-0109,State House,12,Greg Jamison,REP,209
-Minnehaha,0105 Precinct-0106 Precinct-0109,State House,12,Amber Arlint,REP,199
-Minnehaha,0110 Precinct-0117 Precinct-0119,State House,13,Tony Venhuizen,REP,227
-Minnehaha,0110 Precinct-0117 Precinct-0119,State House,13,Sue Peterson,REP,313
-Minnehaha,0201 Precinct-0202 Precinct-0203 Precinct-0206,State House,13,Tony Venhuizen,REP,514
-Minnehaha,0201 Precinct-0202 Precinct-0203 Precinct-0206,State House,13,Sue Peterson,REP,561
-Minnehaha,0208 Precinct-0209 Precinct-0214 Precinct-0301 Precinct-0305 Precinct-0309 Precinct-0310 Precinct-0311 Precinct-0312 Precinct-0313 Precinct-0314 Precinct-0315 Precinct-0316 Precinct-0317 Precinct-0402 Precinct-0403 Precinct-0404,State House,12,Kristin Hayward,DEM,294
-Minnehaha,0208 Precinct-0209 Precinct-0214 Precinct-0301 Precinct-0305 Precinct-0309 Precinct-0310 Precinct-0311 Precinct-0312 Precinct-0313 Precinct-0314 Precinct-0315 Precinct-0316 Precinct-0317 Precinct-0402 Precinct-0403 Precinct-0404,State House,12,Erin Royer,DEM,292
-Minnehaha,0208 Precinct-0209 Precinct-0214 Precinct-0301 Precinct-0305 Precinct-0309 Precinct-0310 Precinct-0311 Precinct-0312 Precinct-0313 Precinct-0314 Precinct-0315 Precinct-0316 Precinct-0317 Precinct-0402 Precinct-0403 Precinct-0404,State House,12,Greg Jamison,REP,412
-Minnehaha,0208 Precinct-0209 Precinct-0214 Precinct-0301 Precinct-0305 Precinct-0309 Precinct-0310 Precinct-0311 Precinct-0312 Precinct-0313 Precinct-0314 Precinct-0315 Precinct-0316 Precinct-0317 Precinct-0402 Precinct-0403 Precinct-0404,State House,12,Amber Arlint,REP,389
-Minnehaha,0405 Precinct-0406 Precinct-0407 Precinct-0408 Precinct-0409 Precinct-0410 Precinct-0411 Precinct-0412 Precinct-0413 Precinct-0415 Precinct-0501 Precinct-0502 Precinct-0503 Precinct-0504 Precinct-0506,State House,12,Kristin Hayward,DEM,136
-Minnehaha,0405 Precinct-0406 Precinct-0407 Precinct-0408 Precinct-0409 Precinct-0410 Precinct-0411 Precinct-0412 Precinct-0413 Precinct-0415 Precinct-0501 Precinct-0502 Precinct-0503 Precinct-0504 Precinct-0506,State House,12,Erin Royer,DEM,136
-Minnehaha,0405 Precinct-0406 Precinct-0407 Precinct-0408 Precinct-0409 Precinct-0410 Precinct-0411 Precinct-0412 Precinct-0413 Precinct-0415 Precinct-0501 Precinct-0502 Precinct-0503 Precinct-0504 Precinct-0506,State House,12,Greg Jamison,REP,102
-Minnehaha,0405 Precinct-0406 Precinct-0407 Precinct-0408 Precinct-0409 Precinct-0410 Precinct-0411 Precinct-0412 Precinct-0413 Precinct-0415 Precinct-0501 Precinct-0502 Precinct-0503 Precinct-0504 Precinct-0506,State House,12,Amber Arlint,REP,103
-Minnehaha,0507 Precinct-0508 Precinct-0509,State House,12,Kristin Hayward,DEM,199
-Minnehaha,0507 Precinct-0508 Precinct-0509,State House,12,Erin Royer,DEM,207
-Minnehaha,0507 Precinct-0508 Precinct-0509,State House,12,Greg Jamison,REP,124
-Minnehaha,0507 Precinct-0508 Precinct-0509,State House,12,Amber Arlint,REP,113
-Minnehaha,0510,State House,12,Kristin Hayward,DEM,230
-Minnehaha,0510,State House,12,Erin Royer,DEM,236
-Minnehaha,0510,State House,12,Greg Jamison,REP,236
-Minnehaha,0510,State House,12,Amber Arlint,REP,203
-Minnehaha,0512,State House,13,Tony Venhuizen,REP,244
-Minnehaha,0512,State House,13,Sue Peterson,REP,270
-Minnehaha,0513,State House,13,Tony Venhuizen,REP,278
-Minnehaha,0513,State House,13,Sue Peterson,REP,279
-Minnehaha,0514 Precinct-0515,State House,12,Kristin Hayward,DEM,170
-Minnehaha,0514 Precinct-0515,State House,12,Erin Royer,DEM,175
-Minnehaha,0514 Precinct-0515,State House,12,Greg Jamison,REP,153
-Minnehaha,0514 Precinct-0515,State House,12,Amber Arlint,REP,137
-Minnehaha,0517,State House,12,Kristin Hayward,DEM,225
-Minnehaha,0517,State House,12,Erin Royer,DEM,211
-Minnehaha,0517,State House,12,Greg Jamison,REP,247
-Minnehaha,0517,State House,12,Amber Arlint,REP,235
-Minnehaha,0518 Precinct-0519 Precinct-0520,State House,12,Kristin Hayward,DEM,211
-Minnehaha,0518 Precinct-0519 Precinct-0520,State House,12,Erin Royer,DEM,215
-Minnehaha,0518 Precinct-0519 Precinct-0520,State House,12,Greg Jamison,REP,258
-Minnehaha,0518 Precinct-0519 Precinct-0520,State House,12,Amber Arlint,REP,244
-Minnehaha,0521 Precinct-0522 Precinct-0523 Precinct-VP01 Precinct-VP02 Precinct-VP03 Precinct-VP04 Precinct-VP05 25 of 65,State House,12,Kristin Hayward,DEM,173
-Minnehaha,0521 Precinct-0522 Precinct-0523 Precinct-VP01 Precinct-VP02 Precinct-VP03 Precinct-VP04 Precinct-VP05 25 of 65,State House,12,Erin Royer,DEM,215
-Minnehaha,0521 Precinct-0522 Precinct-0523 Precinct-VP01 Precinct-VP02 Precinct-VP03 Precinct-VP04 Precinct-VP05 25 of 65,State House,12,Greg Jamison,REP,185
-Minnehaha,0521 Precinct-0522 Precinct-0523 Precinct-VP01 Precinct-VP02 Precinct-VP03 Precinct-VP04 Precinct-VP05 25 of 65,State House,12,Amber Arlint,REP,176
-Minnehaha,VP06,State House,09,Nick Winkler,DEM,131
-Minnehaha,VP06,State House,09,Kenneth Teunissen,REP,208
-Minnehaha,VP06,State House,09,Bethany Soye,REP,230
-Minnehaha,VP07 Precinct-VP08 Precinct-VP09 Precinct-VP10,State House,09,Nick Winkler,DEM,440
-Minnehaha,VP07 Precinct-VP08 Precinct-VP09 Precinct-VP10,State House,09,Kenneth Teunissen,REP,733
-Minnehaha,VP07 Precinct-VP08 Precinct-VP09 Precinct-VP10,State House,09,Bethany Soye,REP,969
-Minnehaha,VP11 Precinct-VP12 Precinct-VP13 Precinct-VP15 Precinct-VP16,State House,02,Gary Leighton,DEM,443
-Minnehaha,VP11 Precinct-VP12 Precinct-VP13 Precinct-VP15 Precinct-VP16,State House,02,John Sjaarda,REP,723
-Minnehaha,VP11 Precinct-VP12 Precinct-VP13 Precinct-VP15 Precinct-VP16,State House,02,David Kull,REP,908
-Minnehaha,VP17 Precinct-VP21 26 of 65,State House,09,Nick Winkler,DEM,155
-Minnehaha,VP17 Precinct-VP21 26 of 65,State House,09,Kenneth Teunissen,REP,348
-Minnehaha,VP17 Precinct-VP21 26 of 65,State House,09,Bethany Soye,REP,431
+Minnehaha,VP04 20 of 65,State Senate,15,Reynold F. Nesiba,DEM,6
+Minnehaha,0305,State Senate,25,Tom Pischke,REP,7
+Minnehaha,0314,State Senate,25,Tom Pischke,REP,163
+Minnehaha,0405,State Senate,25,Tom Pischke,REP,123
+Minnehaha,0406,State Senate,25,Tom Pischke,REP,22
+Minnehaha,VP01,State Senate,25,Tom Pischke,REP,45
+Minnehaha,VP03,State Senate,25,Tom Pischke,REP,94
+Minnehaha,VP04,State Senate,25,Tom Pischke,REP,712
+Minnehaha,VP07,State Senate,25,Tom Pischke,REP,98
+Minnehaha,VP08,State Senate,25,Tom Pischke,REP,436
+Minnehaha,VP09,State Senate,25,Tom Pischke,REP,843
+Minnehaha,VP10,State Senate,25,Tom Pischke,REP,801
+Minnehaha,VP11,State Senate,25,Tom Pischke,REP,212
+Minnehaha,VP12,State Senate,25,Tom Pischke,REP,91
+Minnehaha,VP13,State Senate,25,Tom Pischke,REP,649
+Minnehaha,VP16,State Senate,25,Tom Pischke,REP,717
+Minnehaha,VP21,State Senate,25,Tom Pischke,REP,1135
+Minnehaha,0104,State Treasurer,,John Cunningham,DEM,365
+Minnehaha,0104,State Treasurer,,Josh Haeder,REP,312
+Minnehaha,0105,State Treasurer,,John Cunningham,DEM,203
+Minnehaha,0105,State Treasurer,,Josh Haeder,REP,219
+Minnehaha,0106,State Treasurer,,John Cunningham,DEM,460
+Minnehaha,0106,State Treasurer,,Josh Haeder,REP,551
+Minnehaha,0109,State Treasurer,,John Cunningham,DEM,407
+Minnehaha,0109,State Treasurer,,Josh Haeder,REP,585
+Minnehaha,0110,State Treasurer,,John Cunningham,DEM,459
+Minnehaha,0110,State Treasurer,,Josh Haeder,REP,623
+Minnehaha,0117,State Treasurer,,John Cunningham,DEM,489
+Minnehaha,0117,State Treasurer,,Josh Haeder,REP,736
+Minnehaha,0119,State Treasurer,,John Cunningham,DEM,275
+Minnehaha,0119,State Treasurer,,Josh Haeder,REP,296
+Minnehaha,0201,State Treasurer,,John Cunningham,DEM,435
+Minnehaha,0201,State Treasurer,,Josh Haeder,REP,606
+Minnehaha,0202,State Treasurer,,John Cunningham,DEM,594
+Minnehaha,0202,State Treasurer,,Josh Haeder,REP,777
+Minnehaha,0203,State Treasurer,,John Cunningham,DEM,468
+Minnehaha,0203,State Treasurer,,Josh Haeder,REP,566
+Minnehaha,0206,State Treasurer,,John Cunningham,DEM,446
+Minnehaha,0206,State Treasurer,,Josh Haeder,REP,619
+Minnehaha,0208,State Treasurer,,John Cunningham,DEM,440
+Minnehaha,0208,State Treasurer,,Josh Haeder,REP,658
+Minnehaha,0209,State Treasurer,,John Cunningham,DEM,466
+Minnehaha,0209,State Treasurer,,Josh Haeder,REP,525
+Minnehaha,0214,State Treasurer,,John Cunningham,DEM,1076
+Minnehaha,0214,State Treasurer,,Josh Haeder,REP,1617
+Minnehaha,0301,State Treasurer,,John Cunningham,DEM,331
+Minnehaha,0301,State Treasurer,,Josh Haeder,REP,415
+Minnehaha,0305,State Treasurer,,John Cunningham,DEM,244
+Minnehaha,0305,State Treasurer,,Josh Haeder,REP,263
+Minnehaha,0309,State Treasurer,,John Cunningham,DEM,526
+Minnehaha,0309,State Treasurer,,Josh Haeder,REP,552
+Minnehaha,0310,State Treasurer,,John Cunningham,DEM,494
+Minnehaha,0310,State Treasurer,,Josh Haeder,REP,879
+Minnehaha,0311,State Treasurer,,John Cunningham,DEM,320
+Minnehaha,0311,State Treasurer,,Josh Haeder,REP,532
+Minnehaha,0312,State Treasurer,,John Cunningham,DEM,399
+Minnehaha,0312,State Treasurer,,Josh Haeder,REP,723
+Minnehaha,0313,State Treasurer,,John Cunningham,DEM,260
+Minnehaha,0313,State Treasurer,,Josh Haeder,REP,425
+Minnehaha,0314,State Treasurer,,John Cunningham,DEM,703
+Minnehaha,0314,State Treasurer,,Josh Haeder,REP,958
+Minnehaha,0315,State Treasurer,,John Cunningham,DEM,425
+Minnehaha,0315,State Treasurer,,Josh Haeder,REP,605
+Minnehaha,0316,State Treasurer,,John Cunningham,DEM,581
+Minnehaha,0316,State Treasurer,,Josh Haeder,REP,1037
+Minnehaha,0317,State Treasurer,,John Cunningham,DEM,719
+Minnehaha,0317,State Treasurer,,Josh Haeder,REP,1214
+Minnehaha,0402,State Treasurer,,John Cunningham,DEM,320
+Minnehaha,0402,State Treasurer,,Josh Haeder,REP,283
+Minnehaha,0403,State Treasurer,,John Cunningham,DEM,203
+Minnehaha,0403,State Treasurer,,Josh Haeder,REP,204
+Minnehaha,0404,State Treasurer,,John Cunningham,DEM,329
+Minnehaha,0404,State Treasurer,,Josh Haeder,REP,301
+Minnehaha,0405,State Treasurer,,John Cunningham,DEM,575
+Minnehaha,0405,State Treasurer,,Josh Haeder,REP,953
+Minnehaha,0406,State Treasurer,,John Cunningham,DEM,150
+Minnehaha,0406,State Treasurer,,Josh Haeder,REP,120
+Minnehaha,0407,State Treasurer,,John Cunningham,DEM,558
+Minnehaha,0407,State Treasurer,,Josh Haeder,REP,652
+Minnehaha,0408,State Treasurer,,John Cunningham,DEM,178
+Minnehaha,0408,State Treasurer,,Josh Haeder,REP,125
+Minnehaha,0409,State Treasurer,,John Cunningham,DEM,337
+Minnehaha,0409,State Treasurer,,Josh Haeder,REP,323
+Minnehaha,0410,State Treasurer,,John Cunningham,DEM,321
+Minnehaha,0410,State Treasurer,,Josh Haeder,REP,394
+Minnehaha,0411,State Treasurer,,John Cunningham,DEM,682
+Minnehaha,0411,State Treasurer,,Josh Haeder,REP,1174
+Minnehaha,0412,State Treasurer,,John Cunningham,DEM,525
+Minnehaha,0412,State Treasurer,,Josh Haeder,REP,586
+Minnehaha,0413,State Treasurer,,John Cunningham,DEM,305
+Minnehaha,0413,State Treasurer,,Josh Haeder,REP,283
+Minnehaha,0415,State Treasurer,,John Cunningham,DEM,721
+Minnehaha,0415,State Treasurer,,Josh Haeder,REP,1279
+Minnehaha,0501,State Treasurer,,John Cunningham,DEM,244
+Minnehaha,0501,State Treasurer,,Josh Haeder,REP,172
+Minnehaha,0502,State Treasurer,,John Cunningham,DEM,400
+Minnehaha,0502,State Treasurer,,Josh Haeder,REP,208
+Minnehaha,0503,State Treasurer,,John Cunningham,DEM,182
+Minnehaha,0503,State Treasurer,,Josh Haeder,REP,137
+Minnehaha,0504,State Treasurer,,John Cunningham,DEM,499
+Minnehaha,0504,State Treasurer,,Josh Haeder,REP,298
+Minnehaha,0506,State Treasurer,,John Cunningham,DEM,470
+Minnehaha,0506,State Treasurer,,Josh Haeder,REP,401
+Minnehaha,0507,State Treasurer,,John Cunningham,DEM,299
+Minnehaha,0507,State Treasurer,,Josh Haeder,REP,229
+Minnehaha,0508,State Treasurer,,John Cunningham,DEM,487
+Minnehaha,0508,State Treasurer,,Josh Haeder,REP,356
+Minnehaha,0509,State Treasurer,,John Cunningham,DEM,209
+Minnehaha,0509,State Treasurer,,Josh Haeder,REP,142
+Minnehaha,0510,State Treasurer,,John Cunningham,DEM,251
+Minnehaha,0510,State Treasurer,,Josh Haeder,REP,241
+Minnehaha,0512,State Treasurer,,John Cunningham,DEM,297
+Minnehaha,0512,State Treasurer,,Josh Haeder,REP,271
+Minnehaha,0513,State Treasurer,,John Cunningham,DEM,302
+Minnehaha,0513,State Treasurer,,Josh Haeder,REP,284
+Minnehaha,0514,State Treasurer,,John Cunningham,DEM,410
+Minnehaha,0514,State Treasurer,,Josh Haeder,REP,297
+Minnehaha,0515,State Treasurer,,John Cunningham,DEM,338
+Minnehaha,0515,State Treasurer,,Josh Haeder,REP,405
+Minnehaha,0517,State Treasurer,,John Cunningham,DEM,231
+Minnehaha,0517,State Treasurer,,Josh Haeder,REP,257
+Minnehaha,0518,State Treasurer,,John Cunningham,DEM,562
+Minnehaha,0518,State Treasurer,,Josh Haeder,REP,392
+Minnehaha,0519,State Treasurer,,John Cunningham,DEM,220
+Minnehaha,0519,State Treasurer,,Josh Haeder,REP,257
+Minnehaha,0520,State Treasurer,,John Cunningham,DEM,382
+Minnehaha,0520,State Treasurer,,Josh Haeder,REP,395
+Minnehaha,0521,State Treasurer,,John Cunningham,DEM,209
+Minnehaha,0521,State Treasurer,,Josh Haeder,REP,187
+Minnehaha,0522,State Treasurer,,John Cunningham,DEM,419
+Minnehaha,0522,State Treasurer,,Josh Haeder,REP,328
+Minnehaha,0523,State Treasurer,,John Cunningham,DEM,344
+Minnehaha,0523,State Treasurer,,Josh Haeder,REP,254
+Minnehaha,VP01,State Treasurer,,John Cunningham,DEM,166
+Minnehaha,VP01,State Treasurer,,Josh Haeder,REP,522
+Minnehaha,VP02,State Treasurer,,John Cunningham,DEM,437
+Minnehaha,VP02,State Treasurer,,Josh Haeder,REP,1177
+Minnehaha,VP03,State Treasurer,,John Cunningham,DEM,533
+Minnehaha,VP03,State Treasurer,,Josh Haeder,REP,1371
+Minnehaha,VP04,State Treasurer,,John Cunningham,DEM,301
+Minnehaha,VP04,State Treasurer,,Josh Haeder,REP,695
+Minnehaha,VP05,State Treasurer,,John Cunningham,DEM,360
+Minnehaha,VP05,State Treasurer,,Josh Haeder,REP,905
+Minnehaha,VP06,State Treasurer,,John Cunningham,DEM,120
+Minnehaha,VP06,State Treasurer,,Josh Haeder,REP,283
+Minnehaha,VP07,State Treasurer,,John Cunningham,DEM,444
+Minnehaha,VP07,State Treasurer,,Josh Haeder,REP,1107
+Minnehaha,VP08,State Treasurer,,John Cunningham,DEM,148
+Minnehaha,VP08,State Treasurer,,Josh Haeder,REP,430
+Minnehaha,VP09,State Treasurer,,John Cunningham,DEM,342
+Minnehaha,VP09,State Treasurer,,Josh Haeder,REP,810
+Minnehaha,VP10,State Treasurer,,John Cunningham,DEM,340
+Minnehaha,VP10,State Treasurer,,Josh Haeder,REP,711
+Minnehaha,VP11,State Treasurer,,John Cunningham,DEM,64
+Minnehaha,VP11,State Treasurer,,Josh Haeder,REP,217
+Minnehaha,VP12,State Treasurer,,John Cunningham,DEM,21
+Minnehaha,VP12,State Treasurer,,Josh Haeder,REP,96
+Minnehaha,VP13,State Treasurer,,John Cunningham,DEM,189
+Minnehaha,VP13,State Treasurer,,Josh Haeder,REP,634
+Minnehaha,VP15,State Treasurer,,John Cunningham,DEM,435
+Minnehaha,VP15,State Treasurer,,Josh Haeder,REP,937
+Minnehaha,VP16,State Treasurer,,John Cunningham,DEM,266
+Minnehaha,VP16,State Treasurer,,Josh Haeder,REP,680
+Minnehaha,VP17,State Treasurer,,John Cunningham,DEM,143
+Minnehaha,VP17,State Treasurer,,Josh Haeder,REP,453
+Minnehaha,VP21,State Treasurer,,John Cunningham,DEM,460
+Minnehaha,VP21,State Treasurer,,Josh Haeder,REP,1037
+Minnehaha,0104,Supreme Court Retention,2,Mark E. Salter - No,,148
+Minnehaha,0104,Supreme Court Retention,2,Mark E. Salter - Yes,,423
+Minnehaha,0105,Supreme Court Retention,2,Mark E. Salter - No,,88
+Minnehaha,0105,Supreme Court Retention,2,Mark E. Salter - Yes,,289
+Minnehaha,0106,Supreme Court Retention,2,Mark E. Salter - No,,217
+Minnehaha,0106,Supreme Court Retention,2,Mark E. Salter - Yes,,653
+Minnehaha,0109,Supreme Court Retention,2,Mark E. Salter - No,,174
+Minnehaha,0109,Supreme Court Retention,2,Mark E. Salter - Yes,,703
+Minnehaha,0110,Supreme Court Retention,2,Mark E. Salter - No,,216
+Minnehaha,0110,Supreme Court Retention,2,Mark E. Salter - Yes,,723
+Minnehaha,0117,Supreme Court Retention,2,Mark E. Salter - No,,241
+Minnehaha,0117,Supreme Court Retention,2,Mark E. Salter - Yes,,793
+Minnehaha,0119,Supreme Court Retention,2,Mark E. Salter - No,,140
+Minnehaha,0119,Supreme Court Retention,2,Mark E. Salter - Yes,,349
+Minnehaha,0201,Supreme Court Retention,2,Mark E. Salter - No,,162
+Minnehaha,0201,Supreme Court Retention,2,Mark E. Salter - Yes,,743
+Minnehaha,0202,Supreme Court Retention,2,Mark E. Salter - No,,159
+Minnehaha,0202,Supreme Court Retention,2,Mark E. Salter - Yes,,1037
+Minnehaha,0203,Supreme Court Retention,2,Mark E. Salter - No,,192
+Minnehaha,0203,Supreme Court Retention,2,Mark E. Salter - Yes,,733
+Minnehaha,0206,Supreme Court Retention,2,Mark E. Salter - No,,162
+Minnehaha,0206,Supreme Court Retention,2,Mark E. Salter - Yes,,732
+Minnehaha,0208,Supreme Court Retention,2,Mark E. Salter - No,,142
+Minnehaha,0208,Supreme Court Retention,2,Mark E. Salter - Yes,,794
+Minnehaha,0209,Supreme Court Retention,2,Mark E. Salter - No,,178
+Minnehaha,0209,Supreme Court Retention,2,Mark E. Salter - Yes,,687
+Minnehaha,0214,Supreme Court Retention,2,Mark E. Salter - No,,387
+Minnehaha,0214,Supreme Court Retention,2,Mark E. Salter - Yes,,1931
+Minnehaha,0301,Supreme Court Retention,2,Mark E. Salter - No,,111
+Minnehaha,0301,Supreme Court Retention,2,Mark E. Salter - Yes,,541
+Minnehaha,0305,Supreme Court Retention,2,Mark E. Salter - No,,105
+Minnehaha,0305,Supreme Court Retention,2,Mark E. Salter - Yes,,326
+Minnehaha,0309,Supreme Court Retention,2,Mark E. Salter - No,,264
+Minnehaha,0309,Supreme Court Retention,2,Mark E. Salter - Yes,,664
+Minnehaha,0310,Supreme Court Retention,2,Mark E. Salter - No,,200
+Minnehaha,0310,Supreme Court Retention,2,Mark E. Salter - Yes,,1016
+Minnehaha,0311,Supreme Court Retention,2,Mark E. Salter - No,,138
+Minnehaha,0311,Supreme Court Retention,2,Mark E. Salter - Yes,,606
+Minnehaha,0312,Supreme Court Retention,2,Mark E. Salter - No,,210
+Minnehaha,0312,Supreme Court Retention,2,Mark E. Salter - Yes,,773
+Minnehaha,0313,Supreme Court Retention,2,Mark E. Salter - No,,136
+Minnehaha,0313,Supreme Court Retention,2,Mark E. Salter - Yes,,471
+Minnehaha,0314,Supreme Court Retention,2,Mark E. Salter - No,,373
+Minnehaha,0314,Supreme Court Retention,2,Mark E. Salter - Yes,,1093
+Minnehaha,0315,Supreme Court Retention,2,Mark E. Salter - No,,181
+Minnehaha,0315,Supreme Court Retention,2,Mark E. Salter - Yes,,722
+Minnehaha,0316,Supreme Court Retention,2,Mark E. Salter - No,,288
+Minnehaha,0316,Supreme Court Retention,2,Mark E. Salter - Yes,,1124
+Minnehaha,0317,Supreme Court Retention,2,Mark E. Salter - No,,331
+Minnehaha,0317,Supreme Court Retention,2,Mark E. Salter - Yes,,1376
+Minnehaha,0402,Supreme Court Retention,2,Mark E. Salter - No,,153
+Minnehaha,0402,Supreme Court Retention,2,Mark E. Salter - Yes,,383
+Minnehaha,0403,Supreme Court Retention,2,Mark E. Salter - No,,113
+Minnehaha,0403,Supreme Court Retention,2,Mark E. Salter - Yes,,241
+Minnehaha,0404,Supreme Court Retention,2,Mark E. Salter - No,,169
+Minnehaha,0404,Supreme Court Retention,2,Mark E. Salter - Yes,,393
+Minnehaha,0405,Supreme Court Retention,2,Mark E. Salter - No,,319
+Minnehaha,0405,Supreme Court Retention,2,Mark E. Salter - Yes,,928
+Minnehaha,0406,Supreme Court Retention,2,Mark E. Salter - No,,78
+Minnehaha,0406,Supreme Court Retention,2,Mark E. Salter - Yes,,174
+Minnehaha,0407,Supreme Court Retention,2,Mark E. Salter - No,,210
+Minnehaha,0407,Supreme Court Retention,2,Mark E. Salter - Yes,,816
+Minnehaha,0408,Supreme Court Retention,2,Mark E. Salter - No,,63
+Minnehaha,0408,Supreme Court Retention,2,Mark E. Salter - Yes,,201
+Minnehaha,0409,Supreme Court Retention,2,Mark E. Salter - No,,156
+Minnehaha,0409,Supreme Court Retention,2,Mark E. Salter - Yes,,423
+Minnehaha,0410,Supreme Court Retention,2,Mark E. Salter - No,,158
+Minnehaha,0410,Supreme Court Retention,2,Mark E. Salter - Yes,,476
+Minnehaha,0411,Supreme Court Retention,2,Mark E. Salter - No,,275
+Minnehaha,0411,Supreme Court Retention,2,Mark E. Salter - Yes,,1295
+Minnehaha,0412,Supreme Court Retention,2,Mark E. Salter - No,,236
+Minnehaha,0412,Supreme Court Retention,2,Mark E. Salter - Yes,,721
+Minnehaha,0413,Supreme Court Retention,2,Mark E. Salter - No,,128
+Minnehaha,0413,Supreme Court Retention,2,Mark E. Salter - Yes,,389
+Minnehaha,0415,Supreme Court Retention,2,Mark E. Salter - No,,315
+Minnehaha,0415,Supreme Court Retention,2,Mark E. Salter - Yes,,1409
+Minnehaha,0501,Supreme Court Retention,2,Mark E. Salter - No,,123
+Minnehaha,0501,Supreme Court Retention,2,Mark E. Salter - Yes,,237
+Minnehaha,0502,Supreme Court Retention,2,Mark E. Salter - No,,159
+Minnehaha,0502,Supreme Court Retention,2,Mark E. Salter - Yes,,342
+Minnehaha,0503,Supreme Court Retention,2,Mark E. Salter - No,,100
+Minnehaha,0503,Supreme Court Retention,2,Mark E. Salter - Yes,,175
+Minnehaha,0504,Supreme Court Retention,2,Mark E. Salter - No,,175
+Minnehaha,0504,Supreme Court Retention,2,Mark E. Salter - Yes,,490
+Minnehaha,0506,Supreme Court Retention,2,Mark E. Salter - No,,202
+Minnehaha,0506,Supreme Court Retention,2,Mark E. Salter - Yes,,552
+Minnehaha,0507,Supreme Court Retention,2,Mark E. Salter - No,,96
+Minnehaha,0507,Supreme Court Retention,2,Mark E. Salter - Yes,,349
+Minnehaha,0508,Supreme Court Retention,2,Mark E. Salter - No,,158
+Minnehaha,0508,Supreme Court Retention,2,Mark E. Salter - Yes,,550
+Minnehaha,0509,Supreme Court Retention,2,Mark E. Salter - No,,94
+Minnehaha,0509,Supreme Court Retention,2,Mark E. Salter - Yes,,207
+Minnehaha,0510,Supreme Court Retention,2,Mark E. Salter - No,,119
+Minnehaha,0510,Supreme Court Retention,2,Mark E. Salter - Yes,,315
+Minnehaha,0512,Supreme Court Retention,2,Mark E. Salter - No,,100
+Minnehaha,0512,Supreme Court Retention,2,Mark E. Salter - Yes,,390
+Minnehaha,0513,Supreme Court Retention,2,Mark E. Salter - No,,102
+Minnehaha,0513,Supreme Court Retention,2,Mark E. Salter - Yes,,399
+Minnehaha,0514,Supreme Court Retention,2,Mark E. Salter - No,,174
+Minnehaha,0514,Supreme Court Retention,2,Mark E. Salter - Yes,,425
+Minnehaha,0515,Supreme Court Retention,2,Mark E. Salter - No,,178
+Minnehaha,0515,Supreme Court Retention,2,Mark E. Salter - Yes,,443
+Minnehaha,0517,Supreme Court Retention,2,Mark E. Salter - No,,84
+Minnehaha,0517,Supreme Court Retention,2,Mark E. Salter - Yes,,357
+Minnehaha,0518,Supreme Court Retention,2,Mark E. Salter - No,,235
+Minnehaha,0518,Supreme Court Retention,2,Mark E. Salter - Yes,,577
+Minnehaha,0519,Supreme Court Retention,2,Mark E. Salter - No,,77
+Minnehaha,0519,Supreme Court Retention,2,Mark E. Salter - Yes,,315
+Minnehaha,0520,Supreme Court Retention,2,Mark E. Salter - No,,185
+Minnehaha,0520,Supreme Court Retention,2,Mark E. Salter - Yes,,486
+Minnehaha,0521,Supreme Court Retention,2,Mark E. Salter - No,,75
+Minnehaha,0521,Supreme Court Retention,2,Mark E. Salter - Yes,,264
+Minnehaha,0522,Supreme Court Retention,2,Mark E. Salter - No,,224
+Minnehaha,0522,Supreme Court Retention,2,Mark E. Salter - Yes,,428
+Minnehaha,0523,Supreme Court Retention,2,Mark E. Salter - No,,157
+Minnehaha,0523,Supreme Court Retention,2,Mark E. Salter - Yes,,367
+Minnehaha,VP01,Supreme Court Retention,2,Mark E. Salter - No,,98
+Minnehaha,VP01,Supreme Court Retention,2,Mark E. Salter - Yes,,506
+Minnehaha,VP02,Supreme Court Retention,2,Mark E. Salter - No,,214
+Minnehaha,VP02,Supreme Court Retention,2,Mark E. Salter - Yes,,1171
+Minnehaha,VP03,Supreme Court Retention,2,Mark E. Salter - No,,285
+Minnehaha,VP03,Supreme Court Retention,2,Mark E. Salter - Yes,,1389
+Minnehaha,VP04,Supreme Court Retention,2,Mark E. Salter - No,,163
+Minnehaha,VP04,Supreme Court Retention,2,Mark E. Salter - Yes,,706
+Minnehaha,VP05,Supreme Court Retention,2,Mark E. Salter - No,,183
+Minnehaha,VP05,Supreme Court Retention,2,Mark E. Salter - Yes,,941
+Minnehaha,VP06,Supreme Court Retention,2,Mark E. Salter - No,,58
+Minnehaha,VP06,Supreme Court Retention,2,Mark E. Salter - Yes,,288
+Minnehaha,VP07,Supreme Court Retention,2,Mark E. Salter - No,,234
+Minnehaha,VP07,Supreme Court Retention,2,Mark E. Salter - Yes,,1149
+Minnehaha,VP08,Supreme Court Retention,2,Mark E. Salter - No,,84
+Minnehaha,VP08,Supreme Court Retention,2,Mark E. Salter - Yes,,414
+Minnehaha,VP09,Supreme Court Retention,2,Mark E. Salter - No,,169
+Minnehaha,VP09,Supreme Court Retention,2,Mark E. Salter - Yes,,844
+Minnehaha,VP10,Supreme Court Retention,2,Mark E. Salter - No,,167
+Minnehaha,VP10,Supreme Court Retention,2,Mark E. Salter - Yes,,761
+Minnehaha,VP11,Supreme Court Retention,2,Mark E. Salter - No,,41
+Minnehaha,VP11,Supreme Court Retention,2,Mark E. Salter - Yes,,199
+Minnehaha,VP12,Supreme Court Retention,2,Mark E. Salter - No,,8
+Minnehaha,VP12,Supreme Court Retention,2,Mark E. Salter - Yes,,97
+Minnehaha,VP13,Supreme Court Retention,2,Mark E. Salter - No,,133
+Minnehaha,VP13,Supreme Court Retention,2,Mark E. Salter - Yes,,582
+Minnehaha,VP15,Supreme Court Retention,2,Mark E. Salter - No,,197
+Minnehaha,VP15,Supreme Court Retention,2,Mark E. Salter - Yes,,1013
+Minnehaha,VP16,Supreme Court Retention,2,Mark E. Salter - No,,134
+Minnehaha,VP16,Supreme Court Retention,2,Mark E. Salter - Yes,,673
+Minnehaha,VP17,Supreme Court Retention,2,Mark E. Salter - No,,80
+Minnehaha,VP17,Supreme Court Retention,2,Mark E. Salter - Yes,,427
+Minnehaha,VP21,Supreme Court Retention,2,Mark E. Salter - No,,209
+Minnehaha,VP21,Supreme Court Retention,2,Mark E. Salter - Yes,,1140
+Minnehaha,0104,Supreme Court Retention,3,Patricia J. DeVaney - No,,150
+Minnehaha,0104,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,427
+Minnehaha,0105,Supreme Court Retention,3,Patricia J. DeVaney - No,,93
+Minnehaha,0105,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,289
+Minnehaha,0106,Supreme Court Retention,3,Patricia J. DeVaney - No,,207
+Minnehaha,0106,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,670
+Minnehaha,0109,Supreme Court Retention,3,Patricia J. DeVaney - No,,167
+Minnehaha,0109,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,707
+Minnehaha,0110,Supreme Court Retention,3,Patricia J. DeVaney - No,,209
+Minnehaha,0110,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,730
+Minnehaha,0117,Supreme Court Retention,3,Patricia J. DeVaney - No,,246
+Minnehaha,0117,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,796
+Minnehaha,0119,Supreme Court Retention,3,Patricia J. DeVaney - No,,131
+Minnehaha,0119,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,359
+Minnehaha,0201,Supreme Court Retention,3,Patricia J. DeVaney - No,,164
+Minnehaha,0201,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,736
+Minnehaha,0202,Supreme Court Retention,3,Patricia J. DeVaney - No,,175
+Minnehaha,0202,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1010
+Minnehaha,0203,Supreme Court Retention,3,Patricia J. DeVaney - No,,202
+Minnehaha,0203,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,715
+Minnehaha,0206,Supreme Court Retention,3,Patricia J. DeVaney - No,,152
+Minnehaha,0206,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,744
+Minnehaha,0208,Supreme Court Retention,3,Patricia J. DeVaney - No,,150
+Minnehaha,0208,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,785
+Minnehaha,0209,Supreme Court Retention,3,Patricia J. DeVaney - No,,181
+Minnehaha,0209,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,686
+Minnehaha,0214,Supreme Court Retention,3,Patricia J. DeVaney - No,,389
+Minnehaha,0214,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1926
+Minnehaha,0301,Supreme Court Retention,3,Patricia J. DeVaney - No,,119
+Minnehaha,0301,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,536
+Minnehaha,0305,Supreme Court Retention,3,Patricia J. DeVaney - No,,97
+Minnehaha,0305,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,331
+Minnehaha,0309,Supreme Court Retention,3,Patricia J. DeVaney - No,,255
+Minnehaha,0309,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,688
+Minnehaha,0310,Supreme Court Retention,3,Patricia J. DeVaney - No,,201
+Minnehaha,0310,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1007
+Minnehaha,0311,Supreme Court Retention,3,Patricia J. DeVaney - No,,137
+Minnehaha,0311,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,606
+Minnehaha,0312,Supreme Court Retention,3,Patricia J. DeVaney - No,,203
+Minnehaha,0312,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,783
+Minnehaha,0313,Supreme Court Retention,3,Patricia J. DeVaney - No,,138
+Minnehaha,0313,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,469
+Minnehaha,0314,Supreme Court Retention,3,Patricia J. DeVaney - No,,372
+Minnehaha,0314,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1103
+Minnehaha,0315,Supreme Court Retention,3,Patricia J. DeVaney - No,,176
+Minnehaha,0315,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,721
+Minnehaha,0316,Supreme Court Retention,3,Patricia J. DeVaney - No,,283
+Minnehaha,0316,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1129
+Minnehaha,0317,Supreme Court Retention,3,Patricia J. DeVaney - No,,332
+Minnehaha,0317,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1365
+Minnehaha,0402,Supreme Court Retention,3,Patricia J. DeVaney - No,,150
+Minnehaha,0402,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,382
+Minnehaha,0403,Supreme Court Retention,3,Patricia J. DeVaney - No,,114
+Minnehaha,0403,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,244
+Minnehaha,0404,Supreme Court Retention,3,Patricia J. DeVaney - No,,164
+Minnehaha,0404,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,411
+Minnehaha,0405,Supreme Court Retention,3,Patricia J. DeVaney - No,,357
+Minnehaha,0405,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,899
+Minnehaha,0406,Supreme Court Retention,3,Patricia J. DeVaney - No,,73
+Minnehaha,0406,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,183
+Minnehaha,0407,Supreme Court Retention,3,Patricia J. DeVaney - No,,195
+Minnehaha,0407,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,828
+Minnehaha,0408,Supreme Court Retention,3,Patricia J. DeVaney - No,,68
+Minnehaha,0408,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,200
+Minnehaha,0409,Supreme Court Retention,3,Patricia J. DeVaney - No,,143
+Minnehaha,0409,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,435
+Minnehaha,0410,Supreme Court Retention,3,Patricia J. DeVaney - No,,149
+Minnehaha,0410,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,495
+Minnehaha,0411,Supreme Court Retention,3,Patricia J. DeVaney - No,,280
+Minnehaha,0411,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1301
+Minnehaha,0412,Supreme Court Retention,3,Patricia J. DeVaney - No,,234
+Minnehaha,0412,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,738
+Minnehaha,0413,Supreme Court Retention,3,Patricia J. DeVaney - No,,128
+Minnehaha,0413,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,393
+Minnehaha,0415,Supreme Court Retention,3,Patricia J. DeVaney - No,,325
+Minnehaha,0415,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1397
+Minnehaha,0501,Supreme Court Retention,3,Patricia J. DeVaney - No,,118
+Minnehaha,0501,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,241
+Minnehaha,0502,Supreme Court Retention,3,Patricia J. DeVaney - No,,148
+Minnehaha,0502,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,359
+Minnehaha,0503,Supreme Court Retention,3,Patricia J. DeVaney - No,,96
+Minnehaha,0503,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,181
+Minnehaha,0504,Supreme Court Retention,3,Patricia J. DeVaney - No,,159
+Minnehaha,0504,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,512
+Minnehaha,0506,Supreme Court Retention,3,Patricia J. DeVaney - No,,215
+Minnehaha,0506,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,545
+Minnehaha,0507,Supreme Court Retention,3,Patricia J. DeVaney - No,,93
+Minnehaha,0507,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,351
+Minnehaha,0508,Supreme Court Retention,3,Patricia J. DeVaney - No,,163
+Minnehaha,0508,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,558
+Minnehaha,0509,Supreme Court Retention,3,Patricia J. DeVaney - No,,87
+Minnehaha,0509,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,217
+Minnehaha,0510,Supreme Court Retention,3,Patricia J. DeVaney - No,,103
+Minnehaha,0510,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,333
+Minnehaha,0512,Supreme Court Retention,3,Patricia J. DeVaney - No,,101
+Minnehaha,0512,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,392
+Minnehaha,0513,Supreme Court Retention,3,Patricia J. DeVaney - No,,106
+Minnehaha,0513,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,392
+Minnehaha,0514,Supreme Court Retention,3,Patricia J. DeVaney - No,,169
+Minnehaha,0514,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,428
+Minnehaha,0515,Supreme Court Retention,3,Patricia J. DeVaney - No,,189
+Minnehaha,0515,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,439
+Minnehaha,0517,Supreme Court Retention,3,Patricia J. DeVaney - No,,79
+Minnehaha,0517,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,362
+Minnehaha,0518,Supreme Court Retention,3,Patricia J. DeVaney - No,,231
+Minnehaha,0518,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,586
+Minnehaha,0519,Supreme Court Retention,3,Patricia J. DeVaney - No,,74
+Minnehaha,0519,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,310
+Minnehaha,0520,Supreme Court Retention,3,Patricia J. DeVaney - No,,181
+Minnehaha,0520,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,486
+Minnehaha,0521,Supreme Court Retention,3,Patricia J. DeVaney - No,,69
+Minnehaha,0521,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,267
+Minnehaha,0522,Supreme Court Retention,3,Patricia J. DeVaney - No,,222
+Minnehaha,0522,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,442
+Minnehaha,0523,Supreme Court Retention,3,Patricia J. DeVaney - No,,145
+Minnehaha,0523,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,383
+Minnehaha,VP01,Supreme Court Retention,3,Patricia J. DeVaney - No,,112
+Minnehaha,VP01,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,495
+Minnehaha,VP02,Supreme Court Retention,3,Patricia J. DeVaney - No,,221
+Minnehaha,VP02,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1154
+Minnehaha,VP03,Supreme Court Retention,3,Patricia J. DeVaney - No,,291
+Minnehaha,VP03,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1379
+Minnehaha,VP04,Supreme Court Retention,3,Patricia J. DeVaney - No,,176
+Minnehaha,VP04,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,703
+Minnehaha,VP05,Supreme Court Retention,3,Patricia J. DeVaney - No,,197
+Minnehaha,VP05,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,923
+Minnehaha,VP06,Supreme Court Retention,3,Patricia J. DeVaney - No,,58
+Minnehaha,VP06,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,282
+Minnehaha,VP07,Supreme Court Retention,3,Patricia J. DeVaney - No,,226
+Minnehaha,VP07,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1167
+Minnehaha,VP08,Supreme Court Retention,3,Patricia J. DeVaney - No,,82
+Minnehaha,VP08,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,420
+Minnehaha,VP09,Supreme Court Retention,3,Patricia J. DeVaney - No,,174
+Minnehaha,VP09,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,847
+Minnehaha,VP10,Supreme Court Retention,3,Patricia J. DeVaney - No,,167
+Minnehaha,VP10,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,766
+Minnehaha,VP11,Supreme Court Retention,3,Patricia J. DeVaney - No,,43
+Minnehaha,VP11,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,201
+Minnehaha,VP12,Supreme Court Retention,3,Patricia J. DeVaney - No,,6
+Minnehaha,VP12,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,101
+Minnehaha,VP13,Supreme Court Retention,3,Patricia J. DeVaney - No,,135
+Minnehaha,VP13,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,586
+Minnehaha,VP15,Supreme Court Retention,3,Patricia J. DeVaney - No,,194
+Minnehaha,VP15,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1017
+Minnehaha,VP16,Supreme Court Retention,3,Patricia J. DeVaney - No,,142
+Minnehaha,VP16,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,666
+Minnehaha,VP17,Supreme Court Retention,3,Patricia J. DeVaney - No,,85
+Minnehaha,VP17,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,428
+Minnehaha,VP21,Supreme Court Retention,3,Patricia J. DeVaney - No,,212
+Minnehaha,VP21,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1156
+Minnehaha,0104,U.S. House,1,Collin Duprel,LIB,212
+Minnehaha,0104,U.S. House,1,Dusty Johnson,REP,435
+Minnehaha,0105,U.S. House,1,Collin Duprel,LIB,125
+Minnehaha,0105,U.S. House,1,Dusty Johnson,REP,276
+Minnehaha,0106,U.S. House,1,Collin Duprel,LIB,300
+Minnehaha,0106,U.S. House,1,Dusty Johnson,REP,712
+Minnehaha,0109,U.S. House,1,Collin Duprel,LIB,237
+Minnehaha,0109,U.S. House,1,Dusty Johnson,REP,756
+Minnehaha,0110,U.S. House,1,Collin Duprel,LIB,309
+Minnehaha,0110,U.S. House,1,Dusty Johnson,REP,794
+Minnehaha,0117,U.S. House,1,Collin Duprel,LIB,345
+Minnehaha,0117,U.S. House,1,Dusty Johnson,REP,901
+Minnehaha,0119,U.S. House,1,Collin Duprel,LIB,197
+Minnehaha,0119,U.S. House,1,Dusty Johnson,REP,365
+Minnehaha,0201,U.S. House,1,Collin Duprel,LIB,232
+Minnehaha,0201,U.S. House,1,Dusty Johnson,REP,783
+Minnehaha,0202,U.S. House,1,Collin Duprel,LIB,294
+Minnehaha,0202,U.S. House,1,Dusty Johnson,REP,1028
+Minnehaha,0203,U.S. House,1,Collin Duprel,LIB,275
+Minnehaha,0203,U.S. House,1,Dusty Johnson,REP,733
+Minnehaha,0206,U.S. House,1,Collin Duprel,LIB,269
+Minnehaha,0206,U.S. House,1,Dusty Johnson,REP,788
+Minnehaha,0208,U.S. House,1,Collin Duprel,LIB,232
+Minnehaha,0208,U.S. House,1,Dusty Johnson,REP,841
+Minnehaha,0209,U.S. House,1,Collin Duprel,LIB,247
+Minnehaha,0209,U.S. House,1,Dusty Johnson,REP,720
+Minnehaha,0214,U.S. House,1,Collin Duprel,LIB,629
+Minnehaha,0214,U.S. House,1,Dusty Johnson,REP,2057
+Minnehaha,0301,U.S. House,1,Collin Duprel,LIB,188
+Minnehaha,0301,U.S. House,1,Dusty Johnson,REP,533
+Minnehaha,0305,U.S. House,1,Collin Duprel,LIB,182
+Minnehaha,0305,U.S. House,1,Dusty Johnson,REP,307
+Minnehaha,0309,U.S. House,1,Collin Duprel,LIB,357
+Minnehaha,0309,U.S. House,1,Dusty Johnson,REP,691
+Minnehaha,0310,U.S. House,1,Collin Duprel,LIB,266
+Minnehaha,0310,U.S. House,1,Dusty Johnson,REP,1128
+Minnehaha,0311,U.S. House,1,Collin Duprel,LIB,202
+Minnehaha,0311,U.S. House,1,Dusty Johnson,REP,668
+Minnehaha,0312,U.S. House,1,Collin Duprel,LIB,260
+Minnehaha,0312,U.S. House,1,Dusty Johnson,REP,868
+Minnehaha,0313,U.S. House,1,Collin Duprel,LIB,186
+Minnehaha,0313,U.S. House,1,Dusty Johnson,REP,509
+Minnehaha,0314,U.S. House,1,Collin Duprel,LIB,495
+Minnehaha,0314,U.S. House,1,Dusty Johnson,REP,1173
+Minnehaha,0315,U.S. House,1,Collin Duprel,LIB,293
+Minnehaha,0315,U.S. House,1,Dusty Johnson,REP,748
+Minnehaha,0316,U.S. House,1,Collin Duprel,LIB,354
+Minnehaha,0316,U.S. House,1,Dusty Johnson,REP,1317
+Minnehaha,0317,U.S. House,1,Collin Duprel,LIB,452
+Minnehaha,0317,U.S. House,1,Dusty Johnson,REP,1524
+Minnehaha,0402,U.S. House,1,Collin Duprel,LIB,224
+Minnehaha,0402,U.S. House,1,Dusty Johnson,REP,376
+Minnehaha,0403,U.S. House,1,Collin Duprel,LIB,136
+Minnehaha,0403,U.S. House,1,Dusty Johnson,REP,258
+Minnehaha,0404,U.S. House,1,Collin Duprel,LIB,230
+Minnehaha,0404,U.S. House,1,Dusty Johnson,REP,387
+Minnehaha,0405,U.S. House,1,Collin Duprel,LIB,438
+Minnehaha,0405,U.S. House,1,Dusty Johnson,REP,1030
+Minnehaha,0406,U.S. House,1,Collin Duprel,LIB,93
+Minnehaha,0406,U.S. House,1,Dusty Johnson,REP,178
+Minnehaha,0407,U.S. House,1,Collin Duprel,LIB,305
+Minnehaha,0407,U.S. House,1,Dusty Johnson,REP,867
+Minnehaha,0408,U.S. House,1,Collin Duprel,LIB,111
+Minnehaha,0408,U.S. House,1,Dusty Johnson,REP,177
+Minnehaha,0409,U.S. House,1,Collin Duprel,LIB,239
+Minnehaha,0409,U.S. House,1,Dusty Johnson,REP,412
+Minnehaha,0410,U.S. House,1,Collin Duprel,LIB,210
+Minnehaha,0410,U.S. House,1,Dusty Johnson,REP,518
+Minnehaha,0411,U.S. House,1,Collin Duprel,LIB,397
+Minnehaha,0411,U.S. House,1,Dusty Johnson,REP,1434
+Minnehaha,0412,U.S. House,1,Collin Duprel,LIB,308
+Minnehaha,0412,U.S. House,1,Dusty Johnson,REP,807
+Minnehaha,0413,U.S. House,1,Collin Duprel,LIB,194
+Minnehaha,0413,U.S. House,1,Dusty Johnson,REP,399
+Minnehaha,0415,U.S. House,1,Collin Duprel,LIB,377
+Minnehaha,0415,U.S. House,1,Dusty Johnson,REP,1584
+Minnehaha,0501,U.S. House,1,Collin Duprel,LIB,163
+Minnehaha,0501,U.S. House,1,Dusty Johnson,REP,218
+Minnehaha,0502,U.S. House,1,Collin Duprel,LIB,244
+Minnehaha,0502,U.S. House,1,Dusty Johnson,REP,319
+Minnehaha,0503,U.S. House,1,Collin Duprel,LIB,126
+Minnehaha,0503,U.S. House,1,Dusty Johnson,REP,176
+Minnehaha,0504,U.S. House,1,Collin Duprel,LIB,291
+Minnehaha,0504,U.S. House,1,Dusty Johnson,REP,437
+Minnehaha,0506,U.S. House,1,Collin Duprel,LIB,299
+Minnehaha,0506,U.S. House,1,Dusty Johnson,REP,541
+Minnehaha,0507,U.S. House,1,Collin Duprel,LIB,162
+Minnehaha,0507,U.S. House,1,Dusty Johnson,REP,323
+Minnehaha,0508,U.S. House,1,Collin Duprel,LIB,246
+Minnehaha,0508,U.S. House,1,Dusty Johnson,REP,541
+Minnehaha,0509,U.S. House,1,Collin Duprel,LIB,134
+Minnehaha,0509,U.S. House,1,Dusty Johnson,REP,209
+Minnehaha,0510,U.S. House,1,Collin Duprel,LIB,173
+Minnehaha,0510,U.S. House,1,Dusty Johnson,REP,318
+Minnehaha,0512,U.S. House,1,Collin Duprel,LIB,183
+Minnehaha,0512,U.S. House,1,Dusty Johnson,REP,381
+Minnehaha,0513,U.S. House,1,Collin Duprel,LIB,170
+Minnehaha,0513,U.S. House,1,Dusty Johnson,REP,394
+Minnehaha,0514,U.S. House,1,Collin Duprel,LIB,248
+Minnehaha,0514,U.S. House,1,Dusty Johnson,REP,425
+Minnehaha,0515,U.S. House,1,Collin Duprel,LIB,271
+Minnehaha,0515,U.S. House,1,Dusty Johnson,REP,434
+Minnehaha,0517,U.S. House,1,Collin Duprel,LIB,141
+Minnehaha,0517,U.S. House,1,Dusty Johnson,REP,333
+Minnehaha,0518,U.S. House,1,Collin Duprel,LIB,359
+Minnehaha,0518,U.S. House,1,Dusty Johnson,REP,536
+Minnehaha,0519,U.S. House,1,Collin Duprel,LIB,117
+Minnehaha,0519,U.S. House,1,Dusty Johnson,REP,323
+Minnehaha,0520,U.S. House,1,Collin Duprel,LIB,265
+Minnehaha,0520,U.S. House,1,Dusty Johnson,REP,490
+Minnehaha,0521,U.S. House,1,Collin Duprel,LIB,101
+Minnehaha,0521,U.S. House,1,Dusty Johnson,REP,276
+Minnehaha,0522,U.S. House,1,Collin Duprel,LIB,302
+Minnehaha,0522,U.S. House,1,Dusty Johnson,REP,437
+Minnehaha,0523,U.S. House,1,Collin Duprel,LIB,250
+Minnehaha,0523,U.S. House,1,Dusty Johnson,REP,320
+Minnehaha,VP01,U.S. House,1,Collin Duprel,LIB,137
+Minnehaha,VP01,U.S. House,1,Dusty Johnson,REP,585
+Minnehaha,VP02,U.S. House,1,Collin Duprel,LIB,260
+Minnehaha,VP02,U.S. House,1,Dusty Johnson,REP,1350
+Minnehaha,VP03,U.S. House,1,Collin Duprel,LIB,338
+Minnehaha,VP03,U.S. House,1,Dusty Johnson,REP,1579
+Minnehaha,VP04,U.S. House,1,Collin Duprel,LIB,216
+Minnehaha,VP04,U.S. House,1,Dusty Johnson,REP,797
+Minnehaha,VP05,U.S. House,1,Collin Duprel,LIB,245
+Minnehaha,VP05,U.S. House,1,Dusty Johnson,REP,1076
+Minnehaha,VP06,U.S. House,1,Collin Duprel,LIB,67
+Minnehaha,VP06,U.S. House,1,Dusty Johnson,REP,340
+Minnehaha,VP07,U.S. House,1,Collin Duprel,LIB,287
+Minnehaha,VP07,U.S. House,1,Dusty Johnson,REP,1304
+Minnehaha,VP08,U.S. House,1,Collin Duprel,LIB,109
+Minnehaha,VP08,U.S. House,1,Dusty Johnson,REP,496
+Minnehaha,VP09,U.S. House,1,Collin Duprel,LIB,226
+Minnehaha,VP09,U.S. House,1,Dusty Johnson,REP,994
+Minnehaha,VP10,U.S. House,1,Collin Duprel,LIB,206
+Minnehaha,VP10,U.S. House,1,Dusty Johnson,REP,871
+Minnehaha,VP11,U.S. House,1,Collin Duprel,LIB,42
+Minnehaha,VP11,U.S. House,1,Dusty Johnson,REP,243
+Minnehaha,VP12,U.S. House,1,Collin Duprel,LIB,13
+Minnehaha,VP12,U.S. House,1,Dusty Johnson,REP,108
+Minnehaha,VP13,U.S. House,1,Collin Duprel,LIB,130
+Minnehaha,VP13,U.S. House,1,Dusty Johnson,REP,730
+Minnehaha,VP15,U.S. House,1,Collin Duprel,LIB,280
+Minnehaha,VP15,U.S. House,1,Dusty Johnson,REP,1130
+Minnehaha,VP16,U.S. House,1,Collin Duprel,LIB,181
+Minnehaha,VP16,U.S. House,1,Dusty Johnson,REP,806
+Minnehaha,VP17,U.S. House,1,Collin Duprel,LIB,93
+Minnehaha,VP17,U.S. House,1,Dusty Johnson,REP,518
+Minnehaha,VP21,U.S. House,1,Collin Duprel,LIB,290
+Minnehaha,VP21,U.S. House,1,Dusty Johnson,REP,1253
+Minnehaha,0104,U.S. Senate,,Brian L. Bengs,DEM,335
+Minnehaha,0104,U.S. Senate,,John R. Thune,REP,375
+Minnehaha,0104,U.S. Senate,,Tamara J Lesnar,LIB,23
+Minnehaha,0105,U.S. Senate,,Brian L. Bengs,DEM,190
+Minnehaha,0105,U.S. Senate,,John R. Thune,REP,248
+Minnehaha,0105,U.S. Senate,,Tamara J Lesnar,LIB,22
+Minnehaha,0106,U.S. Senate,,Brian L. Bengs,DEM,410
+Minnehaha,0106,U.S. Senate,,John R. Thune,REP,649
+Minnehaha,0106,U.S. Senate,,Tamara J Lesnar,LIB,42
+Minnehaha,0109,U.S. Senate,,Brian L. Bengs,DEM,364
+Minnehaha,0109,U.S. Senate,,John R. Thune,REP,686
+Minnehaha,0109,U.S. Senate,,Tamara J Lesnar,LIB,31
+Minnehaha,0110,U.S. Senate,,Brian L. Bengs,DEM,416
+Minnehaha,0110,U.S. Senate,,John R. Thune,REP,731
+Minnehaha,0110,U.S. Senate,,Tamara J Lesnar,LIB,39
+Minnehaha,0117,U.S. Senate,,Brian L. Bengs,DEM,421
+Minnehaha,0117,U.S. Senate,,John R. Thune,REP,863
+Minnehaha,0117,U.S. Senate,,Tamara J Lesnar,LIB,61
+Minnehaha,0119,U.S. Senate,,Brian L. Bengs,DEM,237
+Minnehaha,0119,U.S. Senate,,John R. Thune,REP,349
+Minnehaha,0119,U.S. Senate,,Tamara J Lesnar,LIB,39
+Minnehaha,0201,U.S. Senate,,Brian L. Bengs,DEM,405
+Minnehaha,0201,U.S. Senate,,John R. Thune,REP,679
+Minnehaha,0201,U.S. Senate,,Tamara J Lesnar,LIB,21
+Minnehaha,0202,U.S. Senate,,Brian L. Bengs,DEM,517
+Minnehaha,0202,U.S. Senate,,John R. Thune,REP,906
+Minnehaha,0202,U.S. Senate,,Tamara J Lesnar,LIB,34
+Minnehaha,0203,U.S. Senate,,Brian L. Bengs,DEM,397
+Minnehaha,0203,U.S. Senate,,John R. Thune,REP,663
+Minnehaha,0203,U.S. Senate,,Tamara J Lesnar,LIB,44
+Minnehaha,0206,U.S. Senate,,Brian L. Bengs,DEM,406
+Minnehaha,0206,U.S. Senate,,John R. Thune,REP,706
+Minnehaha,0206,U.S. Senate,,Tamara J Lesnar,LIB,38
+Minnehaha,0208,U.S. Senate,,Brian L. Bengs,DEM,387
+Minnehaha,0208,U.S. Senate,,John R. Thune,REP,771
+Minnehaha,0208,U.S. Senate,,Tamara J Lesnar,LIB,27
+Minnehaha,0209,U.S. Senate,,Brian L. Bengs,DEM,413
+Minnehaha,0209,U.S. Senate,,John R. Thune,REP,627
+Minnehaha,0209,U.S. Senate,,Tamara J Lesnar,LIB,22
+Minnehaha,0214,U.S. Senate,,Brian L. Bengs,DEM,930
+Minnehaha,0214,U.S. Senate,,John R. Thune,REP,1859
+Minnehaha,0214,U.S. Senate,,Tamara J Lesnar,LIB,78
+Minnehaha,0301,U.S. Senate,,Brian L. Bengs,DEM,296
+Minnehaha,0301,U.S. Senate,,John R. Thune,REP,473
+Minnehaha,0301,U.S. Senate,,Tamara J Lesnar,LIB,26
+Minnehaha,0305,U.S. Senate,,Brian L. Bengs,DEM,205
+Minnehaha,0305,U.S. Senate,,John R. Thune,REP,299
+Minnehaha,0305,U.S. Senate,,Tamara J Lesnar,LIB,28
+Minnehaha,0309,U.S. Senate,,Brian L. Bengs,DEM,471
+Minnehaha,0309,U.S. Senate,,John R. Thune,REP,628
+Minnehaha,0309,U.S. Senate,,Tamara J Lesnar,LIB,52
+Minnehaha,0310,U.S. Senate,,Brian L. Bengs,DEM,426
+Minnehaha,0310,U.S. Senate,,John R. Thune,REP,1011
+Minnehaha,0310,U.S. Senate,,Tamara J Lesnar,LIB,40
+Minnehaha,0311,U.S. Senate,,Brian L. Bengs,DEM,273
+Minnehaha,0311,U.S. Senate,,John R. Thune,REP,624
+Minnehaha,0311,U.S. Senate,,Tamara J Lesnar,LIB,30
+Minnehaha,0312,U.S. Senate,,Brian L. Bengs,DEM,321
+Minnehaha,0312,U.S. Senate,,John R. Thune,REP,828
+Minnehaha,0312,U.S. Senate,,Tamara J Lesnar,LIB,46
+Minnehaha,0313,U.S. Senate,,Brian L. Bengs,DEM,231
+Minnehaha,0313,U.S. Senate,,John R. Thune,REP,475
+Minnehaha,0313,U.S. Senate,,Tamara J Lesnar,LIB,36
+Minnehaha,0314,U.S. Senate,,Brian L. Bengs,DEM,623
+Minnehaha,0314,U.S. Senate,,John R. Thune,REP,1099
+Minnehaha,0314,U.S. Senate,,Tamara J Lesnar,LIB,77
+Minnehaha,0315,U.S. Senate,,Brian L. Bengs,DEM,384
+Minnehaha,0315,U.S. Senate,,John R. Thune,REP,696
+Minnehaha,0315,U.S. Senate,,Tamara J Lesnar,LIB,33
+Minnehaha,0316,U.S. Senate,,Brian L. Bengs,DEM,510
+Minnehaha,0316,U.S. Senate,,John R. Thune,REP,1216
+Minnehaha,0316,U.S. Senate,,Tamara J Lesnar,LIB,48
+Minnehaha,0317,U.S. Senate,,Brian L. Bengs,DEM,632
+Minnehaha,0317,U.S. Senate,,John R. Thune,REP,1435
+Minnehaha,0317,U.S. Senate,,Tamara J Lesnar,LIB,53
+Minnehaha,0402,U.S. Senate,,Brian L. Bengs,DEM,281
+Minnehaha,0402,U.S. Senate,,John R. Thune,REP,329
+Minnehaha,0402,U.S. Senate,,Tamara J Lesnar,LIB,44
+Minnehaha,0403,U.S. Senate,,Brian L. Bengs,DEM,174
+Minnehaha,0403,U.S. Senate,,John R. Thune,REP,240
+Minnehaha,0403,U.S. Senate,,Tamara J Lesnar,LIB,19
+Minnehaha,0404,U.S. Senate,,Brian L. Bengs,DEM,268
+Minnehaha,0404,U.S. Senate,,John R. Thune,REP,372
+Minnehaha,0404,U.S. Senate,,Tamara J Lesnar,LIB,43
+Minnehaha,0405,U.S. Senate,,Brian L. Bengs,DEM,530
+Minnehaha,0405,U.S. Senate,,John R. Thune,REP,1005
+Minnehaha,0405,U.S. Senate,,Tamara J Lesnar,LIB,63
+Minnehaha,0406,U.S. Senate,,Brian L. Bengs,DEM,129
+Minnehaha,0406,U.S. Senate,,John R. Thune,REP,157
+Minnehaha,0406,U.S. Senate,,Tamara J Lesnar,LIB,9
+Minnehaha,0407,U.S. Senate,,Brian L. Bengs,DEM,499
+Minnehaha,0407,U.S. Senate,,John R. Thune,REP,751
+Minnehaha,0407,U.S. Senate,,Tamara J Lesnar,LIB,36
+Minnehaha,0408,U.S. Senate,,Brian L. Bengs,DEM,152
+Minnehaha,0408,U.S. Senate,,John R. Thune,REP,153
+Minnehaha,0408,U.S. Senate,,Tamara J Lesnar,LIB,17
+Minnehaha,0409,U.S. Senate,,Brian L. Bengs,DEM,286
+Minnehaha,0409,U.S. Senate,,John R. Thune,REP,369
+Minnehaha,0409,U.S. Senate,,Tamara J Lesnar,LIB,55
+Minnehaha,0410,U.S. Senate,,Brian L. Bengs,DEM,265
+Minnehaha,0410,U.S. Senate,,John R. Thune,REP,477
+Minnehaha,0410,U.S. Senate,,Tamara J Lesnar,LIB,40
+Minnehaha,0411,U.S. Senate,,Brian L. Bengs,DEM,623
+Minnehaha,0411,U.S. Senate,,John R. Thune,REP,1311
+Minnehaha,0411,U.S. Senate,,Tamara J Lesnar,LIB,48
+Minnehaha,0412,U.S. Senate,,Brian L. Bengs,DEM,443
+Minnehaha,0412,U.S. Senate,,John R. Thune,REP,703
+Minnehaha,0412,U.S. Senate,,Tamara J Lesnar,LIB,44
+Minnehaha,0413,U.S. Senate,,Brian L. Bengs,DEM,260
+Minnehaha,0413,U.S. Senate,,John R. Thune,REP,353
+Minnehaha,0413,U.S. Senate,,Tamara J Lesnar,LIB,29
+Minnehaha,0415,U.S. Senate,,Brian L. Bengs,DEM,645
+Minnehaha,0415,U.S. Senate,,John R. Thune,REP,1447
+Minnehaha,0415,U.S. Senate,,Tamara J Lesnar,LIB,49
+Minnehaha,0501,U.S. Senate,,Brian L. Bengs,DEM,216
+Minnehaha,0501,U.S. Senate,,John R. Thune,REP,189
+Minnehaha,0501,U.S. Senate,,Tamara J Lesnar,LIB,34
+Minnehaha,0502,U.S. Senate,,Brian L. Bengs,DEM,375
+Minnehaha,0502,U.S. Senate,,John R. Thune,REP,247
+Minnehaha,0502,U.S. Senate,,Tamara J Lesnar,LIB,29
+Minnehaha,0503,U.S. Senate,,Brian L. Bengs,DEM,172
+Minnehaha,0503,U.S. Senate,,John R. Thune,REP,147
+Minnehaha,0503,U.S. Senate,,Tamara J Lesnar,LIB,22
+Minnehaha,0504,U.S. Senate,,Brian L. Bengs,DEM,468
+Minnehaha,0504,U.S. Senate,,John R. Thune,REP,350
+Minnehaha,0504,U.S. Senate,,Tamara J Lesnar,LIB,37
+Minnehaha,0506,U.S. Senate,,Brian L. Bengs,DEM,411
+Minnehaha,0506,U.S. Senate,,John R. Thune,REP,473
+Minnehaha,0506,U.S. Senate,,Tamara J Lesnar,LIB,51
+Minnehaha,0507,U.S. Senate,,Brian L. Bengs,DEM,275
+Minnehaha,0507,U.S. Senate,,John R. Thune,REP,272
+Minnehaha,0507,U.S. Senate,,Tamara J Lesnar,LIB,19
+Minnehaha,0508,U.S. Senate,,Brian L. Bengs,DEM,450
+Minnehaha,0508,U.S. Senate,,John R. Thune,REP,434
+Minnehaha,0508,U.S. Senate,,Tamara J Lesnar,LIB,24
+Minnehaha,0509,U.S. Senate,,Brian L. Bengs,DEM,189
+Minnehaha,0509,U.S. Senate,,John R. Thune,REP,163
+Minnehaha,0509,U.S. Senate,,Tamara J Lesnar,LIB,31
+Minnehaha,0510,U.S. Senate,,Brian L. Bengs,DEM,243
+Minnehaha,0510,U.S. Senate,,John R. Thune,REP,270
+Minnehaha,0510,U.S. Senate,,Tamara J Lesnar,LIB,29
+Minnehaha,0512,U.S. Senate,,Brian L. Bengs,DEM,272
+Minnehaha,0512,U.S. Senate,,John R. Thune,REP,318
+Minnehaha,0512,U.S. Senate,,Tamara J Lesnar,LIB,31
+Minnehaha,0513,U.S. Senate,,Brian L. Bengs,DEM,285
+Minnehaha,0513,U.S. Senate,,John R. Thune,REP,339
+Minnehaha,0513,U.S. Senate,,Tamara J Lesnar,LIB,16
+Minnehaha,0514,U.S. Senate,,Brian L. Bengs,DEM,360
+Minnehaha,0514,U.S. Senate,,John R. Thune,REP,349
+Minnehaha,0514,U.S. Senate,,Tamara J Lesnar,LIB,50
+Minnehaha,0515,U.S. Senate,,Brian L. Bengs,DEM,315
+Minnehaha,0515,U.S. Senate,,John R. Thune,REP,428
+Minnehaha,0515,U.S. Senate,,Tamara J Lesnar,LIB,32
+Minnehaha,0517,U.S. Senate,,Brian L. Bengs,DEM,211
+Minnehaha,0517,U.S. Senate,,John R. Thune,REP,291
+Minnehaha,0517,U.S. Senate,,Tamara J Lesnar,LIB,20
+Minnehaha,0518,U.S. Senate,,Brian L. Bengs,DEM,506
+Minnehaha,0518,U.S. Senate,,John R. Thune,REP,452
+Minnehaha,0518,U.S. Senate,,Tamara J Lesnar,LIB,63
+Minnehaha,0519,U.S. Senate,,Brian L. Bengs,DEM,210
+Minnehaha,0519,U.S. Senate,,John R. Thune,REP,291
+Minnehaha,0519,U.S. Senate,,Tamara J Lesnar,LIB,14
+Minnehaha,0520,U.S. Senate,,Brian L. Bengs,DEM,337
+Minnehaha,0520,U.S. Senate,,John R. Thune,REP,439
+Minnehaha,0520,U.S. Senate,,Tamara J Lesnar,LIB,56
+Minnehaha,0521,U.S. Senate,,Brian L. Bengs,DEM,193
+Minnehaha,0521,U.S. Senate,,John R. Thune,REP,222
+Minnehaha,0521,U.S. Senate,,Tamara J Lesnar,LIB,10
+Minnehaha,0522,U.S. Senate,,Brian L. Bengs,DEM,373
+Minnehaha,0522,U.S. Senate,,John R. Thune,REP,377
+Minnehaha,0522,U.S. Senate,,Tamara J Lesnar,LIB,61
+Minnehaha,0523,U.S. Senate,,Brian L. Bengs,DEM,311
+Minnehaha,0523,U.S. Senate,,John R. Thune,REP,279
+Minnehaha,0523,U.S. Senate,,Tamara J Lesnar,LIB,44
+Minnehaha,VP01,U.S. Senate,,Brian L. Bengs,DEM,128
+Minnehaha,VP01,U.S. Senate,,John R. Thune,REP,577
+Minnehaha,VP01,U.S. Senate,,Tamara J Lesnar,LIB,38
+Minnehaha,VP02,U.S. Senate,,Brian L. Bengs,DEM,370
+Minnehaha,VP02,U.S. Senate,,John R. Thune,REP,1281
+Minnehaha,VP02,U.S. Senate,,Tamara J Lesnar,LIB,48
+Minnehaha,VP03,U.S. Senate,,Brian L. Bengs,DEM,464
+Minnehaha,VP03,U.S. Senate,,John R. Thune,REP,1476
+Minnehaha,VP03,U.S. Senate,,Tamara J Lesnar,LIB,81
+Minnehaha,VP04,U.S. Senate,,Brian L. Bengs,DEM,249
+Minnehaha,VP04,U.S. Senate,,John R. Thune,REP,779
+Minnehaha,VP04,U.S. Senate,,Tamara J Lesnar,LIB,40
+Minnehaha,VP05,U.S. Senate,,Brian L. Bengs,DEM,314
+Minnehaha,VP05,U.S. Senate,,John R. Thune,REP,1027
+Minnehaha,VP05,U.S. Senate,,Tamara J Lesnar,LIB,49
+Minnehaha,VP06,U.S. Senate,,Brian L. Bengs,DEM,93
+Minnehaha,VP06,U.S. Senate,,John R. Thune,REP,323
+Minnehaha,VP06,U.S. Senate,,Tamara J Lesnar,LIB,15
+Minnehaha,VP07,U.S. Senate,,Brian L. Bengs,DEM,344
+Minnehaha,VP07,U.S. Senate,,John R. Thune,REP,1252
+Minnehaha,VP07,U.S. Senate,,Tamara J Lesnar,LIB,66
+Minnehaha,VP08,U.S. Senate,,Brian L. Bengs,DEM,111
+Minnehaha,VP08,U.S. Senate,,John R. Thune,REP,497
+Minnehaha,VP08,U.S. Senate,,Tamara J Lesnar,LIB,30
+Minnehaha,VP09,U.S. Senate,,Brian L. Bengs,DEM,264
+Minnehaha,VP09,U.S. Senate,,John R. Thune,REP,950
+Minnehaha,VP09,U.S. Senate,,Tamara J Lesnar,LIB,48
+Minnehaha,VP10,U.S. Senate,,Brian L. Bengs,DEM,247
+Minnehaha,VP10,U.S. Senate,,John R. Thune,REP,848
+Minnehaha,VP10,U.S. Senate,,Tamara J Lesnar,LIB,41
+Minnehaha,VP11,U.S. Senate,,Brian L. Bengs,DEM,52
+Minnehaha,VP11,U.S. Senate,,John R. Thune,REP,237
+Minnehaha,VP11,U.S. Senate,,Tamara J Lesnar,LIB,10
+Minnehaha,VP12,U.S. Senate,,Brian L. Bengs,DEM,15
+Minnehaha,VP12,U.S. Senate,,John R. Thune,REP,106
+Minnehaha,VP12,U.S. Senate,,Tamara J Lesnar,LIB,4
+Minnehaha,VP13,U.S. Senate,,Brian L. Bengs,DEM,146
+Minnehaha,VP13,U.S. Senate,,John R. Thune,REP,699
+Minnehaha,VP13,U.S. Senate,,Tamara J Lesnar,LIB,46
+Minnehaha,VP15,U.S. Senate,,Brian L. Bengs,DEM,346
+Minnehaha,VP15,U.S. Senate,,John R. Thune,REP,1103
+Minnehaha,VP15,U.S. Senate,,Tamara J Lesnar,LIB,40
+Minnehaha,VP16,U.S. Senate,,Brian L. Bengs,DEM,220
+Minnehaha,VP16,U.S. Senate,,John R. Thune,REP,786
+Minnehaha,VP16,U.S. Senate,,Tamara J Lesnar,LIB,33
+Minnehaha,VP17,U.S. Senate,,Brian L. Bengs,DEM,115
+Minnehaha,VP17,U.S. Senate,,John R. Thune,REP,505
+Minnehaha,VP17,U.S. Senate,,Tamara J Lesnar,LIB,22
+Minnehaha,VP21,U.S. Senate,,Brian L. Bengs,DEM,367
+Minnehaha,VP21,U.S. Senate,,John R. Thune,REP,1212
+Minnehaha,VP21,U.S. Senate,,Tamara J Lesnar,LIB,51

--- a/2022/counties/20221108__sd__general__minnehaha__precinct.csv
+++ b/2022/counties/20221108__sd__general__minnehaha__precinct.csv
@@ -1,0 +1,3337 @@
+county,precinct,office,district,candidate,party,votes
+Minnehaha,0104,U.S. Senate,,Brian L. Bengs,DEM,335
+Minnehaha,0104,U.S. Senate,,Tamara J Lesnar,LIB,23
+Minnehaha,0104,U.S. Senate,,John R. Thune,REP,375
+Minnehaha,0105,U.S. Senate,,Brian L. Bengs,DEM,190
+Minnehaha,0105,U.S. Senate,,Tamara J Lesnar,LIB,22
+Minnehaha,0105,U.S. Senate,,John R. Thune,REP,248
+Minnehaha,0106,U.S. Senate,,Brian L. Bengs,DEM,410
+Minnehaha,0106,U.S. Senate,,Tamara J Lesnar,LIB,42
+Minnehaha,0106,U.S. Senate,,John R. Thune,REP,649
+Minnehaha,0109,U.S. Senate,,Brian L. Bengs,DEM,364
+Minnehaha,0109,U.S. Senate,,Tamara J Lesnar,LIB,31
+Minnehaha,0109,U.S. Senate,,John R. Thune,REP,686
+Minnehaha,0110,U.S. Senate,,Brian L. Bengs,DEM,416
+Minnehaha,0110,U.S. Senate,,Tamara J Lesnar,LIB,39
+Minnehaha,0110,U.S. Senate,,John R. Thune,REP,731
+Minnehaha,0117,U.S. Senate,,Brian L. Bengs,DEM,421
+Minnehaha,0117,U.S. Senate,,Tamara J Lesnar,LIB,61
+Minnehaha,0117,U.S. Senate,,John R. Thune,REP,863
+Minnehaha,0119,U.S. Senate,,Brian L. Bengs,DEM,237
+Minnehaha,0119,U.S. Senate,,Tamara J Lesnar,LIB,39
+Minnehaha,0119,U.S. Senate,,John R. Thune,REP,349
+Minnehaha,0201,U.S. Senate,,Brian L. Bengs,DEM,405
+Minnehaha,0201,U.S. Senate,,Tamara J Lesnar,LIB,21
+Minnehaha,0201,U.S. Senate,,John R. Thune,REP,679
+Minnehaha,0202,U.S. Senate,,Brian L. Bengs,DEM,517
+Minnehaha,0202,U.S. Senate,,Tamara J Lesnar,LIB,34
+Minnehaha,0202,U.S. Senate,,John R. Thune,REP,906
+Minnehaha,0203,U.S. Senate,,Brian L. Bengs,DEM,397
+Minnehaha,0203,U.S. Senate,,Tamara J Lesnar,LIB,44
+Minnehaha,0203,U.S. Senate,,John R. Thune,REP,663
+Minnehaha,0206,U.S. Senate,,Brian L. Bengs,DEM,406
+Minnehaha,0206,U.S. Senate,,Tamara J Lesnar,LIB,38
+Minnehaha,0206,U.S. Senate,,John R. Thune,REP,706
+Minnehaha,0208,U.S. Senate,,Brian L. Bengs,DEM,387
+Minnehaha,0208,U.S. Senate,,Tamara J Lesnar,LIB,27
+Minnehaha,0208,U.S. Senate,,John R. Thune,REP,771
+Minnehaha,0209,U.S. Senate,,Brian L. Bengs,DEM,413
+Minnehaha,0209,U.S. Senate,,Tamara J Lesnar,LIB,22
+Minnehaha,0209,U.S. Senate,,John R. Thune,REP,627
+Minnehaha,0214,U.S. Senate,,Brian L. Bengs,DEM,930
+Minnehaha,0214,U.S. Senate,,Tamara J Lesnar,LIB,78
+Minnehaha,0214,U.S. Senate,,John R. Thune,REP,1859
+Minnehaha,0301,U.S. Senate,,Brian L. Bengs,DEM,296
+Minnehaha,0301,U.S. Senate,,Tamara J Lesnar,LIB,26
+Minnehaha,0301,U.S. Senate,,John R. Thune,REP,473
+Minnehaha,0305,U.S. Senate,,Brian L. Bengs,DEM,205
+Minnehaha,0305,U.S. Senate,,Tamara J Lesnar,LIB,28
+Minnehaha,0305,U.S. Senate,,John R. Thune,REP,299
+Minnehaha,0309,U.S. Senate,,Brian L. Bengs,DEM,471
+Minnehaha,0309,U.S. Senate,,Tamara J Lesnar,LIB,52
+Minnehaha,0309,U.S. Senate,,John R. Thune,REP,628
+Minnehaha,0310,U.S. Senate,,Brian L. Bengs,DEM,426
+Minnehaha,0310,U.S. Senate,,Tamara J Lesnar,LIB,40
+Minnehaha,0310,U.S. Senate,,John R. Thune,REP,1011
+Minnehaha,0311,U.S. Senate,,Brian L. Bengs,DEM,273
+Minnehaha,0311,U.S. Senate,,Tamara J Lesnar,LIB,30
+Minnehaha,0311,U.S. Senate,,John R. Thune,REP,624
+Minnehaha,0312,U.S. Senate,,Brian L. Bengs,DEM,321
+Minnehaha,0312,U.S. Senate,,Tamara J Lesnar,LIB,46
+Minnehaha,0312,U.S. Senate,,John R. Thune,REP,828
+Minnehaha,0313,U.S. Senate,,Brian L. Bengs,DEM,231
+Minnehaha,0313,U.S. Senate,,Tamara J Lesnar,LIB,36
+Minnehaha,0313,U.S. Senate,,John R. Thune,REP,475
+Minnehaha,0314,U.S. Senate,,Brian L. Bengs,DEM,623
+Minnehaha,0314,U.S. Senate,,Tamara J Lesnar,LIB,77
+Minnehaha,0314,U.S. Senate,,John R. Thune,REP,1099
+Minnehaha,0315,U.S. Senate,,Brian L. Bengs,DEM,384
+Minnehaha,0315,U.S. Senate,,Tamara J Lesnar,LIB,33
+Minnehaha,0315,U.S. Senate,,John R. Thune,REP,696
+Minnehaha,0316,U.S. Senate,,Brian L. Bengs,DEM,510
+Minnehaha,0316,U.S. Senate,,Tamara J Lesnar,LIB,48
+Minnehaha,0316,U.S. Senate,,John R. Thune,REP,1216
+Minnehaha,0317,U.S. Senate,,Brian L. Bengs,DEM,632
+Minnehaha,0317,U.S. Senate,,Tamara J Lesnar,LIB,53
+Minnehaha,0317,U.S. Senate,,John R. Thune,REP,1435
+Minnehaha,0402,U.S. Senate,,Brian L. Bengs,DEM,281
+Minnehaha,0402,U.S. Senate,,Tamara J Lesnar,LIB,44
+Minnehaha,0402,U.S. Senate,,John R. Thune,REP,329
+Minnehaha,0403,U.S. Senate,,Brian L. Bengs,DEM,174
+Minnehaha,0403,U.S. Senate,,Tamara J Lesnar,LIB,19
+Minnehaha,0403,U.S. Senate,,John R. Thune,REP,240
+Minnehaha,0404,U.S. Senate,,Brian L. Bengs,DEM,268
+Minnehaha,0404,U.S. Senate,,Tamara J Lesnar,LIB,43
+Minnehaha,0404,U.S. Senate,,John R. Thune,REP,372
+Minnehaha,0405,U.S. Senate,,Brian L. Bengs,DEM,530
+Minnehaha,0405,U.S. Senate,,Tamara J Lesnar,LIB,63
+Minnehaha,0405,U.S. Senate,,John R. Thune,REP,1005
+Minnehaha,0406,U.S. Senate,,Brian L. Bengs,DEM,129
+Minnehaha,0406,U.S. Senate,,Tamara J Lesnar,LIB,9
+Minnehaha,0406,U.S. Senate,,John R. Thune,REP,157
+Minnehaha,0407,U.S. Senate,,Brian L. Bengs,DEM,499
+Minnehaha,0407,U.S. Senate,,Tamara J Lesnar,LIB,36
+Minnehaha,0407,U.S. Senate,,John R. Thune,REP,751
+Minnehaha,0408,U.S. Senate,,Brian L. Bengs,DEM,152
+Minnehaha,0408,U.S. Senate,,Tamara J Lesnar,LIB,17
+Minnehaha,0408,U.S. Senate,,John R. Thune,REP,153
+Minnehaha,0409,U.S. Senate,,Brian L. Bengs,DEM,286
+Minnehaha,0409,U.S. Senate,,Tamara J Lesnar,LIB,55
+Minnehaha,0409,U.S. Senate,,John R. Thune,REP,369
+Minnehaha,0410,U.S. Senate,,Brian L. Bengs,DEM,265
+Minnehaha,0410,U.S. Senate,,Tamara J Lesnar,LIB,40
+Minnehaha,0410,U.S. Senate,,John R. Thune,REP,477
+Minnehaha,0411,U.S. Senate,,Brian L. Bengs,DEM,623
+Minnehaha,0411,U.S. Senate,,Tamara J Lesnar,LIB,48
+Minnehaha,0411,U.S. Senate,,John R. Thune,REP,1311
+Minnehaha,0412,U.S. Senate,,Brian L. Bengs,DEM,443
+Minnehaha,0412,U.S. Senate,,Tamara J Lesnar,LIB,44
+Minnehaha,0412,U.S. Senate,,John R. Thune,REP,703
+Minnehaha,0413,U.S. Senate,,Brian L. Bengs,DEM,260
+Minnehaha,0413,U.S. Senate,,Tamara J Lesnar,LIB,29
+Minnehaha,0413,U.S. Senate,,John R. Thune,REP,353
+Minnehaha,0415,U.S. Senate,,Brian L. Bengs,DEM,645
+Minnehaha,0415,U.S. Senate,,Tamara J Lesnar,LIB,49
+Minnehaha,0415,U.S. Senate,,John R. Thune,REP,1447
+Minnehaha,0501,U.S. Senate,,Brian L. Bengs,DEM,216
+Minnehaha,0501,U.S. Senate,,Tamara J Lesnar,LIB,34
+Minnehaha,0501,U.S. Senate,,John R. Thune,REP,189
+Minnehaha,0502,U.S. Senate,,Brian L. Bengs,DEM,375
+Minnehaha,0502,U.S. Senate,,Tamara J Lesnar,LIB,29
+Minnehaha,0502,U.S. Senate,,John R. Thune,REP,247
+Minnehaha,0503,U.S. Senate,,Brian L. Bengs,DEM,172
+Minnehaha,0503,U.S. Senate,,Tamara J Lesnar,LIB,22
+Minnehaha,0503,U.S. Senate,,John R. Thune,REP,147
+Minnehaha,0504,U.S. Senate,,Brian L. Bengs,DEM,468
+Minnehaha,0504,U.S. Senate,,Tamara J Lesnar,LIB,37
+Minnehaha,0504,U.S. Senate,,John R. Thune,REP,350
+Minnehaha,0506,U.S. Senate,,Brian L. Bengs,DEM,411
+Minnehaha,0506,U.S. Senate,,Tamara J Lesnar,LIB,51
+Minnehaha,0506,U.S. Senate,,John R. Thune,REP,473
+Minnehaha,0507,U.S. Senate,,Brian L. Bengs,DEM,275
+Minnehaha,0507,U.S. Senate,,Tamara J Lesnar,LIB,19
+Minnehaha,0507,U.S. Senate,,John R. Thune,REP,272
+Minnehaha,0508,U.S. Senate,,Brian L. Bengs,DEM,450
+Minnehaha,0508,U.S. Senate,,Tamara J Lesnar,LIB,24
+Minnehaha,0508,U.S. Senate,,John R. Thune,REP,434
+Minnehaha,0509,U.S. Senate,,Brian L. Bengs,DEM,189
+Minnehaha,0509,U.S. Senate,,Tamara J Lesnar,LIB,31
+Minnehaha,0509,U.S. Senate,,John R. Thune,REP,163
+Minnehaha,0510,U.S. Senate,,Brian L. Bengs,DEM,243
+Minnehaha,0510,U.S. Senate,,Tamara J Lesnar,LIB,29
+Minnehaha,0510,U.S. Senate,,John R. Thune,REP,270
+Minnehaha,0512,U.S. Senate,,Brian L. Bengs,DEM,272
+Minnehaha,0512,U.S. Senate,,Tamara J Lesnar,LIB,31
+Minnehaha,0512,U.S. Senate,,John R. Thune,REP,318
+Minnehaha,0513,U.S. Senate,,Brian L. Bengs,DEM,285
+Minnehaha,0513,U.S. Senate,,Tamara J Lesnar,LIB,16
+Minnehaha,0513,U.S. Senate,,John R. Thune,REP,339
+Minnehaha,0514,U.S. Senate,,Brian L. Bengs,DEM,360
+Minnehaha,0514,U.S. Senate,,Tamara J Lesnar,LIB,50
+Minnehaha,0514,U.S. Senate,,John R. Thune,REP,349
+Minnehaha,0515,U.S. Senate,,Brian L. Bengs,DEM,315
+Minnehaha,0515,U.S. Senate,,Tamara J Lesnar,LIB,32
+Minnehaha,0515,U.S. Senate,,John R. Thune,REP,428
+Minnehaha,0517,U.S. Senate,,Brian L. Bengs,DEM,211
+Minnehaha,0517,U.S. Senate,,Tamara J Lesnar,LIB,20
+Minnehaha,0517,U.S. Senate,,John R. Thune,REP,291
+Minnehaha,0518,U.S. Senate,,Brian L. Bengs,DEM,506
+Minnehaha,0518,U.S. Senate,,Tamara J Lesnar,LIB,63
+Minnehaha,0518,U.S. Senate,,John R. Thune,REP,452
+Minnehaha,0519,U.S. Senate,,Brian L. Bengs,DEM,210
+Minnehaha,0519,U.S. Senate,,Tamara J Lesnar,LIB,14
+Minnehaha,0519,U.S. Senate,,John R. Thune,REP,291
+Minnehaha,0520,U.S. Senate,,Brian L. Bengs,DEM,337
+Minnehaha,0520,U.S. Senate,,Tamara J Lesnar,LIB,56
+Minnehaha,0520,U.S. Senate,,John R. Thune,REP,439
+Minnehaha,0521,U.S. Senate,,Brian L. Bengs,DEM,193
+Minnehaha,0521,U.S. Senate,,Tamara J Lesnar,LIB,10
+Minnehaha,0521,U.S. Senate,,John R. Thune,REP,222
+Minnehaha,0522,U.S. Senate,,Brian L. Bengs,DEM,373
+Minnehaha,0522,U.S. Senate,,Tamara J Lesnar,LIB,61
+Minnehaha,0522,U.S. Senate,,John R. Thune,REP,377
+Minnehaha,0523,U.S. Senate,,Brian L. Bengs,DEM,311
+Minnehaha,0523,U.S. Senate,,Tamara J Lesnar,LIB,44
+Minnehaha,0523,U.S. Senate,,John R. Thune,REP,279
+Minnehaha,VP01,U.S. Senate,,Brian L. Bengs,DEM,128
+Minnehaha,VP01,U.S. Senate,,Tamara J Lesnar,LIB,38
+Minnehaha,VP01,U.S. Senate,,John R. Thune,REP,577
+Minnehaha,VP02,U.S. Senate,,Brian L. Bengs,DEM,370
+Minnehaha,VP02,U.S. Senate,,Tamara J Lesnar,LIB,48
+Minnehaha,VP02,U.S. Senate,,John R. Thune,REP,1281
+Minnehaha,VP03,U.S. Senate,,Brian L. Bengs,DEM,464
+Minnehaha,VP03,U.S. Senate,,Tamara J Lesnar,LIB,81
+Minnehaha,VP03,U.S. Senate,,John R. Thune,REP,1476
+Minnehaha,VP04,U.S. Senate,,Brian L. Bengs,DEM,249
+Minnehaha,VP04,U.S. Senate,,Tamara J Lesnar,LIB,40
+Minnehaha,VP04,U.S. Senate,,John R. Thune,REP,779
+Minnehaha,VP05,U.S. Senate,,Brian L. Bengs,DEM,314
+Minnehaha,VP05,U.S. Senate,,Tamara J Lesnar,LIB,49
+Minnehaha,VP05,U.S. Senate,,John R. Thune,REP,1027
+Minnehaha,VP06,U.S. Senate,,Brian L. Bengs,DEM,93
+Minnehaha,VP06,U.S. Senate,,Tamara J Lesnar,LIB,15
+Minnehaha,VP06,U.S. Senate,,John R. Thune,REP,323
+Minnehaha,VP07,U.S. Senate,,Brian L. Bengs,DEM,344
+Minnehaha,VP07,U.S. Senate,,Tamara J Lesnar,LIB,66
+Minnehaha,VP07,U.S. Senate,,John R. Thune,REP,1252
+Minnehaha,VP08,U.S. Senate,,Brian L. Bengs,DEM,111
+Minnehaha,VP08,U.S. Senate,,Tamara J Lesnar,LIB,30
+Minnehaha,VP08,U.S. Senate,,John R. Thune,REP,497
+Minnehaha,VP09,U.S. Senate,,Brian L. Bengs,DEM,264
+Minnehaha,VP09,U.S. Senate,,Tamara J Lesnar,LIB,48
+Minnehaha,VP09,U.S. Senate,,John R. Thune,REP,950
+Minnehaha,VP10,U.S. Senate,,Brian L. Bengs,DEM,247
+Minnehaha,VP10,U.S. Senate,,Tamara J Lesnar,LIB,41
+Minnehaha,VP10,U.S. Senate,,John R. Thune,REP,848
+Minnehaha,VP11,U.S. Senate,,Brian L. Bengs,DEM,52
+Minnehaha,VP11,U.S. Senate,,Tamara J Lesnar,LIB,10
+Minnehaha,VP11,U.S. Senate,,John R. Thune,REP,237
+Minnehaha,VP12,U.S. Senate,,Brian L. Bengs,DEM,15
+Minnehaha,VP12,U.S. Senate,,Tamara J Lesnar,LIB,4
+Minnehaha,VP12,U.S. Senate,,John R. Thune,REP,106
+Minnehaha,VP13,U.S. Senate,,Brian L. Bengs,DEM,146
+Minnehaha,VP13,U.S. Senate,,Tamara J Lesnar,LIB,46
+Minnehaha,VP13,U.S. Senate,,John R. Thune,REP,699
+Minnehaha,VP15,U.S. Senate,,Brian L. Bengs,DEM,346
+Minnehaha,VP15,U.S. Senate,,Tamara J Lesnar,LIB,40
+Minnehaha,VP15,U.S. Senate,,John R. Thune,REP,1103
+Minnehaha,VP16,U.S. Senate,,Brian L. Bengs,DEM,220
+Minnehaha,VP16,U.S. Senate,,Tamara J Lesnar,LIB,33
+Minnehaha,VP16,U.S. Senate,,John R. Thune,REP,786
+Minnehaha,VP17,U.S. Senate,,Brian L. Bengs,DEM,115
+Minnehaha,VP17,U.S. Senate,,Tamara J Lesnar,LIB,22
+Minnehaha,VP17,U.S. Senate,,John R. Thune,REP,505
+Minnehaha,VP21,U.S. Senate,,Brian L. Bengs,DEM,367
+Minnehaha,VP21,U.S. Senate,,Tamara J Lesnar,LIB,51
+Minnehaha,VP21,U.S. Senate,,John R. Thune,REP,1212
+Minnehaha,0104,U.S. House,1,Collin Duprel,LIB,212
+Minnehaha,0104,U.S. House,1,Dusty Johnson,REP,435
+Minnehaha,0105,U.S. House,1,Collin Duprel,LIB,125
+Minnehaha,0105,U.S. House,1,Dusty Johnson,REP,276
+Minnehaha,0106,U.S. House,1,Collin Duprel,LIB,300
+Minnehaha,0106,U.S. House,1,Dusty Johnson,REP,712
+Minnehaha,0109,U.S. House,1,Collin Duprel,LIB,237
+Minnehaha,0109,U.S. House,1,Dusty Johnson,REP,756
+Minnehaha,0110,U.S. House,1,Collin Duprel,LIB,309
+Minnehaha,0110,U.S. House,1,Dusty Johnson,REP,794
+Minnehaha,0117,U.S. House,1,Collin Duprel,LIB,345
+Minnehaha,0117,U.S. House,1,Dusty Johnson,REP,901
+Minnehaha,0119,U.S. House,1,Collin Duprel,LIB,197
+Minnehaha,0119,U.S. House,1,Dusty Johnson,REP,365
+Minnehaha,0201,U.S. House,1,Collin Duprel,LIB,232
+Minnehaha,0201,U.S. House,1,Dusty Johnson,REP,783
+Minnehaha,0202,U.S. House,1,Collin Duprel,LIB,294
+Minnehaha,0202,U.S. House,1,Dusty Johnson,REP,1028
+Minnehaha,0203,U.S. House,1,Collin Duprel,LIB,275
+Minnehaha,0203,U.S. House,1,Dusty Johnson,REP,733
+Minnehaha,0206,U.S. House,1,Collin Duprel,LIB,269
+Minnehaha,0206,U.S. House,1,Dusty Johnson,REP,788
+Minnehaha,0208,U.S. House,1,Collin Duprel,LIB,232
+Minnehaha,0208,U.S. House,1,Dusty Johnson,REP,841
+Minnehaha,0209,U.S. House,1,Collin Duprel,LIB,247
+Minnehaha,0209,U.S. House,1,Dusty Johnson,REP,720
+Minnehaha,0214,U.S. House,1,Collin Duprel,LIB,629
+Minnehaha,0214,U.S. House,1,Dusty Johnson,REP,2057
+Minnehaha,0301,U.S. House,1,Collin Duprel,LIB,188
+Minnehaha,0301,U.S. House,1,Dusty Johnson,REP,533
+Minnehaha,0305,U.S. House,1,Collin Duprel,LIB,182
+Minnehaha,0305,U.S. House,1,Dusty Johnson,REP,307
+Minnehaha,0309,U.S. House,1,Collin Duprel,LIB,357
+Minnehaha,0309,U.S. House,1,Dusty Johnson,REP,691
+Minnehaha,0310,U.S. House,1,Collin Duprel,LIB,266
+Minnehaha,0310,U.S. House,1,Dusty Johnson,REP,1128
+Minnehaha,0311,U.S. House,1,Collin Duprel,LIB,202
+Minnehaha,0311,U.S. House,1,Dusty Johnson,REP,668
+Minnehaha,0312,U.S. House,1,Collin Duprel,LIB,260
+Minnehaha,0312,U.S. House,1,Dusty Johnson,REP,868
+Minnehaha,0313,U.S. House,1,Collin Duprel,LIB,186
+Minnehaha,0313,U.S. House,1,Dusty Johnson,REP,509
+Minnehaha,0314,U.S. House,1,Collin Duprel,LIB,495
+Minnehaha,0314,U.S. House,1,Dusty Johnson,REP,1173
+Minnehaha,0315,U.S. House,1,Collin Duprel,LIB,293
+Minnehaha,0315,U.S. House,1,Dusty Johnson,REP,748
+Minnehaha,0316,U.S. House,1,Collin Duprel,LIB,354
+Minnehaha,0316,U.S. House,1,Dusty Johnson,REP,1317
+Minnehaha,0317,U.S. House,1,Collin Duprel,LIB,452
+Minnehaha,0317,U.S. House,1,Dusty Johnson,REP,1524
+Minnehaha,0402,U.S. House,1,Collin Duprel,LIB,224
+Minnehaha,0402,U.S. House,1,Dusty Johnson,REP,376
+Minnehaha,0403,U.S. House,1,Collin Duprel,LIB,136
+Minnehaha,0403,U.S. House,1,Dusty Johnson,REP,258
+Minnehaha,0404,U.S. House,1,Collin Duprel,LIB,230
+Minnehaha,0404,U.S. House,1,Dusty Johnson,REP,387
+Minnehaha,0405,U.S. House,1,Collin Duprel,LIB,438
+Minnehaha,0405,U.S. House,1,Dusty Johnson,REP,1030
+Minnehaha,0406,U.S. House,1,Collin Duprel,LIB,93
+Minnehaha,0406,U.S. House,1,Dusty Johnson,REP,178
+Minnehaha,0407,U.S. House,1,Collin Duprel,LIB,305
+Minnehaha,0407,U.S. House,1,Dusty Johnson,REP,867
+Minnehaha,0408,U.S. House,1,Collin Duprel,LIB,111
+Minnehaha,0408,U.S. House,1,Dusty Johnson,REP,177
+Minnehaha,0409,U.S. House,1,Collin Duprel,LIB,239
+Minnehaha,0409,U.S. House,1,Dusty Johnson,REP,412
+Minnehaha,0410,U.S. House,1,Collin Duprel,LIB,210
+Minnehaha,0410,U.S. House,1,Dusty Johnson,REP,518
+Minnehaha,0411,U.S. House,1,Collin Duprel,LIB,397
+Minnehaha,0411,U.S. House,1,Dusty Johnson,REP,1434
+Minnehaha,0412,U.S. House,1,Collin Duprel,LIB,308
+Minnehaha,0412,U.S. House,1,Dusty Johnson,REP,807
+Minnehaha,0413,U.S. House,1,Collin Duprel,LIB,194
+Minnehaha,0413,U.S. House,1,Dusty Johnson,REP,399
+Minnehaha,0415,U.S. House,1,Collin Duprel,LIB,377
+Minnehaha,0415,U.S. House,1,Dusty Johnson,REP,1584
+Minnehaha,0501,U.S. House,1,Collin Duprel,LIB,163
+Minnehaha,0501,U.S. House,1,Dusty Johnson,REP,218
+Minnehaha,0502,U.S. House,1,Collin Duprel,LIB,244
+Minnehaha,0502,U.S. House,1,Dusty Johnson,REP,319
+Minnehaha,0503,U.S. House,1,Collin Duprel,LIB,126
+Minnehaha,0503,U.S. House,1,Dusty Johnson,REP,176
+Minnehaha,0504,U.S. House,1,Collin Duprel,LIB,291
+Minnehaha,0504,U.S. House,1,Dusty Johnson,REP,437
+Minnehaha,0506,U.S. House,1,Collin Duprel,LIB,299
+Minnehaha,0506,U.S. House,1,Dusty Johnson,REP,541
+Minnehaha,0507,U.S. House,1,Collin Duprel,LIB,162
+Minnehaha,0507,U.S. House,1,Dusty Johnson,REP,323
+Minnehaha,0508,U.S. House,1,Collin Duprel,LIB,246
+Minnehaha,0508,U.S. House,1,Dusty Johnson,REP,541
+Minnehaha,0509,U.S. House,1,Collin Duprel,LIB,134
+Minnehaha,0509,U.S. House,1,Dusty Johnson,REP,209
+Minnehaha,0510,U.S. House,1,Collin Duprel,LIB,173
+Minnehaha,0510,U.S. House,1,Dusty Johnson,REP,318
+Minnehaha,0512,U.S. House,1,Collin Duprel,LIB,183
+Minnehaha,0512,U.S. House,1,Dusty Johnson,REP,381
+Minnehaha,0513,U.S. House,1,Collin Duprel,LIB,170
+Minnehaha,0513,U.S. House,1,Dusty Johnson,REP,394
+Minnehaha,0514,U.S. House,1,Collin Duprel,LIB,248
+Minnehaha,0514,U.S. House,1,Dusty Johnson,REP,425
+Minnehaha,0515,U.S. House,1,Collin Duprel,LIB,271
+Minnehaha,0515,U.S. House,1,Dusty Johnson,REP,434
+Minnehaha,0517,U.S. House,1,Collin Duprel,LIB,141
+Minnehaha,0517,U.S. House,1,Dusty Johnson,REP,333
+Minnehaha,0518,U.S. House,1,Collin Duprel,LIB,359
+Minnehaha,0518,U.S. House,1,Dusty Johnson,REP,536
+Minnehaha,0519,U.S. House,1,Collin Duprel,LIB,117
+Minnehaha,0519,U.S. House,1,Dusty Johnson,REP,323
+Minnehaha,0520,U.S. House,1,Collin Duprel,LIB,265
+Minnehaha,0520,U.S. House,1,Dusty Johnson,REP,490
+Minnehaha,0521,U.S. House,1,Collin Duprel,LIB,101
+Minnehaha,0521,U.S. House,1,Dusty Johnson,REP,276
+Minnehaha,0522,U.S. House,1,Collin Duprel,LIB,302
+Minnehaha,0522,U.S. House,1,Dusty Johnson,REP,437
+Minnehaha,0523,U.S. House,1,Collin Duprel,LIB,250
+Minnehaha,0523,U.S. House,1,Dusty Johnson,REP,320
+Minnehaha,VP01,U.S. House,1,Collin Duprel,LIB,137
+Minnehaha,VP01,U.S. House,1,Dusty Johnson,REP,585
+Minnehaha,VP02,U.S. House,1,Collin Duprel,LIB,260
+Minnehaha,VP02,U.S. House,1,Dusty Johnson,REP,1350
+Minnehaha,VP03,U.S. House,1,Collin Duprel,LIB,338
+Minnehaha,VP03,U.S. House,1,Dusty Johnson,REP,1579
+Minnehaha,VP04,U.S. House,1,Collin Duprel,LIB,216
+Minnehaha,VP04,U.S. House,1,Dusty Johnson,REP,797
+Minnehaha,VP05,U.S. House,1,Collin Duprel,LIB,245
+Minnehaha,VP05,U.S. House,1,Dusty Johnson,REP,1076
+Minnehaha,VP06,U.S. House,1,Collin Duprel,LIB,67
+Minnehaha,VP06,U.S. House,1,Dusty Johnson,REP,340
+Minnehaha,VP07,U.S. House,1,Collin Duprel,LIB,287
+Minnehaha,VP07,U.S. House,1,Dusty Johnson,REP,1304
+Minnehaha,VP08,U.S. House,1,Collin Duprel,LIB,109
+Minnehaha,VP08,U.S. House,1,Dusty Johnson,REP,496
+Minnehaha,VP09,U.S. House,1,Collin Duprel,LIB,226
+Minnehaha,VP09,U.S. House,1,Dusty Johnson,REP,994
+Minnehaha,VP10,U.S. House,1,Collin Duprel,LIB,206
+Minnehaha,VP10,U.S. House,1,Dusty Johnson,REP,871
+Minnehaha,VP11,U.S. House,1,Collin Duprel,LIB,42
+Minnehaha,VP11,U.S. House,1,Dusty Johnson,REP,243
+Minnehaha,VP12,U.S. House,1,Collin Duprel,LIB,13
+Minnehaha,VP12,U.S. House,1,Dusty Johnson,REP,108
+Minnehaha,VP13,U.S. House,1,Collin Duprel,LIB,130
+Minnehaha,VP13,U.S. House,1,Dusty Johnson,REP,730
+Minnehaha,VP15,U.S. House,1,Collin Duprel,LIB,280
+Minnehaha,VP15,U.S. House,1,Dusty Johnson,REP,1130
+Minnehaha,VP16,U.S. House,1,Collin Duprel,LIB,181
+Minnehaha,VP16,U.S. House,1,Dusty Johnson,REP,806
+Minnehaha,VP17,U.S. House,1,Collin Duprel,LIB,93
+Minnehaha,VP17,U.S. House,1,Dusty Johnson,REP,518
+Minnehaha,VP21,U.S. House,1,Collin Duprel,LIB,290
+Minnehaha,VP21,U.S. House,1,Dusty Johnson,REP,1253
+Minnehaha,0104,Governor,,Jamie Smith and Jennifer Keintz,DEM,420
+Minnehaha,0104,Governor,,Tracey Quint and Ashley Strand,LIB,15
+Minnehaha,0104,Governor,,Kristi Noem and Larry Rhoden,REP,303
+Minnehaha,0105,Governor,,Jamie Smith and Jennifer Keintz,DEM,242
+Minnehaha,0105,Governor,,Tracey Quint and Ashley Strand,LIB,14
+Minnehaha,0105,Governor,,Kristi Noem and Larry Rhoden,REP,210
+Minnehaha,0106,Governor,,Jamie Smith and Jennifer Keintz,DEM,523
+Minnehaha,0106,Governor,,Tracey Quint and Ashley Strand,LIB,39
+Minnehaha,0106,Governor,,Kristi Noem and Larry Rhoden,REP,545
+Minnehaha,0109,Governor,,Jamie Smith and Jennifer Keintz,DEM,510
+Minnehaha,0109,Governor,,Tracey Quint and Ashley Strand,LIB,30
+Minnehaha,0109,Governor,,Kristi Noem and Larry Rhoden,REP,545
+Minnehaha,0110,Governor,,Jamie Smith and Jennifer Keintz,DEM,542
+Minnehaha,0110,Governor,,Tracey Quint and Ashley Strand,LIB,36
+Minnehaha,0110,Governor,,Kristi Noem and Larry Rhoden,REP,607
+Minnehaha,0117,Governor,,Jamie Smith and Jennifer Keintz,DEM,593
+Minnehaha,0117,Governor,,Tracey Quint and Ashley Strand,LIB,41
+Minnehaha,0117,Governor,,Kristi Noem and Larry Rhoden,REP,715
+Minnehaha,0119,Governor,,Jamie Smith and Jennifer Keintz,DEM,309
+Minnehaha,0119,Governor,,Tracey Quint and Ashley Strand,LIB,32
+Minnehaha,0119,Governor,,Kristi Noem and Larry Rhoden,REP,288
+Minnehaha,0201,Governor,,Jamie Smith and Jennifer Keintz,DEM,561
+Minnehaha,0201,Governor,,Tracey Quint and Ashley Strand,LIB,13
+Minnehaha,0201,Governor,,Kristi Noem and Larry Rhoden,REP,546
+Minnehaha,0202,Governor,,Jamie Smith and Jennifer Keintz,DEM,763
+Minnehaha,0202,Governor,,Tracey Quint and Ashley Strand,LIB,16
+Minnehaha,0202,Governor,,Kristi Noem and Larry Rhoden,REP,687
+Minnehaha,0203,Governor,,Jamie Smith and Jennifer Keintz,DEM,554
+Minnehaha,0203,Governor,,Tracey Quint and Ashley Strand,LIB,37
+Minnehaha,0203,Governor,,Kristi Noem and Larry Rhoden,REP,514
+Minnehaha,0206,Governor,,Jamie Smith and Jennifer Keintz,DEM,559
+Minnehaha,0206,Governor,,Tracey Quint and Ashley Strand,LIB,24
+Minnehaha,0206,Governor,,Kristi Noem and Larry Rhoden,REP,590
+Minnehaha,0208,Governor,,Jamie Smith and Jennifer Keintz,DEM,547
+Minnehaha,0208,Governor,,Tracey Quint and Ashley Strand,LIB,22
+Minnehaha,0208,Governor,,Kristi Noem and Larry Rhoden,REP,620
+Minnehaha,0209,Governor,,Jamie Smith and Jennifer Keintz,DEM,575
+Minnehaha,0209,Governor,,Tracey Quint and Ashley Strand,LIB,14
+Minnehaha,0209,Governor,,Kristi Noem and Larry Rhoden,REP,479
+Minnehaha,0214,Governor,,Jamie Smith and Jennifer Keintz,DEM,1349
+Minnehaha,0214,Governor,,Tracey Quint and Ashley Strand,LIB,54
+Minnehaha,0214,Governor,,Kristi Noem and Larry Rhoden,REP,1502
+Minnehaha,0301,Governor,,Jamie Smith and Jennifer Keintz,DEM,382
+Minnehaha,0301,Governor,,Tracey Quint and Ashley Strand,LIB,15
+Minnehaha,0301,Governor,,Kristi Noem and Larry Rhoden,REP,396
+Minnehaha,0305,Governor,,Jamie Smith and Jennifer Keintz,DEM,253
+Minnehaha,0305,Governor,,Tracey Quint and Ashley Strand,LIB,31
+Minnehaha,0305,Governor,,Kristi Noem and Larry Rhoden,REP,267
+Minnehaha,0309,Governor,,Jamie Smith and Jennifer Keintz,DEM,593
+Minnehaha,0309,Governor,,Tracey Quint and Ashley Strand,LIB,52
+Minnehaha,0309,Governor,,Kristi Noem and Larry Rhoden,REP,516
+Minnehaha,0310,Governor,,Jamie Smith and Jennifer Keintz,DEM,594
+Minnehaha,0310,Governor,,Tracey Quint and Ashley Strand,LIB,26
+Minnehaha,0310,Governor,,Kristi Noem and Larry Rhoden,REP,851
+Minnehaha,0311,Governor,,Jamie Smith and Jennifer Keintz,DEM,396
+Minnehaha,0311,Governor,,Tracey Quint and Ashley Strand,LIB,29
+Minnehaha,0311,Governor,,Kristi Noem and Larry Rhoden,REP,507
+Minnehaha,0312,Governor,,Jamie Smith and Jennifer Keintz,DEM,474
+Minnehaha,0312,Governor,,Tracey Quint and Ashley Strand,LIB,39
+Minnehaha,0312,Governor,,Kristi Noem and Larry Rhoden,REP,704
+Minnehaha,0313,Governor,,Jamie Smith and Jennifer Keintz,DEM,322
+Minnehaha,0313,Governor,,Tracey Quint and Ashley Strand,LIB,28
+Minnehaha,0313,Governor,,Kristi Noem and Larry Rhoden,REP,397
+Minnehaha,0314,Governor,,Jamie Smith and Jennifer Keintz,DEM,826
+Minnehaha,0314,Governor,,Tracey Quint and Ashley Strand,LIB,58
+Minnehaha,0314,Governor,,Kristi Noem and Larry Rhoden,REP,923
+Minnehaha,0315,Governor,,Jamie Smith and Jennifer Keintz,DEM,519
+Minnehaha,0315,Governor,,Tracey Quint and Ashley Strand,LIB,29
+Minnehaha,0315,Governor,,Kristi Noem and Larry Rhoden,REP,578
+Minnehaha,0316,Governor,,Jamie Smith and Jennifer Keintz,DEM,748
+Minnehaha,0316,Governor,,Tracey Quint and Ashley Strand,LIB,40
+Minnehaha,0316,Governor,,Kristi Noem and Larry Rhoden,REP,998
+Minnehaha,0317,Governor,,Jamie Smith and Jennifer Keintz,DEM,911
+Minnehaha,0317,Governor,,Tracey Quint and Ashley Strand,LIB,43
+Minnehaha,0317,Governor,,Kristi Noem and Larry Rhoden,REP,1189
+Minnehaha,0402,Governor,,Jamie Smith and Jennifer Keintz,DEM,368
+Minnehaha,0402,Governor,,Tracey Quint and Ashley Strand,LIB,31
+Minnehaha,0402,Governor,,Kristi Noem and Larry Rhoden,REP,261
+Minnehaha,0403,Governor,,Jamie Smith and Jennifer Keintz,DEM,238
+Minnehaha,0403,Governor,,Tracey Quint and Ashley Strand,LIB,14
+Minnehaha,0403,Governor,,Kristi Noem and Larry Rhoden,REP,185
+Minnehaha,0404,Governor,,Jamie Smith and Jennifer Keintz,DEM,364
+Minnehaha,0404,Governor,,Tracey Quint and Ashley Strand,LIB,43
+Minnehaha,0404,Governor,,Kristi Noem and Larry Rhoden,REP,285
+Minnehaha,0405,Governor,,Jamie Smith and Jennifer Keintz,DEM,613
+Minnehaha,0405,Governor,,Tracey Quint and Ashley Strand,LIB,41
+Minnehaha,0405,Governor,,Kristi Noem and Larry Rhoden,REP,955
+Minnehaha,0406,Governor,,Jamie Smith and Jennifer Keintz,DEM,149
+Minnehaha,0406,Governor,,Tracey Quint and Ashley Strand,LIB,17
+Minnehaha,0406,Governor,,Kristi Noem and Larry Rhoden,REP,129
+Minnehaha,0407,Governor,,Jamie Smith and Jennifer Keintz,DEM,626
+Minnehaha,0407,Governor,,Tracey Quint and Ashley Strand,LIB,32
+Minnehaha,0407,Governor,,Kristi Noem and Larry Rhoden,REP,641
+Minnehaha,0408,Governor,,Jamie Smith and Jennifer Keintz,DEM,183
+Minnehaha,0408,Governor,,Tracey Quint and Ashley Strand,LIB,10
+Minnehaha,0408,Governor,,Kristi Noem and Larry Rhoden,REP,128
+Minnehaha,0409,Governor,,Jamie Smith and Jennifer Keintz,DEM,377
+Minnehaha,0409,Governor,,Tracey Quint and Ashley Strand,LIB,42
+Minnehaha,0409,Governor,,Kristi Noem and Larry Rhoden,REP,299
+Minnehaha,0410,Governor,,Jamie Smith and Jennifer Keintz,DEM,357
+Minnehaha,0410,Governor,,Tracey Quint and Ashley Strand,LIB,27
+Minnehaha,0410,Governor,,Kristi Noem and Larry Rhoden,REP,399
+Minnehaha,0411,Governor,,Jamie Smith and Jennifer Keintz,DEM,805
+Minnehaha,0411,Governor,,Tracey Quint and Ashley Strand,LIB,42
+Minnehaha,0411,Governor,,Kristi Noem and Larry Rhoden,REP,1135
+Minnehaha,0412,Governor,,Jamie Smith and Jennifer Keintz,DEM,599
+Minnehaha,0412,Governor,,Tracey Quint and Ashley Strand,LIB,32
+Minnehaha,0412,Governor,,Kristi Noem and Larry Rhoden,REP,576
+Minnehaha,0413,Governor,,Jamie Smith and Jennifer Keintz,DEM,347
+Minnehaha,0413,Governor,,Tracey Quint and Ashley Strand,LIB,17
+Minnehaha,0413,Governor,,Kristi Noem and Larry Rhoden,REP,283
+Minnehaha,0415,Governor,,Jamie Smith and Jennifer Keintz,DEM,897
+Minnehaha,0415,Governor,,Tracey Quint and Ashley Strand,LIB,30
+Minnehaha,0415,Governor,,Kristi Noem and Larry Rhoden,REP,1228
+Minnehaha,0501,Governor,,Jamie Smith and Jennifer Keintz,DEM,270
+Minnehaha,0501,Governor,,Tracey Quint and Ashley Strand,LIB,19
+Minnehaha,0501,Governor,,Kristi Noem and Larry Rhoden,REP,155
+Minnehaha,0502,Governor,,Jamie Smith and Jennifer Keintz,DEM,445
+Minnehaha,0502,Governor,,Tracey Quint and Ashley Strand,LIB,23
+Minnehaha,0502,Governor,,Kristi Noem and Larry Rhoden,REP,189
+Minnehaha,0503,Governor,,Jamie Smith and Jennifer Keintz,DEM,211
+Minnehaha,0503,Governor,,Tracey Quint and Ashley Strand,LIB,13
+Minnehaha,0503,Governor,,Kristi Noem and Larry Rhoden,REP,119
+Minnehaha,0504,Governor,,Jamie Smith and Jennifer Keintz,DEM,556
+Minnehaha,0504,Governor,,Tracey Quint and Ashley Strand,LIB,30
+Minnehaha,0504,Governor,,Kristi Noem and Larry Rhoden,REP,278
+Minnehaha,0506,Governor,,Jamie Smith and Jennifer Keintz,DEM,547
+Minnehaha,0506,Governor,,Tracey Quint and Ashley Strand,LIB,36
+Minnehaha,0506,Governor,,Kristi Noem and Larry Rhoden,REP,359
+Minnehaha,0507,Governor,,Jamie Smith and Jennifer Keintz,DEM,359
+Minnehaha,0507,Governor,,Tracey Quint and Ashley Strand,LIB,12
+Minnehaha,0507,Governor,,Kristi Noem and Larry Rhoden,REP,203
+Minnehaha,0508,Governor,,Jamie Smith and Jennifer Keintz,DEM,595
+Minnehaha,0508,Governor,,Tracey Quint and Ashley Strand,LIB,16
+Minnehaha,0508,Governor,,Kristi Noem and Larry Rhoden,REP,308
+Minnehaha,0509,Governor,,Jamie Smith and Jennifer Keintz,DEM,260
+Minnehaha,0509,Governor,,Tracey Quint and Ashley Strand,LIB,11
+Minnehaha,0509,Governor,,Kristi Noem and Larry Rhoden,REP,118
+Minnehaha,0510,Governor,,Jamie Smith and Jennifer Keintz,DEM,304
+Minnehaha,0510,Governor,,Tracey Quint and Ashley Strand,LIB,13
+Minnehaha,0510,Governor,,Kristi Noem and Larry Rhoden,REP,226
+Minnehaha,0512,Governor,,Jamie Smith and Jennifer Keintz,DEM,364
+Minnehaha,0512,Governor,,Tracey Quint and Ashley Strand,LIB,19
+Minnehaha,0512,Governor,,Kristi Noem and Larry Rhoden,REP,252
+Minnehaha,0513,Governor,,Jamie Smith and Jennifer Keintz,DEM,390
+Minnehaha,0513,Governor,,Tracey Quint and Ashley Strand,LIB,8
+Minnehaha,0513,Governor,,Kristi Noem and Larry Rhoden,REP,253
+Minnehaha,0514,Governor,,Jamie Smith and Jennifer Keintz,DEM,460
+Minnehaha,0514,Governor,,Tracey Quint and Ashley Strand,LIB,28
+Minnehaha,0514,Governor,,Kristi Noem and Larry Rhoden,REP,281
+Minnehaha,0515,Governor,,Jamie Smith and Jennifer Keintz,DEM,364
+Minnehaha,0515,Governor,,Tracey Quint and Ashley Strand,LIB,27
+Minnehaha,0515,Governor,,Kristi Noem and Larry Rhoden,REP,397
+Minnehaha,0517,Governor,,Jamie Smith and Jennifer Keintz,DEM,262
+Minnehaha,0517,Governor,,Tracey Quint and Ashley Strand,LIB,13
+Minnehaha,0517,Governor,,Kristi Noem and Larry Rhoden,REP,256
+Minnehaha,0518,Governor,,Jamie Smith and Jennifer Keintz,DEM,615
+Minnehaha,0518,Governor,,Tracey Quint and Ashley Strand,LIB,47
+Minnehaha,0518,Governor,,Kristi Noem and Larry Rhoden,REP,364
+Minnehaha,0519,Governor,,Jamie Smith and Jennifer Keintz,DEM,270
+Minnehaha,0519,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Minnehaha,0519,Governor,,Kristi Noem and Larry Rhoden,REP,246
+Minnehaha,0520,Governor,,Jamie Smith and Jennifer Keintz,DEM,432
+Minnehaha,0520,Governor,,Tracey Quint and Ashley Strand,LIB,39
+Minnehaha,0520,Governor,,Kristi Noem and Larry Rhoden,REP,373
+Minnehaha,0521,Governor,,Jamie Smith and Jennifer Keintz,DEM,247
+Minnehaha,0521,Governor,,Tracey Quint and Ashley Strand,LIB,9
+Minnehaha,0521,Governor,,Kristi Noem and Larry Rhoden,REP,169
+Minnehaha,0522,Governor,,Jamie Smith and Jennifer Keintz,DEM,467
+Minnehaha,0522,Governor,,Tracey Quint and Ashley Strand,LIB,40
+Minnehaha,0522,Governor,,Kristi Noem and Larry Rhoden,REP,309
+Minnehaha,0523,Governor,,Jamie Smith and Jennifer Keintz,DEM,391
+Minnehaha,0523,Governor,,Tracey Quint and Ashley Strand,LIB,28
+Minnehaha,0523,Governor,,Kristi Noem and Larry Rhoden,REP,220
+Minnehaha,VP01,Governor,,Jamie Smith and Jennifer Keintz,DEM,171
+Minnehaha,VP01,Governor,,Tracey Quint and Ashley Strand,LIB,29
+Minnehaha,VP01,Governor,,Kristi Noem and Larry Rhoden,REP,546
+Minnehaha,VP02,Governor,,Jamie Smith and Jennifer Keintz,DEM,546
+Minnehaha,VP02,Governor,,Tracey Quint and Ashley Strand,LIB,36
+Minnehaha,VP02,Governor,,Kristi Noem and Larry Rhoden,REP,1124
+Minnehaha,VP03,Governor,,Jamie Smith and Jennifer Keintz,DEM,640
+Minnehaha,VP03,Governor,,Tracey Quint and Ashley Strand,LIB,48
+Minnehaha,VP03,Governor,,Kristi Noem and Larry Rhoden,REP,1349
+Minnehaha,VP04,Governor,,Jamie Smith and Jennifer Keintz,DEM,350
+Minnehaha,VP04,Governor,,Tracey Quint and Ashley Strand,LIB,30
+Minnehaha,VP04,Governor,,Kristi Noem and Larry Rhoden,REP,689
+Minnehaha,VP05,Governor,,Jamie Smith and Jennifer Keintz,DEM,459
+Minnehaha,VP05,Governor,,Tracey Quint and Ashley Strand,LIB,30
+Minnehaha,VP05,Governor,,Kristi Noem and Larry Rhoden,REP,902
+Minnehaha,VP06,Governor,,Jamie Smith and Jennifer Keintz,DEM,138
+Minnehaha,VP06,Governor,,Tracey Quint and Ashley Strand,LIB,11
+Minnehaha,VP06,Governor,,Kristi Noem and Larry Rhoden,REP,283
+Minnehaha,VP07,Governor,,Jamie Smith and Jennifer Keintz,DEM,504
+Minnehaha,VP07,Governor,,Tracey Quint and Ashley Strand,LIB,48
+Minnehaha,VP07,Governor,,Kristi Noem and Larry Rhoden,REP,1111
+Minnehaha,VP08,Governor,,Jamie Smith and Jennifer Keintz,DEM,163
+Minnehaha,VP08,Governor,,Tracey Quint and Ashley Strand,LIB,18
+Minnehaha,VP08,Governor,,Kristi Noem and Larry Rhoden,REP,461
+Minnehaha,VP09,Governor,,Jamie Smith and Jennifer Keintz,DEM,396
+Minnehaha,VP09,Governor,,Tracey Quint and Ashley Strand,LIB,25
+Minnehaha,VP09,Governor,,Kristi Noem and Larry Rhoden,REP,852
+Minnehaha,VP10,Governor,,Jamie Smith and Jennifer Keintz,DEM,380
+Minnehaha,VP10,Governor,,Tracey Quint and Ashley Strand,LIB,34
+Minnehaha,VP10,Governor,,Kristi Noem and Larry Rhoden,REP,730
+Minnehaha,VP11,Governor,,Jamie Smith and Jennifer Keintz,DEM,77
+Minnehaha,VP11,Governor,,Tracey Quint and Ashley Strand,LIB,6
+Minnehaha,VP11,Governor,,Kristi Noem and Larry Rhoden,REP,216
+Minnehaha,VP12,Governor,,Jamie Smith and Jennifer Keintz,DEM,30
+Minnehaha,VP12,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Minnehaha,VP12,Governor,,Kristi Noem and Larry Rhoden,REP,94
+Minnehaha,VP13,Governor,,Jamie Smith and Jennifer Keintz,DEM,204
+Minnehaha,VP13,Governor,,Tracey Quint and Ashley Strand,LIB,42
+Minnehaha,VP13,Governor,,Kristi Noem and Larry Rhoden,REP,647
+Minnehaha,VP15,Governor,,Jamie Smith and Jennifer Keintz,DEM,508
+Minnehaha,VP15,Governor,,Tracey Quint and Ashley Strand,LIB,29
+Minnehaha,VP15,Governor,,Kristi Noem and Larry Rhoden,REP,960
+Minnehaha,VP16,Governor,,Jamie Smith and Jennifer Keintz,DEM,318
+Minnehaha,VP16,Governor,,Tracey Quint and Ashley Strand,LIB,29
+Minnehaha,VP16,Governor,,Kristi Noem and Larry Rhoden,REP,701
+Minnehaha,VP17,Governor,,Jamie Smith and Jennifer Keintz,DEM,173
+Minnehaha,VP17,Governor,,Tracey Quint and Ashley Strand,LIB,20
+Minnehaha,VP17,Governor,,Kristi Noem and Larry Rhoden,REP,447
+Minnehaha,VP21,Governor,,Jamie Smith and Jennifer Keintz,DEM,522
+Minnehaha,VP21,Governor,,Tracey Quint and Ashley Strand,LIB,43
+Minnehaha,VP21,Governor,,Kristi Noem and Larry Rhoden,REP,1066
+Minnehaha,0104,Secretary of State,,Thomas A Cool,DEM,389
+Minnehaha,0104,Secretary of State,,Monae Johnson,REP,296
+Minnehaha,0105,Secretary of State,,Thomas A Cool,DEM,213
+Minnehaha,0105,Secretary of State,,Monae Johnson,REP,218
+Minnehaha,0106,Secretary of State,,Thomas A Cool,DEM,512
+Minnehaha,0106,Secretary of State,,Monae Johnson,REP,527
+Minnehaha,0109,Secretary of State,,Thomas A Cool,DEM,479
+Minnehaha,0109,Secretary of State,,Monae Johnson,REP,536
+Minnehaha,0110,Secretary of State,,Thomas A Cool,DEM,518
+Minnehaha,0110,Secretary of State,,Monae Johnson,REP,604
+Minnehaha,0117,Secretary of State,,Thomas A Cool,DEM,542
+Minnehaha,0117,Secretary of State,,Monae Johnson,REP,732
+Minnehaha,0119,Secretary of State,,Thomas A Cool,DEM,286
+Minnehaha,0119,Secretary of State,,Monae Johnson,REP,306
+Minnehaha,0201,Secretary of State,,Thomas A Cool,DEM,495
+Minnehaha,0201,Secretary of State,,Monae Johnson,REP,569
+Minnehaha,0202,Secretary of State,,Thomas A Cool,DEM,660
+Minnehaha,0202,Secretary of State,,Monae Johnson,REP,730
+Minnehaha,0203,Secretary of State,,Thomas A Cool,DEM,520
+Minnehaha,0203,Secretary of State,,Monae Johnson,REP,539
+Minnehaha,0206,Secretary of State,,Thomas A Cool,DEM,500
+Minnehaha,0206,Secretary of State,,Monae Johnson,REP,590
+Minnehaha,0208,Secretary of State,,Thomas A Cool,DEM,513
+Minnehaha,0208,Secretary of State,,Monae Johnson,REP,611
+Minnehaha,0209,Secretary of State,,Thomas A Cool,DEM,515
+Minnehaha,0209,Secretary of State,,Monae Johnson,REP,492
+Minnehaha,0214,Secretary of State,,Thomas A Cool,DEM,1202
+Minnehaha,0214,Secretary of State,,Monae Johnson,REP,1525
+Minnehaha,0301,Secretary of State,,Thomas A Cool,DEM,364
+Minnehaha,0301,Secretary of State,,Monae Johnson,REP,398
+Minnehaha,0305,Secretary of State,,Thomas A Cool,DEM,260
+Minnehaha,0305,Secretary of State,,Monae Johnson,REP,253
+Minnehaha,0309,Secretary of State,,Thomas A Cool,DEM,571
+Minnehaha,0309,Secretary of State,,Monae Johnson,REP,524
+Minnehaha,0310,Secretary of State,,Thomas A Cool,DEM,583
+Minnehaha,0310,Secretary of State,,Monae Johnson,REP,833
+Minnehaha,0311,Secretary of State,,Thomas A Cool,DEM,388
+Minnehaha,0311,Secretary of State,,Monae Johnson,REP,504
+Minnehaha,0312,Secretary of State,,Thomas A Cool,DEM,437
+Minnehaha,0312,Secretary of State,,Monae Johnson,REP,701
+Minnehaha,0313,Secretary of State,,Thomas A Cool,DEM,311
+Minnehaha,0313,Secretary of State,,Monae Johnson,REP,399
+Minnehaha,0314,Secretary of State,,Thomas A Cool,DEM,781
+Minnehaha,0314,Secretary of State,,Monae Johnson,REP,925
+Minnehaha,0315,Secretary of State,,Thomas A Cool,DEM,493
+Minnehaha,0315,Secretary of State,,Monae Johnson,REP,568
+Minnehaha,0316,Secretary of State,,Thomas A Cool,DEM,681
+Minnehaha,0316,Secretary of State,,Monae Johnson,REP,983
+Minnehaha,0317,Secretary of State,,Thomas A Cool,DEM,845
+Minnehaha,0317,Secretary of State,,Monae Johnson,REP,1155
+Minnehaha,0402,Secretary of State,,Thomas A Cool,DEM,360
+Minnehaha,0402,Secretary of State,,Monae Johnson,REP,264
+Minnehaha,0403,Secretary of State,,Thomas A Cool,DEM,225
+Minnehaha,0403,Secretary of State,,Monae Johnson,REP,191
+Minnehaha,0404,Secretary of State,,Thomas A Cool,DEM,341
+Minnehaha,0404,Secretary of State,,Monae Johnson,REP,294
+Minnehaha,0405,Secretary of State,,Thomas A Cool,DEM,603
+Minnehaha,0405,Secretary of State,,Monae Johnson,REP,936
+Minnehaha,0406,Secretary of State,,Thomas A Cool,DEM,156
+Minnehaha,0406,Secretary of State,,Monae Johnson,REP,121
+Minnehaha,0407,Secretary of State,,Thomas A Cool,DEM,619
+Minnehaha,0407,Secretary of State,,Monae Johnson,REP,607
+Minnehaha,0408,Secretary of State,,Thomas A Cool,DEM,178
+Minnehaha,0408,Secretary of State,,Monae Johnson,REP,122
+Minnehaha,0409,Secretary of State,,Thomas A Cool,DEM,358
+Minnehaha,0409,Secretary of State,,Monae Johnson,REP,312
+Minnehaha,0410,Secretary of State,,Thomas A Cool,DEM,342
+Minnehaha,0410,Secretary of State,,Monae Johnson,REP,390
+Minnehaha,0411,Secretary of State,,Thomas A Cool,DEM,772
+Minnehaha,0411,Secretary of State,,Monae Johnson,REP,1119
+Minnehaha,0412,Secretary of State,,Thomas A Cool,DEM,570
+Minnehaha,0412,Secretary of State,,Monae Johnson,REP,561
+Minnehaha,0413,Secretary of State,,Thomas A Cool,DEM,334
+Minnehaha,0413,Secretary of State,,Monae Johnson,REP,272
+Minnehaha,0415,Secretary of State,,Thomas A Cool,DEM,822
+Minnehaha,0415,Secretary of State,,Monae Johnson,REP,1217
+Minnehaha,0501,Secretary of State,,Thomas A Cool,DEM,256
+Minnehaha,0501,Secretary of State,,Monae Johnson,REP,165
+Minnehaha,0502,Secretary of State,,Thomas A Cool,DEM,431
+Minnehaha,0502,Secretary of State,,Monae Johnson,REP,187
+Minnehaha,0503,Secretary of State,,Thomas A Cool,DEM,199
+Minnehaha,0503,Secretary of State,,Monae Johnson,REP,122
+Minnehaha,0504,Secretary of State,,Thomas A Cool,DEM,535
+Minnehaha,0504,Secretary of State,,Monae Johnson,REP,276
+Minnehaha,0506,Secretary of State,,Thomas A Cool,DEM,520
+Minnehaha,0506,Secretary of State,,Monae Johnson,REP,363
+Minnehaha,0507,Secretary of State,,Thomas A Cool,DEM,333
+Minnehaha,0507,Secretary of State,,Monae Johnson,REP,206
+Minnehaha,0508,Secretary of State,,Thomas A Cool,DEM,548
+Minnehaha,0508,Secretary of State,,Monae Johnson,REP,325
+Minnehaha,0509,Secretary of State,,Thomas A Cool,DEM,235
+Minnehaha,0509,Secretary of State,,Monae Johnson,REP,128
+Minnehaha,0510,Secretary of State,,Thomas A Cool,DEM,285
+Minnehaha,0510,Secretary of State,,Monae Johnson,REP,217
+Minnehaha,0512,Secretary of State,,Thomas A Cool,DEM,326
+Minnehaha,0512,Secretary of State,,Monae Johnson,REP,261
+Minnehaha,0513,Secretary of State,,Thomas A Cool,DEM,356
+Minnehaha,0513,Secretary of State,,Monae Johnson,REP,253
+Minnehaha,0514,Secretary of State,,Thomas A Cool,DEM,441
+Minnehaha,0514,Secretary of State,,Monae Johnson,REP,278
+Minnehaha,0515,Secretary of State,,Thomas A Cool,DEM,352
+Minnehaha,0515,Secretary of State,,Monae Johnson,REP,405
+Minnehaha,0517,Secretary of State,,Thomas A Cool,DEM,264
+Minnehaha,0517,Secretary of State,,Monae Johnson,REP,237
+Minnehaha,0518,Secretary of State,,Thomas A Cool,DEM,584
+Minnehaha,0518,Secretary of State,,Monae Johnson,REP,378
+Minnehaha,0519,Secretary of State,,Thomas A Cool,DEM,242
+Minnehaha,0519,Secretary of State,,Monae Johnson,REP,250
+Minnehaha,0520,Secretary of State,,Thomas A Cool,DEM,429
+Minnehaha,0520,Secretary of State,,Monae Johnson,REP,372
+Minnehaha,0521,Secretary of State,,Thomas A Cool,DEM,231
+Minnehaha,0521,Secretary of State,,Monae Johnson,REP,177
+Minnehaha,0522,Secretary of State,,Thomas A Cool,DEM,455
+Minnehaha,0522,Secretary of State,,Monae Johnson,REP,303
+Minnehaha,0523,Secretary of State,,Thomas A Cool,DEM,375
+Minnehaha,0523,Secretary of State,,Monae Johnson,REP,244
+Minnehaha,VP01,Secretary of State,,Thomas A Cool,DEM,189
+Minnehaha,VP01,Secretary of State,,Monae Johnson,REP,521
+Minnehaha,VP02,Secretary of State,,Thomas A Cool,DEM,515
+Minnehaha,VP02,Secretary of State,,Monae Johnson,REP,1118
+Minnehaha,VP03,Secretary of State,,Thomas A Cool,DEM,600
+Minnehaha,VP03,Secretary of State,,Monae Johnson,REP,1345
+Minnehaha,VP04,Secretary of State,,Thomas A Cool,DEM,333
+Minnehaha,VP04,Secretary of State,,Monae Johnson,REP,681
+Minnehaha,VP05,Secretary of State,,Thomas A Cool,DEM,414
+Minnehaha,VP05,Secretary of State,,Monae Johnson,REP,888
+Minnehaha,VP06,Secretary of State,,Thomas A Cool,DEM,140
+Minnehaha,VP06,Secretary of State,,Monae Johnson,REP,269
+Minnehaha,VP07,Secretary of State,,Thomas A Cool,DEM,505
+Minnehaha,VP07,Secretary of State,,Monae Johnson,REP,1079
+Minnehaha,VP08,Secretary of State,,Thomas A Cool,DEM,170
+Minnehaha,VP08,Secretary of State,,Monae Johnson,REP,426
+Minnehaha,VP09,Secretary of State,,Thomas A Cool,DEM,369
+Minnehaha,VP09,Secretary of State,,Monae Johnson,REP,805
+Minnehaha,VP10,Secretary of State,,Thomas A Cool,DEM,367
+Minnehaha,VP10,Secretary of State,,Monae Johnson,REP,703
+Minnehaha,VP11,Secretary of State,,Thomas A Cool,DEM,73
+Minnehaha,VP11,Secretary of State,,Monae Johnson,REP,215
+Minnehaha,VP12,Secretary of State,,Thomas A Cool,DEM,31
+Minnehaha,VP12,Secretary of State,,Monae Johnson,REP,90
+Minnehaha,VP13,Secretary of State,,Thomas A Cool,DEM,206
+Minnehaha,VP13,Secretary of State,,Monae Johnson,REP,639
+Minnehaha,VP15,Secretary of State,,Thomas A Cool,DEM,489
+Minnehaha,VP15,Secretary of State,,Monae Johnson,REP,930
+Minnehaha,VP16,Secretary of State,,Thomas A Cool,DEM,316
+Minnehaha,VP16,Secretary of State,,Monae Johnson,REP,662
+Minnehaha,VP17,Secretary of State,,Thomas A Cool,DEM,179
+Minnehaha,VP17,Secretary of State,,Monae Johnson,REP,435
+Minnehaha,VP21,Secretary of State,,Thomas A Cool,DEM,503
+Minnehaha,VP21,Secretary of State,,Monae Johnson,REP,1035
+Minnehaha,0104,Attorney General,,Marty J. Jackley,REP,435
+Minnehaha,0105,Attorney General,,Marty J. Jackley,REP,286
+Minnehaha,0106,Attorney General,,Marty J. Jackley,REP,722
+Minnehaha,0109,Attorney General,,Marty J. Jackley,REP,740
+Minnehaha,0110,Attorney General,,Marty J. Jackley,REP,776
+Minnehaha,0117,Attorney General,,Marty J. Jackley,REP,909
+Minnehaha,0119,Attorney General,,Marty J. Jackley,REP,379
+Minnehaha,0201,Attorney General,,Marty J. Jackley,REP,776
+Minnehaha,0202,Attorney General,,Marty J. Jackley,REP,996
+Minnehaha,0203,Attorney General,,Marty J. Jackley,REP,713
+Minnehaha,0206,Attorney General,,Marty J. Jackley,REP,776
+Minnehaha,0208,Attorney General,,Marty J. Jackley,REP,835
+Minnehaha,0209,Attorney General,,Marty J. Jackley,REP,710
+Minnehaha,0214,Attorney General,,Marty J. Jackley,REP,2079
+Minnehaha,0301,Attorney General,,Marty J. Jackley,REP,543
+Minnehaha,0305,Attorney General,,Marty J. Jackley,REP,326
+Minnehaha,0309,Attorney General,,Marty J. Jackley,REP,703
+Minnehaha,0310,Attorney General,,Marty J. Jackley,REP,1070
+Minnehaha,0311,Attorney General,,Marty J. Jackley,REP,675
+Minnehaha,0312,Attorney General,,Marty J. Jackley,REP,888
+Minnehaha,0313,Attorney General,,Marty J. Jackley,REP,508
+Minnehaha,0314,Attorney General,,Marty J. Jackley,REP,1199
+Minnehaha,0315,Attorney General,,Marty J. Jackley,REP,730
+Minnehaha,0316,Attorney General,,Marty J. Jackley,REP,1306
+Minnehaha,0317,Attorney General,,Marty J. Jackley,REP,1509
+Minnehaha,0402,Attorney General,,Marty J. Jackley,REP,389
+Minnehaha,0403,Attorney General,,Marty J. Jackley,REP,256
+Minnehaha,0404,Attorney General,,Marty J. Jackley,REP,401
+Minnehaha,0405,Attorney General,,Marty J. Jackley,REP,1043
+Minnehaha,0406,Attorney General,,Marty J. Jackley,REP,175
+Minnehaha,0407,Attorney General,,Marty J. Jackley,REP,856
+Minnehaha,0408,Attorney General,,Marty J. Jackley,REP,191
+Minnehaha,0409,Attorney General,,Marty J. Jackley,REP,437
+Minnehaha,0410,Attorney General,,Marty J. Jackley,REP,521
+Minnehaha,0411,Attorney General,,Marty J. Jackley,REP,1448
+Minnehaha,0412,Attorney General,,Marty J. Jackley,REP,789
+Minnehaha,0413,Attorney General,,Marty J. Jackley,REP,398
+Minnehaha,0415,Attorney General,,Marty J. Jackley,REP,1534
+Minnehaha,0501,Attorney General,,Marty J. Jackley,REP,231
+Minnehaha,0502,Attorney General,,Marty J. Jackley,REP,297
+Minnehaha,0503,Attorney General,,Marty J. Jackley,REP,183
+Minnehaha,0504,Attorney General,,Marty J. Jackley,REP,428
+Minnehaha,0506,Attorney General,,Marty J. Jackley,REP,558
+Minnehaha,0507,Attorney General,,Marty J. Jackley,REP,318
+Minnehaha,0508,Attorney General,,Marty J. Jackley,REP,493
+Minnehaha,0509,Attorney General,,Marty J. Jackley,REP,209
+Minnehaha,0510,Attorney General,,Marty J. Jackley,REP,318
+Minnehaha,0512,Attorney General,,Marty J. Jackley,REP,380
+Minnehaha,0513,Attorney General,,Marty J. Jackley,REP,402
+Minnehaha,0514,Attorney General,,Marty J. Jackley,REP,437
+Minnehaha,0515,Attorney General,,Marty J. Jackley,REP,474
+Minnehaha,0517,Attorney General,,Marty J. Jackley,REP,340
+Minnehaha,0518,Attorney General,,Marty J. Jackley,REP,521
+Minnehaha,0519,Attorney General,,Marty J. Jackley,REP,331
+Minnehaha,0520,Attorney General,,Marty J. Jackley,REP,490
+Minnehaha,0521,Attorney General,,Marty J. Jackley,REP,258
+Minnehaha,0522,Attorney General,,Marty J. Jackley,REP,446
+Minnehaha,0523,Attorney General,,Marty J. Jackley,REP,327
+Minnehaha,VP01,Attorney General,,Marty J. Jackley,REP,594
+Minnehaha,VP02,Attorney General,,Marty J. Jackley,REP,1331
+Minnehaha,VP03,Attorney General,,Marty J. Jackley,REP,1589
+Minnehaha,VP04,Attorney General,,Marty J. Jackley,REP,811
+Minnehaha,VP05,Attorney General,,Marty J. Jackley,REP,1084
+Minnehaha,VP06,Attorney General,,Marty J. Jackley,REP,342
+Minnehaha,VP07,Attorney General,,Marty J. Jackley,REP,1299
+Minnehaha,VP08,Attorney General,,Marty J. Jackley,REP,494
+Minnehaha,VP09,Attorney General,,Marty J. Jackley,REP,937
+Minnehaha,VP10,Attorney General,,Marty J. Jackley,REP,866
+Minnehaha,VP11,Attorney General,,Marty J. Jackley,REP,237
+Minnehaha,VP12,Attorney General,,Marty J. Jackley,REP,106
+Minnehaha,VP13,Attorney General,,Marty J. Jackley,REP,714
+Minnehaha,VP15,Attorney General,,Marty J. Jackley,REP,1172
+Minnehaha,VP16,Attorney General,,Marty J. Jackley,REP,779
+Minnehaha,VP17,Attorney General,,Marty J. Jackley,REP,524
+Minnehaha,VP21,Attorney General,,Marty J. Jackley,REP,1227
+Minnehaha,0104,State Auditor,,Stephanie Marty,DEM,367
+Minnehaha,0104,State Auditor,,Rene Meyer,LIB,24
+Minnehaha,0104,State Auditor,,Richard Sattgast,REP,290
+Minnehaha,0105,State Auditor,,Stephanie Marty,DEM,204
+Minnehaha,0105,State Auditor,,Rene Meyer,LIB,23
+Minnehaha,0105,State Auditor,,Richard Sattgast,REP,207
+Minnehaha,0106,State Auditor,,Stephanie Marty,DEM,451
+Minnehaha,0106,State Auditor,,Rene Meyer,LIB,61
+Minnehaha,0106,State Auditor,,Richard Sattgast,REP,524
+Minnehaha,0109,State Auditor,,Stephanie Marty,DEM,409
+Minnehaha,0109,State Auditor,,Rene Meyer,LIB,47
+Minnehaha,0109,State Auditor,,Richard Sattgast,REP,545
+Minnehaha,0110,State Auditor,,Stephanie Marty,DEM,441
+Minnehaha,0110,State Auditor,,Rene Meyer,LIB,78
+Minnehaha,0110,State Auditor,,Richard Sattgast,REP,573
+Minnehaha,0117,State Auditor,,Stephanie Marty,DEM,476
+Minnehaha,0117,State Auditor,,Rene Meyer,LIB,72
+Minnehaha,0117,State Auditor,,Richard Sattgast,REP,703
+Minnehaha,0119,State Auditor,,Stephanie Marty,DEM,254
+Minnehaha,0119,State Auditor,,Rene Meyer,LIB,49
+Minnehaha,0119,State Auditor,,Richard Sattgast,REP,279
+Minnehaha,0201,State Auditor,,Stephanie Marty,DEM,436
+Minnehaha,0201,State Auditor,,Rene Meyer,LIB,35
+Minnehaha,0201,State Auditor,,Richard Sattgast,REP,571
+Minnehaha,0202,State Auditor,,Stephanie Marty,DEM,586
+Minnehaha,0202,State Auditor,,Rene Meyer,LIB,41
+Minnehaha,0202,State Auditor,,Richard Sattgast,REP,758
+Minnehaha,0203,State Auditor,,Stephanie Marty,DEM,438
+Minnehaha,0203,State Auditor,,Rene Meyer,LIB,62
+Minnehaha,0203,State Auditor,,Richard Sattgast,REP,538
+Minnehaha,0206,State Auditor,,Stephanie Marty,DEM,438
+Minnehaha,0206,State Auditor,,Rene Meyer,LIB,45
+Minnehaha,0206,State Auditor,,Richard Sattgast,REP,577
+Minnehaha,0208,State Auditor,,Stephanie Marty,DEM,431
+Minnehaha,0208,State Auditor,,Rene Meyer,LIB,54
+Minnehaha,0208,State Auditor,,Richard Sattgast,REP,619
+Minnehaha,0209,State Auditor,,Stephanie Marty,DEM,456
+Minnehaha,0209,State Auditor,,Rene Meyer,LIB,30
+Minnehaha,0209,State Auditor,,Richard Sattgast,REP,515
+Minnehaha,0214,State Auditor,,Stephanie Marty,DEM,1038
+Minnehaha,0214,State Auditor,,Rene Meyer,LIB,104
+Minnehaha,0214,State Auditor,,Richard Sattgast,REP,1567
+Minnehaha,0301,State Auditor,,Stephanie Marty,DEM,315
+Minnehaha,0301,State Auditor,,Rene Meyer,LIB,34
+Minnehaha,0301,State Auditor,,Richard Sattgast,REP,406
+Minnehaha,0305,State Auditor,,Stephanie Marty,DEM,217
+Minnehaha,0305,State Auditor,,Rene Meyer,LIB,46
+Minnehaha,0305,State Auditor,,Richard Sattgast,REP,248
+Minnehaha,0309,State Auditor,,Stephanie Marty,DEM,511
+Minnehaha,0309,State Auditor,,Rene Meyer,LIB,72
+Minnehaha,0309,State Auditor,,Richard Sattgast,REP,507
+Minnehaha,0310,State Auditor,,Stephanie Marty,DEM,491
+Minnehaha,0310,State Auditor,,Rene Meyer,LIB,57
+Minnehaha,0310,State Auditor,,Richard Sattgast,REP,835
+Minnehaha,0311,State Auditor,,Stephanie Marty,DEM,311
+Minnehaha,0311,State Auditor,,Rene Meyer,LIB,40
+Minnehaha,0311,State Auditor,,Richard Sattgast,REP,530
+Minnehaha,0312,State Auditor,,Stephanie Marty,DEM,375
+Minnehaha,0312,State Auditor,,Rene Meyer,LIB,76
+Minnehaha,0312,State Auditor,,Richard Sattgast,REP,680
+Minnehaha,0313,State Auditor,,Stephanie Marty,DEM,263
+Minnehaha,0313,State Auditor,,Rene Meyer,LIB,39
+Minnehaha,0313,State Auditor,,Richard Sattgast,REP,395
+Minnehaha,0314,State Auditor,,Stephanie Marty,DEM,676
+Minnehaha,0314,State Auditor,,Rene Meyer,LIB,115
+Minnehaha,0314,State Auditor,,Richard Sattgast,REP,887
+Minnehaha,0315,State Auditor,,Stephanie Marty,DEM,423
+Minnehaha,0315,State Auditor,,Rene Meyer,LIB,45
+Minnehaha,0315,State Auditor,,Richard Sattgast,REP,565
+Minnehaha,0316,State Auditor,,Stephanie Marty,DEM,577
+Minnehaha,0316,State Auditor,,Rene Meyer,LIB,68
+Minnehaha,0316,State Auditor,,Richard Sattgast,REP,988
+Minnehaha,0317,State Auditor,,Stephanie Marty,DEM,721
+Minnehaha,0317,State Auditor,,Rene Meyer,LIB,74
+Minnehaha,0317,State Auditor,,Richard Sattgast,REP,1170
+Minnehaha,0402,State Auditor,,Stephanie Marty,DEM,303
+Minnehaha,0402,State Auditor,,Rene Meyer,LIB,56
+Minnehaha,0402,State Auditor,,Richard Sattgast,REP,263
+Minnehaha,0403,State Auditor,,Stephanie Marty,DEM,195
+Minnehaha,0403,State Auditor,,Rene Meyer,LIB,27
+Minnehaha,0403,State Auditor,,Richard Sattgast,REP,190
+Minnehaha,0404,State Auditor,,Stephanie Marty,DEM,305
+Minnehaha,0404,State Auditor,,Rene Meyer,LIB,71
+Minnehaha,0404,State Auditor,,Richard Sattgast,REP,264
+Minnehaha,0405,State Auditor,,Stephanie Marty,DEM,562
+Minnehaha,0405,State Auditor,,Rene Meyer,LIB,71
+Minnehaha,0405,State Auditor,,Richard Sattgast,REP,911
+Minnehaha,0406,State Auditor,,Stephanie Marty,DEM,138
+Minnehaha,0406,State Auditor,,Rene Meyer,LIB,19
+Minnehaha,0406,State Auditor,,Richard Sattgast,REP,121
+Minnehaha,0407,State Auditor,,Stephanie Marty,DEM,545
+Minnehaha,0407,State Auditor,,Rene Meyer,LIB,36
+Minnehaha,0407,State Auditor,,Richard Sattgast,REP,633
+Minnehaha,0408,State Auditor,,Stephanie Marty,DEM,167
+Minnehaha,0408,State Auditor,,Rene Meyer,LIB,21
+Minnehaha,0408,State Auditor,,Richard Sattgast,REP,119
+Minnehaha,0409,State Auditor,,Stephanie Marty,DEM,329
+Minnehaha,0409,State Auditor,,Rene Meyer,LIB,69
+Minnehaha,0409,State Auditor,,Richard Sattgast,REP,273
+Minnehaha,0410,State Auditor,,Stephanie Marty,DEM,306
+Minnehaha,0410,State Auditor,,Rene Meyer,LIB,49
+Minnehaha,0410,State Auditor,,Richard Sattgast,REP,370
+Minnehaha,0411,State Auditor,,Stephanie Marty,DEM,662
+Minnehaha,0411,State Auditor,,Rene Meyer,LIB,79
+Minnehaha,0411,State Auditor,,Richard Sattgast,REP,1120
+Minnehaha,0412,State Auditor,,Stephanie Marty,DEM,523
+Minnehaha,0412,State Auditor,,Rene Meyer,LIB,45
+Minnehaha,0412,State Auditor,,Richard Sattgast,REP,557
+Minnehaha,0413,State Auditor,,Stephanie Marty,DEM,298
+Minnehaha,0413,State Auditor,,Rene Meyer,LIB,39
+Minnehaha,0413,State Auditor,,Richard Sattgast,REP,263
+Minnehaha,0415,State Auditor,,Stephanie Marty,DEM,724
+Minnehaha,0415,State Auditor,,Rene Meyer,LIB,70
+Minnehaha,0415,State Auditor,,Richard Sattgast,REP,1221
+Minnehaha,0501,State Auditor,,Stephanie Marty,DEM,231
+Minnehaha,0501,State Auditor,,Rene Meyer,LIB,29
+Minnehaha,0501,State Auditor,,Richard Sattgast,REP,160
+Minnehaha,0502,State Auditor,,Stephanie Marty,DEM,386
+Minnehaha,0502,State Auditor,,Rene Meyer,LIB,44
+Minnehaha,0502,State Auditor,,Richard Sattgast,REP,185
+Minnehaha,0503,State Auditor,,Stephanie Marty,DEM,180
+Minnehaha,0503,State Auditor,,Rene Meyer,LIB,32
+Minnehaha,0503,State Auditor,,Richard Sattgast,REP,111
+Minnehaha,0504,State Auditor,,Stephanie Marty,DEM,499
+Minnehaha,0504,State Auditor,,Rene Meyer,LIB,44
+Minnehaha,0504,State Auditor,,Richard Sattgast,REP,266
+Minnehaha,0506,State Auditor,,Stephanie Marty,DEM,453
+Minnehaha,0506,State Auditor,,Rene Meyer,LIB,63
+Minnehaha,0506,State Auditor,,Richard Sattgast,REP,361
+Minnehaha,0507,State Auditor,,Stephanie Marty,DEM,297
+Minnehaha,0507,State Auditor,,Rene Meyer,LIB,25
+Minnehaha,0507,State Auditor,,Richard Sattgast,REP,214
+Minnehaha,0508,State Auditor,,Stephanie Marty,DEM,483
+Minnehaha,0508,State Auditor,,Rene Meyer,LIB,39
+Minnehaha,0508,State Auditor,,Richard Sattgast,REP,328
+Minnehaha,0509,State Auditor,,Stephanie Marty,DEM,208
+Minnehaha,0509,State Auditor,,Rene Meyer,LIB,25
+Minnehaha,0509,State Auditor,,Richard Sattgast,REP,118
+Minnehaha,0510,State Auditor,,Stephanie Marty,DEM,250
+Minnehaha,0510,State Auditor,,Rene Meyer,LIB,30
+Minnehaha,0510,State Auditor,,Richard Sattgast,REP,223
+Minnehaha,0512,State Auditor,,Stephanie Marty,DEM,288
+Minnehaha,0512,State Auditor,,Rene Meyer,LIB,30
+Minnehaha,0512,State Auditor,,Richard Sattgast,REP,266
+Minnehaha,0513,State Auditor,,Stephanie Marty,DEM,309
+Minnehaha,0513,State Auditor,,Rene Meyer,LIB,24
+Minnehaha,0513,State Auditor,,Richard Sattgast,REP,265
+Minnehaha,0514,State Auditor,,Stephanie Marty,DEM,394
+Minnehaha,0514,State Auditor,,Rene Meyer,LIB,51
+Minnehaha,0514,State Auditor,,Richard Sattgast,REP,275
+Minnehaha,0515,State Auditor,,Stephanie Marty,DEM,327
+Minnehaha,0515,State Auditor,,Rene Meyer,LIB,45
+Minnehaha,0515,State Auditor,,Richard Sattgast,REP,374
+Minnehaha,0517,State Auditor,,Stephanie Marty,DEM,228
+Minnehaha,0517,State Auditor,,Rene Meyer,LIB,28
+Minnehaha,0517,State Auditor,,Richard Sattgast,REP,238
+Minnehaha,0518,State Auditor,,Stephanie Marty,DEM,537
+Minnehaha,0518,State Auditor,,Rene Meyer,LIB,71
+Minnehaha,0518,State Auditor,,Richard Sattgast,REP,342
+Minnehaha,0519,State Auditor,,Stephanie Marty,DEM,209
+Minnehaha,0519,State Auditor,,Rene Meyer,LIB,29
+Minnehaha,0519,State Auditor,,Richard Sattgast,REP,246
+Minnehaha,0520,State Auditor,,Stephanie Marty,DEM,372
+Minnehaha,0520,State Auditor,,Rene Meyer,LIB,57
+Minnehaha,0520,State Auditor,,Richard Sattgast,REP,357
+Minnehaha,0521,State Auditor,,Stephanie Marty,DEM,202
+Minnehaha,0521,State Auditor,,Rene Meyer,LIB,16
+Minnehaha,0521,State Auditor,,Richard Sattgast,REP,183
+Minnehaha,0522,State Auditor,,Stephanie Marty,DEM,399
+Minnehaha,0522,State Auditor,,Rene Meyer,LIB,71
+Minnehaha,0522,State Auditor,,Richard Sattgast,REP,296
+Minnehaha,0523,State Auditor,,Stephanie Marty,DEM,333
+Minnehaha,0523,State Auditor,,Rene Meyer,LIB,48
+Minnehaha,0523,State Auditor,,Richard Sattgast,REP,230
+Minnehaha,VP01,State Auditor,,Stephanie Marty,DEM,148
+Minnehaha,VP01,State Auditor,,Rene Meyer,LIB,53
+Minnehaha,VP01,State Auditor,,Richard Sattgast,REP,496
+Minnehaha,VP02,State Auditor,,Stephanie Marty,DEM,441
+Minnehaha,VP02,State Auditor,,Rene Meyer,LIB,68
+Minnehaha,VP02,State Auditor,,Richard Sattgast,REP,1114
+Minnehaha,VP03,State Auditor,,Stephanie Marty,DEM,539
+Minnehaha,VP03,State Auditor,,Rene Meyer,LIB,88
+Minnehaha,VP03,State Auditor,,Richard Sattgast,REP,1310
+Minnehaha,VP04,State Auditor,,Stephanie Marty,DEM,289
+Minnehaha,VP04,State Auditor,,Rene Meyer,LIB,58
+Minnehaha,VP04,State Auditor,,Richard Sattgast,REP,670
+Minnehaha,VP05,State Auditor,,Stephanie Marty,DEM,360
+Minnehaha,VP05,State Auditor,,Rene Meyer,LIB,61
+Minnehaha,VP05,State Auditor,,Richard Sattgast,REP,863
+Minnehaha,VP06,State Auditor,,Stephanie Marty,DEM,121
+Minnehaha,VP06,State Auditor,,Rene Meyer,LIB,21
+Minnehaha,VP06,State Auditor,,Richard Sattgast,REP,267
+Minnehaha,VP07,State Auditor,,Stephanie Marty,DEM,450
+Minnehaha,VP07,State Auditor,,Rene Meyer,LIB,72
+Minnehaha,VP07,State Auditor,,Richard Sattgast,REP,1046
+Minnehaha,VP08,State Auditor,,Stephanie Marty,DEM,140
+Minnehaha,VP08,State Auditor,,Rene Meyer,LIB,36
+Minnehaha,VP08,State Auditor,,Richard Sattgast,REP,409
+Minnehaha,VP09,State Auditor,,Stephanie Marty,DEM,317
+Minnehaha,VP09,State Auditor,,Rene Meyer,LIB,58
+Minnehaha,VP09,State Auditor,,Richard Sattgast,REP,781
+Minnehaha,VP10,State Auditor,,Stephanie Marty,DEM,328
+Minnehaha,VP10,State Auditor,,Rene Meyer,LIB,62
+Minnehaha,VP10,State Auditor,,Richard Sattgast,REP,663
+Minnehaha,VP11,State Auditor,,Stephanie Marty,DEM,69
+Minnehaha,VP11,State Auditor,,Rene Meyer,LIB,9
+Minnehaha,VP11,State Auditor,,Richard Sattgast,REP,204
+Minnehaha,VP12,State Auditor,,Stephanie Marty,DEM,21
+Minnehaha,VP12,State Auditor,,Rene Meyer,LIB,5
+Minnehaha,VP12,State Auditor,,Richard Sattgast,REP,92
+Minnehaha,VP13,State Auditor,,Stephanie Marty,DEM,182
+Minnehaha,VP13,State Auditor,,Rene Meyer,LIB,56
+Minnehaha,VP13,State Auditor,,Richard Sattgast,REP,591
+Minnehaha,VP15,State Auditor,,Stephanie Marty,DEM,413
+Minnehaha,VP15,State Auditor,,Rene Meyer,LIB,62
+Minnehaha,VP15,State Auditor,,Richard Sattgast,REP,909
+Minnehaha,VP16,State Auditor,,Stephanie Marty,DEM,257
+Minnehaha,VP16,State Auditor,,Rene Meyer,LIB,60
+Minnehaha,VP16,State Auditor,,Richard Sattgast,REP,654
+Minnehaha,VP17,State Auditor,,Stephanie Marty,DEM,137
+Minnehaha,VP17,State Auditor,,Rene Meyer,LIB,28
+Minnehaha,VP17,State Auditor,,Richard Sattgast,REP,449
+Minnehaha,VP21,State Auditor,,Stephanie Marty,DEM,456
+Minnehaha,VP21,State Auditor,,Rene Meyer,LIB,73
+Minnehaha,VP21,State Auditor,,Richard Sattgast,REP,991
+Minnehaha,0104,State Treasurer,,John Cunningham,DEM,365
+Minnehaha,0104,State Treasurer,,Josh Haeder,REP,312
+Minnehaha,0105,State Treasurer,,John Cunningham,DEM,203
+Minnehaha,0105,State Treasurer,,Josh Haeder,REP,219
+Minnehaha,0106,State Treasurer,,John Cunningham,DEM,460
+Minnehaha,0106,State Treasurer,,Josh Haeder,REP,551
+Minnehaha,0109,State Treasurer,,John Cunningham,DEM,407
+Minnehaha,0109,State Treasurer,,Josh Haeder,REP,585
+Minnehaha,0110,State Treasurer,,John Cunningham,DEM,459
+Minnehaha,0110,State Treasurer,,Josh Haeder,REP,623
+Minnehaha,0117,State Treasurer,,John Cunningham,DEM,489
+Minnehaha,0117,State Treasurer,,Josh Haeder,REP,736
+Minnehaha,0119,State Treasurer,,John Cunningham,DEM,275
+Minnehaha,0119,State Treasurer,,Josh Haeder,REP,296
+Minnehaha,0201,State Treasurer,,John Cunningham,DEM,435
+Minnehaha,0201,State Treasurer,,Josh Haeder,REP,606
+Minnehaha,0202,State Treasurer,,John Cunningham,DEM,594
+Minnehaha,0202,State Treasurer,,Josh Haeder,REP,777
+Minnehaha,0203,State Treasurer,,John Cunningham,DEM,468
+Minnehaha,0203,State Treasurer,,Josh Haeder,REP,566
+Minnehaha,0206,State Treasurer,,John Cunningham,DEM,446
+Minnehaha,0206,State Treasurer,,Josh Haeder,REP,619
+Minnehaha,0208,State Treasurer,,John Cunningham,DEM,440
+Minnehaha,0208,State Treasurer,,Josh Haeder,REP,658
+Minnehaha,0209,State Treasurer,,John Cunningham,DEM,466
+Minnehaha,0209,State Treasurer,,Josh Haeder,REP,525
+Minnehaha,0214,State Treasurer,,John Cunningham,DEM,1076
+Minnehaha,0214,State Treasurer,,Josh Haeder,REP,1617
+Minnehaha,0301,State Treasurer,,John Cunningham,DEM,331
+Minnehaha,0301,State Treasurer,,Josh Haeder,REP,415
+Minnehaha,0305,State Treasurer,,John Cunningham,DEM,244
+Minnehaha,0305,State Treasurer,,Josh Haeder,REP,263
+Minnehaha,0309,State Treasurer,,John Cunningham,DEM,526
+Minnehaha,0309,State Treasurer,,Josh Haeder,REP,552
+Minnehaha,0310,State Treasurer,,John Cunningham,DEM,494
+Minnehaha,0310,State Treasurer,,Josh Haeder,REP,879
+Minnehaha,0311,State Treasurer,,John Cunningham,DEM,320
+Minnehaha,0311,State Treasurer,,Josh Haeder,REP,532
+Minnehaha,0312,State Treasurer,,John Cunningham,DEM,399
+Minnehaha,0312,State Treasurer,,Josh Haeder,REP,723
+Minnehaha,0313,State Treasurer,,John Cunningham,DEM,260
+Minnehaha,0313,State Treasurer,,Josh Haeder,REP,425
+Minnehaha,0314,State Treasurer,,John Cunningham,DEM,703
+Minnehaha,0314,State Treasurer,,Josh Haeder,REP,958
+Minnehaha,0315,State Treasurer,,John Cunningham,DEM,425
+Minnehaha,0315,State Treasurer,,Josh Haeder,REP,605
+Minnehaha,0316,State Treasurer,,John Cunningham,DEM,581
+Minnehaha,0316,State Treasurer,,Josh Haeder,REP,1037
+Minnehaha,0317,State Treasurer,,John Cunningham,DEM,719
+Minnehaha,0317,State Treasurer,,Josh Haeder,REP,1214
+Minnehaha,0402,State Treasurer,,John Cunningham,DEM,320
+Minnehaha,0402,State Treasurer,,Josh Haeder,REP,283
+Minnehaha,0403,State Treasurer,,John Cunningham,DEM,203
+Minnehaha,0403,State Treasurer,,Josh Haeder,REP,204
+Minnehaha,0404,State Treasurer,,John Cunningham,DEM,329
+Minnehaha,0404,State Treasurer,,Josh Haeder,REP,301
+Minnehaha,0405,State Treasurer,,John Cunningham,DEM,575
+Minnehaha,0405,State Treasurer,,Josh Haeder,REP,953
+Minnehaha,0406,State Treasurer,,John Cunningham,DEM,150
+Minnehaha,0406,State Treasurer,,Josh Haeder,REP,120
+Minnehaha,0407,State Treasurer,,John Cunningham,DEM,558
+Minnehaha,0407,State Treasurer,,Josh Haeder,REP,652
+Minnehaha,0408,State Treasurer,,John Cunningham,DEM,178
+Minnehaha,0408,State Treasurer,,Josh Haeder,REP,125
+Minnehaha,0409,State Treasurer,,John Cunningham,DEM,337
+Minnehaha,0409,State Treasurer,,Josh Haeder,REP,323
+Minnehaha,0410,State Treasurer,,John Cunningham,DEM,321
+Minnehaha,0410,State Treasurer,,Josh Haeder,REP,394
+Minnehaha,0411,State Treasurer,,John Cunningham,DEM,682
+Minnehaha,0411,State Treasurer,,Josh Haeder,REP,1174
+Minnehaha,0412,State Treasurer,,John Cunningham,DEM,525
+Minnehaha,0412,State Treasurer,,Josh Haeder,REP,586
+Minnehaha,0413,State Treasurer,,John Cunningham,DEM,305
+Minnehaha,0413,State Treasurer,,Josh Haeder,REP,283
+Minnehaha,0415,State Treasurer,,John Cunningham,DEM,721
+Minnehaha,0415,State Treasurer,,Josh Haeder,REP,1279
+Minnehaha,0501,State Treasurer,,John Cunningham,DEM,244
+Minnehaha,0501,State Treasurer,,Josh Haeder,REP,172
+Minnehaha,0502,State Treasurer,,John Cunningham,DEM,400
+Minnehaha,0502,State Treasurer,,Josh Haeder,REP,208
+Minnehaha,0503,State Treasurer,,John Cunningham,DEM,182
+Minnehaha,0503,State Treasurer,,Josh Haeder,REP,137
+Minnehaha,0504,State Treasurer,,John Cunningham,DEM,499
+Minnehaha,0504,State Treasurer,,Josh Haeder,REP,298
+Minnehaha,0506,State Treasurer,,John Cunningham,DEM,470
+Minnehaha,0506,State Treasurer,,Josh Haeder,REP,401
+Minnehaha,0507,State Treasurer,,John Cunningham,DEM,299
+Minnehaha,0507,State Treasurer,,Josh Haeder,REP,229
+Minnehaha,0508,State Treasurer,,John Cunningham,DEM,487
+Minnehaha,0508,State Treasurer,,Josh Haeder,REP,356
+Minnehaha,0509,State Treasurer,,John Cunningham,DEM,209
+Minnehaha,0509,State Treasurer,,Josh Haeder,REP,142
+Minnehaha,0510,State Treasurer,,John Cunningham,DEM,251
+Minnehaha,0510,State Treasurer,,Josh Haeder,REP,241
+Minnehaha,0512,State Treasurer,,John Cunningham,DEM,297
+Minnehaha,0512,State Treasurer,,Josh Haeder,REP,271
+Minnehaha,0513,State Treasurer,,John Cunningham,DEM,302
+Minnehaha,0513,State Treasurer,,Josh Haeder,REP,284
+Minnehaha,0514,State Treasurer,,John Cunningham,DEM,410
+Minnehaha,0514,State Treasurer,,Josh Haeder,REP,297
+Minnehaha,0515,State Treasurer,,John Cunningham,DEM,338
+Minnehaha,0515,State Treasurer,,Josh Haeder,REP,405
+Minnehaha,0517,State Treasurer,,John Cunningham,DEM,231
+Minnehaha,0517,State Treasurer,,Josh Haeder,REP,257
+Minnehaha,0518,State Treasurer,,John Cunningham,DEM,562
+Minnehaha,0518,State Treasurer,,Josh Haeder,REP,392
+Minnehaha,0519,State Treasurer,,John Cunningham,DEM,220
+Minnehaha,0519,State Treasurer,,Josh Haeder,REP,257
+Minnehaha,0520,State Treasurer,,John Cunningham,DEM,382
+Minnehaha,0520,State Treasurer,,Josh Haeder,REP,395
+Minnehaha,0521,State Treasurer,,John Cunningham,DEM,209
+Minnehaha,0521,State Treasurer,,Josh Haeder,REP,187
+Minnehaha,0522,State Treasurer,,John Cunningham,DEM,419
+Minnehaha,0522,State Treasurer,,Josh Haeder,REP,328
+Minnehaha,0523,State Treasurer,,John Cunningham,DEM,344
+Minnehaha,0523,State Treasurer,,Josh Haeder,REP,254
+Minnehaha,VP01,State Treasurer,,John Cunningham,DEM,166
+Minnehaha,VP01,State Treasurer,,Josh Haeder,REP,522
+Minnehaha,VP02,State Treasurer,,John Cunningham,DEM,437
+Minnehaha,VP02,State Treasurer,,Josh Haeder,REP,1177
+Minnehaha,VP03,State Treasurer,,John Cunningham,DEM,533
+Minnehaha,VP03,State Treasurer,,Josh Haeder,REP,1371
+Minnehaha,VP04,State Treasurer,,John Cunningham,DEM,301
+Minnehaha,VP04,State Treasurer,,Josh Haeder,REP,695
+Minnehaha,VP05,State Treasurer,,John Cunningham,DEM,360
+Minnehaha,VP05,State Treasurer,,Josh Haeder,REP,905
+Minnehaha,VP06,State Treasurer,,John Cunningham,DEM,120
+Minnehaha,VP06,State Treasurer,,Josh Haeder,REP,283
+Minnehaha,VP07,State Treasurer,,John Cunningham,DEM,444
+Minnehaha,VP07,State Treasurer,,Josh Haeder,REP,1107
+Minnehaha,VP08,State Treasurer,,John Cunningham,DEM,148
+Minnehaha,VP08,State Treasurer,,Josh Haeder,REP,430
+Minnehaha,VP09,State Treasurer,,John Cunningham,DEM,342
+Minnehaha,VP09,State Treasurer,,Josh Haeder,REP,810
+Minnehaha,VP10,State Treasurer,,John Cunningham,DEM,340
+Minnehaha,VP10,State Treasurer,,Josh Haeder,REP,711
+Minnehaha,VP11,State Treasurer,,John Cunningham,DEM,64
+Minnehaha,VP11,State Treasurer,,Josh Haeder,REP,217
+Minnehaha,VP12,State Treasurer,,John Cunningham,DEM,21
+Minnehaha,VP12,State Treasurer,,Josh Haeder,REP,96
+Minnehaha,VP13,State Treasurer,,John Cunningham,DEM,189
+Minnehaha,VP13,State Treasurer,,Josh Haeder,REP,634
+Minnehaha,VP15,State Treasurer,,John Cunningham,DEM,435
+Minnehaha,VP15,State Treasurer,,Josh Haeder,REP,937
+Minnehaha,VP16,State Treasurer,,John Cunningham,DEM,266
+Minnehaha,VP16,State Treasurer,,Josh Haeder,REP,680
+Minnehaha,VP17,State Treasurer,,John Cunningham,DEM,143
+Minnehaha,VP17,State Treasurer,,Josh Haeder,REP,453
+Minnehaha,VP21,State Treasurer,,John Cunningham,DEM,460
+Minnehaha,VP21,State Treasurer,,Josh Haeder,REP,1037
+Minnehaha,0104,Commissioner of School and Public Lands,,Timothy Azure,DEM,353
+Minnehaha,0104,Commissioner of School and Public Lands,,Brock Greenfield,REP,298
+Minnehaha,0105,Commissioner of School and Public Lands,,Timothy Azure,DEM,200
+Minnehaha,0105,Commissioner of School and Public Lands,,Brock Greenfield,REP,215
+Minnehaha,0106,Commissioner of School and Public Lands,,Timothy Azure,DEM,455
+Minnehaha,0106,Commissioner of School and Public Lands,,Brock Greenfield,REP,537
+Minnehaha,0109,Commissioner of School and Public Lands,,Timothy Azure,DEM,400
+Minnehaha,0109,Commissioner of School and Public Lands,,Brock Greenfield,REP,572
+Minnehaha,0110,Commissioner of School and Public Lands,,Timothy Azure,DEM,448
+Minnehaha,0110,Commissioner of School and Public Lands,,Brock Greenfield,REP,608
+Minnehaha,0117,Commissioner of School and Public Lands,,Timothy Azure,DEM,480
+Minnehaha,0117,Commissioner of School and Public Lands,,Brock Greenfield,REP,744
+Minnehaha,0119,Commissioner of School and Public Lands,,Timothy Azure,DEM,270
+Minnehaha,0119,Commissioner of School and Public Lands,,Brock Greenfield,REP,290
+Minnehaha,0201,Commissioner of School and Public Lands,,Timothy Azure,DEM,430
+Minnehaha,0201,Commissioner of School and Public Lands,,Brock Greenfield,REP,588
+Minnehaha,0202,Commissioner of School and Public Lands,,Timothy Azure,DEM,576
+Minnehaha,0202,Commissioner of School and Public Lands,,Brock Greenfield,REP,761
+Minnehaha,0203,Commissioner of School and Public Lands,,Timothy Azure,DEM,452
+Minnehaha,0203,Commissioner of School and Public Lands,,Brock Greenfield,REP,558
+Minnehaha,0206,Commissioner of School and Public Lands,,Timothy Azure,DEM,454
+Minnehaha,0206,Commissioner of School and Public Lands,,Brock Greenfield,REP,596
+Minnehaha,0208,Commissioner of School and Public Lands,,Timothy Azure,DEM,435
+Minnehaha,0208,Commissioner of School and Public Lands,,Brock Greenfield,REP,630
+Minnehaha,0209,Commissioner of School and Public Lands,,Timothy Azure,DEM,446
+Minnehaha,0209,Commissioner of School and Public Lands,,Brock Greenfield,REP,521
+Minnehaha,0214,Commissioner of School and Public Lands,,Timothy Azure,DEM,1047
+Minnehaha,0214,Commissioner of School and Public Lands,,Brock Greenfield,REP,1589
+Minnehaha,0301,Commissioner of School and Public Lands,,Timothy Azure,DEM,323
+Minnehaha,0301,Commissioner of School and Public Lands,,Brock Greenfield,REP,413
+Minnehaha,0305,Commissioner of School and Public Lands,,Timothy Azure,DEM,226
+Minnehaha,0305,Commissioner of School and Public Lands,,Brock Greenfield,REP,260
+Minnehaha,0309,Commissioner of School and Public Lands,,Timothy Azure,DEM,518
+Minnehaha,0309,Commissioner of School and Public Lands,,Brock Greenfield,REP,539
+Minnehaha,0310,Commissioner of School and Public Lands,,Timothy Azure,DEM,501
+Minnehaha,0310,Commissioner of School and Public Lands,,Brock Greenfield,REP,850
+Minnehaha,0311,Commissioner of School and Public Lands,,Timothy Azure,DEM,330
+Minnehaha,0311,Commissioner of School and Public Lands,,Brock Greenfield,REP,523
+Minnehaha,0312,Commissioner of School and Public Lands,,Timothy Azure,DEM,390
+Minnehaha,0312,Commissioner of School and Public Lands,,Brock Greenfield,REP,696
+Minnehaha,0313,Commissioner of School and Public Lands,,Timothy Azure,DEM,269
+Minnehaha,0313,Commissioner of School and Public Lands,,Brock Greenfield,REP,411
+Minnehaha,0314,Commissioner of School and Public Lands,,Timothy Azure,DEM,705
+Minnehaha,0314,Commissioner of School and Public Lands,,Brock Greenfield,REP,930
+Minnehaha,0315,Commissioner of School and Public Lands,,Timothy Azure,DEM,429
+Minnehaha,0315,Commissioner of School and Public Lands,,Brock Greenfield,REP,572
+Minnehaha,0316,Commissioner of School and Public Lands,,Timothy Azure,DEM,569
+Minnehaha,0316,Commissioner of School and Public Lands,,Brock Greenfield,REP,1021
+Minnehaha,0317,Commissioner of School and Public Lands,,Timothy Azure,DEM,731
+Minnehaha,0317,Commissioner of School and Public Lands,,Brock Greenfield,REP,1174
+Minnehaha,0402,Commissioner of School and Public Lands,,Timothy Azure,DEM,322
+Minnehaha,0402,Commissioner of School and Public Lands,,Brock Greenfield,REP,277
+Minnehaha,0403,Commissioner of School and Public Lands,,Timothy Azure,DEM,196
+Minnehaha,0403,Commissioner of School and Public Lands,,Brock Greenfield,REP,199
+Minnehaha,0404,Commissioner of School and Public Lands,,Timothy Azure,DEM,323
+Minnehaha,0404,Commissioner of School and Public Lands,,Brock Greenfield,REP,300
+Minnehaha,0405,Commissioner of School and Public Lands,,Timothy Azure,DEM,570
+Minnehaha,0405,Commissioner of School and Public Lands,,Brock Greenfield,REP,955
+Minnehaha,0406,Commissioner of School and Public Lands,,Timothy Azure,DEM,146
+Minnehaha,0406,Commissioner of School and Public Lands,,Brock Greenfield,REP,124
+Minnehaha,0407,Commissioner of School and Public Lands,,Timothy Azure,DEM,550
+Minnehaha,0407,Commissioner of School and Public Lands,,Brock Greenfield,REP,630
+Minnehaha,0408,Commissioner of School and Public Lands,,Timothy Azure,DEM,168
+Minnehaha,0408,Commissioner of School and Public Lands,,Brock Greenfield,REP,126
+Minnehaha,0409,Commissioner of School and Public Lands,,Timothy Azure,DEM,342
+Minnehaha,0409,Commissioner of School and Public Lands,,Brock Greenfield,REP,308
+Minnehaha,0410,Commissioner of School and Public Lands,,Timothy Azure,DEM,317
+Minnehaha,0410,Commissioner of School and Public Lands,,Brock Greenfield,REP,401
+Minnehaha,0411,Commissioner of School and Public Lands,,Timothy Azure,DEM,666
+Minnehaha,0411,Commissioner of School and Public Lands,,Brock Greenfield,REP,1147
+Minnehaha,0412,Commissioner of School and Public Lands,,Timothy Azure,DEM,516
+Minnehaha,0412,Commissioner of School and Public Lands,,Brock Greenfield,REP,570
+Minnehaha,0413,Commissioner of School and Public Lands,,Timothy Azure,DEM,302
+Minnehaha,0413,Commissioner of School and Public Lands,,Brock Greenfield,REP,273
+Minnehaha,0415,Commissioner of School and Public Lands,,Timothy Azure,DEM,706
+Minnehaha,0415,Commissioner of School and Public Lands,,Brock Greenfield,REP,1257
+Minnehaha,0501,Commissioner of School and Public Lands,,Timothy Azure,DEM,247
+Minnehaha,0501,Commissioner of School and Public Lands,,Brock Greenfield,REP,157
+Minnehaha,0502,Commissioner of School and Public Lands,,Timothy Azure,DEM,389
+Minnehaha,0502,Commissioner of School and Public Lands,,Brock Greenfield,REP,212
+Minnehaha,0503,Commissioner of School and Public Lands,,Timothy Azure,DEM,186
+Minnehaha,0503,Commissioner of School and Public Lands,,Brock Greenfield,REP,125
+Minnehaha,0504,Commissioner of School and Public Lands,,Timothy Azure,DEM,501
+Minnehaha,0504,Commissioner of School and Public Lands,,Brock Greenfield,REP,283
+Minnehaha,0506,Commissioner of School and Public Lands,,Timothy Azure,DEM,467
+Minnehaha,0506,Commissioner of School and Public Lands,,Brock Greenfield,REP,381
+Minnehaha,0507,Commissioner of School and Public Lands,,Timothy Azure,DEM,306
+Minnehaha,0507,Commissioner of School and Public Lands,,Brock Greenfield,REP,215
+Minnehaha,0508,Commissioner of School and Public Lands,,Timothy Azure,DEM,491
+Minnehaha,0508,Commissioner of School and Public Lands,,Brock Greenfield,REP,339
+Minnehaha,0509,Commissioner of School and Public Lands,,Timothy Azure,DEM,213
+Minnehaha,0509,Commissioner of School and Public Lands,,Brock Greenfield,REP,131
+Minnehaha,0510,Commissioner of School and Public Lands,,Timothy Azure,DEM,253
+Minnehaha,0510,Commissioner of School and Public Lands,,Brock Greenfield,REP,227
+Minnehaha,0512,Commissioner of School and Public Lands,,Timothy Azure,DEM,303
+Minnehaha,0512,Commissioner of School and Public Lands,,Brock Greenfield,REP,268
+Minnehaha,0513,Commissioner of School and Public Lands,,Timothy Azure,DEM,300
+Minnehaha,0513,Commissioner of School and Public Lands,,Brock Greenfield,REP,277
+Minnehaha,0514,Commissioner of School and Public Lands,,Timothy Azure,DEM,406
+Minnehaha,0514,Commissioner of School and Public Lands,,Brock Greenfield,REP,301
+Minnehaha,0515,Commissioner of School and Public Lands,,Timothy Azure,DEM,337
+Minnehaha,0515,Commissioner of School and Public Lands,,Brock Greenfield,REP,400
+Minnehaha,0517,Commissioner of School and Public Lands,,Timothy Azure,DEM,231
+Minnehaha,0517,Commissioner of School and Public Lands,,Brock Greenfield,REP,253
+Minnehaha,0518,Commissioner of School and Public Lands,,Timothy Azure,DEM,552
+Minnehaha,0518,Commissioner of School and Public Lands,,Brock Greenfield,REP,384
+Minnehaha,0519,Commissioner of School and Public Lands,,Timothy Azure,DEM,223
+Minnehaha,0519,Commissioner of School and Public Lands,,Brock Greenfield,REP,256
+Minnehaha,0520,Commissioner of School and Public Lands,,Timothy Azure,DEM,394
+Minnehaha,0520,Commissioner of School and Public Lands,,Brock Greenfield,REP,378
+Minnehaha,0521,Commissioner of School and Public Lands,,Timothy Azure,DEM,198
+Minnehaha,0521,Commissioner of School and Public Lands,,Brock Greenfield,REP,197
+Minnehaha,0522,Commissioner of School and Public Lands,,Timothy Azure,DEM,421
+Minnehaha,0522,Commissioner of School and Public Lands,,Brock Greenfield,REP,321
+Minnehaha,0523,Commissioner of School and Public Lands,,Timothy Azure,DEM,351
+Minnehaha,0523,Commissioner of School and Public Lands,,Brock Greenfield,REP,247
+Minnehaha,VP01,Commissioner of School and Public Lands,,Timothy Azure,DEM,161
+Minnehaha,VP01,Commissioner of School and Public Lands,,Brock Greenfield,REP,515
+Minnehaha,VP02,Commissioner of School and Public Lands,,Timothy Azure,DEM,443
+Minnehaha,VP02,Commissioner of School and Public Lands,,Brock Greenfield,REP,1144
+Minnehaha,VP03,Commissioner of School and Public Lands,,Timothy Azure,DEM,550
+Minnehaha,VP03,Commissioner of School and Public Lands,,Brock Greenfield,REP,1339
+Minnehaha,VP04,Commissioner of School and Public Lands,,Timothy Azure,DEM,289
+Minnehaha,VP04,Commissioner of School and Public Lands,,Brock Greenfield,REP,685
+Minnehaha,VP05,Commissioner of School and Public Lands,,Timothy Azure,DEM,355
+Minnehaha,VP05,Commissioner of School and Public Lands,,Brock Greenfield,REP,885
+Minnehaha,VP06,Commissioner of School and Public Lands,,Timothy Azure,DEM,121
+Minnehaha,VP06,Commissioner of School and Public Lands,,Brock Greenfield,REP,273
+Minnehaha,VP07,Commissioner of School and Public Lands,,Timothy Azure,DEM,454
+Minnehaha,VP07,Commissioner of School and Public Lands,,Brock Greenfield,REP,1061
+Minnehaha,VP08,Commissioner of School and Public Lands,,Timothy Azure,DEM,145
+Minnehaha,VP08,Commissioner of School and Public Lands,,Brock Greenfield,REP,429
+Minnehaha,VP09,Commissioner of School and Public Lands,,Timothy Azure,DEM,326
+Minnehaha,VP09,Commissioner of School and Public Lands,,Brock Greenfield,REP,796
+Minnehaha,VP10,Commissioner of School and Public Lands,,Timothy Azure,DEM,326
+Minnehaha,VP10,Commissioner of School and Public Lands,,Brock Greenfield,REP,704
+Minnehaha,VP11,Commissioner of School and Public Lands,,Timothy Azure,DEM,63
+Minnehaha,VP11,Commissioner of School and Public Lands,,Brock Greenfield,REP,212
+Minnehaha,VP12,Commissioner of School and Public Lands,,Timothy Azure,DEM,22
+Minnehaha,VP12,Commissioner of School and Public Lands,,Brock Greenfield,REP,93
+Minnehaha,VP13,Commissioner of School and Public Lands,,Timothy Azure,DEM,169
+Minnehaha,VP13,Commissioner of School and Public Lands,,Brock Greenfield,REP,627
+Minnehaha,VP15,Commissioner of School and Public Lands,,Timothy Azure,DEM,429
+Minnehaha,VP15,Commissioner of School and Public Lands,,Brock Greenfield,REP,919
+Minnehaha,VP16,Commissioner of School and Public Lands,,Timothy Azure,DEM,268
+Minnehaha,VP16,Commissioner of School and Public Lands,,Brock Greenfield,REP,651
+Minnehaha,VP17,Commissioner of School and Public Lands,,Timothy Azure,DEM,137
+Minnehaha,VP17,Commissioner of School and Public Lands,,Brock Greenfield,REP,445
+Minnehaha,VP21,Commissioner of School and Public Lands,,Timothy Azure,DEM,452
+Minnehaha,VP21,Commissioner of School and Public Lands,,Brock Greenfield,REP,1014
+Minnehaha,0104,Public Utilities Commissioner,,Jeffrey Barth,DEM,352
+Minnehaha,0104,Public Utilities Commissioner,,Chris Nelson,REP,320
+Minnehaha,0105,Public Utilities Commissioner,,Jeffrey Barth,DEM,213
+Minnehaha,0105,Public Utilities Commissioner,,Chris Nelson,REP,223
+Minnehaha,0106,Public Utilities Commissioner,,Jeffrey Barth,DEM,454
+Minnehaha,0106,Public Utilities Commissioner,,Chris Nelson,REP,581
+Minnehaha,0109,Public Utilities Commissioner,,Jeffrey Barth,DEM,416
+Minnehaha,0109,Public Utilities Commissioner,,Chris Nelson,REP,596
+Minnehaha,0110,Public Utilities Commissioner,,Jeffrey Barth,DEM,457
+Minnehaha,0110,Public Utilities Commissioner,,Chris Nelson,REP,630
+Minnehaha,0117,Public Utilities Commissioner,,Jeffrey Barth,DEM,469
+Minnehaha,0117,Public Utilities Commissioner,,Chris Nelson,REP,782
+Minnehaha,0119,Public Utilities Commissioner,,Jeffrey Barth,DEM,266
+Minnehaha,0119,Public Utilities Commissioner,,Chris Nelson,REP,311
+Minnehaha,0201,Public Utilities Commissioner,,Jeffrey Barth,DEM,415
+Minnehaha,0201,Public Utilities Commissioner,,Chris Nelson,REP,632
+Minnehaha,0202,Public Utilities Commissioner,,Jeffrey Barth,DEM,576
+Minnehaha,0202,Public Utilities Commissioner,,Chris Nelson,REP,814
+Minnehaha,0203,Public Utilities Commissioner,,Jeffrey Barth,DEM,461
+Minnehaha,0203,Public Utilities Commissioner,,Chris Nelson,REP,582
+Minnehaha,0206,Public Utilities Commissioner,,Jeffrey Barth,DEM,455
+Minnehaha,0206,Public Utilities Commissioner,,Chris Nelson,REP,622
+Minnehaha,0208,Public Utilities Commissioner,,Jeffrey Barth,DEM,439
+Minnehaha,0208,Public Utilities Commissioner,,Chris Nelson,REP,672
+Minnehaha,0209,Public Utilities Commissioner,,Jeffrey Barth,DEM,476
+Minnehaha,0209,Public Utilities Commissioner,,Chris Nelson,REP,520
+Minnehaha,0214,Public Utilities Commissioner,,Jeffrey Barth,DEM,1042
+Minnehaha,0214,Public Utilities Commissioner,,Chris Nelson,REP,1672
+Minnehaha,0301,Public Utilities Commissioner,,Jeffrey Barth,DEM,313
+Minnehaha,0301,Public Utilities Commissioner,,Chris Nelson,REP,443
+Minnehaha,0305,Public Utilities Commissioner,,Jeffrey Barth,DEM,231
+Minnehaha,0305,Public Utilities Commissioner,,Chris Nelson,REP,273
+Minnehaha,0309,Public Utilities Commissioner,,Jeffrey Barth,DEM,501
+Minnehaha,0309,Public Utilities Commissioner,,Chris Nelson,REP,571
+Minnehaha,0310,Public Utilities Commissioner,,Jeffrey Barth,DEM,497
+Minnehaha,0310,Public Utilities Commissioner,,Chris Nelson,REP,890
+Minnehaha,0311,Public Utilities Commissioner,,Jeffrey Barth,DEM,313
+Minnehaha,0311,Public Utilities Commissioner,,Chris Nelson,REP,562
+Minnehaha,0312,Public Utilities Commissioner,,Jeffrey Barth,DEM,398
+Minnehaha,0312,Public Utilities Commissioner,,Chris Nelson,REP,742
+Minnehaha,0313,Public Utilities Commissioner,,Jeffrey Barth,DEM,266
+Minnehaha,0313,Public Utilities Commissioner,,Chris Nelson,REP,433
+Minnehaha,0314,Public Utilities Commissioner,,Jeffrey Barth,DEM,687
+Minnehaha,0314,Public Utilities Commissioner,,Chris Nelson,REP,994
+Minnehaha,0315,Public Utilities Commissioner,,Jeffrey Barth,DEM,432
+Minnehaha,0315,Public Utilities Commissioner,,Chris Nelson,REP,605
+Minnehaha,0316,Public Utilities Commissioner,,Jeffrey Barth,DEM,579
+Minnehaha,0316,Public Utilities Commissioner,,Chris Nelson,REP,1060
+Minnehaha,0317,Public Utilities Commissioner,,Jeffrey Barth,DEM,723
+Minnehaha,0317,Public Utilities Commissioner,,Chris Nelson,REP,1243
+Minnehaha,0402,Public Utilities Commissioner,,Jeffrey Barth,DEM,318
+Minnehaha,0402,Public Utilities Commissioner,,Chris Nelson,REP,296
+Minnehaha,0403,Public Utilities Commissioner,,Jeffrey Barth,DEM,207
+Minnehaha,0403,Public Utilities Commissioner,,Chris Nelson,REP,205
+Minnehaha,0404,Public Utilities Commissioner,,Jeffrey Barth,DEM,322
+Minnehaha,0404,Public Utilities Commissioner,,Chris Nelson,REP,313
+Minnehaha,0405,Public Utilities Commissioner,,Jeffrey Barth,DEM,578
+Minnehaha,0405,Public Utilities Commissioner,,Chris Nelson,REP,963
+Minnehaha,0406,Public Utilities Commissioner,,Jeffrey Barth,DEM,144
+Minnehaha,0406,Public Utilities Commissioner,,Chris Nelson,REP,136
+Minnehaha,0407,Public Utilities Commissioner,,Jeffrey Barth,DEM,542
+Minnehaha,0407,Public Utilities Commissioner,,Chris Nelson,REP,665
+Minnehaha,0408,Public Utilities Commissioner,,Jeffrey Barth,DEM,174
+Minnehaha,0408,Public Utilities Commissioner,,Chris Nelson,REP,133
+Minnehaha,0409,Public Utilities Commissioner,,Jeffrey Barth,DEM,340
+Minnehaha,0409,Public Utilities Commissioner,,Chris Nelson,REP,326
+Minnehaha,0410,Public Utilities Commissioner,,Jeffrey Barth,DEM,326
+Minnehaha,0410,Public Utilities Commissioner,,Chris Nelson,REP,402
+Minnehaha,0411,Public Utilities Commissioner,,Jeffrey Barth,DEM,673
+Minnehaha,0411,Public Utilities Commissioner,,Chris Nelson,REP,1208
+Minnehaha,0412,Public Utilities Commissioner,,Jeffrey Barth,DEM,534
+Minnehaha,0412,Public Utilities Commissioner,,Chris Nelson,REP,602
+Minnehaha,0413,Public Utilities Commissioner,,Jeffrey Barth,DEM,303
+Minnehaha,0413,Public Utilities Commissioner,,Chris Nelson,REP,293
+Minnehaha,0415,Public Utilities Commissioner,,Jeffrey Barth,DEM,768
+Minnehaha,0415,Public Utilities Commissioner,,Chris Nelson,REP,1247
+Minnehaha,0501,Public Utilities Commissioner,,Jeffrey Barth,DEM,245
+Minnehaha,0501,Public Utilities Commissioner,,Chris Nelson,REP,164
+Minnehaha,0502,Public Utilities Commissioner,,Jeffrey Barth,DEM,384
+Minnehaha,0502,Public Utilities Commissioner,,Chris Nelson,REP,227
+Minnehaha,0503,Public Utilities Commissioner,,Jeffrey Barth,DEM,182
+Minnehaha,0503,Public Utilities Commissioner,,Chris Nelson,REP,135
+Minnehaha,0504,Public Utilities Commissioner,,Jeffrey Barth,DEM,509
+Minnehaha,0504,Public Utilities Commissioner,,Chris Nelson,REP,303
+Minnehaha,0506,Public Utilities Commissioner,,Jeffrey Barth,DEM,472
+Minnehaha,0506,Public Utilities Commissioner,,Chris Nelson,REP,410
+Minnehaha,0507,Public Utilities Commissioner,,Jeffrey Barth,DEM,307
+Minnehaha,0507,Public Utilities Commissioner,,Chris Nelson,REP,237
+Minnehaha,0508,Public Utilities Commissioner,,Jeffrey Barth,DEM,500
+Minnehaha,0508,Public Utilities Commissioner,,Chris Nelson,REP,363
+Minnehaha,0509,Public Utilities Commissioner,,Jeffrey Barth,DEM,202
+Minnehaha,0509,Public Utilities Commissioner,,Chris Nelson,REP,147
+Minnehaha,0510,Public Utilities Commissioner,,Jeffrey Barth,DEM,252
+Minnehaha,0510,Public Utilities Commissioner,,Chris Nelson,REP,256
+Minnehaha,0512,Public Utilities Commissioner,,Jeffrey Barth,DEM,296
+Minnehaha,0512,Public Utilities Commissioner,,Chris Nelson,REP,288
+Minnehaha,0513,Public Utilities Commissioner,,Jeffrey Barth,DEM,318
+Minnehaha,0513,Public Utilities Commissioner,,Chris Nelson,REP,279
+Minnehaha,0514,Public Utilities Commissioner,,Jeffrey Barth,DEM,405
+Minnehaha,0514,Public Utilities Commissioner,,Chris Nelson,REP,315
+Minnehaha,0515,Public Utilities Commissioner,,Jeffrey Barth,DEM,329
+Minnehaha,0515,Public Utilities Commissioner,,Chris Nelson,REP,415
+Minnehaha,0517,Public Utilities Commissioner,,Jeffrey Barth,DEM,238
+Minnehaha,0517,Public Utilities Commissioner,,Chris Nelson,REP,262
+Minnehaha,0518,Public Utilities Commissioner,,Jeffrey Barth,DEM,551
+Minnehaha,0518,Public Utilities Commissioner,,Chris Nelson,REP,409
+Minnehaha,0519,Public Utilities Commissioner,,Jeffrey Barth,DEM,224
+Minnehaha,0519,Public Utilities Commissioner,,Chris Nelson,REP,265
+Minnehaha,0520,Public Utilities Commissioner,,Jeffrey Barth,DEM,380
+Minnehaha,0520,Public Utilities Commissioner,,Chris Nelson,REP,398
+Minnehaha,0521,Public Utilities Commissioner,,Jeffrey Barth,DEM,196
+Minnehaha,0521,Public Utilities Commissioner,,Chris Nelson,REP,205
+Minnehaha,0522,Public Utilities Commissioner,,Jeffrey Barth,DEM,417
+Minnehaha,0522,Public Utilities Commissioner,,Chris Nelson,REP,343
+Minnehaha,0523,Public Utilities Commissioner,,Jeffrey Barth,DEM,345
+Minnehaha,0523,Public Utilities Commissioner,,Chris Nelson,REP,261
+Minnehaha,VP01,Public Utilities Commissioner,,Jeffrey Barth,DEM,213
+Minnehaha,VP01,Public Utilities Commissioner,,Chris Nelson,REP,495
+Minnehaha,VP02,Public Utilities Commissioner,,Jeffrey Barth,DEM,486
+Minnehaha,VP02,Public Utilities Commissioner,,Chris Nelson,REP,1160
+Minnehaha,VP03,Public Utilities Commissioner,,Jeffrey Barth,DEM,563
+Minnehaha,VP03,Public Utilities Commissioner,,Chris Nelson,REP,1378
+Minnehaha,VP04,Public Utilities Commissioner,,Jeffrey Barth,DEM,304
+Minnehaha,VP04,Public Utilities Commissioner,,Chris Nelson,REP,719
+Minnehaha,VP05,Public Utilities Commissioner,,Jeffrey Barth,DEM,357
+Minnehaha,VP05,Public Utilities Commissioner,,Chris Nelson,REP,935
+Minnehaha,VP06,Public Utilities Commissioner,,Jeffrey Barth,DEM,118
+Minnehaha,VP06,Public Utilities Commissioner,,Chris Nelson,REP,294
+Minnehaha,VP07,Public Utilities Commissioner,,Jeffrey Barth,DEM,472
+Minnehaha,VP07,Public Utilities Commissioner,,Chris Nelson,REP,1109
+Minnehaha,VP08,Public Utilities Commissioner,,Jeffrey Barth,DEM,188
+Minnehaha,VP08,Public Utilities Commissioner,,Chris Nelson,REP,411
+Minnehaha,VP09,Public Utilities Commissioner,,Jeffrey Barth,DEM,344
+Minnehaha,VP09,Public Utilities Commissioner,,Chris Nelson,REP,845
+Minnehaha,VP10,Public Utilities Commissioner,,Jeffrey Barth,DEM,398
+Minnehaha,VP10,Public Utilities Commissioner,,Chris Nelson,REP,694
+Minnehaha,VP11,Public Utilities Commissioner,,Jeffrey Barth,DEM,80
+Minnehaha,VP11,Public Utilities Commissioner,,Chris Nelson,REP,210
+Minnehaha,VP12,Public Utilities Commissioner,,Jeffrey Barth,DEM,47
+Minnehaha,VP12,Public Utilities Commissioner,,Chris Nelson,REP,74
+Minnehaha,VP13,Public Utilities Commissioner,,Jeffrey Barth,DEM,206
+Minnehaha,VP13,Public Utilities Commissioner,,Chris Nelson,REP,639
+Minnehaha,VP15,Public Utilities Commissioner,,Jeffrey Barth,DEM,440
+Minnehaha,VP15,Public Utilities Commissioner,,Chris Nelson,REP,958
+Minnehaha,VP16,Public Utilities Commissioner,,Jeffrey Barth,DEM,292
+Minnehaha,VP16,Public Utilities Commissioner,,Chris Nelson,REP,685
+Minnehaha,VP17,Public Utilities Commissioner,,Jeffrey Barth,DEM,185
+Minnehaha,VP17,Public Utilities Commissioner,,Chris Nelson,REP,427
+Minnehaha,VP21,Public Utilities Commissioner,,Jeffrey Barth,DEM,467
+Minnehaha,VP21,Public Utilities Commissioner,,Chris Nelson,REP,1087
+Minnehaha,0104,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,365
+Minnehaha,0105,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,226
+Minnehaha,0106,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,583
+Minnehaha,0109,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,574
+Minnehaha,0110,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,612
+Minnehaha,0117,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,652
+Minnehaha,0119,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,317
+Minnehaha,0201,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,621
+Minnehaha,0202,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,814
+Minnehaha,0203,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,609
+Minnehaha,0206,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,610
+Minnehaha,0208,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,609
+Minnehaha,0209,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,605
+Minnehaha,0214,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,1611
+Minnehaha,0301,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,435
+Minnehaha,0305,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,245
+Minnehaha,0309,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,571
+Minnehaha,0310,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,846
+Minnehaha,0311,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,505
+Minnehaha,0312,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,657
+Minnehaha,0313,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,378
+Minnehaha,0314,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,944
+Minnehaha,0315,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,562
+Minnehaha,0316,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,1007
+Minnehaha,0317,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,1149
+Minnehaha,0402,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,323
+Minnehaha,0403,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,226
+Minnehaha,0404,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,338
+Minnehaha,0405,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,755
+Minnehaha,0406,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,145
+Minnehaha,0407,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,682
+Minnehaha,0408,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,166
+Minnehaha,0409,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,352
+Minnehaha,0410,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,401
+Minnehaha,0411,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,1100
+Minnehaha,0412,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,584
+Minnehaha,0413,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,326
+Minnehaha,0415,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,1180
+Minnehaha,0501,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,215
+Minnehaha,0502,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,318
+Minnehaha,0503,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,157
+Minnehaha,0504,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,399
+Minnehaha,0506,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,463
+Minnehaha,0507,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,290
+Minnehaha,0508,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,481
+Minnehaha,0509,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,186
+Minnehaha,0510,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,275
+Minnehaha,0512,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,312
+Minnehaha,0513,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,347
+Minnehaha,0514,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,372
+Minnehaha,0515,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,339
+Minnehaha,0517,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,308
+Minnehaha,0518,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,479
+Minnehaha,0519,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,266
+Minnehaha,0520,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,420
+Minnehaha,0521,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,243
+Minnehaha,0522,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,377
+Minnehaha,0523,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,299
+Minnehaha,VP01,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,415
+Minnehaha,VP02,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,996
+Minnehaha,VP03,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,1149
+Minnehaha,VP04,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,604
+Minnehaha,VP05,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,763
+Minnehaha,VP06,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,221
+Minnehaha,VP07,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,969
+Minnehaha,VP08,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,341
+Minnehaha,VP09,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,670
+Minnehaha,VP10,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,639
+Minnehaha,VP11,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,166
+Minnehaha,VP12,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,73
+Minnehaha,VP13,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,476
+Minnehaha,VP15,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,873
+Minnehaha,VP16,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,556
+Minnehaha,VP17,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,361
+Minnehaha,VP21,Judge of the Circuit Court,Position A Second Circuit,Robin Houwman,NON,890
+Minnehaha,0104,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,311
+Minnehaha,0105,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,197
+Minnehaha,0106,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,463
+Minnehaha,0109,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,476
+Minnehaha,0110,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,482
+Minnehaha,0117,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,526
+Minnehaha,0119,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,259
+Minnehaha,0201,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,462
+Minnehaha,0202,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,626
+Minnehaha,0203,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,481
+Minnehaha,0206,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,482
+Minnehaha,0208,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,487
+Minnehaha,0209,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,478
+Minnehaha,0214,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,1293
+Minnehaha,0301,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,340
+Minnehaha,0305,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,195
+Minnehaha,0309,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,477
+Minnehaha,0310,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,659
+Minnehaha,0311,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,419
+Minnehaha,0312,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,536
+Minnehaha,0313,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,295
+Minnehaha,0314,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,796
+Minnehaha,0315,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,440
+Minnehaha,0316,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,809
+Minnehaha,0317,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,931
+Minnehaha,0402,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,257
+Minnehaha,0403,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,184
+Minnehaha,0404,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,273
+Minnehaha,0405,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,597
+Minnehaha,0406,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,114
+Minnehaha,0407,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,535
+Minnehaha,0408,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,137
+Minnehaha,0409,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,304
+Minnehaha,0410,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,325
+Minnehaha,0411,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,875
+Minnehaha,0412,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,463
+Minnehaha,0413,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,270
+Minnehaha,0415,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,950
+Minnehaha,0501,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,182
+Minnehaha,0502,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,241
+Minnehaha,0503,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,123
+Minnehaha,0504,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,307
+Minnehaha,0506,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,374
+Minnehaha,0507,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,223
+Minnehaha,0508,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,345
+Minnehaha,0509,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,153
+Minnehaha,0510,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,225
+Minnehaha,0512,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,242
+Minnehaha,0513,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,265
+Minnehaha,0514,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,286
+Minnehaha,0515,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,287
+Minnehaha,0517,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,245
+Minnehaha,0518,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,377
+Minnehaha,0519,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,203
+Minnehaha,0520,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,339
+Minnehaha,0521,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,181
+Minnehaha,0522,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,319
+Minnehaha,0523,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,241
+Minnehaha,VP01,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,341
+Minnehaha,VP02,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,780
+Minnehaha,VP03,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,924
+Minnehaha,VP04,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,469
+Minnehaha,VP05,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,618
+Minnehaha,VP06,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,171
+Minnehaha,VP07,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,772
+Minnehaha,VP08,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,256
+Minnehaha,VP09,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,529
+Minnehaha,VP10,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,503
+Minnehaha,VP11,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,123
+Minnehaha,VP12,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,61
+Minnehaha,VP13,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,388
+Minnehaha,VP15,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,710
+Minnehaha,VP16,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,428
+Minnehaha,VP17,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,292
+Minnehaha,VP21,Judge of the Circuit Court,Position B Second Circuit,Sandra H Hanson,NON,737
+Minnehaha,0104,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,247
+Minnehaha,0104,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,138
+Minnehaha,0105,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,156
+Minnehaha,0105,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,94
+Minnehaha,0106,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,341
+Minnehaha,0106,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,236
+Minnehaha,0109,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,360
+Minnehaha,0109,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,213
+Minnehaha,0110,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,367
+Minnehaha,0110,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,225
+Minnehaha,0117,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,376
+Minnehaha,0117,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,284
+Minnehaha,0119,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,188
+Minnehaha,0119,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,131
+Minnehaha,0201,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,418
+Minnehaha,0201,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,202
+Minnehaha,0202,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,603
+Minnehaha,0202,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,265
+Minnehaha,0203,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,385
+Minnehaha,0203,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,228
+Minnehaha,0206,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,388
+Minnehaha,0206,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,241
+Minnehaha,0208,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,435
+Minnehaha,0208,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,237
+Minnehaha,0209,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,442
+Minnehaha,0209,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,205
+Minnehaha,0214,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,997
+Minnehaha,0214,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,594
+Minnehaha,0301,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,293
+Minnehaha,0301,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,153
+Minnehaha,0305,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,160
+Minnehaha,0305,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,103
+Minnehaha,0309,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,346
+Minnehaha,0309,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,244
+Minnehaha,0310,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,525
+Minnehaha,0310,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,332
+Minnehaha,0311,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,331
+Minnehaha,0311,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,179
+Minnehaha,0312,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,404
+Minnehaha,0312,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,239
+Minnehaha,0313,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,248
+Minnehaha,0313,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,156
+Minnehaha,0314,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,555
+Minnehaha,0314,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,376
+Minnehaha,0315,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,356
+Minnehaha,0315,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,243
+Minnehaha,0316,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,621
+Minnehaha,0316,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,377
+Minnehaha,0317,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,687
+Minnehaha,0317,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,444
+Minnehaha,0402,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,224
+Minnehaha,0402,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,130
+Minnehaha,0403,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,145
+Minnehaha,0403,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,90
+Minnehaha,0404,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,210
+Minnehaha,0404,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,137
+Minnehaha,0405,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,405
+Minnehaha,0405,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,318
+Minnehaha,0406,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,103
+Minnehaha,0406,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,59
+Minnehaha,0407,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,422
+Minnehaha,0407,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,288
+Minnehaha,0408,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,107
+Minnehaha,0408,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,72
+Minnehaha,0409,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,263
+Minnehaha,0409,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,131
+Minnehaha,0410,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,265
+Minnehaha,0410,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,161
+Minnehaha,0411,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,655
+Minnehaha,0411,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,387
+Minnehaha,0412,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,407
+Minnehaha,0412,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,226
+Minnehaha,0413,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,217
+Minnehaha,0413,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,127
+Minnehaha,0415,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,730
+Minnehaha,0415,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,412
+Minnehaha,0501,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,146
+Minnehaha,0501,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,91
+Minnehaha,0502,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,189
+Minnehaha,0502,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,110
+Minnehaha,0503,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,113
+Minnehaha,0503,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,63
+Minnehaha,0504,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,266
+Minnehaha,0504,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,161
+Minnehaha,0506,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,315
+Minnehaha,0506,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,172
+Minnehaha,0507,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,219
+Minnehaha,0507,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,113
+Minnehaha,0508,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,340
+Minnehaha,0508,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,172
+Minnehaha,0509,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,103
+Minnehaha,0509,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,96
+Minnehaha,0510,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,175
+Minnehaha,0510,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,129
+Minnehaha,0512,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,228
+Minnehaha,0512,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,116
+Minnehaha,0513,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,233
+Minnehaha,0513,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,113
+Minnehaha,0514,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,254
+Minnehaha,0514,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,126
+Minnehaha,0515,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,182
+Minnehaha,0515,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,158
+Minnehaha,0517,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,208
+Minnehaha,0517,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,95
+Minnehaha,0518,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,341
+Minnehaha,0518,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,189
+Minnehaha,0519,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,175
+Minnehaha,0519,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,107
+Minnehaha,0520,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,268
+Minnehaha,0520,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,185
+Minnehaha,0521,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,158
+Minnehaha,0521,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,79
+Minnehaha,0522,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,240
+Minnehaha,0522,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,184
+Minnehaha,0523,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,201
+Minnehaha,0523,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,130
+Minnehaha,VP01,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,262
+Minnehaha,VP01,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,159
+Minnehaha,VP02,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,606
+Minnehaha,VP02,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,322
+Minnehaha,VP03,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,706
+Minnehaha,VP03,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,391
+Minnehaha,VP04,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,425
+Minnehaha,VP04,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,181
+Minnehaha,VP05,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,493
+Minnehaha,VP05,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,226
+Minnehaha,VP06,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,169
+Minnehaha,VP06,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,72
+Minnehaha,VP07,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,543
+Minnehaha,VP07,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,382
+Minnehaha,VP08,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,194
+Minnehaha,VP08,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,126
+Minnehaha,VP09,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,435
+Minnehaha,VP09,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,219
+Minnehaha,VP10,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,383
+Minnehaha,VP10,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,216
+Minnehaha,VP11,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,94
+Minnehaha,VP11,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,65
+Minnehaha,VP12,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,48
+Minnehaha,VP12,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,24
+Minnehaha,VP13,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,268
+Minnehaha,VP13,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,190
+Minnehaha,VP15,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,564
+Minnehaha,VP15,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,235
+Minnehaha,VP16,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,345
+Minnehaha,VP16,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,204
+Minnehaha,VP17,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,212
+Minnehaha,VP17,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,143
+Minnehaha,VP21,Judge of the Circuit Court,Position C Second Circuit,Doug Barnett,NON,568
+Minnehaha,VP21,Judge of the Circuit Court,Position C Second Circuit,Eric C. Johnson,NON,320
+Minnehaha,0104,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,286
+Minnehaha,0105,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,179
+Minnehaha,0106,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,439
+Minnehaha,0109,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,440
+Minnehaha,0110,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,442
+Minnehaha,0117,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,490
+Minnehaha,0119,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,241
+Minnehaha,0201,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,453
+Minnehaha,0202,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,595
+Minnehaha,0203,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,467
+Minnehaha,0206,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,477
+Minnehaha,0208,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,458
+Minnehaha,0209,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,449
+Minnehaha,0214,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,1229
+Minnehaha,0301,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,326
+Minnehaha,0305,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,188
+Minnehaha,0309,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,451
+Minnehaha,0310,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,648
+Minnehaha,0311,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,407
+Minnehaha,0312,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,508
+Minnehaha,0313,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,296
+Minnehaha,0314,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,731
+Minnehaha,0315,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,427
+Minnehaha,0316,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,758
+Minnehaha,0317,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,890
+Minnehaha,0402,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,258
+Minnehaha,0403,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,174
+Minnehaha,0404,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,266
+Minnehaha,0405,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,562
+Minnehaha,0406,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,107
+Minnehaha,0407,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,516
+Minnehaha,0408,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,130
+Minnehaha,0409,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,291
+Minnehaha,0410,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,305
+Minnehaha,0411,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,823
+Minnehaha,0412,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,440
+Minnehaha,0413,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,259
+Minnehaha,0415,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,895
+Minnehaha,0501,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,172
+Minnehaha,0502,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,240
+Minnehaha,0503,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,119
+Minnehaha,0504,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,295
+Minnehaha,0506,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,363
+Minnehaha,0507,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,213
+Minnehaha,0508,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,347
+Minnehaha,0509,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,145
+Minnehaha,0510,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,216
+Minnehaha,0512,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,231
+Minnehaha,0513,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,253
+Minnehaha,0514,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,285
+Minnehaha,0515,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,259
+Minnehaha,0517,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,228
+Minnehaha,0518,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,368
+Minnehaha,0519,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,184
+Minnehaha,0520,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,322
+Minnehaha,0521,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,180
+Minnehaha,0522,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,299
+Minnehaha,0523,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,232
+Minnehaha,VP01,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,314
+Minnehaha,VP02,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,726
+Minnehaha,VP03,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,863
+Minnehaha,VP04,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,447
+Minnehaha,VP05,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,593
+Minnehaha,VP06,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,153
+Minnehaha,VP07,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,731
+Minnehaha,VP08,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,236
+Minnehaha,VP09,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,501
+Minnehaha,VP10,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,469
+Minnehaha,VP11,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,117
+Minnehaha,VP12,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,53
+Minnehaha,VP13,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,339
+Minnehaha,VP15,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,669
+Minnehaha,VP16,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,401
+Minnehaha,VP17,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,274
+Minnehaha,VP21,Judge of the Circuit Court,Position D Second Circuit,Natalie Damgaard,NON,675
+Minnehaha,0104,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,290
+Minnehaha,0105,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,194
+Minnehaha,0106,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,449
+Minnehaha,0109,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,462
+Minnehaha,0110,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,458
+Minnehaha,0117,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,481
+Minnehaha,0119,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,240
+Minnehaha,0201,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,508
+Minnehaha,0202,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,656
+Minnehaha,0203,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,489
+Minnehaha,0206,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,481
+Minnehaha,0208,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,498
+Minnehaha,0209,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,487
+Minnehaha,0214,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,1262
+Minnehaha,0301,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,350
+Minnehaha,0305,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,188
+Minnehaha,0309,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,452
+Minnehaha,0310,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,656
+Minnehaha,0311,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,413
+Minnehaha,0312,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,502
+Minnehaha,0313,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,309
+Minnehaha,0314,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,734
+Minnehaha,0315,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,439
+Minnehaha,0316,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,765
+Minnehaha,0317,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,895
+Minnehaha,0402,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,255
+Minnehaha,0403,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,178
+Minnehaha,0404,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,270
+Minnehaha,0405,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,559
+Minnehaha,0406,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,108
+Minnehaha,0407,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,527
+Minnehaha,0408,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,128
+Minnehaha,0409,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,285
+Minnehaha,0410,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,318
+Minnehaha,0411,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,818
+Minnehaha,0412,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,457
+Minnehaha,0413,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,272
+Minnehaha,0415,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,926
+Minnehaha,0501,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,168
+Minnehaha,0502,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,241
+Minnehaha,0503,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,114
+Minnehaha,0504,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,310
+Minnehaha,0506,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,380
+Minnehaha,0507,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,226
+Minnehaha,0508,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,374
+Minnehaha,0509,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,141
+Minnehaha,0510,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,215
+Minnehaha,0512,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,260
+Minnehaha,0513,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,263
+Minnehaha,0514,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,278
+Minnehaha,0515,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,251
+Minnehaha,0517,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,240
+Minnehaha,0518,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,383
+Minnehaha,0519,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,214
+Minnehaha,0520,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,337
+Minnehaha,0521,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,179
+Minnehaha,0522,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,306
+Minnehaha,0523,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,228
+Minnehaha,VP01,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,317
+Minnehaha,VP02,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,747
+Minnehaha,VP03,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,883
+Minnehaha,VP04,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,460
+Minnehaha,VP05,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,594
+Minnehaha,VP06,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,163
+Minnehaha,VP07,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,717
+Minnehaha,VP08,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,242
+Minnehaha,VP09,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,529
+Minnehaha,VP10,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,484
+Minnehaha,VP11,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,126
+Minnehaha,VP12,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,57
+Minnehaha,VP13,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,365
+Minnehaha,VP15,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,654
+Minnehaha,VP16,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,421
+Minnehaha,VP17,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,277
+Minnehaha,VP21,Judge of the Circuit Court,Position E Second Circuit,John Pekas,NON,687
+Minnehaha,0104,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,271
+Minnehaha,0105,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,170
+Minnehaha,0106,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,424
+Minnehaha,0109,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,440
+Minnehaha,0110,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,424
+Minnehaha,0117,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,467
+Minnehaha,0119,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,230
+Minnehaha,0201,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,438
+Minnehaha,0202,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,603
+Minnehaha,0203,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,442
+Minnehaha,0206,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,453
+Minnehaha,0208,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,456
+Minnehaha,0209,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,445
+Minnehaha,0214,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,1196
+Minnehaha,0301,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,319
+Minnehaha,0305,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,175
+Minnehaha,0309,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,428
+Minnehaha,0310,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,619
+Minnehaha,0311,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,401
+Minnehaha,0312,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,485
+Minnehaha,0313,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,291
+Minnehaha,0314,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,711
+Minnehaha,0315,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,411
+Minnehaha,0316,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,734
+Minnehaha,0317,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,857
+Minnehaha,0402,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,238
+Minnehaha,0403,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,168
+Minnehaha,0404,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,250
+Minnehaha,0405,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,549
+Minnehaha,0406,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,107
+Minnehaha,0407,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,495
+Minnehaha,0408,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,123
+Minnehaha,0409,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,274
+Minnehaha,0410,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,297
+Minnehaha,0411,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,784
+Minnehaha,0412,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,419
+Minnehaha,0413,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,246
+Minnehaha,0415,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,870
+Minnehaha,0501,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,164
+Minnehaha,0502,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,233
+Minnehaha,0503,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,115
+Minnehaha,0504,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,286
+Minnehaha,0506,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,352
+Minnehaha,0507,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,213
+Minnehaha,0508,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,346
+Minnehaha,0509,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,139
+Minnehaha,0510,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,210
+Minnehaha,0512,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,222
+Minnehaha,0513,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,247
+Minnehaha,0514,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,267
+Minnehaha,0515,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,249
+Minnehaha,0517,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,225
+Minnehaha,0518,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,358
+Minnehaha,0519,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,192
+Minnehaha,0520,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,308
+Minnehaha,0521,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,180
+Minnehaha,0522,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,284
+Minnehaha,0523,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,231
+Minnehaha,VP01,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,298
+Minnehaha,VP02,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,696
+Minnehaha,VP03,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,842
+Minnehaha,VP04,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,429
+Minnehaha,VP05,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,558
+Minnehaha,VP06,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,148
+Minnehaha,VP07,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,682
+Minnehaha,VP08,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,225
+Minnehaha,VP09,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,478
+Minnehaha,VP10,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,447
+Minnehaha,VP11,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,111
+Minnehaha,VP12,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,53
+Minnehaha,VP13,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,324
+Minnehaha,VP15,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,645
+Minnehaha,VP16,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,388
+Minnehaha,VP17,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,264
+Minnehaha,VP21,Judge of the Circuit Court,Position F Second Circuit,Camela Theeler,NON,641
+Minnehaha,0104,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,272
+Minnehaha,0105,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,177
+Minnehaha,0106,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,424
+Minnehaha,0109,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,449
+Minnehaha,0110,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,442
+Minnehaha,0117,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,464
+Minnehaha,0119,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,234
+Minnehaha,0201,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,443
+Minnehaha,0202,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,605
+Minnehaha,0203,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,450
+Minnehaha,0206,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,445
+Minnehaha,0208,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,461
+Minnehaha,0209,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,443
+Minnehaha,0214,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,1199
+Minnehaha,0301,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,317
+Minnehaha,0305,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,175
+Minnehaha,0309,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,430
+Minnehaha,0310,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,615
+Minnehaha,0311,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,398
+Minnehaha,0312,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,487
+Minnehaha,0313,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,290
+Minnehaha,0314,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,720
+Minnehaha,0315,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,414
+Minnehaha,0316,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,723
+Minnehaha,0317,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,855
+Minnehaha,0402,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,235
+Minnehaha,0403,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,172
+Minnehaha,0404,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,253
+Minnehaha,0405,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,550
+Minnehaha,0406,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,106
+Minnehaha,0407,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,496
+Minnehaha,0408,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,130
+Minnehaha,0409,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,280
+Minnehaha,0410,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,298
+Minnehaha,0411,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,774
+Minnehaha,0412,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,423
+Minnehaha,0413,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,249
+Minnehaha,0415,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,881
+Minnehaha,0501,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,170
+Minnehaha,0502,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,234
+Minnehaha,0503,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,114
+Minnehaha,0504,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,293
+Minnehaha,0506,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,348
+Minnehaha,0507,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,212
+Minnehaha,0508,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,329
+Minnehaha,0509,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,143
+Minnehaha,0510,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,212
+Minnehaha,0512,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,221
+Minnehaha,0513,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,243
+Minnehaha,0514,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,273
+Minnehaha,0515,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,256
+Minnehaha,0517,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,226
+Minnehaha,0518,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,360
+Minnehaha,0519,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,189
+Minnehaha,0520,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,314
+Minnehaha,0521,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,178
+Minnehaha,0522,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,296
+Minnehaha,0523,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,229
+Minnehaha,VP01,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,309
+Minnehaha,VP02,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,711
+Minnehaha,VP03,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,855
+Minnehaha,VP04,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,429
+Minnehaha,VP05,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,571
+Minnehaha,VP06,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,152
+Minnehaha,VP07,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,707
+Minnehaha,VP08,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,237
+Minnehaha,VP09,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,486
+Minnehaha,VP10,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,456
+Minnehaha,VP11,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,115
+Minnehaha,VP12,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,54
+Minnehaha,VP13,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,324
+Minnehaha,VP15,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,648
+Minnehaha,VP16,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,389
+Minnehaha,VP17,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,264
+Minnehaha,VP21,Judge of the Circuit Court,Position G Second Circuit,Jennifer D. Mammenga,NON,644
+Minnehaha,0104,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,279
+Minnehaha,0105,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,177
+Minnehaha,0106,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,435
+Minnehaha,0109,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,455
+Minnehaha,0110,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,436
+Minnehaha,0117,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,474
+Minnehaha,0119,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,233
+Minnehaha,0201,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,458
+Minnehaha,0202,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,623
+Minnehaha,0203,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,446
+Minnehaha,0206,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,453
+Minnehaha,0208,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,464
+Minnehaha,0209,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,450
+Minnehaha,0214,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,1217
+Minnehaha,0301,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,347
+Minnehaha,0305,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,189
+Minnehaha,0309,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,435
+Minnehaha,0310,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,626
+Minnehaha,0311,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,404
+Minnehaha,0312,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,502
+Minnehaha,0313,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,298
+Minnehaha,0314,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,715
+Minnehaha,0315,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,417
+Minnehaha,0316,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,749
+Minnehaha,0317,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,863
+Minnehaha,0402,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,242
+Minnehaha,0403,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,171
+Minnehaha,0404,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,255
+Minnehaha,0405,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,547
+Minnehaha,0406,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,107
+Minnehaha,0407,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,496
+Minnehaha,0408,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,125
+Minnehaha,0409,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,281
+Minnehaha,0410,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,300
+Minnehaha,0411,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,787
+Minnehaha,0412,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,416
+Minnehaha,0413,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,255
+Minnehaha,0415,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,897
+Minnehaha,0501,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,165
+Minnehaha,0502,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,236
+Minnehaha,0503,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,116
+Minnehaha,0504,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,296
+Minnehaha,0506,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,343
+Minnehaha,0507,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,219
+Minnehaha,0508,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,343
+Minnehaha,0509,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,137
+Minnehaha,0510,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,211
+Minnehaha,0512,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,241
+Minnehaha,0513,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,257
+Minnehaha,0514,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,275
+Minnehaha,0515,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,246
+Minnehaha,0517,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,232
+Minnehaha,0518,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,379
+Minnehaha,0519,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,194
+Minnehaha,0520,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,323
+Minnehaha,0521,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,181
+Minnehaha,0522,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,294
+Minnehaha,0523,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,229
+Minnehaha,VP01,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,296
+Minnehaha,VP02,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,703
+Minnehaha,VP03,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,847
+Minnehaha,VP04,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,450
+Minnehaha,VP05,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,582
+Minnehaha,VP06,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,153
+Minnehaha,VP07,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,709
+Minnehaha,VP08,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,232
+Minnehaha,VP09,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,484
+Minnehaha,VP10,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,460
+Minnehaha,VP11,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,112
+Minnehaha,VP12,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,55
+Minnehaha,VP13,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,325
+Minnehaha,VP15,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,640
+Minnehaha,VP16,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,392
+Minnehaha,VP17,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,264
+Minnehaha,VP21,Judge of the Circuit Court,Position H Second Circuit,Susan M. Sabers,NON,659
+Minnehaha,0104,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,277
+Minnehaha,0105,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,173
+Minnehaha,0106,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,414
+Minnehaha,0109,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,426
+Minnehaha,0110,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,428
+Minnehaha,0117,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,467
+Minnehaha,0119,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,232
+Minnehaha,0201,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,447
+Minnehaha,0202,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,586
+Minnehaha,0203,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,449
+Minnehaha,0206,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,448
+Minnehaha,0208,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,456
+Minnehaha,0209,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,433
+Minnehaha,0214,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,1197
+Minnehaha,0301,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,319
+Minnehaha,0305,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,178
+Minnehaha,0309,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,432
+Minnehaha,0310,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,613
+Minnehaha,0311,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,382
+Minnehaha,0312,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,491
+Minnehaha,0313,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,293
+Minnehaha,0314,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,713
+Minnehaha,0315,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,417
+Minnehaha,0316,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,725
+Minnehaha,0317,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,858
+Minnehaha,0402,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,234
+Minnehaha,0403,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,172
+Minnehaha,0404,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,250
+Minnehaha,0405,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,543
+Minnehaha,0406,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,105
+Minnehaha,0407,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,494
+Minnehaha,0408,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,122
+Minnehaha,0409,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,273
+Minnehaha,0410,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,299
+Minnehaha,0411,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,790
+Minnehaha,0412,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,422
+Minnehaha,0413,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,250
+Minnehaha,0415,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,886
+Minnehaha,0501,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,167
+Minnehaha,0502,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,230
+Minnehaha,0503,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,117
+Minnehaha,0504,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,273
+Minnehaha,0506,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,344
+Minnehaha,0507,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,209
+Minnehaha,0508,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,322
+Minnehaha,0509,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,138
+Minnehaha,0510,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,211
+Minnehaha,0512,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,235
+Minnehaha,0513,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,247
+Minnehaha,0514,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,263
+Minnehaha,0515,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,243
+Minnehaha,0517,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,221
+Minnehaha,0518,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,350
+Minnehaha,0519,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,184
+Minnehaha,0520,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,323
+Minnehaha,0521,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,168
+Minnehaha,0522,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,299
+Minnehaha,0523,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,225
+Minnehaha,VP01,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,305
+Minnehaha,VP02,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,712
+Minnehaha,VP03,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,834
+Minnehaha,VP04,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,431
+Minnehaha,VP05,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,557
+Minnehaha,VP06,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,148
+Minnehaha,VP07,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,708
+Minnehaha,VP08,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,226
+Minnehaha,VP09,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,470
+Minnehaha,VP10,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,448
+Minnehaha,VP11,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,101
+Minnehaha,VP12,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,55
+Minnehaha,VP13,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,342
+Minnehaha,VP15,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,630
+Minnehaha,VP16,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,381
+Minnehaha,VP17,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,261
+Minnehaha,VP21,Judge of the Circuit Court,Position I Second Circuit,Doug Hoffman,NON,649
+Minnehaha,0104,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,264
+Minnehaha,0105,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,166
+Minnehaha,0106,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,404
+Minnehaha,0109,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,423
+Minnehaha,0110,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,416
+Minnehaha,0117,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,455
+Minnehaha,0119,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,223
+Minnehaha,0201,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,427
+Minnehaha,0202,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,573
+Minnehaha,0203,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,436
+Minnehaha,0206,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,430
+Minnehaha,0208,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,431
+Minnehaha,0209,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,426
+Minnehaha,0214,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,1158
+Minnehaha,0301,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,302
+Minnehaha,0305,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,177
+Minnehaha,0309,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,415
+Minnehaha,0310,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,601
+Minnehaha,0311,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,378
+Minnehaha,0312,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,470
+Minnehaha,0313,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,286
+Minnehaha,0314,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,696
+Minnehaha,0315,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,397
+Minnehaha,0316,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,704
+Minnehaha,0317,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,823
+Minnehaha,0402,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,225
+Minnehaha,0403,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,163
+Minnehaha,0404,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,238
+Minnehaha,0405,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,529
+Minnehaha,0406,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,97
+Minnehaha,0407,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,467
+Minnehaha,0408,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,120
+Minnehaha,0409,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,262
+Minnehaha,0410,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,278
+Minnehaha,0411,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,740
+Minnehaha,0412,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,389
+Minnehaha,0413,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,242
+Minnehaha,0415,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,862
+Minnehaha,0501,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,157
+Minnehaha,0502,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,225
+Minnehaha,0503,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,109
+Minnehaha,0504,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,265
+Minnehaha,0506,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,324
+Minnehaha,0507,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,202
+Minnehaha,0508,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,320
+Minnehaha,0509,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,132
+Minnehaha,0510,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,199
+Minnehaha,0512,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,220
+Minnehaha,0513,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,236
+Minnehaha,0514,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,259
+Minnehaha,0515,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,240
+Minnehaha,0517,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,216
+Minnehaha,0518,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,345
+Minnehaha,0519,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,177
+Minnehaha,0520,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,296
+Minnehaha,0521,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,169
+Minnehaha,0522,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,276
+Minnehaha,0523,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,206
+Minnehaha,VP01,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,302
+Minnehaha,VP02,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,696
+Minnehaha,VP03,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,810
+Minnehaha,VP04,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,419
+Minnehaha,VP05,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,536
+Minnehaha,VP06,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,145
+Minnehaha,VP07,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,673
+Minnehaha,VP08,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,218
+Minnehaha,VP09,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,453
+Minnehaha,VP10,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,441
+Minnehaha,VP11,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,99
+Minnehaha,VP12,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,51
+Minnehaha,VP13,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,322
+Minnehaha,VP15,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,617
+Minnehaha,VP16,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,373
+Minnehaha,VP17,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,253
+Minnehaha,VP21,Judge of the Circuit Court,Position J Second Circuit,James Power,NON,632
+Minnehaha,0104,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,268
+Minnehaha,0105,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,174
+Minnehaha,0106,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,420
+Minnehaha,0109,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,432
+Minnehaha,0110,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,420
+Minnehaha,0117,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,461
+Minnehaha,0119,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,222
+Minnehaha,0201,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,487
+Minnehaha,0202,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,616
+Minnehaha,0203,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,461
+Minnehaha,0206,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,448
+Minnehaha,0208,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,467
+Minnehaha,0209,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,455
+Minnehaha,0214,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,1229
+Minnehaha,0301,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,335
+Minnehaha,0305,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,176
+Minnehaha,0309,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,427
+Minnehaha,0310,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,621
+Minnehaha,0311,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,389
+Minnehaha,0312,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,477
+Minnehaha,0313,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,297
+Minnehaha,0314,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,701
+Minnehaha,0315,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,410
+Minnehaha,0316,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,711
+Minnehaha,0317,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,841
+Minnehaha,0402,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,235
+Minnehaha,0403,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,163
+Minnehaha,0404,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,241
+Minnehaha,0405,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,541
+Minnehaha,0406,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,100
+Minnehaha,0407,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,483
+Minnehaha,0408,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,116
+Minnehaha,0409,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,268
+Minnehaha,0410,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,290
+Minnehaha,0411,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,770
+Minnehaha,0412,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,410
+Minnehaha,0413,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,243
+Minnehaha,0415,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,901
+Minnehaha,0501,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,153
+Minnehaha,0502,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,235
+Minnehaha,0503,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,113
+Minnehaha,0504,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,286
+Minnehaha,0506,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,353
+Minnehaha,0507,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,219
+Minnehaha,0508,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,341
+Minnehaha,0509,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,135
+Minnehaha,0510,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,201
+Minnehaha,0512,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,227
+Minnehaha,0513,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,258
+Minnehaha,0514,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,266
+Minnehaha,0515,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,239
+Minnehaha,0517,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,233
+Minnehaha,0518,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,355
+Minnehaha,0519,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,192
+Minnehaha,0520,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,306
+Minnehaha,0521,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,181
+Minnehaha,0522,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,285
+Minnehaha,0523,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,219
+Minnehaha,VP01,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,303
+Minnehaha,VP02,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,715
+Minnehaha,VP03,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,815
+Minnehaha,VP04,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,434
+Minnehaha,VP05,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,557
+Minnehaha,VP06,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,149
+Minnehaha,VP07,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,678
+Minnehaha,VP08,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,230
+Minnehaha,VP09,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,465
+Minnehaha,VP10,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,444
+Minnehaha,VP11,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,104
+Minnehaha,VP12,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,55
+Minnehaha,VP13,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,323
+Minnehaha,VP15,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,631
+Minnehaha,VP16,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,383
+Minnehaha,VP17,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,266
+Minnehaha,VP21,Judge of the Circuit Court,Position K Second Circuit,Jon C. Sogn,NON,642
+Minnehaha,0104,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,281
+Minnehaha,0105,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,173
+Minnehaha,0106,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,429
+Minnehaha,0109,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,440
+Minnehaha,0110,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,421
+Minnehaha,0117,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,467
+Minnehaha,0119,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,240
+Minnehaha,0201,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,434
+Minnehaha,0202,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,575
+Minnehaha,0203,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,447
+Minnehaha,0206,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,447
+Minnehaha,0208,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,457
+Minnehaha,0209,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,435
+Minnehaha,0214,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,1175
+Minnehaha,0301,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,315
+Minnehaha,0305,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,179
+Minnehaha,0309,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,427
+Minnehaha,0310,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,618
+Minnehaha,0311,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,391
+Minnehaha,0312,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,486
+Minnehaha,0313,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,285
+Minnehaha,0314,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,723
+Minnehaha,0315,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,412
+Minnehaha,0316,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,720
+Minnehaha,0317,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,844
+Minnehaha,0402,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,236
+Minnehaha,0403,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,168
+Minnehaha,0404,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,254
+Minnehaha,0405,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,558
+Minnehaha,0406,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,99
+Minnehaha,0407,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,487
+Minnehaha,0408,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,124
+Minnehaha,0409,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,278
+Minnehaha,0410,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,291
+Minnehaha,0411,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,779
+Minnehaha,0412,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,417
+Minnehaha,0413,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,250
+Minnehaha,0415,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,875
+Minnehaha,0501,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,172
+Minnehaha,0502,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,228
+Minnehaha,0503,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,115
+Minnehaha,0504,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,279
+Minnehaha,0506,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,338
+Minnehaha,0507,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,203
+Minnehaha,0508,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,332
+Minnehaha,0509,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,142
+Minnehaha,0510,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,208
+Minnehaha,0512,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,220
+Minnehaha,0513,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,243
+Minnehaha,0514,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,271
+Minnehaha,0515,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,247
+Minnehaha,0517,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,217
+Minnehaha,0518,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,362
+Minnehaha,0519,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,186
+Minnehaha,0520,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,322
+Minnehaha,0521,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,181
+Minnehaha,0522,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,300
+Minnehaha,0523,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,232
+Minnehaha,VP01,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,304
+Minnehaha,VP02,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,701
+Minnehaha,VP03,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,844
+Minnehaha,VP04,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,433
+Minnehaha,VP05,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,564
+Minnehaha,VP06,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,150
+Minnehaha,VP07,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,696
+Minnehaha,VP08,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,226
+Minnehaha,VP09,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,475
+Minnehaha,VP10,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,462
+Minnehaha,VP11,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,112
+Minnehaha,VP12,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,58
+Minnehaha,VP13,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,329
+Minnehaha,VP15,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,655
+Minnehaha,VP16,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,385
+Minnehaha,VP17,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,262
+Minnehaha,VP21,Judge of the Circuit Court,Position L Second Circuit,Rachel R. Rasmussen,NON,659
+Minnehaha,0104,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,427
+Minnehaha,0104,Supreme Court Retention,3,Patricia J. DeVaney - No,,150
+Minnehaha,0105,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,289
+Minnehaha,0105,Supreme Court Retention,3,Patricia J. DeVaney - No,,93
+Minnehaha,0106,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,670
+Minnehaha,0106,Supreme Court Retention,3,Patricia J. DeVaney - No,,207
+Minnehaha,0109,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,707
+Minnehaha,0109,Supreme Court Retention,3,Patricia J. DeVaney - No,,167
+Minnehaha,0110,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,730
+Minnehaha,0110,Supreme Court Retention,3,Patricia J. DeVaney - No,,209
+Minnehaha,0117,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,796
+Minnehaha,0117,Supreme Court Retention,3,Patricia J. DeVaney - No,,246
+Minnehaha,0119,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,359
+Minnehaha,0119,Supreme Court Retention,3,Patricia J. DeVaney - No,,131
+Minnehaha,0201,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,736
+Minnehaha,0201,Supreme Court Retention,3,Patricia J. DeVaney - No,,164
+Minnehaha,0202,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1010
+Minnehaha,0202,Supreme Court Retention,3,Patricia J. DeVaney - No,,175
+Minnehaha,0203,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,715
+Minnehaha,0203,Supreme Court Retention,3,Patricia J. DeVaney - No,,202
+Minnehaha,0206,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,744
+Minnehaha,0206,Supreme Court Retention,3,Patricia J. DeVaney - No,,152
+Minnehaha,0208,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,785
+Minnehaha,0208,Supreme Court Retention,3,Patricia J. DeVaney - No,,150
+Minnehaha,0209,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,686
+Minnehaha,0209,Supreme Court Retention,3,Patricia J. DeVaney - No,,181
+Minnehaha,0214,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1926
+Minnehaha,0214,Supreme Court Retention,3,Patricia J. DeVaney - No,,389
+Minnehaha,0301,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,536
+Minnehaha,0301,Supreme Court Retention,3,Patricia J. DeVaney - No,,119
+Minnehaha,0305,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,331
+Minnehaha,0305,Supreme Court Retention,3,Patricia J. DeVaney - No,,97
+Minnehaha,0309,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,688
+Minnehaha,0309,Supreme Court Retention,3,Patricia J. DeVaney - No,,255
+Minnehaha,0310,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1007
+Minnehaha,0310,Supreme Court Retention,3,Patricia J. DeVaney - No,,201
+Minnehaha,0311,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,606
+Minnehaha,0311,Supreme Court Retention,3,Patricia J. DeVaney - No,,137
+Minnehaha,0312,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,783
+Minnehaha,0312,Supreme Court Retention,3,Patricia J. DeVaney - No,,203
+Minnehaha,0313,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,469
+Minnehaha,0313,Supreme Court Retention,3,Patricia J. DeVaney - No,,138
+Minnehaha,0314,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1103
+Minnehaha,0314,Supreme Court Retention,3,Patricia J. DeVaney - No,,372
+Minnehaha,0315,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,721
+Minnehaha,0315,Supreme Court Retention,3,Patricia J. DeVaney - No,,176
+Minnehaha,0316,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1129
+Minnehaha,0316,Supreme Court Retention,3,Patricia J. DeVaney - No,,283
+Minnehaha,0317,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1365
+Minnehaha,0317,Supreme Court Retention,3,Patricia J. DeVaney - No,,332
+Minnehaha,0402,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,382
+Minnehaha,0402,Supreme Court Retention,3,Patricia J. DeVaney - No,,150
+Minnehaha,0403,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,244
+Minnehaha,0403,Supreme Court Retention,3,Patricia J. DeVaney - No,,114
+Minnehaha,0404,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,411
+Minnehaha,0404,Supreme Court Retention,3,Patricia J. DeVaney - No,,164
+Minnehaha,0405,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,899
+Minnehaha,0405,Supreme Court Retention,3,Patricia J. DeVaney - No,,357
+Minnehaha,0406,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,183
+Minnehaha,0406,Supreme Court Retention,3,Patricia J. DeVaney - No,,73
+Minnehaha,0407,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,828
+Minnehaha,0407,Supreme Court Retention,3,Patricia J. DeVaney - No,,195
+Minnehaha,0408,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,200
+Minnehaha,0408,Supreme Court Retention,3,Patricia J. DeVaney - No,,68
+Minnehaha,0409,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,435
+Minnehaha,0409,Supreme Court Retention,3,Patricia J. DeVaney - No,,143
+Minnehaha,0410,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,495
+Minnehaha,0410,Supreme Court Retention,3,Patricia J. DeVaney - No,,149
+Minnehaha,0411,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1301
+Minnehaha,0411,Supreme Court Retention,3,Patricia J. DeVaney - No,,280
+Minnehaha,0412,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,738
+Minnehaha,0412,Supreme Court Retention,3,Patricia J. DeVaney - No,,234
+Minnehaha,0413,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,393
+Minnehaha,0413,Supreme Court Retention,3,Patricia J. DeVaney - No,,128
+Minnehaha,0415,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1397
+Minnehaha,0415,Supreme Court Retention,3,Patricia J. DeVaney - No,,325
+Minnehaha,0501,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,241
+Minnehaha,0501,Supreme Court Retention,3,Patricia J. DeVaney - No,,118
+Minnehaha,0502,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,359
+Minnehaha,0502,Supreme Court Retention,3,Patricia J. DeVaney - No,,148
+Minnehaha,0503,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,181
+Minnehaha,0503,Supreme Court Retention,3,Patricia J. DeVaney - No,,96
+Minnehaha,0504,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,512
+Minnehaha,0504,Supreme Court Retention,3,Patricia J. DeVaney - No,,159
+Minnehaha,0506,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,545
+Minnehaha,0506,Supreme Court Retention,3,Patricia J. DeVaney - No,,215
+Minnehaha,0507,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,351
+Minnehaha,0507,Supreme Court Retention,3,Patricia J. DeVaney - No,,93
+Minnehaha,0508,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,558
+Minnehaha,0508,Supreme Court Retention,3,Patricia J. DeVaney - No,,163
+Minnehaha,0509,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,217
+Minnehaha,0509,Supreme Court Retention,3,Patricia J. DeVaney - No,,87
+Minnehaha,0510,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,333
+Minnehaha,0510,Supreme Court Retention,3,Patricia J. DeVaney - No,,103
+Minnehaha,0512,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,392
+Minnehaha,0512,Supreme Court Retention,3,Patricia J. DeVaney - No,,101
+Minnehaha,0513,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,392
+Minnehaha,0513,Supreme Court Retention,3,Patricia J. DeVaney - No,,106
+Minnehaha,0514,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,428
+Minnehaha,0514,Supreme Court Retention,3,Patricia J. DeVaney - No,,169
+Minnehaha,0515,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,439
+Minnehaha,0515,Supreme Court Retention,3,Patricia J. DeVaney - No,,189
+Minnehaha,0517,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,362
+Minnehaha,0517,Supreme Court Retention,3,Patricia J. DeVaney - No,,79
+Minnehaha,0518,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,586
+Minnehaha,0518,Supreme Court Retention,3,Patricia J. DeVaney - No,,231
+Minnehaha,0519,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,310
+Minnehaha,0519,Supreme Court Retention,3,Patricia J. DeVaney - No,,74
+Minnehaha,0520,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,486
+Minnehaha,0520,Supreme Court Retention,3,Patricia J. DeVaney - No,,181
+Minnehaha,0521,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,267
+Minnehaha,0521,Supreme Court Retention,3,Patricia J. DeVaney - No,,69
+Minnehaha,0522,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,442
+Minnehaha,0522,Supreme Court Retention,3,Patricia J. DeVaney - No,,222
+Minnehaha,0523,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,383
+Minnehaha,0523,Supreme Court Retention,3,Patricia J. DeVaney - No,,145
+Minnehaha,VP01,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,495
+Minnehaha,VP01,Supreme Court Retention,3,Patricia J. DeVaney - No,,112
+Minnehaha,VP02,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1154
+Minnehaha,VP02,Supreme Court Retention,3,Patricia J. DeVaney - No,,221
+Minnehaha,VP03,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1379
+Minnehaha,VP03,Supreme Court Retention,3,Patricia J. DeVaney - No,,291
+Minnehaha,VP04,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,703
+Minnehaha,VP04,Supreme Court Retention,3,Patricia J. DeVaney - No,,176
+Minnehaha,VP05,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,923
+Minnehaha,VP05,Supreme Court Retention,3,Patricia J. DeVaney - No,,197
+Minnehaha,VP06,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,282
+Minnehaha,VP06,Supreme Court Retention,3,Patricia J. DeVaney - No,,58
+Minnehaha,VP07,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1167
+Minnehaha,VP07,Supreme Court Retention,3,Patricia J. DeVaney - No,,226
+Minnehaha,VP08,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,420
+Minnehaha,VP08,Supreme Court Retention,3,Patricia J. DeVaney - No,,82
+Minnehaha,VP09,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,847
+Minnehaha,VP09,Supreme Court Retention,3,Patricia J. DeVaney - No,,174
+Minnehaha,VP10,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,766
+Minnehaha,VP10,Supreme Court Retention,3,Patricia J. DeVaney - No,,167
+Minnehaha,VP11,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,201
+Minnehaha,VP11,Supreme Court Retention,3,Patricia J. DeVaney - No,,43
+Minnehaha,VP12,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,101
+Minnehaha,VP12,Supreme Court Retention,3,Patricia J. DeVaney - No,,6
+Minnehaha,VP13,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,586
+Minnehaha,VP13,Supreme Court Retention,3,Patricia J. DeVaney - No,,135
+Minnehaha,VP15,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1017
+Minnehaha,VP15,Supreme Court Retention,3,Patricia J. DeVaney - No,,194
+Minnehaha,VP16,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,666
+Minnehaha,VP16,Supreme Court Retention,3,Patricia J. DeVaney - No,,142
+Minnehaha,VP17,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,428
+Minnehaha,VP17,Supreme Court Retention,3,Patricia J. DeVaney - No,,85
+Minnehaha,VP21,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1156
+Minnehaha,VP21,Supreme Court Retention,3,Patricia J. DeVaney - No,,212
+Minnehaha,0104,Supreme Court Retention,2,Mark E. Salter - Yes,,423
+Minnehaha,0104,Supreme Court Retention,2,Mark E. Salter - No,,148
+Minnehaha,0105,Supreme Court Retention,2,Mark E. Salter - Yes,,289
+Minnehaha,0105,Supreme Court Retention,2,Mark E. Salter - No,,88
+Minnehaha,0106,Supreme Court Retention,2,Mark E. Salter - Yes,,653
+Minnehaha,0106,Supreme Court Retention,2,Mark E. Salter - No,,217
+Minnehaha,0109,Supreme Court Retention,2,Mark E. Salter - Yes,,703
+Minnehaha,0109,Supreme Court Retention,2,Mark E. Salter - No,,174
+Minnehaha,0110,Supreme Court Retention,2,Mark E. Salter - Yes,,723
+Minnehaha,0110,Supreme Court Retention,2,Mark E. Salter - No,,216
+Minnehaha,0117,Supreme Court Retention,2,Mark E. Salter - Yes,,793
+Minnehaha,0117,Supreme Court Retention,2,Mark E. Salter - No,,241
+Minnehaha,0119,Supreme Court Retention,2,Mark E. Salter - Yes,,349
+Minnehaha,0119,Supreme Court Retention,2,Mark E. Salter - No,,140
+Minnehaha,0201,Supreme Court Retention,2,Mark E. Salter - Yes,,743
+Minnehaha,0201,Supreme Court Retention,2,Mark E. Salter - No,,162
+Minnehaha,0202,Supreme Court Retention,2,Mark E. Salter - Yes,,1037
+Minnehaha,0202,Supreme Court Retention,2,Mark E. Salter - No,,159
+Minnehaha,0203,Supreme Court Retention,2,Mark E. Salter - Yes,,733
+Minnehaha,0203,Supreme Court Retention,2,Mark E. Salter - No,,192
+Minnehaha,0206,Supreme Court Retention,2,Mark E. Salter - Yes,,732
+Minnehaha,0206,Supreme Court Retention,2,Mark E. Salter - No,,162
+Minnehaha,0208,Supreme Court Retention,2,Mark E. Salter - Yes,,794
+Minnehaha,0208,Supreme Court Retention,2,Mark E. Salter - No,,142
+Minnehaha,0209,Supreme Court Retention,2,Mark E. Salter - Yes,,687
+Minnehaha,0209,Supreme Court Retention,2,Mark E. Salter - No,,178
+Minnehaha,0214,Supreme Court Retention,2,Mark E. Salter - Yes,,1931
+Minnehaha,0214,Supreme Court Retention,2,Mark E. Salter - No,,387
+Minnehaha,0301,Supreme Court Retention,2,Mark E. Salter - Yes,,541
+Minnehaha,0301,Supreme Court Retention,2,Mark E. Salter - No,,111
+Minnehaha,0305,Supreme Court Retention,2,Mark E. Salter - Yes,,326
+Minnehaha,0305,Supreme Court Retention,2,Mark E. Salter - No,,105
+Minnehaha,0309,Supreme Court Retention,2,Mark E. Salter - Yes,,664
+Minnehaha,0309,Supreme Court Retention,2,Mark E. Salter - No,,264
+Minnehaha,0310,Supreme Court Retention,2,Mark E. Salter - Yes,,1016
+Minnehaha,0310,Supreme Court Retention,2,Mark E. Salter - No,,200
+Minnehaha,0311,Supreme Court Retention,2,Mark E. Salter - Yes,,606
+Minnehaha,0311,Supreme Court Retention,2,Mark E. Salter - No,,138
+Minnehaha,0312,Supreme Court Retention,2,Mark E. Salter - Yes,,773
+Minnehaha,0312,Supreme Court Retention,2,Mark E. Salter - No,,210
+Minnehaha,0313,Supreme Court Retention,2,Mark E. Salter - Yes,,471
+Minnehaha,0313,Supreme Court Retention,2,Mark E. Salter - No,,136
+Minnehaha,0314,Supreme Court Retention,2,Mark E. Salter - Yes,,1093
+Minnehaha,0314,Supreme Court Retention,2,Mark E. Salter - No,,373
+Minnehaha,0315,Supreme Court Retention,2,Mark E. Salter - Yes,,722
+Minnehaha,0315,Supreme Court Retention,2,Mark E. Salter - No,,181
+Minnehaha,0316,Supreme Court Retention,2,Mark E. Salter - Yes,,1124
+Minnehaha,0316,Supreme Court Retention,2,Mark E. Salter - No,,288
+Minnehaha,0317,Supreme Court Retention,2,Mark E. Salter - Yes,,1376
+Minnehaha,0317,Supreme Court Retention,2,Mark E. Salter - No,,331
+Minnehaha,0402,Supreme Court Retention,2,Mark E. Salter - Yes,,383
+Minnehaha,0402,Supreme Court Retention,2,Mark E. Salter - No,,153
+Minnehaha,0403,Supreme Court Retention,2,Mark E. Salter - Yes,,241
+Minnehaha,0403,Supreme Court Retention,2,Mark E. Salter - No,,113
+Minnehaha,0404,Supreme Court Retention,2,Mark E. Salter - Yes,,393
+Minnehaha,0404,Supreme Court Retention,2,Mark E. Salter - No,,169
+Minnehaha,0405,Supreme Court Retention,2,Mark E. Salter - Yes,,928
+Minnehaha,0405,Supreme Court Retention,2,Mark E. Salter - No,,319
+Minnehaha,0406,Supreme Court Retention,2,Mark E. Salter - Yes,,174
+Minnehaha,0406,Supreme Court Retention,2,Mark E. Salter - No,,78
+Minnehaha,0407,Supreme Court Retention,2,Mark E. Salter - Yes,,816
+Minnehaha,0407,Supreme Court Retention,2,Mark E. Salter - No,,210
+Minnehaha,0408,Supreme Court Retention,2,Mark E. Salter - Yes,,201
+Minnehaha,0408,Supreme Court Retention,2,Mark E. Salter - No,,63
+Minnehaha,0409,Supreme Court Retention,2,Mark E. Salter - Yes,,423
+Minnehaha,0409,Supreme Court Retention,2,Mark E. Salter - No,,156
+Minnehaha,0410,Supreme Court Retention,2,Mark E. Salter - Yes,,476
+Minnehaha,0410,Supreme Court Retention,2,Mark E. Salter - No,,158
+Minnehaha,0411,Supreme Court Retention,2,Mark E. Salter - Yes,,1295
+Minnehaha,0411,Supreme Court Retention,2,Mark E. Salter - No,,275
+Minnehaha,0412,Supreme Court Retention,2,Mark E. Salter - Yes,,721
+Minnehaha,0412,Supreme Court Retention,2,Mark E. Salter - No,,236
+Minnehaha,0413,Supreme Court Retention,2,Mark E. Salter - Yes,,389
+Minnehaha,0413,Supreme Court Retention,2,Mark E. Salter - No,,128
+Minnehaha,0415,Supreme Court Retention,2,Mark E. Salter - Yes,,1409
+Minnehaha,0415,Supreme Court Retention,2,Mark E. Salter - No,,315
+Minnehaha,0501,Supreme Court Retention,2,Mark E. Salter - Yes,,237
+Minnehaha,0501,Supreme Court Retention,2,Mark E. Salter - No,,123
+Minnehaha,0502,Supreme Court Retention,2,Mark E. Salter - Yes,,342
+Minnehaha,0502,Supreme Court Retention,2,Mark E. Salter - No,,159
+Minnehaha,0503,Supreme Court Retention,2,Mark E. Salter - Yes,,175
+Minnehaha,0503,Supreme Court Retention,2,Mark E. Salter - No,,100
+Minnehaha,0504,Supreme Court Retention,2,Mark E. Salter - Yes,,490
+Minnehaha,0504,Supreme Court Retention,2,Mark E. Salter - No,,175
+Minnehaha,0506,Supreme Court Retention,2,Mark E. Salter - Yes,,552
+Minnehaha,0506,Supreme Court Retention,2,Mark E. Salter - No,,202
+Minnehaha,0507,Supreme Court Retention,2,Mark E. Salter - Yes,,349
+Minnehaha,0507,Supreme Court Retention,2,Mark E. Salter - No,,96
+Minnehaha,0508,Supreme Court Retention,2,Mark E. Salter - Yes,,550
+Minnehaha,0508,Supreme Court Retention,2,Mark E. Salter - No,,158
+Minnehaha,0509,Supreme Court Retention,2,Mark E. Salter - Yes,,207
+Minnehaha,0509,Supreme Court Retention,2,Mark E. Salter - No,,94
+Minnehaha,0510,Supreme Court Retention,2,Mark E. Salter - Yes,,315
+Minnehaha,0510,Supreme Court Retention,2,Mark E. Salter - No,,119
+Minnehaha,0512,Supreme Court Retention,2,Mark E. Salter - Yes,,390
+Minnehaha,0512,Supreme Court Retention,2,Mark E. Salter - No,,100
+Minnehaha,0513,Supreme Court Retention,2,Mark E. Salter - Yes,,399
+Minnehaha,0513,Supreme Court Retention,2,Mark E. Salter - No,,102
+Minnehaha,0514,Supreme Court Retention,2,Mark E. Salter - Yes,,425
+Minnehaha,0514,Supreme Court Retention,2,Mark E. Salter - No,,174
+Minnehaha,0515,Supreme Court Retention,2,Mark E. Salter - Yes,,443
+Minnehaha,0515,Supreme Court Retention,2,Mark E. Salter - No,,178
+Minnehaha,0517,Supreme Court Retention,2,Mark E. Salter - Yes,,357
+Minnehaha,0517,Supreme Court Retention,2,Mark E. Salter - No,,84
+Minnehaha,0518,Supreme Court Retention,2,Mark E. Salter - Yes,,577
+Minnehaha,0518,Supreme Court Retention,2,Mark E. Salter - No,,235
+Minnehaha,0519,Supreme Court Retention,2,Mark E. Salter - Yes,,315
+Minnehaha,0519,Supreme Court Retention,2,Mark E. Salter - No,,77
+Minnehaha,0520,Supreme Court Retention,2,Mark E. Salter - Yes,,486
+Minnehaha,0520,Supreme Court Retention,2,Mark E. Salter - No,,185
+Minnehaha,0521,Supreme Court Retention,2,Mark E. Salter - Yes,,264
+Minnehaha,0521,Supreme Court Retention,2,Mark E. Salter - No,,75
+Minnehaha,0522,Supreme Court Retention,2,Mark E. Salter - Yes,,428
+Minnehaha,0522,Supreme Court Retention,2,Mark E. Salter - No,,224
+Minnehaha,0523,Supreme Court Retention,2,Mark E. Salter - Yes,,367
+Minnehaha,0523,Supreme Court Retention,2,Mark E. Salter - No,,157
+Minnehaha,VP01,Supreme Court Retention,2,Mark E. Salter - Yes,,506
+Minnehaha,VP01,Supreme Court Retention,2,Mark E. Salter - No,,98
+Minnehaha,VP02,Supreme Court Retention,2,Mark E. Salter - Yes,,1171
+Minnehaha,VP02,Supreme Court Retention,2,Mark E. Salter - No,,214
+Minnehaha,VP03,Supreme Court Retention,2,Mark E. Salter - Yes,,1389
+Minnehaha,VP03,Supreme Court Retention,2,Mark E. Salter - No,,285
+Minnehaha,VP04,Supreme Court Retention,2,Mark E. Salter - Yes,,706
+Minnehaha,VP04,Supreme Court Retention,2,Mark E. Salter - No,,163
+Minnehaha,VP05,Supreme Court Retention,2,Mark E. Salter - Yes,,941
+Minnehaha,VP05,Supreme Court Retention,2,Mark E. Salter - No,,183
+Minnehaha,VP06,Supreme Court Retention,2,Mark E. Salter - Yes,,288
+Minnehaha,VP06,Supreme Court Retention,2,Mark E. Salter - No,,58
+Minnehaha,VP07,Supreme Court Retention,2,Mark E. Salter - Yes,,1149
+Minnehaha,VP07,Supreme Court Retention,2,Mark E. Salter - No,,234
+Minnehaha,VP08,Supreme Court Retention,2,Mark E. Salter - Yes,,414
+Minnehaha,VP08,Supreme Court Retention,2,Mark E. Salter - No,,84
+Minnehaha,VP09,Supreme Court Retention,2,Mark E. Salter - Yes,,844
+Minnehaha,VP09,Supreme Court Retention,2,Mark E. Salter - No,,169
+Minnehaha,VP10,Supreme Court Retention,2,Mark E. Salter - Yes,,761
+Minnehaha,VP10,Supreme Court Retention,2,Mark E. Salter - No,,167
+Minnehaha,VP11,Supreme Court Retention,2,Mark E. Salter - Yes,,199
+Minnehaha,VP11,Supreme Court Retention,2,Mark E. Salter - No,,41
+Minnehaha,VP12,Supreme Court Retention,2,Mark E. Salter - Yes,,97
+Minnehaha,VP12,Supreme Court Retention,2,Mark E. Salter - No,,8
+Minnehaha,VP13,Supreme Court Retention,2,Mark E. Salter - Yes,,582
+Minnehaha,VP13,Supreme Court Retention,2,Mark E. Salter - No,,133
+Minnehaha,VP15,Supreme Court Retention,2,Mark E. Salter - Yes,,1013
+Minnehaha,VP15,Supreme Court Retention,2,Mark E. Salter - No,,197
+Minnehaha,VP16,Supreme Court Retention,2,Mark E. Salter - Yes,,673
+Minnehaha,VP16,Supreme Court Retention,2,Mark E. Salter - No,,134
+Minnehaha,VP17,Supreme Court Retention,2,Mark E. Salter - Yes,,427
+Minnehaha,VP17,Supreme Court Retention,2,Mark E. Salter - No,,80
+Minnehaha,VP21,Supreme Court Retention,2,Mark E. Salter - Yes,,1140
+Minnehaha,VP21,Supreme Court Retention,2,Mark E. Salter - No,,209
+Minnehaha,0104,Constitutional Amendment D,,Yes,,547
+Minnehaha,0104,Constitutional Amendment D,,No,,170
+Minnehaha,0105,Constitutional Amendment D,,Yes,,345
+Minnehaha,0105,Constitutional Amendment D,,No,,111
+Minnehaha,0106,Constitutional Amendment D,,Yes,,719
+Minnehaha,0106,Constitutional Amendment D,,No,,357
+Minnehaha,0109,Constitutional Amendment D,,Yes,,720
+Minnehaha,0109,Constitutional Amendment D,,No,,341
+Minnehaha,0110,Constitutional Amendment D,,Yes,,779
+Minnehaha,0110,Constitutional Amendment D,,No,,375
+Minnehaha,0117,Constitutional Amendment D,,Yes,,789
+Minnehaha,0117,Constitutional Amendment D,,No,,528
+Minnehaha,0119,Constitutional Amendment D,,Yes,,411
+Minnehaha,0119,Constitutional Amendment D,,No,,198
+Minnehaha,0201,Constitutional Amendment D,,Yes,,722
+Minnehaha,0201,Constitutional Amendment D,,No,,376
+Minnehaha,0202,Constitutional Amendment D,,Yes,,940
+Minnehaha,0202,Constitutional Amendment D,,No,,504
+Minnehaha,0203,Constitutional Amendment D,,Yes,,731
+Minnehaha,0203,Constitutional Amendment D,,No,,362
+Minnehaha,0206,Constitutional Amendment D,,Yes,,766
+Minnehaha,0206,Constitutional Amendment D,,No,,374
+Minnehaha,0208,Constitutional Amendment D,,Yes,,739
+Minnehaha,0208,Constitutional Amendment D,,No,,426
+Minnehaha,0209,Constitutional Amendment D,,Yes,,704
+Minnehaha,0209,Constitutional Amendment D,,No,,352
+Minnehaha,0214,Constitutional Amendment D,,Yes,,1760
+Minnehaha,0214,Constitutional Amendment D,,No,,1085
+Minnehaha,0301,Constitutional Amendment D,,Yes,,517
+Minnehaha,0301,Constitutional Amendment D,,No,,261
+Minnehaha,0305,Constitutional Amendment D,,Yes,,368
+Minnehaha,0305,Constitutional Amendment D,,No,,169
+Minnehaha,0309,Constitutional Amendment D,,Yes,,809
+Minnehaha,0309,Constitutional Amendment D,,No,,312
+Minnehaha,0310,Constitutional Amendment D,,Yes,,856
+Minnehaha,0310,Constitutional Amendment D,,No,,597
+Minnehaha,0311,Constitutional Amendment D,,Yes,,548
+Minnehaha,0311,Constitutional Amendment D,,No,,369
+Minnehaha,0312,Constitutional Amendment D,,Yes,,755
+Minnehaha,0312,Constitutional Amendment D,,No,,437
+Minnehaha,0313,Constitutional Amendment D,,Yes,,453
+Minnehaha,0313,Constitutional Amendment D,,No,,287
+Minnehaha,0314,Constitutional Amendment D,,Yes,,1115
+Minnehaha,0314,Constitutional Amendment D,,No,,658
+Minnehaha,0315,Constitutional Amendment D,,Yes,,750
+Minnehaha,0315,Constitutional Amendment D,,No,,358
+Minnehaha,0316,Constitutional Amendment D,,Yes,,1084
+Minnehaha,0316,Constitutional Amendment D,,No,,658
+Minnehaha,0317,Constitutional Amendment D,,Yes,,1280
+Minnehaha,0317,Constitutional Amendment D,,No,,807
+Minnehaha,0402,Constitutional Amendment D,,Yes,,476
+Minnehaha,0402,Constitutional Amendment D,,No,,177
+Minnehaha,0403,Constitutional Amendment D,,Yes,,312
+Minnehaha,0403,Constitutional Amendment D,,No,,116
+Minnehaha,0404,Constitutional Amendment D,,Yes,,507
+Minnehaha,0404,Constitutional Amendment D,,No,,170
+Minnehaha,0405,Constitutional Amendment D,,Yes,,891
+Minnehaha,0405,Constitutional Amendment D,,No,,652
+Minnehaha,0406,Constitutional Amendment D,,Yes,,211
+Minnehaha,0406,Constitutional Amendment D,,No,,75
+Minnehaha,0407,Constitutional Amendment D,,Yes,,807
+Minnehaha,0407,Constitutional Amendment D,,No,,445
+Minnehaha,0408,Constitutional Amendment D,,Yes,,218
+Minnehaha,0408,Constitutional Amendment D,,No,,95
+Minnehaha,0409,Constitutional Amendment D,,Yes,,500
+Minnehaha,0409,Constitutional Amendment D,,No,,205
+Minnehaha,0410,Constitutional Amendment D,,Yes,,509
+Minnehaha,0410,Constitutional Amendment D,,No,,265
+Minnehaha,0411,Constitutional Amendment D,,Yes,,1175
+Minnehaha,0411,Constitutional Amendment D,,No,,777
+Minnehaha,0412,Constitutional Amendment D,,Yes,,796
+Minnehaha,0412,Constitutional Amendment D,,No,,385
+Minnehaha,0413,Constitutional Amendment D,,Yes,,450
+Minnehaha,0413,Constitutional Amendment D,,No,,180
+Minnehaha,0415,Constitutional Amendment D,,Yes,,1261
+Minnehaha,0415,Constitutional Amendment D,,No,,839
+Minnehaha,0501,Constitutional Amendment D,,Yes,,336
+Minnehaha,0501,Constitutional Amendment D,,No,,102
+Minnehaha,0502,Constitutional Amendment D,,Yes,,520
+Minnehaha,0502,Constitutional Amendment D,,No,,123
+Minnehaha,0503,Constitutional Amendment D,,Yes,,279
+Minnehaha,0503,Constitutional Amendment D,,No,,64
+Minnehaha,0504,Constitutional Amendment D,,Yes,,661
+Minnehaha,0504,Constitutional Amendment D,,No,,181
+Minnehaha,0506,Constitutional Amendment D,,Yes,,678
+Minnehaha,0506,Constitutional Amendment D,,No,,247
+Minnehaha,0507,Constitutional Amendment D,,Yes,,429
+Minnehaha,0507,Constitutional Amendment D,,No,,131
+Minnehaha,0508,Constitutional Amendment D,,Yes,,662
+Minnehaha,0508,Constitutional Amendment D,,No,,237
+Minnehaha,0509,Constitutional Amendment D,,Yes,,308
+Minnehaha,0509,Constitutional Amendment D,,No,,68
+Minnehaha,0510,Constitutional Amendment D,,Yes,,397
+Minnehaha,0510,Constitutional Amendment D,,No,,137
+Minnehaha,0512,Constitutional Amendment D,,Yes,,458
+Minnehaha,0512,Constitutional Amendment D,,No,,168
+Minnehaha,0513,Constitutional Amendment D,,Yes,,469
+Minnehaha,0513,Constitutional Amendment D,,No,,161
+Minnehaha,0514,Constitutional Amendment D,,Yes,,551
+Minnehaha,0514,Constitutional Amendment D,,No,,197
+Minnehaha,0515,Constitutional Amendment D,,Yes,,467
+Minnehaha,0515,Constitutional Amendment D,,No,,292
+Minnehaha,0517,Constitutional Amendment D,,Yes,,359
+Minnehaha,0517,Constitutional Amendment D,,No,,158
+Minnehaha,0518,Constitutional Amendment D,,Yes,,757
+Minnehaha,0518,Constitutional Amendment D,,No,,243
+Minnehaha,0519,Constitutional Amendment D,,Yes,,340
+Minnehaha,0519,Constitutional Amendment D,,No,,169
+Minnehaha,0520,Constitutional Amendment D,,Yes,,591
+Minnehaha,0520,Constitutional Amendment D,,No,,239
+Minnehaha,0521,Constitutional Amendment D,,Yes,,290
+Minnehaha,0521,Constitutional Amendment D,,No,,127
+Minnehaha,0522,Constitutional Amendment D,,Yes,,605
+Minnehaha,0522,Constitutional Amendment D,,No,,202
+Minnehaha,0523,Constitutional Amendment D,,Yes,,474
+Minnehaha,0523,Constitutional Amendment D,,No,,153
+Minnehaha,VP01,Constitutional Amendment D,,Yes,,367
+Minnehaha,VP01,Constitutional Amendment D,,No,,371
+Minnehaha,VP02,Constitutional Amendment D,,Yes,,863
+Minnehaha,VP02,Constitutional Amendment D,,No,,829
+Minnehaha,VP03,Constitutional Amendment D,,Yes,,1019
+Minnehaha,VP03,Constitutional Amendment D,,No,,972
+Minnehaha,VP04,Constitutional Amendment D,,Yes,,540
+Minnehaha,VP04,Constitutional Amendment D,,No,,504
+Minnehaha,VP05,Constitutional Amendment D,,Yes,,767
+Minnehaha,VP05,Constitutional Amendment D,,No,,615
+Minnehaha,VP06,Constitutional Amendment D,,Yes,,239
+Minnehaha,VP06,Constitutional Amendment D,,No,,196
+Minnehaha,VP07,Constitutional Amendment D,,Yes,,887
+Minnehaha,VP07,Constitutional Amendment D,,No,,750
+Minnehaha,VP08,Constitutional Amendment D,,Yes,,310
+Minnehaha,VP08,Constitutional Amendment D,,No,,318
+Minnehaha,VP09,Constitutional Amendment D,,Yes,,633
+Minnehaha,VP09,Constitutional Amendment D,,No,,605
+Minnehaha,VP10,Constitutional Amendment D,,Yes,,635
+Minnehaha,VP10,Constitutional Amendment D,,No,,480
+Minnehaha,VP11,Constitutional Amendment D,,Yes,,123
+Minnehaha,VP11,Constitutional Amendment D,,No,,175
+Minnehaha,VP12,Constitutional Amendment D,,Yes,,52
+Minnehaha,VP12,Constitutional Amendment D,,No,,72
+Minnehaha,VP13,Constitutional Amendment D,,Yes,,418
+Minnehaha,VP13,Constitutional Amendment D,,No,,459
+Minnehaha,VP15,Constitutional Amendment D,,Yes,,820
+Minnehaha,VP15,Constitutional Amendment D,,No,,652
+Minnehaha,VP16,Constitutional Amendment D,,Yes,,539
+Minnehaha,VP16,Constitutional Amendment D,,No,,487
+Minnehaha,VP17,Constitutional Amendment D,,Yes,,309
+Minnehaha,VP17,Constitutional Amendment D,,No,,316
+Minnehaha,VP21,Constitutional Amendment D,,Yes,,880
+Minnehaha,VP21,Constitutional Amendment D,,No,,729
+Minnehaha,0104,Initiated Measure 27,,Yes,,421
+Minnehaha,0104,Initiated Measure 27,,No,,306
+Minnehaha,0105,Initiated Measure 27,,Yes,,247
+Minnehaha,0105,Initiated Measure 27,,No,,210
+Minnehaha,0106,Initiated Measure 27,,Yes,,577
+Minnehaha,0106,Initiated Measure 27,,No,,519
+Minnehaha,0109,Initiated Measure 27,,Yes,,579
+Minnehaha,0109,Initiated Measure 27,,No,,498
+Minnehaha,0110,Initiated Measure 27,,Yes,,696
+Minnehaha,0110,Initiated Measure 27,,No,,490
+Minnehaha,0117,Initiated Measure 27,,Yes,,754
+Minnehaha,0117,Initiated Measure 27,,No,,589
+Minnehaha,0119,Initiated Measure 27,,Yes,,415
+Minnehaha,0119,Initiated Measure 27,,No,,204
+Minnehaha,0201,Initiated Measure 27,,Yes,,557
+Minnehaha,0201,Initiated Measure 27,,No,,558
+Minnehaha,0202,Initiated Measure 27,,Yes,,750
+Minnehaha,0202,Initiated Measure 27,,No,,711
+Minnehaha,0203,Initiated Measure 27,,Yes,,606
+Minnehaha,0203,Initiated Measure 27,,No,,508
+Minnehaha,0206,Initiated Measure 27,,Yes,,620
+Minnehaha,0206,Initiated Measure 27,,No,,542
+Minnehaha,0208,Initiated Measure 27,,Yes,,540
+Minnehaha,0208,Initiated Measure 27,,No,,636
+Minnehaha,0209,Initiated Measure 27,,Yes,,580
+Minnehaha,0209,Initiated Measure 27,,No,,494
+Minnehaha,0214,Initiated Measure 27,,Yes,,1471
+Minnehaha,0214,Initiated Measure 27,,No,,1425
+Minnehaha,0301,Initiated Measure 27,,Yes,,410
+Minnehaha,0301,Initiated Measure 27,,No,,379
+Minnehaha,0305,Initiated Measure 27,,Yes,,353
+Minnehaha,0305,Initiated Measure 27,,No,,186
+Minnehaha,0309,Initiated Measure 27,,Yes,,758
+Minnehaha,0309,Initiated Measure 27,,No,,384
+Minnehaha,0310,Initiated Measure 27,,Yes,,693
+Minnehaha,0310,Initiated Measure 27,,No,,770
+Minnehaha,0311,Initiated Measure 27,,Yes,,435
+Minnehaha,0311,Initiated Measure 27,,No,,500
+Minnehaha,0312,Initiated Measure 27,,Yes,,694
+Minnehaha,0312,Initiated Measure 27,,No,,525
+Minnehaha,0313,Initiated Measure 27,,Yes,,395
+Minnehaha,0313,Initiated Measure 27,,No,,349
+Minnehaha,0314,Initiated Measure 27,,Yes,,1088
+Minnehaha,0314,Initiated Measure 27,,No,,718
+Minnehaha,0315,Initiated Measure 27,,Yes,,608
+Minnehaha,0315,Initiated Measure 27,,No,,510
+Minnehaha,0316,Initiated Measure 27,,Yes,,971
+Minnehaha,0316,Initiated Measure 27,,No,,816
+Minnehaha,0317,Initiated Measure 27,,Yes,,1179
+Minnehaha,0317,Initiated Measure 27,,No,,946
+Minnehaha,0402,Initiated Measure 27,,Yes,,443
+Minnehaha,0402,Initiated Measure 27,,No,,219
+Minnehaha,0403,Initiated Measure 27,,Yes,,304
+Minnehaha,0403,Initiated Measure 27,,No,,134
+Minnehaha,0404,Initiated Measure 27,,Yes,,499
+Minnehaha,0404,Initiated Measure 27,,No,,197
+Minnehaha,0405,Initiated Measure 27,,Yes,,946
+Minnehaha,0405,Initiated Measure 27,,No,,610
+Minnehaha,0406,Initiated Measure 27,,Yes,,189
+Minnehaha,0406,Initiated Measure 27,,No,,101
+Minnehaha,0407,Initiated Measure 27,,Yes,,691
+Minnehaha,0407,Initiated Measure 27,,No,,589
+Minnehaha,0408,Initiated Measure 27,,Yes,,211
+Minnehaha,0408,Initiated Measure 27,,No,,107
+Minnehaha,0409,Initiated Measure 27,,Yes,,497
+Minnehaha,0409,Initiated Measure 27,,No,,224
+Minnehaha,0410,Initiated Measure 27,,Yes,,443
+Minnehaha,0410,Initiated Measure 27,,No,,341
+Minnehaha,0411,Initiated Measure 27,,Yes,,1015
+Minnehaha,0411,Initiated Measure 27,,No,,976
+Minnehaha,0412,Initiated Measure 27,,Yes,,704
+Minnehaha,0412,Initiated Measure 27,,No,,502
+Minnehaha,0413,Initiated Measure 27,,Yes,,389
+Minnehaha,0413,Initiated Measure 27,,No,,249
+Minnehaha,0415,Initiated Measure 27,,Yes,,1030
+Minnehaha,0415,Initiated Measure 27,,No,,1115
+Minnehaha,0501,Initiated Measure 27,,Yes,,327
+Minnehaha,0501,Initiated Measure 27,,No,,114
+Minnehaha,0502,Initiated Measure 27,,Yes,,484
+Minnehaha,0502,Initiated Measure 27,,No,,169
+Minnehaha,0503,Initiated Measure 27,,Yes,,256
+Minnehaha,0503,Initiated Measure 27,,No,,89
+Minnehaha,0504,Initiated Measure 27,,Yes,,597
+Minnehaha,0504,Initiated Measure 27,,No,,259
+Minnehaha,0506,Initiated Measure 27,,Yes,,602
+Minnehaha,0506,Initiated Measure 27,,No,,330
+Minnehaha,0507,Initiated Measure 27,,Yes,,372
+Minnehaha,0507,Initiated Measure 27,,No,,200
+Minnehaha,0508,Initiated Measure 27,,Yes,,589
+Minnehaha,0508,Initiated Measure 27,,No,,330
+Minnehaha,0509,Initiated Measure 27,,Yes,,291
+Minnehaha,0509,Initiated Measure 27,,No,,96
+Minnehaha,0510,Initiated Measure 27,,Yes,,355
+Minnehaha,0510,Initiated Measure 27,,No,,189
+Minnehaha,0512,Initiated Measure 27,,Yes,,408
+Minnehaha,0512,Initiated Measure 27,,No,,225
+Minnehaha,0513,Initiated Measure 27,,Yes,,419
+Minnehaha,0513,Initiated Measure 27,,No,,227
+Minnehaha,0514,Initiated Measure 27,,Yes,,519
+Minnehaha,0514,Initiated Measure 27,,No,,245
+Minnehaha,0515,Initiated Measure 27,,Yes,,508
+Minnehaha,0515,Initiated Measure 27,,No,,267
+Minnehaha,0517,Initiated Measure 27,,Yes,,282
+Minnehaha,0517,Initiated Measure 27,,No,,248
+Minnehaha,0518,Initiated Measure 27,,Yes,,673
+Minnehaha,0518,Initiated Measure 27,,No,,348
+Minnehaha,0519,Initiated Measure 27,,Yes,,292
+Minnehaha,0519,Initiated Measure 27,,No,,226
+Minnehaha,0520,Initiated Measure 27,,Yes,,534
+Minnehaha,0520,Initiated Measure 27,,No,,310
+Minnehaha,0521,Initiated Measure 27,,Yes,,269
+Minnehaha,0521,Initiated Measure 27,,No,,150
+Minnehaha,0522,Initiated Measure 27,,Yes,,598
+Minnehaha,0522,Initiated Measure 27,,No,,215
+Minnehaha,0523,Initiated Measure 27,,Yes,,462
+Minnehaha,0523,Initiated Measure 27,,No,,174
+Minnehaha,VP01,Initiated Measure 27,,Yes,,327
+Minnehaha,VP01,Initiated Measure 27,,No,,417
+Minnehaha,VP02,Initiated Measure 27,,Yes,,662
+Minnehaha,VP02,Initiated Measure 27,,No,,1046
+Minnehaha,VP03,Initiated Measure 27,,Yes,,953
+Minnehaha,VP03,Initiated Measure 27,,No,,1079
+Minnehaha,VP04,Initiated Measure 27,,Yes,,507
+Minnehaha,VP04,Initiated Measure 27,,No,,560
+Minnehaha,VP05,Initiated Measure 27,,Yes,,668
+Minnehaha,VP05,Initiated Measure 27,,No,,733
+Minnehaha,VP06,Initiated Measure 27,,Yes,,199
+Minnehaha,VP06,Initiated Measure 27,,No,,239
+Minnehaha,VP07,Initiated Measure 27,,Yes,,732
+Minnehaha,VP07,Initiated Measure 27,,No,,932
+Minnehaha,VP08,Initiated Measure 27,,Yes,,264
+Minnehaha,VP08,Initiated Measure 27,,No,,376
+Minnehaha,VP09,Initiated Measure 27,,Yes,,615
+Minnehaha,VP09,Initiated Measure 27,,No,,648
+Minnehaha,VP10,Initiated Measure 27,,Yes,,540
+Minnehaha,VP10,Initiated Measure 27,,No,,595
+Minnehaha,VP11,Initiated Measure 27,,Yes,,101
+Minnehaha,VP11,Initiated Measure 27,,No,,196
+Minnehaha,VP12,Initiated Measure 27,,Yes,,45
+Minnehaha,VP12,Initiated Measure 27,,No,,79
+Minnehaha,VP13,Initiated Measure 27,,Yes,,335
+Minnehaha,VP13,Initiated Measure 27,,No,,554
+Minnehaha,VP15,Initiated Measure 27,,Yes,,700
+Minnehaha,VP15,Initiated Measure 27,,No,,793
+Minnehaha,VP16,Initiated Measure 27,,Yes,,489
+Minnehaha,VP16,Initiated Measure 27,,No,,558
+Minnehaha,VP17,Initiated Measure 27,,Yes,,236
+Minnehaha,VP17,Initiated Measure 27,,No,,397
+Minnehaha,VP21,Initiated Measure 27,,Yes,,728
+Minnehaha,VP21,Initiated Measure 27,,No,,898
+Minnehaha,0104,State Senate,12,Jessica Meyers,DEM,386
+Minnehaha,0104,State Senate,12,Arch Beal,REP,301
+Minnehaha,0105,State Senate,12,Jessica Meyers,DEM,216
+Minnehaha,0105,State Senate,12,Arch Beal,REP,219
+Minnehaha,0301 Precinct-0305,State Senate,12,Jessica Meyers,DEM,344
+Minnehaha,0301 Precinct-0305,State Senate,12,Arch Beal,REP,422
+Minnehaha,0402,State Senate,10,Liz Larson,DEM,353
+Minnehaha,0402,State Senate,10,Maggie Sutton,REP,268
+Minnehaha,0403,State Senate,10,Liz Larson,DEM,218
+Minnehaha,0403,State Senate,10,Maggie Sutton,REP,199
+Minnehaha,0404,State Senate,10,Liz Larson,DEM,351
+Minnehaha,0404,State Senate,10,Maggie Sutton,REP,296
+Minnehaha,0405 Precinct-0406,State Senate,10,Liz Larson,DEM,133
+Minnehaha,0405 Precinct-0406,State Senate,10,Maggie Sutton,REP,109
+Minnehaha,0407,State Senate,10,Liz Larson,DEM,601
+Minnehaha,0407,State Senate,10,Maggie Sutton,REP,621
+Minnehaha,0408,State Senate,10,Liz Larson,DEM,180
+Minnehaha,0408,State Senate,10,Maggie Sutton,REP,127
+Minnehaha,0409,State Senate,10,Liz Larson,DEM,362
+Minnehaha,0409,State Senate,10,Maggie Sutton,REP,314
+Minnehaha,0410,State Senate,10,Liz Larson,DEM,204
+Minnehaha,0410,State Senate,10,Maggie Sutton,REP,212
+Minnehaha,0502,State Senate,10,Liz Larson,DEM,125
+Minnehaha,0502,State Senate,10,Maggie Sutton,REP,47
+Minnehaha,0503,State Senate,12,Jessica Meyers,DEM,159
+Minnehaha,0503,State Senate,12,Arch Beal,REP,111
+Minnehaha,0504,State Senate,10,Liz Larson,DEM,541
+Minnehaha,0504,State Senate,10,Maggie Sutton,REP,274
+Minnehaha,0506,State Senate,10,Liz Larson,DEM,505
+Minnehaha,0506,State Senate,10,Maggie Sutton,REP,390
+Minnehaha,0507,State Senate,10,Liz Larson,DEM,342
+Minnehaha,0507,State Senate,10,Maggie Sutton,REP,206
+Minnehaha,0508,State Senate,10,Liz Larson,DEM,546
+Minnehaha,0508,State Senate,10,Maggie Sutton,REP,326
+Minnehaha,0509,State Senate,12,Jessica Meyers,DEM,235
+Minnehaha,0509,State Senate,12,Arch Beal,REP,119
+Minnehaha,0510 Precinct-0512,State Senate,12,Jessica Meyers,DEM,274
+Minnehaha,0510 Precinct-0512,State Senate,12,Arch Beal,REP,239
+Minnehaha,0513 Precinct-0514 Precinct-0515,State Senate,12,Jessica Meyers,DEM,206
+Minnehaha,0513 Precinct-0514 Precinct-0515,State Senate,12,Arch Beal,REP,159
+Minnehaha,0517 Precinct-0518,State Senate,12,Jessica Meyers,DEM,245
+Minnehaha,0517 Precinct-0518,State Senate,12,Arch Beal,REP,259
+Minnehaha,0519,State Senate,12,Jessica Meyers,DEM,256
+Minnehaha,0519,State Senate,12,Arch Beal,REP,250
+Minnehaha,0520 Precinct-0521 Precinct-0522,State Senate,12,Jessica Meyers,DEM,223
+Minnehaha,0520 Precinct-0521 Precinct-0522,State Senate,12,Arch Beal,REP,185
+Minnehaha,VP02,State Senate,10,Liz Larson,DEM,27
+Minnehaha,VP02,State Senate,10,Maggie Sutton,REP,40
+Minnehaha,0104 Precinct-0105 Precinct-0106 Precinct-0109 Precinct-0110 Precinct-0117 Precinct-0119,State Senate,13,Jack Kolbeck,REP,292
+Minnehaha,0104 Precinct-0105 Precinct-0106 Precinct-0109 Precinct-0110 Precinct-0117 Precinct-0119,State Senate,13,Lora Hubbel,IND,249
+Minnehaha,0201,State Senate,13,Jack Kolbeck,REP,679
+Minnehaha,0201,State Senate,13,Lora Hubbel,IND,300
+Minnehaha,0202,State Senate,14,Matthew Tysdal,DEM,658
+Minnehaha,0202,State Senate,14,Larry P. Zikmund,REP,752
+Minnehaha,0203,State Senate,14,Matthew Tysdal,DEM,497
+Minnehaha,0203,State Senate,14,Larry P. Zikmund,REP,564
+Minnehaha,0206,State Senate,14,Matthew Tysdal,DEM,509
+Minnehaha,0206,State Senate,14,Larry P. Zikmund,REP,596
+Minnehaha,0208,State Senate,14,Matthew Tysdal,DEM,500
+Minnehaha,0208,State Senate,14,Larry P. Zikmund,REP,626
+Minnehaha,0209,State Senate,14,Matthew Tysdal,DEM,486
+Minnehaha,0209,State Senate,14,Larry P. Zikmund,REP,537
+Minnehaha,0214 Precinct-0301,State Senate,14,Matthew Tysdal,DEM,894
+Minnehaha,0214 Precinct-0301,State Senate,14,Larry P. Zikmund,REP,1146
+Minnehaha,0305 Precinct-0309 Precinct-0310 Precinct-0311,State Senate,15,Reynold F. Nesiba,DEM,232
+Minnehaha,0305 Precinct-0309 Precinct-0310 Precinct-0311,State Senate,15,Brenda Lawrence,REP,252
+Minnehaha,0402 Precinct-0403 Precinct-0404 Precinct-0405,State Senate,15,Reynold F. Nesiba,DEM,520
+Minnehaha,0402 Precinct-0403 Precinct-0404 Precinct-0405,State Senate,15,Brenda Lawrence,REP,833
+Minnehaha,0410 Precinct-0411 Precinct-0412,State Senate,14,Matthew Tysdal,DEM,571
+Minnehaha,0410 Precinct-0411 Precinct-0412,State Senate,14,Larry P. Zikmund,REP,560
+Minnehaha,0413,State Senate,14,Matthew Tysdal,DEM,319
+Minnehaha,0413,State Senate,14,Larry P. Zikmund,REP,291
+Minnehaha,0415,State Senate,14,Matthew Tysdal,DEM,566
+Minnehaha,0415,State Senate,14,Larry P. Zikmund,REP,775
+Minnehaha,0501,State Senate,15,Reynold F. Nesiba,DEM,245
+Minnehaha,0501,State Senate,15,Brenda Lawrence,REP,169
+Minnehaha,0502,State Senate,15,Reynold F. Nesiba,DEM,301
+Minnehaha,0502,State Senate,15,Brenda Lawrence,REP,151
+Minnehaha,0503 Precinct-0504 Precinct-0506 Precinct-0507,State Senate,15,Reynold F. Nesiba,DEM,40
+Minnehaha,0503 Precinct-0504 Precinct-0506 Precinct-0507,State Senate,15,Brenda Lawrence,REP,18
+Minnehaha,0508 Precinct-0509 Precinct-0510 Precinct-0512,State Senate,13,Jack Kolbeck,REP,312
+Minnehaha,0508 Precinct-0509 Precinct-0510 Precinct-0512,State Senate,13,Lora Hubbel,IND,215
+Minnehaha,0513,State Senate,13,Jack Kolbeck,REP,352
+Minnehaha,0513,State Senate,13,Lora Hubbel,IND,190
+Minnehaha,0514,State Senate,15,Reynold F. Nesiba,DEM,231
+Minnehaha,0514,State Senate,15,Brenda Lawrence,REP,132
+Minnehaha,0515,State Senate,15,Reynold F. Nesiba,DEM,333
+Minnehaha,0515,State Senate,15,Brenda Lawrence,REP,405
+Minnehaha,0517 Precinct-0518 Precinct-0519,State Senate,15,Reynold F. Nesiba,DEM,570
+Minnehaha,0517 Precinct-0518 Precinct-0519,State Senate,15,Brenda Lawrence,REP,388
+Minnehaha,0520 Precinct-0521,State Senate,15,Reynold F. Nesiba,DEM,415
+Minnehaha,0520 Precinct-0521,State Senate,15,Brenda Lawrence,REP,378
+Minnehaha,0522,State Senate,15,Reynold F. Nesiba,DEM,440
+Minnehaha,0522,State Senate,15,Brenda Lawrence,REP,317
+Minnehaha,0523,State Senate,15,Reynold F. Nesiba,DEM,364
+Minnehaha,0523,State Senate,15,Brenda Lawrence,REP,239
+Minnehaha,VP02,State Senate,14,Matthew Tysdal,DEM,1
+Minnehaha,VP02,State Senate,14,Larry P. Zikmund,REP,7
+Minnehaha,VP04 20 of 65,State Senate,15,Reynold F. Nesiba,DEM,6
+Minnehaha,VP04 20 of 65,State Senate,15,Brenda Lawrence,REP,28
+Minnehaha,0104 Precinct-0105 Precinct-0106 Precinct-0109 Precinct-0110 Precinct-0117 Precinct-0119 Precinct-0201 Precinct-0202 Precinct-0203,State House,09,Nick Winkler,DEM,2
+Minnehaha,0104 Precinct-0105 Precinct-0106 Precinct-0109 Precinct-0110 Precinct-0117 Precinct-0119 Precinct-0201 Precinct-0202 Precinct-0203,State House,09,Kenneth Teunissen,REP,2
+Minnehaha,0104 Precinct-0105 Precinct-0106 Precinct-0109 Precinct-0110 Precinct-0117 Precinct-0119 Precinct-0201 Precinct-0202 Precinct-0203,State House,09,Bethany Soye,REP,2
+Minnehaha,0206 Precinct-0208 Precinct-0209 Precinct-0214 Precinct-0301 Precinct-0305 Precinct-0309,State House,02,Gary Leighton,DEM,287
+Minnehaha,0206 Precinct-0208 Precinct-0209 Precinct-0214 Precinct-0301 Precinct-0305 Precinct-0309,State House,02,John Sjaarda,REP,332
+Minnehaha,0206 Precinct-0208 Precinct-0209 Precinct-0214 Precinct-0301 Precinct-0305 Precinct-0309,State House,02,David Kull,REP,363
+Minnehaha,0310 Precinct-0311 Precinct-0312,State House,09,Nick Winkler,DEM,401
+Minnehaha,0310 Precinct-0311 Precinct-0312,State House,09,Kenneth Teunissen,REP,514
+Minnehaha,0310 Precinct-0311 Precinct-0312,State House,09,Bethany Soye,REP,649
+Minnehaha,0313 Precinct-0314 Precinct-0315,State House,09,Nick Winkler,DEM,642
+Minnehaha,0313 Precinct-0314 Precinct-0315,State House,09,Kenneth Teunissen,REP,603
+Minnehaha,0313 Precinct-0314 Precinct-0315,State House,09,Bethany Soye,REP,773
+Minnehaha,0316,State House,09,Nick Winkler,DEM,627
+Minnehaha,0316,State House,09,Kenneth Teunissen,REP,806
+Minnehaha,0316,State House,09,Bethany Soye,REP,926
+Minnehaha,0317 Precinct-0402 Precinct-0403 Precinct-0404,State House,09,Nick Winkler,DEM,785
+Minnehaha,0317 Precinct-0402 Precinct-0403 Precinct-0404,State House,09,Kenneth Teunissen,REP,928
+Minnehaha,0317 Precinct-0402 Precinct-0403 Precinct-0404,State House,09,Bethany Soye,REP,1054
+Minnehaha,0405 Precinct-0406 Precinct-0407 Precinct-0408,State House,02,Gary Leighton,DEM,0
+Minnehaha,0405 Precinct-0406 Precinct-0407 Precinct-0408,State House,02,John Sjaarda,REP,0
+Minnehaha,0405 Precinct-0406 Precinct-0407 Precinct-0408,State House,02,David Kull,REP,0
+Minnehaha,0409 Precinct-0410,State House,02,Gary Leighton,DEM,129
+Minnehaha,0409 Precinct-0410,State House,02,John Sjaarda,REP,152
+Minnehaha,0409 Precinct-0410,State House,02,David Kull,REP,151
+Minnehaha,0411,State House,02,Gary Leighton,DEM,730
+Minnehaha,0411,State House,02,John Sjaarda,REP,943
+Minnehaha,0411,State House,02,David Kull,REP,997
+Minnehaha,0412 Precinct-0413,State House,02,Gary Leighton,DEM,0
+Minnehaha,0412 Precinct-0413,State House,02,John Sjaarda,REP,0
+Minnehaha,0412 Precinct-0413,State House,02,David Kull,REP,0
+Minnehaha,0415 Precinct-0501 Precinct-0502 Precinct-0503 Precinct-0504 Precinct-0506 Precinct-0507 Precinct-0508 Precinct-0509 Precinct-0510 Precinct-0512,State House,02,Gary Leighton,DEM,237
+Minnehaha,0415 Precinct-0501 Precinct-0502 Precinct-0503 Precinct-0504 Precinct-0506 Precinct-0507 Precinct-0508 Precinct-0509 Precinct-0510 Precinct-0512,State House,02,John Sjaarda,REP,384
+Minnehaha,0415 Precinct-0501 Precinct-0502 Precinct-0503 Precinct-0504 Precinct-0506 Precinct-0507 Precinct-0508 Precinct-0509 Precinct-0510 Precinct-0512,State House,02,David Kull,REP,383
+Minnehaha,0513 Precinct-0514 Precinct-0515 Precinct-0517 Precinct-0518 Precinct-0519 Precinct-0520 Precinct-0521 Precinct-0522 Precinct-0523 Precinct-VP01,State House,02,Gary Leighton,DEM,142
+Minnehaha,0513 Precinct-0514 Precinct-0515 Precinct-0517 Precinct-0518 Precinct-0519 Precinct-0520 Precinct-0521 Precinct-0522 Precinct-0523 Precinct-VP01,State House,02,John Sjaarda,REP,502
+Minnehaha,0513 Precinct-0514 Precinct-0515 Precinct-0517 Precinct-0518 Precinct-0519 Precinct-0520 Precinct-0521 Precinct-0522 Precinct-0523 Precinct-VP01,State House,02,David Kull,REP,357
+Minnehaha,VP02,State House,02,Gary Leighton,DEM,445
+Minnehaha,VP02,State House,02,John Sjaarda,REP,947
+Minnehaha,VP02,State House,02,David Kull,REP,957
+Minnehaha,VP03,State House,02,Gary Leighton,DEM,528
+Minnehaha,VP03,State House,02,John Sjaarda,REP,1029
+Minnehaha,VP03,State House,02,David Kull,REP,1178
+Minnehaha,VP04 Precinct-VP05 23 of 65,State House,02,Gary Leighton,DEM,382
+Minnehaha,VP04 Precinct-VP05 23 of 65,State House,02,John Sjaarda,REP,681
+Minnehaha,VP04 Precinct-VP05 23 of 65,State House,02,David Kull,REP,827
+Minnehaha,0317 Precinct-0402,State House,10,Erin Healy,DEM,363
+Minnehaha,0317 Precinct-0402,State House,10,Kameron Nelson,DEM,254
+Minnehaha,0317 Precinct-0402,State House,10,Tom E Sutton,REP,234
+Minnehaha,0317 Precinct-0402,State House,10,John G. Mogen,REP,242
+Minnehaha,0403,State House,10,Erin Healy,DEM,219
+Minnehaha,0403,State House,10,Kameron Nelson,DEM,175
+Minnehaha,0403,State House,10,Tom E Sutton,REP,171
+Minnehaha,0403,State House,10,John G. Mogen,REP,161
+Minnehaha,0404 Precinct-0405,State House,10,Erin Healy,DEM,345
+Minnehaha,0404 Precinct-0405,State House,10,Kameron Nelson,DEM,258
+Minnehaha,0404 Precinct-0405,State House,10,Tom E Sutton,REP,256
+Minnehaha,0404 Precinct-0405,State House,10,John G. Mogen,REP,255
+Minnehaha,0406,State House,10,Erin Healy,DEM,129
+Minnehaha,0406,State House,10,Kameron Nelson,DEM,105
+Minnehaha,0406,State House,10,Tom E Sutton,REP,99
+Minnehaha,0406,State House,10,John G. Mogen,REP,90
+Minnehaha,0407,State House,10,Erin Healy,DEM,607
+Minnehaha,0407,State House,10,Kameron Nelson,DEM,475
+Minnehaha,0407,State House,10,Tom E Sutton,REP,547
+Minnehaha,0407,State House,10,John G. Mogen,REP,562
+Minnehaha,0408,State House,10,Erin Healy,DEM,181
+Minnehaha,0408,State House,10,Kameron Nelson,DEM,141
+Minnehaha,0408,State House,10,Tom E Sutton,REP,116
+Minnehaha,0408,State House,10,John G. Mogen,REP,104
+Minnehaha,0409,State House,10,Erin Healy,DEM,403
+Minnehaha,0409,State House,10,Kameron Nelson,DEM,282
+Minnehaha,0409,State House,10,Tom E Sutton,REP,278
+Minnehaha,0409,State House,10,John G. Mogen,REP,242
+Minnehaha,0410 Precinct-0411 Precinct-0412 Precinct-0413,State House,10,Erin Healy,DEM,203
+Minnehaha,0410 Precinct-0411 Precinct-0412 Precinct-0413,State House,10,Kameron Nelson,DEM,155
+Minnehaha,0410 Precinct-0411 Precinct-0412 Precinct-0413,State House,10,Tom E Sutton,REP,199
+Minnehaha,0410 Precinct-0411 Precinct-0412 Precinct-0413,State House,10,John G. Mogen,REP,186
+Minnehaha,0415 Precinct-0501 Precinct-0502 Precinct-0503,State House,10,Erin Healy,DEM,127
+Minnehaha,0415 Precinct-0501 Precinct-0502 Precinct-0503,State House,10,Kameron Nelson,DEM,106
+Minnehaha,0415 Precinct-0501 Precinct-0502 Precinct-0503,State House,10,Tom E Sutton,REP,46
+Minnehaha,0415 Precinct-0501 Precinct-0502 Precinct-0503,State House,10,John G. Mogen,REP,44
+Minnehaha,0504,State House,10,Erin Healy,DEM,547
+Minnehaha,0504,State House,10,Kameron Nelson,DEM,432
+Minnehaha,0504,State House,10,Tom E Sutton,REP,233
+Minnehaha,0504,State House,10,John G. Mogen,REP,278
+Minnehaha,0506,State House,10,Erin Healy,DEM,527
+Minnehaha,0506,State House,10,Kameron Nelson,DEM,399
+Minnehaha,0506,State House,10,Tom E Sutton,REP,322
+Minnehaha,0506,State House,10,John G. Mogen,REP,363
+Minnehaha,0507,State House,10,Erin Healy,DEM,362
+Minnehaha,0507,State House,10,Kameron Nelson,DEM,256
+Minnehaha,0507,State House,10,Tom E Sutton,REP,175
+Minnehaha,0507,State House,10,John G. Mogen,REP,211
+Minnehaha,0508 Precinct-0509 Precinct-0510 Precinct-0512 Precinct-0513 Precinct-0514 Precinct-0515 Precinct-0517,State House,10,Erin Healy,DEM,573
+Minnehaha,0508 Precinct-0509 Precinct-0510 Precinct-0512 Precinct-0513 Precinct-0514 Precinct-0515 Precinct-0517,State House,10,Kameron Nelson,DEM,447
+Minnehaha,0508 Precinct-0509 Precinct-0510 Precinct-0512 Precinct-0513 Precinct-0514 Precinct-0515 Precinct-0517,State House,10,Tom E Sutton,REP,270
+Minnehaha,0508 Precinct-0509 Precinct-0510 Precinct-0512 Precinct-0513 Precinct-0514 Precinct-0515 Precinct-0517,State House,10,John G. Mogen,REP,339
+Minnehaha,0518 Precinct-0519 Precinct-0520 Precinct-0521 Precinct-0522 Precinct-0523 Precinct-VP01 Precinct-VP02 Precinct-VP03 Precinct-VP04 Precinct-VP05 24 of 65,State House,10,Erin Healy,DEM,27
+Minnehaha,0518 Precinct-0519 Precinct-0520 Precinct-0521 Precinct-0522 Precinct-0523 Precinct-VP01 Precinct-VP02 Precinct-VP03 Precinct-VP04 Precinct-VP05 24 of 65,State House,10,Kameron Nelson,DEM,25
+Minnehaha,0518 Precinct-0519 Precinct-0520 Precinct-0521 Precinct-0522 Precinct-0523 Precinct-VP01 Precinct-VP02 Precinct-VP03 Precinct-VP04 Precinct-VP05 24 of 65,State House,10,Tom E Sutton,REP,34
+Minnehaha,0518 Precinct-0519 Precinct-0520 Precinct-0521 Precinct-0522 Precinct-0523 Precinct-VP01 Precinct-VP02 Precinct-VP03 Precinct-VP04 Precinct-VP05 24 of 65,State House,10,John G. Mogen,REP,37
+Minnehaha,0104,State House,12,Kristin Hayward,DEM,328
+Minnehaha,0104,State House,12,Erin Royer,DEM,318
+Minnehaha,0104,State House,12,Greg Jamison,REP,298
+Minnehaha,0104,State House,12,Amber Arlint,REP,288
+Minnehaha,0105 Precinct-0106 Precinct-0109,State House,12,Kristin Hayward,DEM,190
+Minnehaha,0105 Precinct-0106 Precinct-0109,State House,12,Erin Royer,DEM,174
+Minnehaha,0105 Precinct-0106 Precinct-0109,State House,12,Greg Jamison,REP,209
+Minnehaha,0105 Precinct-0106 Precinct-0109,State House,12,Amber Arlint,REP,199
+Minnehaha,0110 Precinct-0117 Precinct-0119,State House,13,Tony Venhuizen,REP,227
+Minnehaha,0110 Precinct-0117 Precinct-0119,State House,13,Sue Peterson,REP,313
+Minnehaha,0201 Precinct-0202 Precinct-0203 Precinct-0206,State House,13,Tony Venhuizen,REP,514
+Minnehaha,0201 Precinct-0202 Precinct-0203 Precinct-0206,State House,13,Sue Peterson,REP,561
+Minnehaha,0208 Precinct-0209 Precinct-0214 Precinct-0301 Precinct-0305 Precinct-0309 Precinct-0310 Precinct-0311 Precinct-0312 Precinct-0313 Precinct-0314 Precinct-0315 Precinct-0316 Precinct-0317 Precinct-0402 Precinct-0403 Precinct-0404,State House,12,Kristin Hayward,DEM,294
+Minnehaha,0208 Precinct-0209 Precinct-0214 Precinct-0301 Precinct-0305 Precinct-0309 Precinct-0310 Precinct-0311 Precinct-0312 Precinct-0313 Precinct-0314 Precinct-0315 Precinct-0316 Precinct-0317 Precinct-0402 Precinct-0403 Precinct-0404,State House,12,Erin Royer,DEM,292
+Minnehaha,0208 Precinct-0209 Precinct-0214 Precinct-0301 Precinct-0305 Precinct-0309 Precinct-0310 Precinct-0311 Precinct-0312 Precinct-0313 Precinct-0314 Precinct-0315 Precinct-0316 Precinct-0317 Precinct-0402 Precinct-0403 Precinct-0404,State House,12,Greg Jamison,REP,412
+Minnehaha,0208 Precinct-0209 Precinct-0214 Precinct-0301 Precinct-0305 Precinct-0309 Precinct-0310 Precinct-0311 Precinct-0312 Precinct-0313 Precinct-0314 Precinct-0315 Precinct-0316 Precinct-0317 Precinct-0402 Precinct-0403 Precinct-0404,State House,12,Amber Arlint,REP,389
+Minnehaha,0405 Precinct-0406 Precinct-0407 Precinct-0408 Precinct-0409 Precinct-0410 Precinct-0411 Precinct-0412 Precinct-0413 Precinct-0415 Precinct-0501 Precinct-0502 Precinct-0503 Precinct-0504 Precinct-0506,State House,12,Kristin Hayward,DEM,136
+Minnehaha,0405 Precinct-0406 Precinct-0407 Precinct-0408 Precinct-0409 Precinct-0410 Precinct-0411 Precinct-0412 Precinct-0413 Precinct-0415 Precinct-0501 Precinct-0502 Precinct-0503 Precinct-0504 Precinct-0506,State House,12,Erin Royer,DEM,136
+Minnehaha,0405 Precinct-0406 Precinct-0407 Precinct-0408 Precinct-0409 Precinct-0410 Precinct-0411 Precinct-0412 Precinct-0413 Precinct-0415 Precinct-0501 Precinct-0502 Precinct-0503 Precinct-0504 Precinct-0506,State House,12,Greg Jamison,REP,102
+Minnehaha,0405 Precinct-0406 Precinct-0407 Precinct-0408 Precinct-0409 Precinct-0410 Precinct-0411 Precinct-0412 Precinct-0413 Precinct-0415 Precinct-0501 Precinct-0502 Precinct-0503 Precinct-0504 Precinct-0506,State House,12,Amber Arlint,REP,103
+Minnehaha,0507 Precinct-0508 Precinct-0509,State House,12,Kristin Hayward,DEM,199
+Minnehaha,0507 Precinct-0508 Precinct-0509,State House,12,Erin Royer,DEM,207
+Minnehaha,0507 Precinct-0508 Precinct-0509,State House,12,Greg Jamison,REP,124
+Minnehaha,0507 Precinct-0508 Precinct-0509,State House,12,Amber Arlint,REP,113
+Minnehaha,0510,State House,12,Kristin Hayward,DEM,230
+Minnehaha,0510,State House,12,Erin Royer,DEM,236
+Minnehaha,0510,State House,12,Greg Jamison,REP,236
+Minnehaha,0510,State House,12,Amber Arlint,REP,203
+Minnehaha,0512,State House,13,Tony Venhuizen,REP,244
+Minnehaha,0512,State House,13,Sue Peterson,REP,270
+Minnehaha,0513,State House,13,Tony Venhuizen,REP,278
+Minnehaha,0513,State House,13,Sue Peterson,REP,279
+Minnehaha,0514 Precinct-0515,State House,12,Kristin Hayward,DEM,170
+Minnehaha,0514 Precinct-0515,State House,12,Erin Royer,DEM,175
+Minnehaha,0514 Precinct-0515,State House,12,Greg Jamison,REP,153
+Minnehaha,0514 Precinct-0515,State House,12,Amber Arlint,REP,137
+Minnehaha,0517,State House,12,Kristin Hayward,DEM,225
+Minnehaha,0517,State House,12,Erin Royer,DEM,211
+Minnehaha,0517,State House,12,Greg Jamison,REP,247
+Minnehaha,0517,State House,12,Amber Arlint,REP,235
+Minnehaha,0518 Precinct-0519 Precinct-0520,State House,12,Kristin Hayward,DEM,211
+Minnehaha,0518 Precinct-0519 Precinct-0520,State House,12,Erin Royer,DEM,215
+Minnehaha,0518 Precinct-0519 Precinct-0520,State House,12,Greg Jamison,REP,258
+Minnehaha,0518 Precinct-0519 Precinct-0520,State House,12,Amber Arlint,REP,244
+Minnehaha,0521 Precinct-0522 Precinct-0523 Precinct-VP01 Precinct-VP02 Precinct-VP03 Precinct-VP04 Precinct-VP05 25 of 65,State House,12,Kristin Hayward,DEM,173
+Minnehaha,0521 Precinct-0522 Precinct-0523 Precinct-VP01 Precinct-VP02 Precinct-VP03 Precinct-VP04 Precinct-VP05 25 of 65,State House,12,Erin Royer,DEM,215
+Minnehaha,0521 Precinct-0522 Precinct-0523 Precinct-VP01 Precinct-VP02 Precinct-VP03 Precinct-VP04 Precinct-VP05 25 of 65,State House,12,Greg Jamison,REP,185
+Minnehaha,0521 Precinct-0522 Precinct-0523 Precinct-VP01 Precinct-VP02 Precinct-VP03 Precinct-VP04 Precinct-VP05 25 of 65,State House,12,Amber Arlint,REP,176
+Minnehaha,VP06,State House,09,Nick Winkler,DEM,131
+Minnehaha,VP06,State House,09,Kenneth Teunissen,REP,208
+Minnehaha,VP06,State House,09,Bethany Soye,REP,230
+Minnehaha,VP07 Precinct-VP08 Precinct-VP09 Precinct-VP10,State House,09,Nick Winkler,DEM,440
+Minnehaha,VP07 Precinct-VP08 Precinct-VP09 Precinct-VP10,State House,09,Kenneth Teunissen,REP,733
+Minnehaha,VP07 Precinct-VP08 Precinct-VP09 Precinct-VP10,State House,09,Bethany Soye,REP,969
+Minnehaha,VP11 Precinct-VP12 Precinct-VP13 Precinct-VP15 Precinct-VP16,State House,02,Gary Leighton,DEM,443
+Minnehaha,VP11 Precinct-VP12 Precinct-VP13 Precinct-VP15 Precinct-VP16,State House,02,John Sjaarda,REP,723
+Minnehaha,VP11 Precinct-VP12 Precinct-VP13 Precinct-VP15 Precinct-VP16,State House,02,David Kull,REP,908
+Minnehaha,VP17 Precinct-VP21 26 of 65,State House,09,Nick Winkler,DEM,155
+Minnehaha,VP17 Precinct-VP21 26 of 65,State House,09,Kenneth Teunissen,REP,348
+Minnehaha,VP17 Precinct-VP21 26 of 65,State House,09,Bethany Soye,REP,431

--- a/2022/counties/20221108__sd__general__moody__precinct.csv
+++ b/2022/counties/20221108__sd__general__moody__precinct.csv
@@ -1,0 +1,241 @@
+county,precinct,office,district,candidate,party,votes
+Moody,1,U.S. Senate,,Brian L. Bengs,DEM,166
+Moody,1,U.S. Senate,,Tamara J Lesnar,LIB,13
+Moody,1,U.S. Senate,,John R. Thune,REP,252
+Moody,2,U.S. Senate,,Brian L. Bengs,DEM,199
+Moody,2,U.S. Senate,,Tamara J Lesnar,LIB,25
+Moody,2,U.S. Senate,,John R. Thune,REP,254
+Moody,3,U.S. Senate,,Brian L. Bengs,DEM,95
+Moody,3,U.S. Senate,,Tamara J Lesnar,LIB,22
+Moody,3,U.S. Senate,,John R. Thune,REP,398
+Moody,34,U.S. Senate,,Brian L. Bengs,DEM,74
+Moody,34,U.S. Senate,,Tamara J Lesnar,LIB,18
+Moody,34,U.S. Senate,,John R. Thune,REP,244
+Moody,4,U.S. Senate,,Brian L. Bengs,DEM,48
+Moody,4,U.S. Senate,,Tamara J Lesnar,LIB,10
+Moody,4,U.S. Senate,,John R. Thune,REP,210
+Moody,5,U.S. Senate,,Brian L. Bengs,DEM,112
+Moody,5,U.S. Senate,,Tamara J Lesnar,LIB,21
+Moody,5,U.S. Senate,,John R. Thune,REP,481
+Moody,1,U.S. House,1,Collin Duprel,LIB,121
+Moody,1,U.S. House,1,Dusty Johnson,REP,289
+Moody,2,U.S. House,1,Collin Duprel,LIB,150
+Moody,2,U.S. House,1,Dusty Johnson,REP,298
+Moody,3,U.S. House,1,Collin Duprel,LIB,83
+Moody,3,U.S. House,1,Dusty Johnson,REP,416
+Moody,34,U.S. House,1,Collin Duprel,LIB,77
+Moody,34,U.S. House,1,Dusty Johnson,REP,252
+Moody,4,U.S. House,1,Collin Duprel,LIB,42
+Moody,4,U.S. House,1,Dusty Johnson,REP,219
+Moody,5,U.S. House,1,Collin Duprel,LIB,101
+Moody,5,U.S. House,1,Dusty Johnson,REP,502
+Moody,1,Governor,,Jamie Smith and Jennifer Keintz,DEM,213
+Moody,1,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Moody,1,Governor,,Kristi Noem and Larry Rhoden,REP,212
+Moody,2,Governor,,Jamie Smith and Jennifer Keintz,DEM,257
+Moody,2,Governor,,Tracey Quint and Ashley Strand,LIB,15
+Moody,2,Governor,,Kristi Noem and Larry Rhoden,REP,209
+Moody,3,Governor,,Jamie Smith and Jennifer Keintz,DEM,138
+Moody,3,Governor,,Tracey Quint and Ashley Strand,LIB,13
+Moody,3,Governor,,Kristi Noem and Larry Rhoden,REP,362
+Moody,34,Governor,,Jamie Smith and Jennifer Keintz,DEM,100
+Moody,34,Governor,,Tracey Quint and Ashley Strand,LIB,11
+Moody,34,Governor,,Kristi Noem and Larry Rhoden,REP,225
+Moody,4,Governor,,Jamie Smith and Jennifer Keintz,DEM,57
+Moody,4,Governor,,Tracey Quint and Ashley Strand,LIB,9
+Moody,4,Governor,,Kristi Noem and Larry Rhoden,REP,204
+Moody,5,Governor,,Jamie Smith and Jennifer Keintz,DEM,145
+Moody,5,Governor,,Tracey Quint and Ashley Strand,LIB,16
+Moody,5,Governor,,Kristi Noem and Larry Rhoden,REP,456
+Moody,1,Secretary of State,,Thomas A Cool,DEM,220
+Moody,1,Secretary of State,,Monae Johnson,REP,196
+Moody,2,Secretary of State,,Thomas A Cool,DEM,267
+Moody,2,Secretary of State,,Monae Johnson,REP,191
+Moody,3,Secretary of State,,Thomas A Cool,DEM,155
+Moody,3,Secretary of State,,Monae Johnson,REP,340
+Moody,34,Secretary of State,,Thomas A Cool,DEM,106
+Moody,34,Secretary of State,,Monae Johnson,REP,213
+Moody,4,Secretary of State,,Thomas A Cool,DEM,69
+Moody,4,Secretary of State,,Monae Johnson,REP,191
+Moody,5,Secretary of State,,Thomas A Cool,DEM,163
+Moody,5,Secretary of State,,Monae Johnson,REP,422
+Moody,1,Attorney General,,Marty J. Jackley,REP,285
+Moody,2,Attorney General,,Marty J. Jackley,REP,272
+Moody,3,Attorney General,,Marty J. Jackley,REP,394
+Moody,34,Attorney General,,Marty J. Jackley,REP,257
+Moody,4,Attorney General,,Marty J. Jackley,REP,215
+Moody,5,Attorney General,,Marty J. Jackley,REP,485
+Moody,1,State Auditor,,Stephanie Marty,DEM,191
+Moody,1,State Auditor,,Rene Meyer,LIB,23
+Moody,1,State Auditor,,Richard Sattgast,REP,197
+Moody,2,State Auditor,,Stephanie Marty,DEM,243
+Moody,2,State Auditor,,Rene Meyer,LIB,29
+Moody,2,State Auditor,,Richard Sattgast,REP,185
+Moody,3,State Auditor,,Stephanie Marty,DEM,145
+Moody,3,State Auditor,,Rene Meyer,LIB,22
+Moody,3,State Auditor,,Richard Sattgast,REP,321
+Moody,34,State Auditor,,Stephanie Marty,DEM,96
+Moody,34,State Auditor,,Rene Meyer,LIB,22
+Moody,34,State Auditor,,Richard Sattgast,REP,199
+Moody,4,State Auditor,,Stephanie Marty,DEM,62
+Moody,4,State Auditor,,Rene Meyer,LIB,11
+Moody,4,State Auditor,,Richard Sattgast,REP,177
+Moody,5,State Auditor,,Stephanie Marty,DEM,145
+Moody,5,State Auditor,,Rene Meyer,LIB,28
+Moody,5,State Auditor,,Richard Sattgast,REP,410
+Moody,1,State Treasurer,,John Cunningham,DEM,200
+Moody,1,State Treasurer,,Josh Haeder,REP,204
+Moody,2,State Treasurer,,John Cunningham,DEM,248
+Moody,2,State Treasurer,,Josh Haeder,REP,197
+Moody,3,State Treasurer,,John Cunningham,DEM,148
+Moody,3,State Treasurer,,Josh Haeder,REP,337
+Moody,34,State Treasurer,,John Cunningham,DEM,103
+Moody,34,State Treasurer,,Josh Haeder,REP,210
+Moody,4,State Treasurer,,John Cunningham,DEM,63
+Moody,4,State Treasurer,,Josh Haeder,REP,188
+Moody,5,State Treasurer,,John Cunningham,DEM,141
+Moody,5,State Treasurer,,Josh Haeder,REP,439
+Moody,1,Commissioner of School and Public Lands,,Timothy Azure,DEM,197
+Moody,1,Commissioner of School and Public Lands,,Brock Greenfield,REP,204
+Moody,2,Commissioner of School and Public Lands,,Timothy Azure,DEM,242
+Moody,2,Commissioner of School and Public Lands,,Brock Greenfield,REP,201
+Moody,3,Commissioner of School and Public Lands,,Timothy Azure,DEM,135
+Moody,3,Commissioner of School and Public Lands,,Brock Greenfield,REP,343
+Moody,34,Commissioner of School and Public Lands,,Timothy Azure,DEM,104
+Moody,34,Commissioner of School and Public Lands,,Brock Greenfield,REP,207
+Moody,4,Commissioner of School and Public Lands,,Timothy Azure,DEM,55
+Moody,4,Commissioner of School and Public Lands,,Brock Greenfield,REP,189
+Moody,5,Commissioner of School and Public Lands,,Timothy Azure,DEM,144
+Moody,5,Commissioner of School and Public Lands,,Brock Greenfield,REP,433
+Moody,1,Public Utilities Commissioner,,Jeffrey Barth,DEM,198
+Moody,1,Public Utilities Commissioner,,Chris Nelson,REP,217
+Moody,2,Public Utilities Commissioner,,Jeffrey Barth,DEM,228
+Moody,2,Public Utilities Commissioner,,Chris Nelson,REP,226
+Moody,3,Public Utilities Commissioner,,Jeffrey Barth,DEM,145
+Moody,3,Public Utilities Commissioner,,Chris Nelson,REP,344
+Moody,34,Public Utilities Commissioner,,Jeffrey Barth,DEM,104
+Moody,34,Public Utilities Commissioner,,Chris Nelson,REP,219
+Moody,4,Public Utilities Commissioner,,Jeffrey Barth,DEM,79
+Moody,4,Public Utilities Commissioner,,Chris Nelson,REP,179
+Moody,5,Public Utilities Commissioner,,Jeffrey Barth,DEM,132
+Moody,5,Public Utilities Commissioner,,Chris Nelson,REP,458
+Moody,1,State Senate,25,Tom Pischke,REP,240
+Moody,2,State Senate,25,Tom Pischke,REP,225
+Moody,3,State Senate,25,Tom Pischke,REP,373
+Moody,34,State Senate,25,Tom Pischke,REP,233
+Moody,4,State Senate,25,Tom Pischke,REP,206
+Moody,5,State Senate,25,Tom Pischke,REP,443
+Moody,1,State House,25,Dan Ahlers,DEM,209
+Moody,1,State House,25,David Kills A Hundred,DEM,154
+Moody,1,State House,25,Jon Hansen,REP,166
+Moody,1,State House,25,Randy Gross,REP,226
+Moody,2,State House,25,Dan Ahlers,DEM,228
+Moody,2,State House,25,David Kills A Hundred,DEM,196
+Moody,2,State House,25,Jon Hansen,REP,162
+Moody,2,State House,25,Randy Gross,REP,201
+Moody,3,State House,25,Dan Ahlers,DEM,198
+Moody,3,State House,25,David Kills A Hundred,DEM,77
+Moody,3,State House,25,Jon Hansen,REP,309
+Moody,3,State House,25,Randy Gross,REP,316
+Moody,34,State House,25,Dan Ahlers,DEM,101
+Moody,34,State House,25,David Kills A Hundred,DEM,77
+Moody,34,State House,25,Jon Hansen,REP,172
+Moody,34,State House,25,Randy Gross,REP,222
+Moody,4,State House,25,Dan Ahlers,DEM,73
+Moody,4,State House,25,David Kills A Hundred,DEM,37
+Moody,4,State House,25,Jon Hansen,REP,160
+Moody,4,State House,25,Randy Gross,REP,193
+Moody,5,State House,25,Dan Ahlers,DEM,192
+Moody,5,State House,25,David Kills A Hundred,DEM,101
+Moody,5,State House,25,Jon Hansen,REP,345
+Moody,5,State House,25,Randy Gross,REP,424
+Moody,1,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,188
+Moody,2,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,199
+Moody,3,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,214
+Moody,34,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,155
+Moody,4,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,107
+Moody,5,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,261
+Moody,1,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,178
+Moody,2,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,175
+Moody,3,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,212
+Moody,34,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,146
+Moody,4,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,104
+Moody,5,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,260
+Moody,1,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,172
+Moody,2,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,169
+Moody,3,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,204
+Moody,34,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,140
+Moody,4,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,106
+Moody,5,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,248
+Moody,1,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,176
+Moody,2,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,177
+Moody,3,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,208
+Moody,34,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,144
+Moody,4,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,106
+Moody,5,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,264
+Moody,1,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,115
+Moody,1,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,105
+Moody,2,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,106
+Moody,2,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,113
+Moody,3,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,92
+Moody,3,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,126
+Moody,34,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,79
+Moody,34,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,91
+Moody,4,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,48
+Moody,4,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,66
+Moody,5,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,124
+Moody,5,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,156
+Moody,1,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,173
+Moody,2,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,186
+Moody,3,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,202
+Moody,34,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,143
+Moody,4,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,105
+Moody,5,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,258
+Moody,1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,319
+Moody,1,Supreme Court Retention,3,Patricia J. DeVaney - No,,68
+Moody,2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,335
+Moody,2,Supreme Court Retention,3,Patricia J. DeVaney - No,,89
+Moody,3,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,382
+Moody,3,Supreme Court Retention,3,Patricia J. DeVaney - No,,63
+Moody,34,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,223
+Moody,34,Supreme Court Retention,3,Patricia J. DeVaney - No,,65
+Moody,4,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,188
+Moody,4,Supreme Court Retention,3,Patricia J. DeVaney - No,,32
+Moody,5,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,447
+Moody,5,Supreme Court Retention,3,Patricia J. DeVaney - No,,72
+Moody,1,Supreme Court Retention,2,Mark E. Salter - Yes,,307
+Moody,1,Supreme Court Retention,2,Mark E. Salter - No,,71
+Moody,2,Supreme Court Retention,2,Mark E. Salter - Yes,,323
+Moody,2,Supreme Court Retention,2,Mark E. Salter - No,,101
+Moody,3,Supreme Court Retention,2,Mark E. Salter - Yes,,368
+Moody,3,Supreme Court Retention,2,Mark E. Salter - No,,73
+Moody,34,Supreme Court Retention,2,Mark E. Salter - Yes,,220
+Moody,34,Supreme Court Retention,2,Mark E. Salter - No,,67
+Moody,4,Supreme Court Retention,2,Mark E. Salter - Yes,,184
+Moody,4,Supreme Court Retention,2,Mark E. Salter - No,,32
+Moody,5,Supreme Court Retention,2,Mark E. Salter - Yes,,449
+Moody,5,Supreme Court Retention,2,Mark E. Salter - No,,65
+Moody,1,Constitutional Amendment D,,Yes,,286
+Moody,1,Constitutional Amendment D,,No,,143
+Moody,2,Constitutional Amendment D,,Yes,,318
+Moody,2,Constitutional Amendment D,,No,,150
+Moody,3,Constitutional Amendment D,,Yes,,239
+Moody,3,Constitutional Amendment D,,No,,263
+Moody,34,Constitutional Amendment D,,Yes,,176
+Moody,34,Constitutional Amendment D,,No,,156
+Moody,4,Constitutional Amendment D,,Yes,,119
+Moody,4,Constitutional Amendment D,,No,,140
+Moody,5,Constitutional Amendment D,,Yes,,287
+Moody,5,Constitutional Amendment D,,No,,316
+Moody,1,Initiated Measure 27,,Yes,,225
+Moody,1,Initiated Measure 27,,No,,209
+Moody,2,Initiated Measure 27,,Yes,,273
+Moody,2,Initiated Measure 27,,No,,203
+Moody,3,Initiated Measure 27,,Yes,,205
+Moody,3,Initiated Measure 27,,No,,305
+Moody,34,Initiated Measure 27,,Yes,,122
+Moody,34,Initiated Measure 27,,No,,213
+Moody,4,Initiated Measure 27,,Yes,,93
+Moody,4,Initiated Measure 27,,No,,172
+Moody,5,Initiated Measure 27,,Yes,,250
+Moody,5,Initiated Measure 27,,No,,368

--- a/2022/counties/20221108__sd__general__oglala_lakota__precinct.csv
+++ b/2022/counties/20221108__sd__general__oglala_lakota__precinct.csv
@@ -1,0 +1,337 @@
+county,precinct,office,district,candidate,party,votes
+Oglala Lakota,Gymnasium/Oglala Lakota,U.S. Senate,,Brian L. Bengs,DEM,89
+Oglala Lakota,Gymnasium/Oglala Lakota,U.S. Senate,,Tamara J Lesnar,LIB,6
+Oglala Lakota,Gymnasium/Oglala Lakota,U.S. Senate,,John R. Thune,REP,46
+Oglala Lakota,Brother Renee Hall,U.S. Senate,,Brian L. Bengs,DEM,327
+Oglala Lakota,Brother Renee Hall,U.S. Senate,,Tamara J Lesnar,LIB,29
+Oglala Lakota,Brother Renee Hall,U.S. Senate,,John R. Thune,REP,89
+Oglala Lakota,?,U.S. Senate,,Brian L. Bengs,DEM,276
+Oglala Lakota,?,U.S. Senate,,Tamara J Lesnar,LIB,17
+Oglala Lakota,?,U.S. Senate,,John R. Thune,REP,52
+Oglala Lakota,Little Wound School,U.S. Senate,,Brian L. Bengs,DEM,304
+Oglala Lakota,Little Wound School,U.S. Senate,,Tamara J Lesnar,LIB,19
+Oglala Lakota,Little Wound School,U.S. Senate,,John R. Thune,REP,57
+Oglala Lakota,Gymasium/Pine Ridge,U.S. Senate,,Brian L. Bengs,DEM,691
+Oglala Lakota,Gymasium/Pine Ridge,U.S. Senate,,Tamara J Lesnar,LIB,39
+Oglala Lakota,Gymasium/Pine Ridge,U.S. Senate,,John R. Thune,REP,102
+Oglala Lakota,Red Shirt School,U.S. Senate,,Brian L. Bengs,DEM,45
+Oglala Lakota,Red Shirt School,U.S. Senate,,Tamara J Lesnar,LIB,4
+Oglala Lakota,Red Shirt School,U.S. Senate,,John R. Thune,REP,30
+Oglala Lakota,?,U.S. Senate,,Brian L. Bengs,DEM,93
+Oglala Lakota,?,U.S. Senate,,Tamara J Lesnar,LIB,10
+Oglala Lakota,?,U.S. Senate,,John R. Thune,REP,23
+Oglala Lakota,?,U.S. Senate,,Brian L. Bengs,DEM,64
+Oglala Lakota,?,U.S. Senate,,Tamara J Lesnar,LIB,5
+Oglala Lakota,?,U.S. Senate,,John R. Thune,REP,23
+Oglala Lakota,Gymnasium/Oglala Lakota,U.S. House,1,Collin Duprel,LIB,61
+Oglala Lakota,Gymnasium/Oglala Lakota,U.S. House,1,Dusty Johnson,REP,57
+Oglala Lakota,Brother Renee Hall,U.S. House,1,Collin Duprel,LIB,233
+Oglala Lakota,Brother Renee Hall,U.S. House,1,Dusty Johnson,REP,133
+Oglala Lakota,?,U.S. House,1,Collin Duprel,LIB,191
+Oglala Lakota,?,U.S. House,1,Dusty Johnson,REP,89
+Oglala Lakota,Little Wound School,U.S. House,1,Collin Duprel,LIB,225
+Oglala Lakota,Little Wound School,U.S. House,1,Dusty Johnson,REP,76
+Oglala Lakota,Gymasium/Pine Ridge,U.S. House,1,Collin Duprel,LIB,470
+Oglala Lakota,Gymasium/Pine Ridge,U.S. House,1,Dusty Johnson,REP,194
+Oglala Lakota,Red Shirt School,U.S. House,1,Collin Duprel,LIB,36
+Oglala Lakota,Red Shirt School,U.S. House,1,Dusty Johnson,REP,36
+Oglala Lakota,?,U.S. House,1,Collin Duprel,LIB,68
+Oglala Lakota,?,U.S. House,1,Dusty Johnson,REP,32
+Oglala Lakota,?,U.S. House,1,Collin Duprel,LIB,52
+Oglala Lakota,?,U.S. House,1,Dusty Johnson,REP,30
+Oglala Lakota,Gymnasium/Oglala Lakota,Governor,,Jamie Smith and Jennifer Keintz,DEM,103
+Oglala Lakota,Gymnasium/Oglala Lakota,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Oglala Lakota,Gymnasium/Oglala Lakota,Governor,,Kristi Noem and Larry Rhoden,REP,38
+Oglala Lakota,Brother Renee Hall,Governor,,Jamie Smith and Jennifer Keintz,DEM,397
+Oglala Lakota,Brother Renee Hall,Governor,,Tracey Quint and Ashley Strand,LIB,20
+Oglala Lakota,Brother Renee Hall,Governor,,Kristi Noem and Larry Rhoden,REP,38
+Oglala Lakota,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,317
+Oglala Lakota,?,Governor,,Tracey Quint and Ashley Strand,LIB,17
+Oglala Lakota,?,Governor,,Kristi Noem and Larry Rhoden,REP,17
+Oglala Lakota,Little Wound School,Governor,,Jamie Smith and Jennifer Keintz,DEM,339
+Oglala Lakota,Little Wound School,Governor,,Tracey Quint and Ashley Strand,LIB,15
+Oglala Lakota,Little Wound School,Governor,,Kristi Noem and Larry Rhoden,REP,31
+Oglala Lakota,Gymasium/Pine Ridge,Governor,,Jamie Smith and Jennifer Keintz,DEM,774
+Oglala Lakota,Gymasium/Pine Ridge,Governor,,Tracey Quint and Ashley Strand,LIB,22
+Oglala Lakota,Gymasium/Pine Ridge,Governor,,Kristi Noem and Larry Rhoden,REP,50
+Oglala Lakota,Red Shirt School,Governor,,Jamie Smith and Jennifer Keintz,DEM,51
+Oglala Lakota,Red Shirt School,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Oglala Lakota,Red Shirt School,Governor,,Kristi Noem and Larry Rhoden,REP,24
+Oglala Lakota,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,118
+Oglala Lakota,?,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Oglala Lakota,?,Governor,,Kristi Noem and Larry Rhoden,REP,7
+Oglala Lakota,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,73
+Oglala Lakota,?,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Oglala Lakota,?,Governor,,Kristi Noem and Larry Rhoden,REP,16
+Oglala Lakota,Gymnasium/Oglala Lakota,Secretary of State,,Thomas A Cool,DEM,101
+Oglala Lakota,Gymnasium/Oglala Lakota,Secretary of State,,Monae Johnson,REP,40
+Oglala Lakota,Brother Renee Hall,Secretary of State,,Thomas A Cool,DEM,371
+Oglala Lakota,Brother Renee Hall,Secretary of State,,Monae Johnson,REP,65
+Oglala Lakota,?,Secretary of State,,Thomas A Cool,DEM,307
+Oglala Lakota,?,Secretary of State,,Monae Johnson,REP,32
+Oglala Lakota,Little Wound School,Secretary of State,,Thomas A Cool,DEM,344
+Oglala Lakota,Little Wound School,Secretary of State,,Monae Johnson,REP,30
+Oglala Lakota,Gymasium/Pine Ridge,Secretary of State,,Thomas A Cool,DEM,755
+Oglala Lakota,Gymasium/Pine Ridge,Secretary of State,,Monae Johnson,REP,69
+Oglala Lakota,Red Shirt School,Secretary of State,,Thomas A Cool,DEM,49
+Oglala Lakota,Red Shirt School,Secretary of State,,Monae Johnson,REP,26
+Oglala Lakota,?,Secretary of State,,Thomas A Cool,DEM,112
+Oglala Lakota,?,Secretary of State,,Monae Johnson,REP,11
+Oglala Lakota,?,Secretary of State,,Thomas A Cool,DEM,73
+Oglala Lakota,?,Secretary of State,,Monae Johnson,REP,18
+Oglala Lakota,Gymnasium/Oglala Lakota,Attorney General,,Marty J. Jackley,REP,58
+Oglala Lakota,Brother Renee Hall,Attorney General,,Marty J. Jackley,REP,129
+Oglala Lakota,?,Attorney General,,Marty J. Jackley,REP,86
+Oglala Lakota,Little Wound School,Attorney General,,Marty J. Jackley,REP,88
+Oglala Lakota,Gymasium/Pine Ridge,Attorney General,,Marty J. Jackley,REP,195
+Oglala Lakota,Red Shirt School,Attorney General,,Marty J. Jackley,REP,41
+Oglala Lakota,?,Attorney General,,Marty J. Jackley,REP,32
+Oglala Lakota,?,Attorney General,,Marty J. Jackley,REP,34
+Oglala Lakota,Gymnasium/Oglala Lakota,State Auditor,,Stephanie Marty,DEM,95
+Oglala Lakota,Gymnasium/Oglala Lakota,State Auditor,,Rene Meyer,LIB,5
+Oglala Lakota,Gymnasium/Oglala Lakota,State Auditor,,Richard Sattgast,REP,35
+Oglala Lakota,Brother Renee Hall,State Auditor,,Stephanie Marty,DEM,370
+Oglala Lakota,Brother Renee Hall,State Auditor,,Rene Meyer,LIB,31
+Oglala Lakota,Brother Renee Hall,State Auditor,,Richard Sattgast,REP,36
+Oglala Lakota,?,State Auditor,,Stephanie Marty,DEM,304
+Oglala Lakota,?,State Auditor,,Rene Meyer,LIB,20
+Oglala Lakota,?,State Auditor,,Richard Sattgast,REP,16
+Oglala Lakota,Little Wound School,State Auditor,,Stephanie Marty,DEM,322
+Oglala Lakota,Little Wound School,State Auditor,,Rene Meyer,LIB,25
+Oglala Lakota,Little Wound School,State Auditor,,Richard Sattgast,REP,23
+Oglala Lakota,Gymasium/Pine Ridge,State Auditor,,Stephanie Marty,DEM,740
+Oglala Lakota,Gymasium/Pine Ridge,State Auditor,,Rene Meyer,LIB,33
+Oglala Lakota,Gymasium/Pine Ridge,State Auditor,,Richard Sattgast,REP,46
+Oglala Lakota,Red Shirt School,State Auditor,,Stephanie Marty,DEM,49
+Oglala Lakota,Red Shirt School,State Auditor,,Rene Meyer,LIB,8
+Oglala Lakota,Red Shirt School,State Auditor,,Richard Sattgast,REP,20
+Oglala Lakota,?,State Auditor,,Stephanie Marty,DEM,108
+Oglala Lakota,?,State Auditor,,Rene Meyer,LIB,7
+Oglala Lakota,?,State Auditor,,Richard Sattgast,REP,7
+Oglala Lakota,?,State Auditor,,Stephanie Marty,DEM,73
+Oglala Lakota,?,State Auditor,,Rene Meyer,LIB,3
+Oglala Lakota,?,State Auditor,,Richard Sattgast,REP,16
+Oglala Lakota,Gymnasium/Oglala Lakota,State Treasurer,,John Cunningham,DEM,100
+Oglala Lakota,Gymnasium/Oglala Lakota,State Treasurer,,Josh Haeder,REP,39
+Oglala Lakota,Brother Renee Hall,State Treasurer,,John Cunningham,DEM,372
+Oglala Lakota,Brother Renee Hall,State Treasurer,,Josh Haeder,REP,54
+Oglala Lakota,?,State Treasurer,,John Cunningham,DEM,320
+Oglala Lakota,?,State Treasurer,,Josh Haeder,REP,18
+Oglala Lakota,Little Wound School,State Treasurer,,John Cunningham,DEM,334
+Oglala Lakota,Little Wound School,State Treasurer,,Josh Haeder,REP,27
+Oglala Lakota,Gymasium/Pine Ridge,State Treasurer,,John Cunningham,DEM,764
+Oglala Lakota,Gymasium/Pine Ridge,State Treasurer,,Josh Haeder,REP,57
+Oglala Lakota,Red Shirt School,State Treasurer,,John Cunningham,DEM,52
+Oglala Lakota,Red Shirt School,State Treasurer,,Josh Haeder,REP,25
+Oglala Lakota,?,State Treasurer,,John Cunningham,DEM,115
+Oglala Lakota,?,State Treasurer,,Josh Haeder,REP,9
+Oglala Lakota,?,State Treasurer,,John Cunningham,DEM,75
+Oglala Lakota,?,State Treasurer,,Josh Haeder,REP,14
+Oglala Lakota,Gymnasium/Oglala Lakota,Commissioner of School and Public Lands,,Timothy Azure,DEM,100
+Oglala Lakota,Gymnasium/Oglala Lakota,Commissioner of School and Public Lands,,Brock Greenfield,REP,36
+Oglala Lakota,Brother Renee Hall,Commissioner of School and Public Lands,,Timothy Azure,DEM,375
+Oglala Lakota,Brother Renee Hall,Commissioner of School and Public Lands,,Brock Greenfield,REP,50
+Oglala Lakota,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,315
+Oglala Lakota,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,25
+Oglala Lakota,Little Wound School,Commissioner of School and Public Lands,,Timothy Azure,DEM,334
+Oglala Lakota,Little Wound School,Commissioner of School and Public Lands,,Brock Greenfield,REP,26
+Oglala Lakota,Gymasium/Pine Ridge,Commissioner of School and Public Lands,,Timothy Azure,DEM,750
+Oglala Lakota,Gymasium/Pine Ridge,Commissioner of School and Public Lands,,Brock Greenfield,REP,53
+Oglala Lakota,Red Shirt School,Commissioner of School and Public Lands,,Timothy Azure,DEM,49
+Oglala Lakota,Red Shirt School,Commissioner of School and Public Lands,,Brock Greenfield,REP,24
+Oglala Lakota,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,113
+Oglala Lakota,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,9
+Oglala Lakota,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,73
+Oglala Lakota,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,17
+Oglala Lakota,Gymnasium/Oglala Lakota,Public Utilities Commissioner,,Jeffrey Barth,DEM,92
+Oglala Lakota,Gymnasium/Oglala Lakota,Public Utilities Commissioner,,Chris Nelson,REP,43
+Oglala Lakota,Brother Renee Hall,Public Utilities Commissioner,,Jeffrey Barth,DEM,357
+Oglala Lakota,Brother Renee Hall,Public Utilities Commissioner,,Chris Nelson,REP,58
+Oglala Lakota,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,301
+Oglala Lakota,?,Public Utilities Commissioner,,Chris Nelson,REP,33
+Oglala Lakota,Little Wound School,Public Utilities Commissioner,,Jeffrey Barth,DEM,322
+Oglala Lakota,Little Wound School,Public Utilities Commissioner,,Chris Nelson,REP,32
+Oglala Lakota,Gymasium/Pine Ridge,Public Utilities Commissioner,,Jeffrey Barth,DEM,734
+Oglala Lakota,Gymasium/Pine Ridge,Public Utilities Commissioner,,Chris Nelson,REP,58
+Oglala Lakota,Red Shirt School,Public Utilities Commissioner,,Jeffrey Barth,DEM,47
+Oglala Lakota,Red Shirt School,Public Utilities Commissioner,,Chris Nelson,REP,27
+Oglala Lakota,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,110
+Oglala Lakota,?,Public Utilities Commissioner,,Chris Nelson,REP,13
+Oglala Lakota,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,72
+Oglala Lakota,?,Public Utilities Commissioner,,Chris Nelson,REP,15
+Oglala Lakota,Gymnasium/Oglala Lakota,State Senate,27,Red Dawn Foster,DEM,98
+Oglala Lakota,Gymnasium/Oglala Lakota,State Senate,27,David Jones,REP,42
+Oglala Lakota,Brother Renee Hall,State Senate,27,Red Dawn Foster,DEM,430
+Oglala Lakota,Brother Renee Hall,State Senate,27,David Jones,REP,29
+Oglala Lakota,?,State Senate,27,Red Dawn Foster,DEM,329
+Oglala Lakota,?,State Senate,27,David Jones,REP,15
+Oglala Lakota,Little Wound School,State Senate,27,Red Dawn Foster,DEM,364
+Oglala Lakota,Little Wound School,State Senate,27,David Jones,REP,22
+Oglala Lakota,Gymasium/Pine Ridge,State Senate,27,Red Dawn Foster,DEM,793
+Oglala Lakota,Gymasium/Pine Ridge,State Senate,27,David Jones,REP,49
+Oglala Lakota,Red Shirt School,State Senate,27,Red Dawn Foster,DEM,55
+Oglala Lakota,Red Shirt School,State Senate,27,David Jones,REP,23
+Oglala Lakota,?,State Senate,27,Red Dawn Foster,DEM,120
+Oglala Lakota,?,State Senate,27,David Jones,REP,9
+Oglala Lakota,?,State Senate,27,Red Dawn Foster,DEM,72
+Oglala Lakota,?,State Senate,27,David Jones,REP,19
+Oglala Lakota,Gymnasium/Oglala Lakota,State House,27,Peri Pourier,DEM,94
+Oglala Lakota,Gymnasium/Oglala Lakota,State House,27,Norma Rendon,DEM,73
+Oglala Lakota,Gymnasium/Oglala Lakota,State House,27,Liz May,REP,40
+Oglala Lakota,Gymnasium/Oglala Lakota,State House,27,Bud May,REP,37
+Oglala Lakota,Brother Renee Hall,State House,27,Peri Pourier,DEM,389
+Oglala Lakota,Brother Renee Hall,State House,27,Norma Rendon,DEM,264
+Oglala Lakota,Brother Renee Hall,State House,27,Liz May,REP,31
+Oglala Lakota,Brother Renee Hall,State House,27,Bud May,REP,25
+Oglala Lakota,?,State House,27,Peri Pourier,DEM,296
+Oglala Lakota,?,State House,27,Norma Rendon,DEM,268
+Oglala Lakota,?,State House,27,Liz May,REP,21
+Oglala Lakota,?,State House,27,Bud May,REP,16
+Oglala Lakota,Little Wound School,State House,27,Peri Pourier,DEM,334
+Oglala Lakota,Little Wound School,State House,27,Norma Rendon,DEM,249
+Oglala Lakota,Little Wound School,State House,27,Liz May,REP,52
+Oglala Lakota,Little Wound School,State House,27,Bud May,REP,20
+Oglala Lakota,Gymasium/Pine Ridge,State House,27,Peri Pourier,DEM,760
+Oglala Lakota,Gymasium/Pine Ridge,State House,27,Norma Rendon,DEM,593
+Oglala Lakota,Gymasium/Pine Ridge,State House,27,Liz May,REP,50
+Oglala Lakota,Gymasium/Pine Ridge,State House,27,Bud May,REP,45
+Oglala Lakota,Red Shirt School,State House,27,Peri Pourier,DEM,51
+Oglala Lakota,Red Shirt School,State House,27,Norma Rendon,DEM,33
+Oglala Lakota,Red Shirt School,State House,27,Liz May,REP,28
+Oglala Lakota,Red Shirt School,State House,27,Bud May,REP,20
+Oglala Lakota,?,State House,27,Peri Pourier,DEM,105
+Oglala Lakota,?,State House,27,Norma Rendon,DEM,88
+Oglala Lakota,?,State House,27,Liz May,REP,11
+Oglala Lakota,?,State House,27,Bud May,REP,10
+Oglala Lakota,?,State House,27,Peri Pourier,DEM,64
+Oglala Lakota,?,State House,27,Norma Rendon,DEM,59
+Oglala Lakota,?,State House,27,Liz May,REP,19
+Oglala Lakota,?,State House,27,Bud May,REP,15
+Oglala Lakota,Gymnasium/Oglala Lakota,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,33
+Oglala Lakota,Brother Renee Hall,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,126
+Oglala Lakota,?,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,62
+Oglala Lakota,Little Wound School,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,73
+Oglala Lakota,Gymasium/Pine Ridge,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,167
+Oglala Lakota,Red Shirt School,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,16
+Oglala Lakota,?,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,33
+Oglala Lakota,?,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,21
+Oglala Lakota,Gymnasium/Oglala Lakota,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,36
+Oglala Lakota,Brother Renee Hall,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,104
+Oglala Lakota,?,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,60
+Oglala Lakota,Little Wound School,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,69
+Oglala Lakota,Gymasium/Pine Ridge,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,144
+Oglala Lakota,Red Shirt School,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,16
+Oglala Lakota,?,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,25
+Oglala Lakota,?,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,20
+Oglala Lakota,Gymnasium/Oglala Lakota,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,31
+Oglala Lakota,Brother Renee Hall,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,113
+Oglala Lakota,?,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,64
+Oglala Lakota,Little Wound School,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,70
+Oglala Lakota,Gymasium/Pine Ridge,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,146
+Oglala Lakota,Red Shirt School,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,19
+Oglala Lakota,?,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,26
+Oglala Lakota,?,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,19
+Oglala Lakota,Gymnasium/Oglala Lakota,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,30
+Oglala Lakota,Brother Renee Hall,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,104
+Oglala Lakota,?,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,48
+Oglala Lakota,Little Wound School,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,63
+Oglala Lakota,Gymasium/Pine Ridge,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,131
+Oglala Lakota,Red Shirt School,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,19
+Oglala Lakota,?,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,25
+Oglala Lakota,?,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,19
+Oglala Lakota,Gymnasium/Oglala Lakota,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,33
+Oglala Lakota,Brother Renee Hall,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,104
+Oglala Lakota,?,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,60
+Oglala Lakota,Little Wound School,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,68
+Oglala Lakota,Gymasium/Pine Ridge,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,144
+Oglala Lakota,Red Shirt School,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,18
+Oglala Lakota,?,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,29
+Oglala Lakota,?,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,21
+Oglala Lakota,Gymnasium/Oglala Lakota,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,28
+Oglala Lakota,Brother Renee Hall,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,99
+Oglala Lakota,?,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,56
+Oglala Lakota,Little Wound School,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,55
+Oglala Lakota,Gymasium/Pine Ridge,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,128
+Oglala Lakota,Red Shirt School,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,14
+Oglala Lakota,?,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,25
+Oglala Lakota,?,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,16
+Oglala Lakota,Gymnasium/Oglala Lakota,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,28
+Oglala Lakota,Brother Renee Hall,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,97
+Oglala Lakota,?,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,50
+Oglala Lakota,Little Wound School,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,54
+Oglala Lakota,Gymasium/Pine Ridge,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,128
+Oglala Lakota,Red Shirt School,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,14
+Oglala Lakota,?,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,25
+Oglala Lakota,?,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,18
+Oglala Lakota,Gymnasium/Oglala Lakota,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,35
+Oglala Lakota,Brother Renee Hall,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,113
+Oglala Lakota,?,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,62
+Oglala Lakota,Little Wound School,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,70
+Oglala Lakota,Gymasium/Pine Ridge,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,150
+Oglala Lakota,Red Shirt School,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,18
+Oglala Lakota,?,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,27
+Oglala Lakota,?,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,19
+Oglala Lakota,Gymnasium/Oglala Lakota,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,75
+Oglala Lakota,Gymnasium/Oglala Lakota,Supreme Court Retention,3,Patricia J. DeVaney - No,,52
+Oglala Lakota,Brother Renee Hall,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,232
+Oglala Lakota,Brother Renee Hall,Supreme Court Retention,3,Patricia J. DeVaney - No,,170
+Oglala Lakota,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,151
+Oglala Lakota,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,167
+Oglala Lakota,Little Wound School,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,165
+Oglala Lakota,Little Wound School,Supreme Court Retention,3,Patricia J. DeVaney - No,,160
+Oglala Lakota,Gymasium/Pine Ridge,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,346
+Oglala Lakota,Gymasium/Pine Ridge,Supreme Court Retention,3,Patricia J. DeVaney - No,,348
+Oglala Lakota,Red Shirt School,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,42
+Oglala Lakota,Red Shirt School,Supreme Court Retention,3,Patricia J. DeVaney - No,,29
+Oglala Lakota,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,59
+Oglala Lakota,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,56
+Oglala Lakota,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,42
+Oglala Lakota,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,36
+Oglala Lakota,Gymnasium/Oglala Lakota,Supreme Court Retention,2,Mark E. Salter - Yes,,76
+Oglala Lakota,Gymnasium/Oglala Lakota,Supreme Court Retention,2,Mark E. Salter - No,,50
+Oglala Lakota,Brother Renee Hall,Supreme Court Retention,2,Mark E. Salter - Yes,,219
+Oglala Lakota,Brother Renee Hall,Supreme Court Retention,2,Mark E. Salter - No,,183
+Oglala Lakota,?,Supreme Court Retention,2,Mark E. Salter - Yes,,151
+Oglala Lakota,?,Supreme Court Retention,2,Mark E. Salter - No,,164
+Oglala Lakota,Little Wound School,Supreme Court Retention,2,Mark E. Salter - Yes,,141
+Oglala Lakota,Little Wound School,Supreme Court Retention,2,Mark E. Salter - No,,184
+Oglala Lakota,Gymasium/Pine Ridge,Supreme Court Retention,2,Mark E. Salter - Yes,,342
+Oglala Lakota,Gymasium/Pine Ridge,Supreme Court Retention,2,Mark E. Salter - No,,345
+Oglala Lakota,Red Shirt School,Supreme Court Retention,2,Mark E. Salter - Yes,,41
+Oglala Lakota,Red Shirt School,Supreme Court Retention,2,Mark E. Salter - No,,30
+Oglala Lakota,?,Supreme Court Retention,2,Mark E. Salter - Yes,,48
+Oglala Lakota,?,Supreme Court Retention,2,Mark E. Salter - No,,67
+Oglala Lakota,?,Supreme Court Retention,2,Mark E. Salter - Yes,,41
+Oglala Lakota,?,Supreme Court Retention,2,Mark E. Salter - No,,35
+Oglala Lakota,Gymnasium/Oglala Lakota,Constitutional Amendment D,,Yes,,112
+Oglala Lakota,Gymnasium/Oglala Lakota,Constitutional Amendment D,,No,,28
+Oglala Lakota,Brother Renee Hall,Constitutional Amendment D,,Yes,,375
+Oglala Lakota,Brother Renee Hall,Constitutional Amendment D,,No,,54
+Oglala Lakota,?,Constitutional Amendment D,,Yes,,300
+Oglala Lakota,?,Constitutional Amendment D,,No,,30
+Oglala Lakota,Little Wound School,Constitutional Amendment D,,Yes,,338
+Oglala Lakota,Little Wound School,Constitutional Amendment D,,No,,36
+Oglala Lakota,Gymasium/Pine Ridge,Constitutional Amendment D,,Yes,,733
+Oglala Lakota,Gymasium/Pine Ridge,Constitutional Amendment D,,No,,61
+Oglala Lakota,Red Shirt School,Constitutional Amendment D,,Yes,,52
+Oglala Lakota,Red Shirt School,Constitutional Amendment D,,No,,20
+Oglala Lakota,?,Constitutional Amendment D,,Yes,,104
+Oglala Lakota,?,Constitutional Amendment D,,No,,13
+Oglala Lakota,?,Constitutional Amendment D,,Yes,,73
+Oglala Lakota,?,Constitutional Amendment D,,No,,14
+Oglala Lakota,Gymnasium/Oglala Lakota,Initiated Measure 27,,Yes,,98
+Oglala Lakota,Gymnasium/Oglala Lakota,Initiated Measure 27,,No,,44
+Oglala Lakota,Brother Renee Hall,Initiated Measure 27,,Yes,,333
+Oglala Lakota,Brother Renee Hall,Initiated Measure 27,,No,,109
+Oglala Lakota,?,Initiated Measure 27,,Yes,,256
+Oglala Lakota,?,Initiated Measure 27,,No,,77
+Oglala Lakota,Little Wound School,Initiated Measure 27,,Yes,,318
+Oglala Lakota,Little Wound School,Initiated Measure 27,,No,,63
+Oglala Lakota,Gymasium/Pine Ridge,Initiated Measure 27,,Yes,,688
+Oglala Lakota,Gymasium/Pine Ridge,Initiated Measure 27,,No,,116
+Oglala Lakota,Red Shirt School,Initiated Measure 27,,Yes,,50
+Oglala Lakota,Red Shirt School,Initiated Measure 27,,No,,22
+Oglala Lakota,?,Initiated Measure 27,,Yes,,102
+Oglala Lakota,?,Initiated Measure 27,,No,,18
+Oglala Lakota,?,Initiated Measure 27,,Yes,,69
+Oglala Lakota,?,Initiated Measure 27,,No,,18

--- a/2022/counties/20221108__sd__general__pennington__precinct.csv
+++ b/2022/counties/20221108__sd__general__pennington__precinct.csv
@@ -1,0 +1,1895 @@
+county,precinct,office,district,candidate,party,votes
+Pennington,1-1,U.S. Senate,,Brian L. Bengs,DEM,313
+Pennington,1-1,U.S. Senate,,Tamara J Lesnar,LIB,62
+Pennington,1-1,U.S. Senate,,John R. Thune,REP,814
+Pennington,1-2,U.S. Senate,,Brian L. Bengs,DEM,331
+Pennington,1-2,U.S. Senate,,Tamara J Lesnar,LIB,67
+Pennington,1-2,U.S. Senate,,John R. Thune,REP,909
+Pennington,1-3,U.S. Senate,,Brian L. Bengs,DEM,360
+Pennington,1-3,U.S. Senate,,Tamara J Lesnar,LIB,42
+Pennington,1-3,U.S. Senate,,John R. Thune,REP,1060
+Pennington,1-4,U.S. Senate,,Brian L. Bengs,DEM,179
+Pennington,1-4,U.S. Senate,,Tamara J Lesnar,LIB,29
+Pennington,1-4,U.S. Senate,,John R. Thune,REP,600
+Pennington,1-5,U.S. Senate,,Brian L. Bengs,DEM,454
+Pennington,1-5,U.S. Senate,,Tamara J Lesnar,LIB,75
+Pennington,1-5,U.S. Senate,,John R. Thune,REP,938
+Pennington,2-1,U.S. Senate,,Brian L. Bengs,DEM,114
+Pennington,2-1,U.S. Senate,,Tamara J Lesnar,LIB,26
+Pennington,2-1,U.S. Senate,,John R. Thune,REP,132
+Pennington,2-2,U.S. Senate,,Brian L. Bengs,DEM,317
+Pennington,2-2,U.S. Senate,,Tamara J Lesnar,LIB,63
+Pennington,2-2,U.S. Senate,,John R. Thune,REP,850
+Pennington,2-3,U.S. Senate,,Brian L. Bengs,DEM,277
+Pennington,2-3,U.S. Senate,,Tamara J Lesnar,LIB,54
+Pennington,2-3,U.S. Senate,,John R. Thune,REP,454
+Pennington,2-4,U.S. Senate,,Brian L. Bengs,DEM,336
+Pennington,2-4,U.S. Senate,,Tamara J Lesnar,LIB,49
+Pennington,2-4,U.S. Senate,,John R. Thune,REP,484
+Pennington,2-5,U.S. Senate,,Brian L. Bengs,DEM,263
+Pennington,2-5,U.S. Senate,,Tamara J Lesnar,LIB,45
+Pennington,2-5,U.S. Senate,,John R. Thune,REP,500
+Pennington,3-1,U.S. Senate,,Brian L. Bengs,DEM,118
+Pennington,3-1,U.S. Senate,,Tamara J Lesnar,LIB,19
+Pennington,3-1,U.S. Senate,,John R. Thune,REP,198
+Pennington,3-2,U.S. Senate,,Brian L. Bengs,DEM,697
+Pennington,3-2,U.S. Senate,,Tamara J Lesnar,LIB,97
+Pennington,3-2,U.S. Senate,,John R. Thune,REP,1407
+Pennington,3-3,U.S. Senate,,Brian L. Bengs,DEM,584
+Pennington,3-3,U.S. Senate,,Tamara J Lesnar,LIB,84
+Pennington,3-3,U.S. Senate,,John R. Thune,REP,1488
+Pennington,3-4,U.S. Senate,,Brian L. Bengs,DEM,482
+Pennington,3-4,U.S. Senate,,Tamara J Lesnar,LIB,54
+Pennington,3-4,U.S. Senate,,John R. Thune,REP,1237
+Pennington,3-5,U.S. Senate,,Brian L. Bengs,DEM,272
+Pennington,3-5,U.S. Senate,,Tamara J Lesnar,LIB,36
+Pennington,3-5,U.S. Senate,,John R. Thune,REP,910
+Pennington,4-1,U.S. Senate,,Brian L. Bengs,DEM,351
+Pennington,4-1,U.S. Senate,,Tamara J Lesnar,LIB,65
+Pennington,4-1,U.S. Senate,,John R. Thune,REP,408
+Pennington,4-2,U.S. Senate,,Brian L. Bengs,DEM,385
+Pennington,4-2,U.S. Senate,,Tamara J Lesnar,LIB,87
+Pennington,4-2,U.S. Senate,,John R. Thune,REP,589
+Pennington,4-3,U.S. Senate,,Brian L. Bengs,DEM,302
+Pennington,4-3,U.S. Senate,,Tamara J Lesnar,LIB,60
+Pennington,4-3,U.S. Senate,,John R. Thune,REP,706
+Pennington,4-4,U.S. Senate,,Brian L. Bengs,DEM,248
+Pennington,4-4,U.S. Senate,,Tamara J Lesnar,LIB,48
+Pennington,4-4,U.S. Senate,,John R. Thune,REP,317
+Pennington,4-5,U.S. Senate,,Brian L. Bengs,DEM,130
+Pennington,4-5,U.S. Senate,,Tamara J Lesnar,LIB,31
+Pennington,4-5,U.S. Senate,,John R. Thune,REP,282
+Pennington,5-1,U.S. Senate,,Brian L. Bengs,DEM,216
+Pennington,5-1,U.S. Senate,,Tamara J Lesnar,LIB,39
+Pennington,5-1,U.S. Senate,,John R. Thune,REP,355
+Pennington,5-2,U.S. Senate,,Brian L. Bengs,DEM,327
+Pennington,5-2,U.S. Senate,,Tamara J Lesnar,LIB,54
+Pennington,5-2,U.S. Senate,,John R. Thune,REP,469
+Pennington,5-3,U.S. Senate,,Brian L. Bengs,DEM,456
+Pennington,5-3,U.S. Senate,,Tamara J Lesnar,LIB,72
+Pennington,5-3,U.S. Senate,,John R. Thune,REP,748
+Pennington,5-4,U.S. Senate,,Brian L. Bengs,DEM,723
+Pennington,5-4,U.S. Senate,,Tamara J Lesnar,LIB,91
+Pennington,5-4,U.S. Senate,,John R. Thune,REP,724
+Pennington,5-5,U.S. Senate,,Brian L. Bengs,DEM,588
+Pennington,5-5,U.S. Senate,,Tamara J Lesnar,LIB,102
+Pennington,5-5,U.S. Senate,,John R. Thune,REP,1226
+Pennington,AW,U.S. Senate,,Brian L. Bengs,DEM,607
+Pennington,AW,U.S. Senate,,Tamara J Lesnar,LIB,62
+Pennington,AW,U.S. Senate,,John R. Thune,REP,1750
+Pennington,BE,U.S. Senate,,Brian L. Bengs,DEM,435
+Pennington,BE,U.S. Senate,,Tamara J Lesnar,LIB,112
+Pennington,BE,U.S. Senate,,John R. Thune,REP,1288
+Pennington,CA,U.S. Senate,,Brian L. Bengs,DEM,70
+Pennington,CA,U.S. Senate,,Tamara J Lesnar,LIB,40
+Pennington,CA,U.S. Senate,,John R. Thune,REP,477
+Pennington,CL,U.S. Senate,,Brian L. Bengs,DEM,150
+Pennington,CL,U.S. Senate,,Tamara J Lesnar,LIB,24
+Pennington,CL,U.S. Senate,,John R. Thune,REP,409
+Pennington,DT,U.S. Senate,,Brian L. Bengs,DEM,119
+Pennington,DT,U.S. Senate,,Tamara J Lesnar,LIB,21
+Pennington,DT,U.S. Senate,,John R. Thune,REP,483
+Pennington,HC,U.S. Senate,,Brian L. Bengs,DEM,275
+Pennington,HC,U.S. Senate,,Tamara J Lesnar,LIB,63
+Pennington,HC,U.S. Senate,,John R. Thune,REP,868
+Pennington,HR,U.S. Senate,,Brian L. Bengs,DEM,223
+Pennington,HR,U.S. Senate,,Tamara J Lesnar,LIB,62
+Pennington,HR,U.S. Senate,,John R. Thune,REP,953
+Pennington,JS,U.S. Senate,,Brian L. Bengs,DEM,287
+Pennington,JS,U.S. Senate,,Tamara J Lesnar,LIB,73
+Pennington,JS,U.S. Senate,,John R. Thune,REP,908
+Pennington,KY,U.S. Senate,,Brian L. Bengs,DEM,119
+Pennington,KY,U.S. Senate,,Tamara J Lesnar,LIB,25
+Pennington,KY,U.S. Senate,,John R. Thune,REP,375
+Pennington,LS,U.S. Senate,,Brian L. Bengs,DEM,58
+Pennington,LS,U.S. Senate,,Tamara J Lesnar,LIB,19
+Pennington,LS,U.S. Senate,,John R. Thune,REP,323
+Pennington,NH,U.S. Senate,,Brian L. Bengs,DEM,33
+Pennington,NH,U.S. Senate,,Tamara J Lesnar,LIB,15
+Pennington,NH,U.S. Senate,,John R. Thune,REP,106
+Pennington,NU,U.S. Senate,,Brian L. Bengs,DEM,71
+Pennington,NU,U.S. Senate,,Tamara J Lesnar,LIB,29
+Pennington,NU,U.S. Senate,,John R. Thune,REP,485
+Pennington,QU,U.S. Senate,,Brian L. Bengs,DEM,13
+Pennington,QU,U.S. Senate,,Tamara J Lesnar,LIB,29
+Pennington,QU,U.S. Senate,,John R. Thune,REP,187
+Pennington,RK,U.S. Senate,,Brian L. Bengs,DEM,2
+Pennington,RK,U.S. Senate,,Tamara J Lesnar,LIB,4
+Pennington,RK,U.S. Senate,,John R. Thune,REP,28
+Pennington,RV,U.S. Senate,,Brian L. Bengs,DEM,248
+Pennington,RV,U.S. Senate,,Tamara J Lesnar,LIB,74
+Pennington,RV,U.S. Senate,,John R. Thune,REP,758
+Pennington,SR,U.S. Senate,,Brian L. Bengs,DEM,48
+Pennington,SR,U.S. Senate,,Tamara J Lesnar,LIB,14
+Pennington,SR,U.S. Senate,,John R. Thune,REP,158
+Pennington,VF,U.S. Senate,,Brian L. Bengs,DEM,286
+Pennington,VF,U.S. Senate,,Tamara J Lesnar,LIB,94
+Pennington,VF,U.S. Senate,,John R. Thune,REP,1026
+Pennington,VV,U.S. Senate,,Brian L. Bengs,DEM,234
+Pennington,VV,U.S. Senate,,Tamara J Lesnar,LIB,46
+Pennington,VV,U.S. Senate,,John R. Thune,REP,783
+Pennington,WL,U.S. Senate,,Brian L. Bengs,DEM,33
+Pennington,WL,U.S. Senate,,Tamara J Lesnar,LIB,13
+Pennington,WL,U.S. Senate,,John R. Thune,REP,324
+Pennington,WP,U.S. Senate,,Brian L. Bengs,DEM,302
+Pennington,WP,U.S. Senate,,Tamara J Lesnar,LIB,38
+Pennington,WP,U.S. Senate,,John R. Thune,REP,833
+Pennington,WS,U.S. Senate,,Brian L. Bengs,DEM,5
+Pennington,WS,U.S. Senate,,Tamara J Lesnar,LIB,6
+Pennington,WS,U.S. Senate,,John R. Thune,REP,71
+Pennington,1-1,U.S. House,1,Collin Duprel,LIB,276
+Pennington,1-1,U.S. House,1,Dusty Johnson,REP,839
+Pennington,1-2,U.S. House,1,Collin Duprel,LIB,300
+Pennington,1-2,U.S. House,1,Dusty Johnson,REP,950
+Pennington,1-3,U.S. House,1,Collin Duprel,LIB,288
+Pennington,1-3,U.S. House,1,Dusty Johnson,REP,1094
+Pennington,1-4,U.S. House,1,Collin Duprel,LIB,156
+Pennington,1-4,U.S. House,1,Dusty Johnson,REP,599
+Pennington,1-5,U.S. House,1,Collin Duprel,LIB,381
+Pennington,1-5,U.S. House,1,Dusty Johnson,REP,1005
+Pennington,2-1,U.S. House,1,Collin Duprel,LIB,115
+Pennington,2-1,U.S. House,1,Dusty Johnson,REP,134
+Pennington,2-2,U.S. House,1,Collin Duprel,LIB,319
+Pennington,2-2,U.S. House,1,Dusty Johnson,REP,838
+Pennington,2-3,U.S. House,1,Collin Duprel,LIB,268
+Pennington,2-3,U.S. House,1,Dusty Johnson,REP,448
+Pennington,2-4,U.S. House,1,Collin Duprel,LIB,295
+Pennington,2-4,U.S. House,1,Dusty Johnson,REP,516
+Pennington,2-5,U.S. House,1,Collin Duprel,LIB,236
+Pennington,2-5,U.S. House,1,Dusty Johnson,REP,518
+Pennington,3-1,U.S. House,1,Collin Duprel,LIB,98
+Pennington,3-1,U.S. House,1,Dusty Johnson,REP,220
+Pennington,3-2,U.S. House,1,Collin Duprel,LIB,552
+Pennington,3-2,U.S. House,1,Dusty Johnson,REP,1509
+Pennington,3-3,U.S. House,1,Collin Duprel,LIB,446
+Pennington,3-3,U.S. House,1,Dusty Johnson,REP,1562
+Pennington,3-4,U.S. House,1,Collin Duprel,LIB,350
+Pennington,3-4,U.S. House,1,Dusty Johnson,REP,1306
+Pennington,3-5,U.S. House,1,Collin Duprel,LIB,206
+Pennington,3-5,U.S. House,1,Dusty Johnson,REP,965
+Pennington,4-1,U.S. House,1,Collin Duprel,LIB,319
+Pennington,4-1,U.S. House,1,Dusty Johnson,REP,421
+Pennington,4-2,U.S. House,1,Collin Duprel,LIB,371
+Pennington,4-2,U.S. House,1,Dusty Johnson,REP,617
+Pennington,4-3,U.S. House,1,Collin Duprel,LIB,296
+Pennington,4-3,U.S. House,1,Dusty Johnson,REP,724
+Pennington,4-4,U.S. House,1,Collin Duprel,LIB,230
+Pennington,4-4,U.S. House,1,Dusty Johnson,REP,327
+Pennington,4-5,U.S. House,1,Collin Duprel,LIB,135
+Pennington,4-5,U.S. House,1,Dusty Johnson,REP,286
+Pennington,5-1,U.S. House,1,Collin Duprel,LIB,185
+Pennington,5-1,U.S. House,1,Dusty Johnson,REP,367
+Pennington,5-2,U.S. House,1,Collin Duprel,LIB,269
+Pennington,5-2,U.S. House,1,Dusty Johnson,REP,526
+Pennington,5-3,U.S. House,1,Collin Duprel,LIB,392
+Pennington,5-3,U.S. House,1,Dusty Johnson,REP,788
+Pennington,5-4,U.S. House,1,Collin Duprel,LIB,518
+Pennington,5-4,U.S. House,1,Dusty Johnson,REP,834
+Pennington,5-5,U.S. House,1,Collin Duprel,LIB,454
+Pennington,5-5,U.S. House,1,Dusty Johnson,REP,1320
+Pennington,AW,U.S. House,1,Collin Duprel,LIB,454
+Pennington,AW,U.S. House,1,Dusty Johnson,REP,1758
+Pennington,BE,U.S. House,1,Collin Duprel,LIB,468
+Pennington,BE,U.S. House,1,Dusty Johnson,REP,1286
+Pennington,CA,U.S. House,1,Collin Duprel,LIB,122
+Pennington,CA,U.S. House,1,Dusty Johnson,REP,446
+Pennington,CL,U.S. House,1,Collin Duprel,LIB,117
+Pennington,CL,U.S. House,1,Dusty Johnson,REP,422
+Pennington,DT,U.S. House,1,Collin Duprel,LIB,117
+Pennington,DT,U.S. House,1,Dusty Johnson,REP,486
+Pennington,HC,U.S. House,1,Collin Duprel,LIB,247
+Pennington,HC,U.S. House,1,Dusty Johnson,REP,900
+Pennington,HR,U.S. House,1,Collin Duprel,LIB,212
+Pennington,HR,U.S. House,1,Dusty Johnson,REP,966
+Pennington,JS,U.S. House,1,Collin Duprel,LIB,270
+Pennington,JS,U.S. House,1,Dusty Johnson,REP,944
+Pennington,KY,U.S. House,1,Collin Duprel,LIB,104
+Pennington,KY,U.S. House,1,Dusty Johnson,REP,384
+Pennington,LS,U.S. House,1,Collin Duprel,LIB,64
+Pennington,LS,U.S. House,1,Dusty Johnson,REP,323
+Pennington,NH,U.S. House,1,Collin Duprel,LIB,41
+Pennington,NH,U.S. House,1,Dusty Johnson,REP,102
+Pennington,NU,U.S. House,1,Collin Duprel,LIB,109
+Pennington,NU,U.S. House,1,Dusty Johnson,REP,460
+Pennington,QU,U.S. House,1,Collin Duprel,LIB,52
+Pennington,QU,U.S. House,1,Dusty Johnson,REP,173
+Pennington,RK,U.S. House,1,Collin Duprel,LIB,6
+Pennington,RK,U.S. House,1,Dusty Johnson,REP,27
+Pennington,RV,U.S. House,1,Collin Duprel,LIB,263
+Pennington,RV,U.S. House,1,Dusty Johnson,REP,758
+Pennington,SR,U.S. House,1,Collin Duprel,LIB,44
+Pennington,SR,U.S. House,1,Dusty Johnson,REP,159
+Pennington,VF,U.S. House,1,Collin Duprel,LIB,359
+Pennington,VF,U.S. House,1,Dusty Johnson,REP,988
+Pennington,VV,U.S. House,1,Collin Duprel,LIB,236
+Pennington,VV,U.S. House,1,Dusty Johnson,REP,779
+Pennington,WL,U.S. House,1,Collin Duprel,LIB,57
+Pennington,WL,U.S. House,1,Dusty Johnson,REP,309
+Pennington,WP,U.S. House,1,Collin Duprel,LIB,268
+Pennington,WP,U.S. House,1,Dusty Johnson,REP,859
+Pennington,WS,U.S. House,1,Collin Duprel,LIB,15
+Pennington,WS,U.S. House,1,Dusty Johnson,REP,63
+Pennington,1-1,Governor,,Jamie Smith and Jennifer Keintz,DEM,413
+Pennington,1-1,Governor,,Tracey Quint and Ashley Strand,LIB,42
+Pennington,1-1,Governor,,Kristi Noem and Larry Rhoden,REP,740
+Pennington,1-2,Governor,,Jamie Smith and Jennifer Keintz,DEM,474
+Pennington,1-2,Governor,,Tracey Quint and Ashley Strand,LIB,52
+Pennington,1-2,Governor,,Kristi Noem and Larry Rhoden,REP,784
+Pennington,1-3,Governor,,Jamie Smith and Jennifer Keintz,DEM,513
+Pennington,1-3,Governor,,Tracey Quint and Ashley Strand,LIB,30
+Pennington,1-3,Governor,,Kristi Noem and Larry Rhoden,REP,927
+Pennington,1-4,Governor,,Jamie Smith and Jennifer Keintz,DEM,255
+Pennington,1-4,Governor,,Tracey Quint and Ashley Strand,LIB,19
+Pennington,1-4,Governor,,Kristi Noem and Larry Rhoden,REP,532
+Pennington,1-5,Governor,,Jamie Smith and Jennifer Keintz,DEM,595
+Pennington,1-5,Governor,,Tracey Quint and Ashley Strand,LIB,65
+Pennington,1-5,Governor,,Kristi Noem and Larry Rhoden,REP,815
+Pennington,2-1,Governor,,Jamie Smith and Jennifer Keintz,DEM,142
+Pennington,2-1,Governor,,Tracey Quint and Ashley Strand,LIB,21
+Pennington,2-1,Governor,,Kristi Noem and Larry Rhoden,REP,108
+Pennington,2-2,Governor,,Jamie Smith and Jennifer Keintz,DEM,405
+Pennington,2-2,Governor,,Tracey Quint and Ashley Strand,LIB,56
+Pennington,2-2,Governor,,Kristi Noem and Larry Rhoden,REP,771
+Pennington,2-3,Governor,,Jamie Smith and Jennifer Keintz,DEM,344
+Pennington,2-3,Governor,,Tracey Quint and Ashley Strand,LIB,45
+Pennington,2-3,Governor,,Kristi Noem and Larry Rhoden,REP,395
+Pennington,2-4,Governor,,Jamie Smith and Jennifer Keintz,DEM,413
+Pennington,2-4,Governor,,Tracey Quint and Ashley Strand,LIB,37
+Pennington,2-4,Governor,,Kristi Noem and Larry Rhoden,REP,429
+Pennington,2-5,Governor,,Jamie Smith and Jennifer Keintz,DEM,333
+Pennington,2-5,Governor,,Tracey Quint and Ashley Strand,LIB,40
+Pennington,2-5,Governor,,Kristi Noem and Larry Rhoden,REP,437
+Pennington,3-1,Governor,,Jamie Smith and Jennifer Keintz,DEM,153
+Pennington,3-1,Governor,,Tracey Quint and Ashley Strand,LIB,10
+Pennington,3-1,Governor,,Kristi Noem and Larry Rhoden,REP,175
+Pennington,3-2,Governor,,Jamie Smith and Jennifer Keintz,DEM,918
+Pennington,3-2,Governor,,Tracey Quint and Ashley Strand,LIB,54
+Pennington,3-2,Governor,,Kristi Noem and Larry Rhoden,REP,1237
+Pennington,3-3,Governor,,Jamie Smith and Jennifer Keintz,DEM,794
+Pennington,3-3,Governor,,Tracey Quint and Ashley Strand,LIB,55
+Pennington,3-3,Governor,,Kristi Noem and Larry Rhoden,REP,1308
+Pennington,3-4,Governor,,Jamie Smith and Jennifer Keintz,DEM,665
+Pennington,3-4,Governor,,Tracey Quint and Ashley Strand,LIB,28
+Pennington,3-4,Governor,,Kristi Noem and Larry Rhoden,REP,1086
+Pennington,3-5,Governor,,Jamie Smith and Jennifer Keintz,DEM,399
+Pennington,3-5,Governor,,Tracey Quint and Ashley Strand,LIB,22
+Pennington,3-5,Governor,,Kristi Noem and Larry Rhoden,REP,806
+Pennington,4-1,Governor,,Jamie Smith and Jennifer Keintz,DEM,434
+Pennington,4-1,Governor,,Tracey Quint and Ashley Strand,LIB,51
+Pennington,4-1,Governor,,Kristi Noem and Larry Rhoden,REP,343
+Pennington,4-2,Governor,,Jamie Smith and Jennifer Keintz,DEM,503
+Pennington,4-2,Governor,,Tracey Quint and Ashley Strand,LIB,67
+Pennington,4-2,Governor,,Kristi Noem and Larry Rhoden,REP,498
+Pennington,4-3,Governor,,Jamie Smith and Jennifer Keintz,DEM,400
+Pennington,4-3,Governor,,Tracey Quint and Ashley Strand,LIB,33
+Pennington,4-3,Governor,,Kristi Noem and Larry Rhoden,REP,638
+Pennington,4-4,Governor,,Jamie Smith and Jennifer Keintz,DEM,288
+Pennington,4-4,Governor,,Tracey Quint and Ashley Strand,LIB,32
+Pennington,4-4,Governor,,Kristi Noem and Larry Rhoden,REP,297
+Pennington,4-5,Governor,,Jamie Smith and Jennifer Keintz,DEM,168
+Pennington,4-5,Governor,,Tracey Quint and Ashley Strand,LIB,21
+Pennington,4-5,Governor,,Kristi Noem and Larry Rhoden,REP,263
+Pennington,5-1,Governor,,Jamie Smith and Jennifer Keintz,DEM,288
+Pennington,5-1,Governor,,Tracey Quint and Ashley Strand,LIB,24
+Pennington,5-1,Governor,,Kristi Noem and Larry Rhoden,REP,302
+Pennington,5-2,Governor,,Jamie Smith and Jennifer Keintz,DEM,424
+Pennington,5-2,Governor,,Tracey Quint and Ashley Strand,LIB,36
+Pennington,5-2,Governor,,Kristi Noem and Larry Rhoden,REP,398
+Pennington,5-3,Governor,,Jamie Smith and Jennifer Keintz,DEM,585
+Pennington,5-3,Governor,,Tracey Quint and Ashley Strand,LIB,49
+Pennington,5-3,Governor,,Kristi Noem and Larry Rhoden,REP,646
+Pennington,5-4,Governor,,Jamie Smith and Jennifer Keintz,DEM,898
+Pennington,5-4,Governor,,Tracey Quint and Ashley Strand,LIB,58
+Pennington,5-4,Governor,,Kristi Noem and Larry Rhoden,REP,600
+Pennington,5-5,Governor,,Jamie Smith and Jennifer Keintz,DEM,778
+Pennington,5-5,Governor,,Tracey Quint and Ashley Strand,LIB,66
+Pennington,5-5,Governor,,Kristi Noem and Larry Rhoden,REP,1085
+Pennington,AW,Governor,,Jamie Smith and Jennifer Keintz,DEM,624
+Pennington,AW,Governor,,Tracey Quint and Ashley Strand,LIB,27
+Pennington,AW,Governor,,Kristi Noem and Larry Rhoden,REP,1768
+Pennington,BE,Governor,,Jamie Smith and Jennifer Keintz,DEM,549
+Pennington,BE,Governor,,Tracey Quint and Ashley Strand,LIB,102
+Pennington,BE,Governor,,Kristi Noem and Larry Rhoden,REP,1196
+Pennington,CA,Governor,,Jamie Smith and Jennifer Keintz,DEM,95
+Pennington,CA,Governor,,Tracey Quint and Ashley Strand,LIB,18
+Pennington,CA,Governor,,Kristi Noem and Larry Rhoden,REP,480
+Pennington,CL,Governor,,Jamie Smith and Jennifer Keintz,DEM,207
+Pennington,CL,Governor,,Tracey Quint and Ashley Strand,LIB,16
+Pennington,CL,Governor,,Kristi Noem and Larry Rhoden,REP,356
+Pennington,DT,Governor,,Jamie Smith and Jennifer Keintz,DEM,165
+Pennington,DT,Governor,,Tracey Quint and Ashley Strand,LIB,16
+Pennington,DT,Governor,,Kristi Noem and Larry Rhoden,REP,448
+Pennington,HC,Governor,,Jamie Smith and Jennifer Keintz,DEM,343
+Pennington,HC,Governor,,Tracey Quint and Ashley Strand,LIB,41
+Pennington,HC,Governor,,Kristi Noem and Larry Rhoden,REP,828
+Pennington,HR,Governor,,Jamie Smith and Jennifer Keintz,DEM,301
+Pennington,HR,Governor,,Tracey Quint and Ashley Strand,LIB,31
+Pennington,HR,Governor,,Kristi Noem and Larry Rhoden,REP,907
+Pennington,JS,Governor,,Jamie Smith and Jennifer Keintz,DEM,380
+Pennington,JS,Governor,,Tracey Quint and Ashley Strand,LIB,41
+Pennington,JS,Governor,,Kristi Noem and Larry Rhoden,REP,860
+Pennington,KY,Governor,,Jamie Smith and Jennifer Keintz,DEM,144
+Pennington,KY,Governor,,Tracey Quint and Ashley Strand,LIB,20
+Pennington,KY,Governor,,Kristi Noem and Larry Rhoden,REP,356
+Pennington,LS,Governor,,Jamie Smith and Jennifer Keintz,DEM,87
+Pennington,LS,Governor,,Tracey Quint and Ashley Strand,LIB,8
+Pennington,LS,Governor,,Kristi Noem and Larry Rhoden,REP,309
+Pennington,NH,Governor,,Jamie Smith and Jennifer Keintz,DEM,42
+Pennington,NH,Governor,,Tracey Quint and Ashley Strand,LIB,11
+Pennington,NH,Governor,,Kristi Noem and Larry Rhoden,REP,102
+Pennington,NU,Governor,,Jamie Smith and Jennifer Keintz,DEM,85
+Pennington,NU,Governor,,Tracey Quint and Ashley Strand,LIB,11
+Pennington,NU,Governor,,Kristi Noem and Larry Rhoden,REP,490
+Pennington,QU,Governor,,Jamie Smith and Jennifer Keintz,DEM,19
+Pennington,QU,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Pennington,QU,Governor,,Kristi Noem and Larry Rhoden,REP,211
+Pennington,RK,Governor,,Jamie Smith and Jennifer Keintz,DEM,5
+Pennington,RK,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Pennington,RK,Governor,,Kristi Noem and Larry Rhoden,REP,28
+Pennington,RV,Governor,,Jamie Smith and Jennifer Keintz,DEM,343
+Pennington,RV,Governor,,Tracey Quint and Ashley Strand,LIB,62
+Pennington,RV,Governor,,Kristi Noem and Larry Rhoden,REP,677
+Pennington,SR,Governor,,Jamie Smith and Jennifer Keintz,DEM,73
+Pennington,SR,Governor,,Tracey Quint and Ashley Strand,LIB,15
+Pennington,SR,Governor,,Kristi Noem and Larry Rhoden,REP,138
+Pennington,VF,Governor,,Jamie Smith and Jennifer Keintz,DEM,395
+Pennington,VF,Governor,,Tracey Quint and Ashley Strand,LIB,72
+Pennington,VF,Governor,,Kristi Noem and Larry Rhoden,REP,952
+Pennington,VV,Governor,,Jamie Smith and Jennifer Keintz,DEM,321
+Pennington,VV,Governor,,Tracey Quint and Ashley Strand,LIB,44
+Pennington,VV,Governor,,Kristi Noem and Larry Rhoden,REP,710
+Pennington,WL,Governor,,Jamie Smith and Jennifer Keintz,DEM,61
+Pennington,WL,Governor,,Tracey Quint and Ashley Strand,LIB,8
+Pennington,WL,Governor,,Kristi Noem and Larry Rhoden,REP,302
+Pennington,WP,Governor,,Jamie Smith and Jennifer Keintz,DEM,389
+Pennington,WP,Governor,,Tracey Quint and Ashley Strand,LIB,22
+Pennington,WP,Governor,,Kristi Noem and Larry Rhoden,REP,777
+Pennington,WS,Governor,,Jamie Smith and Jennifer Keintz,DEM,5
+Pennington,WS,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Pennington,WS,Governor,,Kristi Noem and Larry Rhoden,REP,71
+Pennington,1-1,Secretary of State,,Thomas A Cool,DEM,390
+Pennington,1-1,Secretary of State,,Monae Johnson,REP,747
+Pennington,1-2,Secretary of State,,Thomas A Cool,DEM,443
+Pennington,1-2,Secretary of State,,Monae Johnson,REP,794
+Pennington,1-3,Secretary of State,,Thomas A Cool,DEM,466
+Pennington,1-3,Secretary of State,,Monae Johnson,REP,952
+Pennington,1-4,Secretary of State,,Thomas A Cool,DEM,227
+Pennington,1-4,Secretary of State,,Monae Johnson,REP,546
+Pennington,1-5,Secretary of State,,Thomas A Cool,DEM,593
+Pennington,1-5,Secretary of State,,Monae Johnson,REP,824
+Pennington,2-1,Secretary of State,,Thomas A Cool,DEM,134
+Pennington,2-1,Secretary of State,,Monae Johnson,REP,122
+Pennington,2-2,Secretary of State,,Thomas A Cool,DEM,385
+Pennington,2-2,Secretary of State,,Monae Johnson,REP,784
+Pennington,2-3,Secretary of State,,Thomas A Cool,DEM,330
+Pennington,2-3,Secretary of State,,Monae Johnson,REP,426
+Pennington,2-4,Secretary of State,,Thomas A Cool,DEM,397
+Pennington,2-4,Secretary of State,,Monae Johnson,REP,428
+Pennington,2-5,Secretary of State,,Thomas A Cool,DEM,310
+Pennington,2-5,Secretary of State,,Monae Johnson,REP,452
+Pennington,3-1,Secretary of State,,Thomas A Cool,DEM,136
+Pennington,3-1,Secretary of State,,Monae Johnson,REP,184
+Pennington,3-2,Secretary of State,,Thomas A Cool,DEM,834
+Pennington,3-2,Secretary of State,,Monae Johnson,REP,1268
+Pennington,3-3,Secretary of State,,Thomas A Cool,DEM,738
+Pennington,3-3,Secretary of State,,Monae Johnson,REP,1328
+Pennington,3-4,Secretary of State,,Thomas A Cool,DEM,591
+Pennington,3-4,Secretary of State,,Monae Johnson,REP,1112
+Pennington,3-5,Secretary of State,,Thomas A Cool,DEM,344
+Pennington,3-5,Secretary of State,,Monae Johnson,REP,835
+Pennington,4-1,Secretary of State,,Thomas A Cool,DEM,430
+Pennington,4-1,Secretary of State,,Monae Johnson,REP,357
+Pennington,4-2,Secretary of State,,Thomas A Cool,DEM,487
+Pennington,4-2,Secretary of State,,Monae Johnson,REP,542
+Pennington,4-3,Secretary of State,,Thomas A Cool,DEM,378
+Pennington,4-3,Secretary of State,,Monae Johnson,REP,647
+Pennington,4-4,Secretary of State,,Thomas A Cool,DEM,295
+Pennington,4-4,Secretary of State,,Monae Johnson,REP,293
+Pennington,4-5,Secretary of State,,Thomas A Cool,DEM,157
+Pennington,4-5,Secretary of State,,Monae Johnson,REP,275
+Pennington,5-1,Secretary of State,,Thomas A Cool,DEM,260
+Pennington,5-1,Secretary of State,,Monae Johnson,REP,323
+Pennington,5-2,Secretary of State,,Thomas A Cool,DEM,402
+Pennington,5-2,Secretary of State,,Monae Johnson,REP,424
+Pennington,5-3,Secretary of State,,Thomas A Cool,DEM,560
+Pennington,5-3,Secretary of State,,Monae Johnson,REP,675
+Pennington,5-4,Secretary of State,,Thomas A Cool,DEM,837
+Pennington,5-4,Secretary of State,,Monae Johnson,REP,633
+Pennington,5-5,Secretary of State,,Thomas A Cool,DEM,710
+Pennington,5-5,Secretary of State,,Monae Johnson,REP,1122
+Pennington,AW,Secretary of State,,Thomas A Cool,DEM,639
+Pennington,AW,Secretary of State,,Monae Johnson,REP,1751
+Pennington,BE,Secretary of State,,Thomas A Cool,DEM,521
+Pennington,BE,Secretary of State,,Monae Johnson,REP,1244
+Pennington,CA,Secretary of State,,Thomas A Cool,DEM,94
+Pennington,CA,Secretary of State,,Monae Johnson,REP,471
+Pennington,CL,Secretary of State,,Thomas A Cool,DEM,182
+Pennington,CL,Secretary of State,,Monae Johnson,REP,374
+Pennington,DT,Secretary of State,,Thomas A Cool,DEM,143
+Pennington,DT,Secretary of State,,Monae Johnson,REP,458
+Pennington,HC,Secretary of State,,Thomas A Cool,DEM,341
+Pennington,HC,Secretary of State,,Monae Johnson,REP,831
+Pennington,HR,Secretary of State,,Thomas A Cool,DEM,283
+Pennington,HR,Secretary of State,,Monae Johnson,REP,926
+Pennington,JS,Secretary of State,,Thomas A Cool,DEM,348
+Pennington,JS,Secretary of State,,Monae Johnson,REP,889
+Pennington,KY,Secretary of State,,Thomas A Cool,DEM,154
+Pennington,KY,Secretary of State,,Monae Johnson,REP,353
+Pennington,LS,Secretary of State,,Thomas A Cool,DEM,80
+Pennington,LS,Secretary of State,,Monae Johnson,REP,312
+Pennington,NH,Secretary of State,,Thomas A Cool,DEM,41
+Pennington,NH,Secretary of State,,Monae Johnson,REP,104
+Pennington,NU,Secretary of State,,Thomas A Cool,DEM,88
+Pennington,NU,Secretary of State,,Monae Johnson,REP,480
+Pennington,QU,Secretary of State,,Thomas A Cool,DEM,17
+Pennington,QU,Secretary of State,,Monae Johnson,REP,207
+Pennington,RK,Secretary of State,,Thomas A Cool,DEM,6
+Pennington,RK,Secretary of State,,Monae Johnson,REP,27
+Pennington,RV,Secretary of State,,Thomas A Cool,DEM,315
+Pennington,RV,Secretary of State,,Monae Johnson,REP,708
+Pennington,SR,Secretary of State,,Thomas A Cool,DEM,64
+Pennington,SR,Secretary of State,,Monae Johnson,REP,153
+Pennington,VF,Secretary of State,,Thomas A Cool,DEM,364
+Pennington,VF,Secretary of State,,Monae Johnson,REP,986
+Pennington,VV,Secretary of State,,Thomas A Cool,DEM,296
+Pennington,VV,Secretary of State,,Monae Johnson,REP,717
+Pennington,WL,Secretary of State,,Thomas A Cool,DEM,60
+Pennington,WL,Secretary of State,,Monae Johnson,REP,291
+Pennington,WP,Secretary of State,,Thomas A Cool,DEM,363
+Pennington,WP,Secretary of State,,Monae Johnson,REP,782
+Pennington,WS,Secretary of State,,Thomas A Cool,DEM,9
+Pennington,WS,Secretary of State,,Monae Johnson,REP,71
+Pennington,1-1,Attorney General,,Marty J. Jackley,REP,884
+Pennington,1-2,Attorney General,,Marty J. Jackley,REP,965
+Pennington,1-3,Attorney General,,Marty J. Jackley,REP,1150
+Pennington,1-4,Attorney General,,Marty J. Jackley,REP,642
+Pennington,1-5,Attorney General,,Marty J. Jackley,REP,1070
+Pennington,2-1,Attorney General,,Marty J. Jackley,REP,146
+Pennington,2-2,Attorney General,,Marty J. Jackley,REP,913
+Pennington,2-3,Attorney General,,Marty J. Jackley,REP,485
+Pennington,2-4,Attorney General,,Marty J. Jackley,REP,553
+Pennington,2-5,Attorney General,,Marty J. Jackley,REP,562
+Pennington,3-1,Attorney General,,Marty J. Jackley,REP,247
+Pennington,3-2,Attorney General,,Marty J. Jackley,REP,1578
+Pennington,3-3,Attorney General,,Marty J. Jackley,REP,1658
+Pennington,3-4,Attorney General,,Marty J. Jackley,REP,1371
+Pennington,3-5,Attorney General,,Marty J. Jackley,REP,988
+Pennington,4-1,Attorney General,,Marty J. Jackley,REP,468
+Pennington,4-2,Attorney General,,Marty J. Jackley,REP,672
+Pennington,4-3,Attorney General,,Marty J. Jackley,REP,795
+Pennington,4-4,Attorney General,,Marty J. Jackley,REP,345
+Pennington,4-5,Attorney General,,Marty J. Jackley,REP,308
+Pennington,5-1,Attorney General,,Marty J. Jackley,REP,401
+Pennington,5-2,Attorney General,,Marty J. Jackley,REP,536
+Pennington,5-3,Attorney General,,Marty J. Jackley,REP,875
+Pennington,5-4,Attorney General,,Marty J. Jackley,REP,886
+Pennington,5-5,Attorney General,,Marty J. Jackley,REP,1403
+Pennington,AW,Attorney General,,Marty J. Jackley,REP,1769
+Pennington,BE,Attorney General,,Marty J. Jackley,REP,1339
+Pennington,CA,Attorney General,,Marty J. Jackley,REP,491
+Pennington,CL,Attorney General,,Marty J. Jackley,REP,430
+Pennington,DT,Attorney General,,Marty J. Jackley,REP,507
+Pennington,HC,Attorney General,,Marty J. Jackley,REP,915
+Pennington,HR,Attorney General,,Marty J. Jackley,REP,1015
+Pennington,JS,Attorney General,,Marty J. Jackley,REP,970
+Pennington,KY,Attorney General,,Marty J. Jackley,REP,383
+Pennington,LS,Attorney General,,Marty J. Jackley,REP,336
+Pennington,NH,Attorney General,,Marty J. Jackley,REP,113
+Pennington,NU,Attorney General,,Marty J. Jackley,REP,497
+Pennington,QU,Attorney General,,Marty J. Jackley,REP,190
+Pennington,RK,Attorney General,,Marty J. Jackley,REP,25
+Pennington,RV,Attorney General,,Marty J. Jackley,REP,788
+Pennington,SR,Attorney General,,Marty J. Jackley,REP,165
+Pennington,VF,Attorney General,,Marty J. Jackley,REP,1054
+Pennington,VV,Attorney General,,Marty J. Jackley,REP,813
+Pennington,WL,Attorney General,,Marty J. Jackley,REP,314
+Pennington,WP,Attorney General,,Marty J. Jackley,REP,898
+Pennington,WS,Attorney General,,Marty J. Jackley,REP,71
+Pennington,1-1,State Auditor,,Stephanie Marty,DEM,356
+Pennington,1-1,State Auditor,,Rene Meyer,LIB,79
+Pennington,1-1,State Auditor,,Richard Sattgast,REP,698
+Pennington,1-2,State Auditor,,Stephanie Marty,DEM,395
+Pennington,1-2,State Auditor,,Rene Meyer,LIB,82
+Pennington,1-2,State Auditor,,Richard Sattgast,REP,761
+Pennington,1-3,State Auditor,,Stephanie Marty,DEM,430
+Pennington,1-3,State Auditor,,Rene Meyer,LIB,66
+Pennington,1-3,State Auditor,,Richard Sattgast,REP,914
+Pennington,1-4,State Auditor,,Stephanie Marty,DEM,215
+Pennington,1-4,State Auditor,,Rene Meyer,LIB,38
+Pennington,1-4,State Auditor,,Richard Sattgast,REP,514
+Pennington,1-5,State Auditor,,Stephanie Marty,DEM,528
+Pennington,1-5,State Auditor,,Rene Meyer,LIB,89
+Pennington,1-5,State Auditor,,Richard Sattgast,REP,806
+Pennington,2-1,State Auditor,,Stephanie Marty,DEM,125
+Pennington,2-1,State Auditor,,Rene Meyer,LIB,30
+Pennington,2-1,State Auditor,,Richard Sattgast,REP,107
+Pennington,2-2,State Auditor,,Stephanie Marty,DEM,338
+Pennington,2-2,State Auditor,,Rene Meyer,LIB,100
+Pennington,2-2,State Auditor,,Richard Sattgast,REP,728
+Pennington,2-3,State Auditor,,Stephanie Marty,DEM,288
+Pennington,2-3,State Auditor,,Rene Meyer,LIB,80
+Pennington,2-3,State Auditor,,Richard Sattgast,REP,379
+Pennington,2-4,State Auditor,,Stephanie Marty,DEM,370
+Pennington,2-4,State Auditor,,Rene Meyer,LIB,83
+Pennington,2-4,State Auditor,,Richard Sattgast,REP,371
+Pennington,2-5,State Auditor,,Stephanie Marty,DEM,290
+Pennington,2-5,State Auditor,,Rene Meyer,LIB,55
+Pennington,2-5,State Auditor,,Richard Sattgast,REP,419
+Pennington,3-1,State Auditor,,Stephanie Marty,DEM,126
+Pennington,3-1,State Auditor,,Rene Meyer,LIB,19
+Pennington,3-1,State Auditor,,Richard Sattgast,REP,174
+Pennington,3-2,State Auditor,,Stephanie Marty,DEM,759
+Pennington,3-2,State Auditor,,Rene Meyer,LIB,133
+Pennington,3-2,State Auditor,,Richard Sattgast,REP,1191
+Pennington,3-3,State Auditor,,Stephanie Marty,DEM,658
+Pennington,3-3,State Auditor,,Rene Meyer,LIB,119
+Pennington,3-3,State Auditor,,Richard Sattgast,REP,1250
+Pennington,3-4,State Auditor,,Stephanie Marty,DEM,526
+Pennington,3-4,State Auditor,,Rene Meyer,LIB,80
+Pennington,3-4,State Auditor,,Richard Sattgast,REP,1083
+Pennington,3-5,State Auditor,,Stephanie Marty,DEM,299
+Pennington,3-5,State Auditor,,Rene Meyer,LIB,42
+Pennington,3-5,State Auditor,,Richard Sattgast,REP,816
+Pennington,4-1,State Auditor,,Stephanie Marty,DEM,390
+Pennington,4-1,State Auditor,,Rene Meyer,LIB,85
+Pennington,4-1,State Auditor,,Richard Sattgast,REP,313
+Pennington,4-2,State Auditor,,Stephanie Marty,DEM,432
+Pennington,4-2,State Auditor,,Rene Meyer,LIB,114
+Pennington,4-2,State Auditor,,Richard Sattgast,REP,472
+Pennington,4-3,State Auditor,,Stephanie Marty,DEM,334
+Pennington,4-3,State Auditor,,Rene Meyer,LIB,87
+Pennington,4-3,State Auditor,,Richard Sattgast,REP,590
+Pennington,4-4,State Auditor,,Stephanie Marty,DEM,263
+Pennington,4-4,State Auditor,,Rene Meyer,LIB,55
+Pennington,4-4,State Auditor,,Richard Sattgast,REP,271
+Pennington,4-5,State Auditor,,Stephanie Marty,DEM,143
+Pennington,4-5,State Auditor,,Rene Meyer,LIB,40
+Pennington,4-5,State Auditor,,Richard Sattgast,REP,245
+Pennington,5-1,State Auditor,,Stephanie Marty,DEM,247
+Pennington,5-1,State Auditor,,Rene Meyer,LIB,56
+Pennington,5-1,State Auditor,,Richard Sattgast,REP,282
+Pennington,5-2,State Auditor,,Stephanie Marty,DEM,365
+Pennington,5-2,State Auditor,,Rene Meyer,LIB,65
+Pennington,5-2,State Auditor,,Richard Sattgast,REP,379
+Pennington,5-3,State Auditor,,Stephanie Marty,DEM,503
+Pennington,5-3,State Auditor,,Rene Meyer,LIB,103
+Pennington,5-3,State Auditor,,Richard Sattgast,REP,608
+Pennington,5-4,State Auditor,,Stephanie Marty,DEM,760
+Pennington,5-4,State Auditor,,Rene Meyer,LIB,113
+Pennington,5-4,State Auditor,,Richard Sattgast,REP,597
+Pennington,5-5,State Auditor,,Stephanie Marty,DEM,630
+Pennington,5-5,State Auditor,,Rene Meyer,LIB,127
+Pennington,5-5,State Auditor,,Richard Sattgast,REP,1050
+Pennington,AW,State Auditor,,Stephanie Marty,DEM,591
+Pennington,AW,State Auditor,,Rene Meyer,LIB,62
+Pennington,AW,State Auditor,,Richard Sattgast,REP,1729
+Pennington,BE,State Auditor,,Stephanie Marty,DEM,473
+Pennington,BE,State Auditor,,Rene Meyer,LIB,177
+Pennington,BE,State Auditor,,Richard Sattgast,REP,1100
+Pennington,CA,State Auditor,,Stephanie Marty,DEM,85
+Pennington,CA,State Auditor,,Rene Meyer,LIB,27
+Pennington,CA,State Auditor,,Richard Sattgast,REP,451
+Pennington,CL,State Auditor,,Stephanie Marty,DEM,164
+Pennington,CL,State Auditor,,Rene Meyer,LIB,26
+Pennington,CL,State Auditor,,Richard Sattgast,REP,364
+Pennington,DT,State Auditor,,Stephanie Marty,DEM,135
+Pennington,DT,State Auditor,,Rene Meyer,LIB,35
+Pennington,DT,State Auditor,,Richard Sattgast,REP,421
+Pennington,HC,State Auditor,,Stephanie Marty,DEM,317
+Pennington,HC,State Auditor,,Rene Meyer,LIB,82
+Pennington,HC,State Auditor,,Richard Sattgast,REP,754
+Pennington,HR,State Auditor,,Stephanie Marty,DEM,257
+Pennington,HR,State Auditor,,Rene Meyer,LIB,71
+Pennington,HR,State Auditor,,Richard Sattgast,REP,857
+Pennington,JS,State Auditor,,Stephanie Marty,DEM,307
+Pennington,JS,State Auditor,,Rene Meyer,LIB,72
+Pennington,JS,State Auditor,,Richard Sattgast,REP,852
+Pennington,KY,State Auditor,,Stephanie Marty,DEM,131
+Pennington,KY,State Auditor,,Rene Meyer,LIB,24
+Pennington,KY,State Auditor,,Richard Sattgast,REP,349
+Pennington,LS,State Auditor,,Stephanie Marty,DEM,66
+Pennington,LS,State Auditor,,Rene Meyer,LIB,23
+Pennington,LS,State Auditor,,Richard Sattgast,REP,304
+Pennington,NH,State Auditor,,Stephanie Marty,DEM,36
+Pennington,NH,State Auditor,,Rene Meyer,LIB,12
+Pennington,NH,State Auditor,,Richard Sattgast,REP,99
+Pennington,NU,State Auditor,,Stephanie Marty,DEM,79
+Pennington,NU,State Auditor,,Rene Meyer,LIB,29
+Pennington,NU,State Auditor,,Richard Sattgast,REP,452
+Pennington,QU,State Auditor,,Stephanie Marty,DEM,16
+Pennington,QU,State Auditor,,Rene Meyer,LIB,17
+Pennington,QU,State Auditor,,Richard Sattgast,REP,188
+Pennington,RK,State Auditor,,Stephanie Marty,DEM,4
+Pennington,RK,State Auditor,,Rene Meyer,LIB,4
+Pennington,RK,State Auditor,,Richard Sattgast,REP,25
+Pennington,RV,State Auditor,,Stephanie Marty,DEM,280
+Pennington,RV,State Auditor,,Rene Meyer,LIB,97
+Pennington,RV,State Auditor,,Richard Sattgast,REP,636
+Pennington,SR,State Auditor,,Stephanie Marty,DEM,62
+Pennington,SR,State Auditor,,Rene Meyer,LIB,16
+Pennington,SR,State Auditor,,Richard Sattgast,REP,135
+Pennington,VF,State Auditor,,Stephanie Marty,DEM,315
+Pennington,VF,State Auditor,,Rene Meyer,LIB,130
+Pennington,VF,State Auditor,,Richard Sattgast,REP,881
+Pennington,VV,State Auditor,,Stephanie Marty,DEM,263
+Pennington,VV,State Auditor,,Rene Meyer,LIB,66
+Pennington,VV,State Auditor,,Richard Sattgast,REP,667
+Pennington,WL,State Auditor,,Stephanie Marty,DEM,55
+Pennington,WL,State Auditor,,Rene Meyer,LIB,20
+Pennington,WL,State Auditor,,Richard Sattgast,REP,273
+Pennington,WP,State Auditor,,Stephanie Marty,DEM,331
+Pennington,WP,State Auditor,,Rene Meyer,LIB,60
+Pennington,WP,State Auditor,,Richard Sattgast,REP,737
+Pennington,WS,State Auditor,,Stephanie Marty,DEM,8
+Pennington,WS,State Auditor,,Rene Meyer,LIB,5
+Pennington,WS,State Auditor,,Richard Sattgast,REP,68
+Pennington,1-1,State Treasurer,,John Cunningham,DEM,352
+Pennington,1-1,State Treasurer,,Josh Haeder,REP,765
+Pennington,1-2,State Treasurer,,John Cunningham,DEM,400
+Pennington,1-2,State Treasurer,,Josh Haeder,REP,832
+Pennington,1-3,State Treasurer,,John Cunningham,DEM,428
+Pennington,1-3,State Treasurer,,Josh Haeder,REP,977
+Pennington,1-4,State Treasurer,,John Cunningham,DEM,209
+Pennington,1-4,State Treasurer,,Josh Haeder,REP,560
+Pennington,1-5,State Treasurer,,John Cunningham,DEM,535
+Pennington,1-5,State Treasurer,,Josh Haeder,REP,871
+Pennington,2-1,State Treasurer,,John Cunningham,DEM,137
+Pennington,2-1,State Treasurer,,Josh Haeder,REP,118
+Pennington,2-2,State Treasurer,,John Cunningham,DEM,349
+Pennington,2-2,State Treasurer,,Josh Haeder,REP,807
+Pennington,2-3,State Treasurer,,John Cunningham,DEM,318
+Pennington,2-3,State Treasurer,,Josh Haeder,REP,421
+Pennington,2-4,State Treasurer,,John Cunningham,DEM,379
+Pennington,2-4,State Treasurer,,Josh Haeder,REP,420
+Pennington,2-5,State Treasurer,,John Cunningham,DEM,299
+Pennington,2-5,State Treasurer,,Josh Haeder,REP,459
+Pennington,3-1,State Treasurer,,John Cunningham,DEM,128
+Pennington,3-1,State Treasurer,,Josh Haeder,REP,190
+Pennington,3-2,State Treasurer,,John Cunningham,DEM,757
+Pennington,3-2,State Treasurer,,Josh Haeder,REP,1314
+Pennington,3-3,State Treasurer,,John Cunningham,DEM,656
+Pennington,3-3,State Treasurer,,Josh Haeder,REP,1360
+Pennington,3-4,State Treasurer,,John Cunningham,DEM,521
+Pennington,3-4,State Treasurer,,Josh Haeder,REP,1160
+Pennington,3-5,State Treasurer,,John Cunningham,DEM,297
+Pennington,3-5,State Treasurer,,Josh Haeder,REP,865
+Pennington,4-1,State Treasurer,,John Cunningham,DEM,412
+Pennington,4-1,State Treasurer,,Josh Haeder,REP,368
+Pennington,4-2,State Treasurer,,John Cunningham,DEM,471
+Pennington,4-2,State Treasurer,,Josh Haeder,REP,537
+Pennington,4-3,State Treasurer,,John Cunningham,DEM,342
+Pennington,4-3,State Treasurer,,Josh Haeder,REP,668
+Pennington,4-4,State Treasurer,,John Cunningham,DEM,283
+Pennington,4-4,State Treasurer,,Josh Haeder,REP,295
+Pennington,4-5,State Treasurer,,John Cunningham,DEM,143
+Pennington,4-5,State Treasurer,,Josh Haeder,REP,278
+Pennington,5-1,State Treasurer,,John Cunningham,DEM,259
+Pennington,5-1,State Treasurer,,Josh Haeder,REP,316
+Pennington,5-2,State Treasurer,,John Cunningham,DEM,390
+Pennington,5-2,State Treasurer,,Josh Haeder,REP,421
+Pennington,5-3,State Treasurer,,John Cunningham,DEM,517
+Pennington,5-3,State Treasurer,,Josh Haeder,REP,690
+Pennington,5-4,State Treasurer,,John Cunningham,DEM,796
+Pennington,5-4,State Treasurer,,Josh Haeder,REP,663
+Pennington,5-5,State Treasurer,,John Cunningham,DEM,646
+Pennington,5-5,State Treasurer,,Josh Haeder,REP,1140
+Pennington,AW,State Treasurer,,John Cunningham,DEM,602
+Pennington,AW,State Treasurer,,Josh Haeder,REP,1765
+Pennington,BE,State Treasurer,,John Cunningham,DEM,510
+Pennington,BE,State Treasurer,,Josh Haeder,REP,1222
+Pennington,CA,State Treasurer,,John Cunningham,DEM,83
+Pennington,CA,State Treasurer,,Josh Haeder,REP,477
+Pennington,CL,State Treasurer,,John Cunningham,DEM,165
+Pennington,CL,State Treasurer,,Josh Haeder,REP,388
+Pennington,DT,State Treasurer,,John Cunningham,DEM,131
+Pennington,DT,State Treasurer,,Josh Haeder,REP,458
+Pennington,HC,State Treasurer,,John Cunningham,DEM,320
+Pennington,HC,State Treasurer,,Josh Haeder,REP,839
+Pennington,HR,State Treasurer,,John Cunningham,DEM,259
+Pennington,HR,State Treasurer,,Josh Haeder,REP,923
+Pennington,JS,State Treasurer,,John Cunningham,DEM,322
+Pennington,JS,State Treasurer,,Josh Haeder,REP,896
+Pennington,KY,State Treasurer,,John Cunningham,DEM,139
+Pennington,KY,State Treasurer,,Josh Haeder,REP,362
+Pennington,LS,State Treasurer,,John Cunningham,DEM,74
+Pennington,LS,State Treasurer,,Josh Haeder,REP,318
+Pennington,NH,State Treasurer,,John Cunningham,DEM,36
+Pennington,NH,State Treasurer,,Josh Haeder,REP,109
+Pennington,NU,State Treasurer,,John Cunningham,DEM,81
+Pennington,NU,State Treasurer,,Josh Haeder,REP,475
+Pennington,QU,State Treasurer,,John Cunningham,DEM,19
+Pennington,QU,State Treasurer,,Josh Haeder,REP,200
+Pennington,RK,State Treasurer,,John Cunningham,DEM,4
+Pennington,RK,State Treasurer,,Josh Haeder,REP,27
+Pennington,RV,State Treasurer,,John Cunningham,DEM,297
+Pennington,RV,State Treasurer,,Josh Haeder,REP,702
+Pennington,SR,State Treasurer,,John Cunningham,DEM,64
+Pennington,SR,State Treasurer,,Josh Haeder,REP,146
+Pennington,VF,State Treasurer,,John Cunningham,DEM,336
+Pennington,VF,State Treasurer,,Josh Haeder,REP,972
+Pennington,VV,State Treasurer,,John Cunningham,DEM,282
+Pennington,VV,State Treasurer,,Josh Haeder,REP,715
+Pennington,WL,State Treasurer,,John Cunningham,DEM,56
+Pennington,WL,State Treasurer,,Josh Haeder,REP,290
+Pennington,WP,State Treasurer,,John Cunningham,DEM,325
+Pennington,WP,State Treasurer,,Josh Haeder,REP,809
+Pennington,WS,State Treasurer,,John Cunningham,DEM,9
+Pennington,WS,State Treasurer,,Josh Haeder,REP,73
+Pennington,1-1,Commissioner of School and Public Lands,,Timothy Azure,DEM,384
+Pennington,1-1,Commissioner of School and Public Lands,,Brock Greenfield,REP,720
+Pennington,1-2,Commissioner of School and Public Lands,,Timothy Azure,DEM,410
+Pennington,1-2,Commissioner of School and Public Lands,,Brock Greenfield,REP,798
+Pennington,1-3,Commissioner of School and Public Lands,,Timothy Azure,DEM,439
+Pennington,1-3,Commissioner of School and Public Lands,,Brock Greenfield,REP,948
+Pennington,1-4,Commissioner of School and Public Lands,,Timothy Azure,DEM,208
+Pennington,1-4,Commissioner of School and Public Lands,,Brock Greenfield,REP,545
+Pennington,1-5,Commissioner of School and Public Lands,,Timothy Azure,DEM,554
+Pennington,1-5,Commissioner of School and Public Lands,,Brock Greenfield,REP,846
+Pennington,2-1,Commissioner of School and Public Lands,,Timothy Azure,DEM,133
+Pennington,2-1,Commissioner of School and Public Lands,,Brock Greenfield,REP,121
+Pennington,2-2,Commissioner of School and Public Lands,,Timothy Azure,DEM,356
+Pennington,2-2,Commissioner of School and Public Lands,,Brock Greenfield,REP,785
+Pennington,2-3,Commissioner of School and Public Lands,,Timothy Azure,DEM,314
+Pennington,2-3,Commissioner of School and Public Lands,,Brock Greenfield,REP,417
+Pennington,2-4,Commissioner of School and Public Lands,,Timothy Azure,DEM,390
+Pennington,2-4,Commissioner of School and Public Lands,,Brock Greenfield,REP,411
+Pennington,2-5,Commissioner of School and Public Lands,,Timothy Azure,DEM,300
+Pennington,2-5,Commissioner of School and Public Lands,,Brock Greenfield,REP,451
+Pennington,3-1,Commissioner of School and Public Lands,,Timothy Azure,DEM,136
+Pennington,3-1,Commissioner of School and Public Lands,,Brock Greenfield,REP,181
+Pennington,3-2,Commissioner of School and Public Lands,,Timothy Azure,DEM,768
+Pennington,3-2,Commissioner of School and Public Lands,,Brock Greenfield,REP,1270
+Pennington,3-3,Commissioner of School and Public Lands,,Timothy Azure,DEM,664
+Pennington,3-3,Commissioner of School and Public Lands,,Brock Greenfield,REP,1330
+Pennington,3-4,Commissioner of School and Public Lands,,Timothy Azure,DEM,546
+Pennington,3-4,Commissioner of School and Public Lands,,Brock Greenfield,REP,1105
+Pennington,3-5,Commissioner of School and Public Lands,,Timothy Azure,DEM,310
+Pennington,3-5,Commissioner of School and Public Lands,,Brock Greenfield,REP,834
+Pennington,4-1,Commissioner of School and Public Lands,,Timothy Azure,DEM,411
+Pennington,4-1,Commissioner of School and Public Lands,,Brock Greenfield,REP,369
+Pennington,4-2,Commissioner of School and Public Lands,,Timothy Azure,DEM,464
+Pennington,4-2,Commissioner of School and Public Lands,,Brock Greenfield,REP,526
+Pennington,4-3,Commissioner of School and Public Lands,,Timothy Azure,DEM,348
+Pennington,4-3,Commissioner of School and Public Lands,,Brock Greenfield,REP,646
+Pennington,4-4,Commissioner of School and Public Lands,,Timothy Azure,DEM,284
+Pennington,4-4,Commissioner of School and Public Lands,,Brock Greenfield,REP,295
+Pennington,4-5,Commissioner of School and Public Lands,,Timothy Azure,DEM,149
+Pennington,4-5,Commissioner of School and Public Lands,,Brock Greenfield,REP,264
+Pennington,5-1,Commissioner of School and Public Lands,,Timothy Azure,DEM,254
+Pennington,5-1,Commissioner of School and Public Lands,,Brock Greenfield,REP,318
+Pennington,5-2,Commissioner of School and Public Lands,,Timothy Azure,DEM,394
+Pennington,5-2,Commissioner of School and Public Lands,,Brock Greenfield,REP,416
+Pennington,5-3,Commissioner of School and Public Lands,,Timothy Azure,DEM,537
+Pennington,5-3,Commissioner of School and Public Lands,,Brock Greenfield,REP,664
+Pennington,5-4,Commissioner of School and Public Lands,,Timothy Azure,DEM,802
+Pennington,5-4,Commissioner of School and Public Lands,,Brock Greenfield,REP,648
+Pennington,5-5,Commissioner of School and Public Lands,,Timothy Azure,DEM,663
+Pennington,5-5,Commissioner of School and Public Lands,,Brock Greenfield,REP,1105
+Pennington,AW,Commissioner of School and Public Lands,,Timothy Azure,DEM,604
+Pennington,AW,Commissioner of School and Public Lands,,Brock Greenfield,REP,1746
+Pennington,BE,Commissioner of School and Public Lands,,Timothy Azure,DEM,505
+Pennington,BE,Commissioner of School and Public Lands,,Brock Greenfield,REP,1222
+Pennington,CA,Commissioner of School and Public Lands,,Timothy Azure,DEM,86
+Pennington,CA,Commissioner of School and Public Lands,,Brock Greenfield,REP,467
+Pennington,CL,Commissioner of School and Public Lands,,Timothy Azure,DEM,172
+Pennington,CL,Commissioner of School and Public Lands,,Brock Greenfield,REP,378
+Pennington,DT,Commissioner of School and Public Lands,,Timothy Azure,DEM,137
+Pennington,DT,Commissioner of School and Public Lands,,Brock Greenfield,REP,451
+Pennington,HC,Commissioner of School and Public Lands,,Timothy Azure,DEM,329
+Pennington,HC,Commissioner of School and Public Lands,,Brock Greenfield,REP,806
+Pennington,HR,Commissioner of School and Public Lands,,Timothy Azure,DEM,266
+Pennington,HR,Commissioner of School and Public Lands,,Brock Greenfield,REP,907
+Pennington,JS,Commissioner of School and Public Lands,,Timothy Azure,DEM,316
+Pennington,JS,Commissioner of School and Public Lands,,Brock Greenfield,REP,880
+Pennington,KY,Commissioner of School and Public Lands,,Timothy Azure,DEM,131
+Pennington,KY,Commissioner of School and Public Lands,,Brock Greenfield,REP,360
+Pennington,LS,Commissioner of School and Public Lands,,Timothy Azure,DEM,71
+Pennington,LS,Commissioner of School and Public Lands,,Brock Greenfield,REP,318
+Pennington,NH,Commissioner of School and Public Lands,,Timothy Azure,DEM,34
+Pennington,NH,Commissioner of School and Public Lands,,Brock Greenfield,REP,110
+Pennington,NU,Commissioner of School and Public Lands,,Timothy Azure,DEM,86
+Pennington,NU,Commissioner of School and Public Lands,,Brock Greenfield,REP,466
+Pennington,QU,Commissioner of School and Public Lands,,Timothy Azure,DEM,17
+Pennington,QU,Commissioner of School and Public Lands,,Brock Greenfield,REP,204
+Pennington,RK,Commissioner of School and Public Lands,,Timothy Azure,DEM,4
+Pennington,RK,Commissioner of School and Public Lands,,Brock Greenfield,REP,28
+Pennington,RV,Commissioner of School and Public Lands,,Timothy Azure,DEM,292
+Pennington,RV,Commissioner of School and Public Lands,,Brock Greenfield,REP,691
+Pennington,SR,Commissioner of School and Public Lands,,Timothy Azure,DEM,59
+Pennington,SR,Commissioner of School and Public Lands,,Brock Greenfield,REP,147
+Pennington,VF,Commissioner of School and Public Lands,,Timothy Azure,DEM,350
+Pennington,VF,Commissioner of School and Public Lands,,Brock Greenfield,REP,953
+Pennington,VV,Commissioner of School and Public Lands,,Timothy Azure,DEM,279
+Pennington,VV,Commissioner of School and Public Lands,,Brock Greenfield,REP,705
+Pennington,WL,Commissioner of School and Public Lands,,Timothy Azure,DEM,51
+Pennington,WL,Commissioner of School and Public Lands,,Brock Greenfield,REP,288
+Pennington,WP,Commissioner of School and Public Lands,,Timothy Azure,DEM,331
+Pennington,WP,Commissioner of School and Public Lands,,Brock Greenfield,REP,785
+Pennington,WS,Commissioner of School and Public Lands,,Timothy Azure,DEM,9
+Pennington,WS,Commissioner of School and Public Lands,,Brock Greenfield,REP,70
+Pennington,1-1,Public Utilities Commissioner,,Jeffrey Barth,DEM,360
+Pennington,1-1,Public Utilities Commissioner,,Chris Nelson,REP,763
+Pennington,1-2,Public Utilities Commissioner,,Jeffrey Barth,DEM,392
+Pennington,1-2,Public Utilities Commissioner,,Chris Nelson,REP,831
+Pennington,1-3,Public Utilities Commissioner,,Jeffrey Barth,DEM,407
+Pennington,1-3,Public Utilities Commissioner,,Chris Nelson,REP,998
+Pennington,1-4,Public Utilities Commissioner,,Jeffrey Barth,DEM,194
+Pennington,1-4,Public Utilities Commissioner,,Chris Nelson,REP,561
+Pennington,1-5,Public Utilities Commissioner,,Jeffrey Barth,DEM,522
+Pennington,1-5,Public Utilities Commissioner,,Chris Nelson,REP,881
+Pennington,2-1,Public Utilities Commissioner,,Jeffrey Barth,DEM,129
+Pennington,2-1,Public Utilities Commissioner,,Chris Nelson,REP,125
+Pennington,2-2,Public Utilities Commissioner,,Jeffrey Barth,DEM,349
+Pennington,2-2,Public Utilities Commissioner,,Chris Nelson,REP,793
+Pennington,2-3,Public Utilities Commissioner,,Jeffrey Barth,DEM,302
+Pennington,2-3,Public Utilities Commissioner,,Chris Nelson,REP,434
+Pennington,2-4,Public Utilities Commissioner,,Jeffrey Barth,DEM,374
+Pennington,2-4,Public Utilities Commissioner,,Chris Nelson,REP,443
+Pennington,2-5,Public Utilities Commissioner,,Jeffrey Barth,DEM,297
+Pennington,2-5,Public Utilities Commissioner,,Chris Nelson,REP,459
+Pennington,3-1,Public Utilities Commissioner,,Jeffrey Barth,DEM,126
+Pennington,3-1,Public Utilities Commissioner,,Chris Nelson,REP,191
+Pennington,3-2,Public Utilities Commissioner,,Jeffrey Barth,DEM,734
+Pennington,3-2,Public Utilities Commissioner,,Chris Nelson,REP,1330
+Pennington,3-3,Public Utilities Commissioner,,Jeffrey Barth,DEM,628
+Pennington,3-3,Public Utilities Commissioner,,Chris Nelson,REP,1389
+Pennington,3-4,Public Utilities Commissioner,,Jeffrey Barth,DEM,505
+Pennington,3-4,Public Utilities Commissioner,,Chris Nelson,REP,1174
+Pennington,3-5,Public Utilities Commissioner,,Jeffrey Barth,DEM,290
+Pennington,3-5,Public Utilities Commissioner,,Chris Nelson,REP,861
+Pennington,4-1,Public Utilities Commissioner,,Jeffrey Barth,DEM,404
+Pennington,4-1,Public Utilities Commissioner,,Chris Nelson,REP,376
+Pennington,4-2,Public Utilities Commissioner,,Jeffrey Barth,DEM,461
+Pennington,4-2,Public Utilities Commissioner,,Chris Nelson,REP,540
+Pennington,4-3,Public Utilities Commissioner,,Jeffrey Barth,DEM,339
+Pennington,4-3,Public Utilities Commissioner,,Chris Nelson,REP,670
+Pennington,4-4,Public Utilities Commissioner,,Jeffrey Barth,DEM,289
+Pennington,4-4,Public Utilities Commissioner,,Chris Nelson,REP,285
+Pennington,4-5,Public Utilities Commissioner,,Jeffrey Barth,DEM,146
+Pennington,4-5,Public Utilities Commissioner,,Chris Nelson,REP,274
+Pennington,5-1,Public Utilities Commissioner,,Jeffrey Barth,DEM,238
+Pennington,5-1,Public Utilities Commissioner,,Chris Nelson,REP,332
+Pennington,5-2,Public Utilities Commissioner,,Jeffrey Barth,DEM,378
+Pennington,5-2,Public Utilities Commissioner,,Chris Nelson,REP,431
+Pennington,5-3,Public Utilities Commissioner,,Jeffrey Barth,DEM,499
+Pennington,5-3,Public Utilities Commissioner,,Chris Nelson,REP,705
+Pennington,5-4,Public Utilities Commissioner,,Jeffrey Barth,DEM,773
+Pennington,5-4,Public Utilities Commissioner,,Chris Nelson,REP,675
+Pennington,5-5,Public Utilities Commissioner,,Jeffrey Barth,DEM,620
+Pennington,5-5,Public Utilities Commissioner,,Chris Nelson,REP,1161
+Pennington,AW,Public Utilities Commissioner,,Jeffrey Barth,DEM,591
+Pennington,AW,Public Utilities Commissioner,,Chris Nelson,REP,1745
+Pennington,BE,Public Utilities Commissioner,,Jeffrey Barth,DEM,479
+Pennington,BE,Public Utilities Commissioner,,Chris Nelson,REP,1241
+Pennington,CA,Public Utilities Commissioner,,Jeffrey Barth,DEM,76
+Pennington,CA,Public Utilities Commissioner,,Chris Nelson,REP,477
+Pennington,CL,Public Utilities Commissioner,,Jeffrey Barth,DEM,161
+Pennington,CL,Public Utilities Commissioner,,Chris Nelson,REP,388
+Pennington,DT,Public Utilities Commissioner,,Jeffrey Barth,DEM,131
+Pennington,DT,Public Utilities Commissioner,,Chris Nelson,REP,460
+Pennington,HC,Public Utilities Commissioner,,Jeffrey Barth,DEM,318
+Pennington,HC,Public Utilities Commissioner,,Chris Nelson,REP,821
+Pennington,HR,Public Utilities Commissioner,,Jeffrey Barth,DEM,254
+Pennington,HR,Public Utilities Commissioner,,Chris Nelson,REP,932
+Pennington,JS,Public Utilities Commissioner,,Jeffrey Barth,DEM,309
+Pennington,JS,Public Utilities Commissioner,,Chris Nelson,REP,919
+Pennington,KY,Public Utilities Commissioner,,Jeffrey Barth,DEM,136
+Pennington,KY,Public Utilities Commissioner,,Chris Nelson,REP,369
+Pennington,LS,Public Utilities Commissioner,,Jeffrey Barth,DEM,72
+Pennington,LS,Public Utilities Commissioner,,Chris Nelson,REP,319
+Pennington,NH,Public Utilities Commissioner,,Jeffrey Barth,DEM,34
+Pennington,NH,Public Utilities Commissioner,,Chris Nelson,REP,108
+Pennington,NU,Public Utilities Commissioner,,Jeffrey Barth,DEM,84
+Pennington,NU,Public Utilities Commissioner,,Chris Nelson,REP,478
+Pennington,QU,Public Utilities Commissioner,,Jeffrey Barth,DEM,17
+Pennington,QU,Public Utilities Commissioner,,Chris Nelson,REP,206
+Pennington,RK,Public Utilities Commissioner,,Jeffrey Barth,DEM,3
+Pennington,RK,Public Utilities Commissioner,,Chris Nelson,REP,29
+Pennington,RV,Public Utilities Commissioner,,Jeffrey Barth,DEM,295
+Pennington,RV,Public Utilities Commissioner,,Chris Nelson,REP,711
+Pennington,SR,Public Utilities Commissioner,,Jeffrey Barth,DEM,62
+Pennington,SR,Public Utilities Commissioner,,Chris Nelson,REP,149
+Pennington,VF,Public Utilities Commissioner,,Jeffrey Barth,DEM,315
+Pennington,VF,Public Utilities Commissioner,,Chris Nelson,REP,995
+Pennington,VV,Public Utilities Commissioner,,Jeffrey Barth,DEM,270
+Pennington,VV,Public Utilities Commissioner,,Chris Nelson,REP,719
+Pennington,WL,Public Utilities Commissioner,,Jeffrey Barth,DEM,52
+Pennington,WL,Public Utilities Commissioner,,Chris Nelson,REP,297
+Pennington,WP,Public Utilities Commissioner,,Jeffrey Barth,DEM,319
+Pennington,WP,Public Utilities Commissioner,,Chris Nelson,REP,816
+Pennington,WS,Public Utilities Commissioner,,Jeffrey Barth,DEM,8
+Pennington,WS,Public Utilities Commissioner,,Chris Nelson,REP,73
+Pennington,1-1,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,461
+Pennington,1-2,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,505
+Pennington,1-3,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,609
+Pennington,1-4,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,335
+Pennington,1-5,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,522
+Pennington,2-1,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,78
+Pennington,2-2,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,469
+Pennington,2-3,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,304
+Pennington,2-4,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,277
+Pennington,2-5,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,309
+Pennington,3-1,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,141
+Pennington,3-2,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,769
+Pennington,3-3,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,817
+Pennington,3-4,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,663
+Pennington,3-5,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,479
+Pennington,4-1,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,266
+Pennington,4-2,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,392
+Pennington,4-3,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,398
+Pennington,4-4,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,201
+Pennington,4-5,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,150
+Pennington,5-1,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,228
+Pennington,5-2,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,285
+Pennington,5-3,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,445
+Pennington,5-4,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,472
+Pennington,5-5,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,710
+Pennington,AW,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,857
+Pennington,BE,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,722
+Pennington,CA,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,208
+Pennington,CL,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,226
+Pennington,DT,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,258
+Pennington,HC,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,450
+Pennington,HR,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,522
+Pennington,JS,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,457
+Pennington,KY,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,166
+Pennington,LS,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,150
+Pennington,NH,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,59
+Pennington,NU,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,204
+Pennington,QU,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,54
+Pennington,RK,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,16
+Pennington,RV,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,421
+Pennington,SR,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,82
+Pennington,VF,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,533
+Pennington,VV,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,431
+Pennington,WL,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,129
+Pennington,WP,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,455
+Pennington,WS,Judge of the Circuit Court,Position A Seventh Circuit,Stacy Vinberg-Wickre,NON,23
+Pennington,1-1,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,455
+Pennington,1-2,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,518
+Pennington,1-3,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,613
+Pennington,1-4,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,335
+Pennington,1-5,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,519
+Pennington,2-1,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,73
+Pennington,2-2,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,463
+Pennington,2-3,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,301
+Pennington,2-4,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,279
+Pennington,2-5,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,301
+Pennington,3-1,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,143
+Pennington,3-2,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,802
+Pennington,3-3,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,813
+Pennington,3-4,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,696
+Pennington,3-5,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,490
+Pennington,4-1,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,280
+Pennington,4-2,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,398
+Pennington,4-3,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,389
+Pennington,4-4,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,185
+Pennington,4-5,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,148
+Pennington,5-1,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,230
+Pennington,5-2,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,287
+Pennington,5-3,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,460
+Pennington,5-4,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,512
+Pennington,5-5,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,731
+Pennington,AW,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,814
+Pennington,BE,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,714
+Pennington,CA,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,212
+Pennington,CL,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,218
+Pennington,DT,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,269
+Pennington,HC,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,444
+Pennington,HR,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,505
+Pennington,JS,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,459
+Pennington,KY,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,164
+Pennington,LS,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,151
+Pennington,NH,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,56
+Pennington,NU,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,208
+Pennington,QU,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,56
+Pennington,RK,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,16
+Pennington,RV,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,424
+Pennington,SR,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,81
+Pennington,VF,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,551
+Pennington,VV,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,423
+Pennington,WL,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,132
+Pennington,WP,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,460
+Pennington,WS,Judge of the Circuit Court,Position B Seventh Circuit,Jeffrey R. Connolly,NON,25
+Pennington,1-1,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,492
+Pennington,1-2,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,546
+Pennington,1-3,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,662
+Pennington,1-4,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,366
+Pennington,1-5,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,574
+Pennington,2-1,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,82
+Pennington,2-2,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,499
+Pennington,2-3,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,316
+Pennington,2-4,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,292
+Pennington,2-5,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,319
+Pennington,3-1,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,146
+Pennington,3-2,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,851
+Pennington,3-3,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,898
+Pennington,3-4,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,746
+Pennington,3-5,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,583
+Pennington,4-1,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,285
+Pennington,4-2,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,411
+Pennington,4-3,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,423
+Pennington,4-4,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,213
+Pennington,4-5,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,158
+Pennington,5-1,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,244
+Pennington,5-2,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,316
+Pennington,5-3,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,480
+Pennington,5-4,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,534
+Pennington,5-5,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,779
+Pennington,AW,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,797
+Pennington,BE,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,721
+Pennington,CA,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,222
+Pennington,CL,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,243
+Pennington,DT,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,292
+Pennington,HC,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,461
+Pennington,HR,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,534
+Pennington,JS,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,484
+Pennington,KY,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,167
+Pennington,LS,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,151
+Pennington,NH,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,57
+Pennington,NU,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,224
+Pennington,QU,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,55
+Pennington,RK,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,17
+Pennington,RV,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,447
+Pennington,SR,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,83
+Pennington,VF,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,567
+Pennington,VV,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,441
+Pennington,WL,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,128
+Pennington,WP,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,508
+Pennington,WS,Judge of the Circuit Court,Position C Seventh Circuit,Heidi L. Linngren,NON,25
+Pennington,1-1,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,442
+Pennington,1-2,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,494
+Pennington,1-3,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,581
+Pennington,1-4,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,319
+Pennington,1-5,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,510
+Pennington,2-1,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,65
+Pennington,2-2,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,458
+Pennington,2-3,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,284
+Pennington,2-4,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,271
+Pennington,2-5,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,289
+Pennington,3-1,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,133
+Pennington,3-2,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,762
+Pennington,3-3,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,803
+Pennington,3-4,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,649
+Pennington,3-5,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,489
+Pennington,4-1,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,255
+Pennington,4-2,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,378
+Pennington,4-3,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,379
+Pennington,4-4,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,180
+Pennington,4-5,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,141
+Pennington,5-1,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,220
+Pennington,5-2,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,272
+Pennington,5-3,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,428
+Pennington,5-4,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,458
+Pennington,5-5,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,689
+Pennington,AW,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,809
+Pennington,BE,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,692
+Pennington,CA,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,205
+Pennington,CL,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,207
+Pennington,DT,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,255
+Pennington,HC,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,424
+Pennington,HR,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,496
+Pennington,JS,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,432
+Pennington,KY,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,158
+Pennington,LS,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,148
+Pennington,NH,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,56
+Pennington,NU,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,196
+Pennington,QU,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,56
+Pennington,RK,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,16
+Pennington,RV,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,408
+Pennington,SR,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,77
+Pennington,VF,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,529
+Pennington,VV,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,421
+Pennington,WL,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,124
+Pennington,WP,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,452
+Pennington,WS,Judge of the Circuit Court,Position D Seventh Circuit,Joshua K. Hendrickson,NON,23
+Pennington,1-1,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,490
+Pennington,1-2,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,548
+Pennington,1-3,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,683
+Pennington,1-4,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,363
+Pennington,1-5,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,590
+Pennington,2-1,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,76
+Pennington,2-2,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,494
+Pennington,2-3,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,319
+Pennington,2-4,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,300
+Pennington,2-5,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,321
+Pennington,3-1,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,156
+Pennington,3-2,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,912
+Pennington,3-3,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,948
+Pennington,3-4,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,836
+Pennington,3-5,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,566
+Pennington,4-1,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,285
+Pennington,4-2,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,408
+Pennington,4-3,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,420
+Pennington,4-4,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,196
+Pennington,4-5,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,162
+Pennington,5-1,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,244
+Pennington,5-2,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,328
+Pennington,5-3,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,515
+Pennington,5-4,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,600
+Pennington,5-5,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,902
+Pennington,AW,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,810
+Pennington,BE,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,718
+Pennington,CA,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,209
+Pennington,CL,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,254
+Pennington,DT,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,304
+Pennington,HC,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,454
+Pennington,HR,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,571
+Pennington,JS,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,504
+Pennington,KY,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,168
+Pennington,LS,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,150
+Pennington,NH,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,60
+Pennington,NU,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,209
+Pennington,QU,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,51
+Pennington,RK,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,20
+Pennington,RV,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,445
+Pennington,SR,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,85
+Pennington,VF,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,558
+Pennington,VV,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,431
+Pennington,WL,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,125
+Pennington,WP,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,535
+Pennington,WS,Judge of the Circuit Court,Position E Seventh Circuit,Jane Wipf Pfeifle,NON,24
+Pennington,1-1,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,467
+Pennington,1-2,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,543
+Pennington,1-3,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,674
+Pennington,1-4,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,349
+Pennington,1-5,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,576
+Pennington,2-1,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,76
+Pennington,2-2,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,483
+Pennington,2-3,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,298
+Pennington,2-4,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,293
+Pennington,2-5,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,309
+Pennington,3-1,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,150
+Pennington,3-2,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,897
+Pennington,3-3,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,926
+Pennington,3-4,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,821
+Pennington,3-5,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,556
+Pennington,4-1,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,272
+Pennington,4-2,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,385
+Pennington,4-3,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,400
+Pennington,4-4,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,184
+Pennington,4-5,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,156
+Pennington,5-1,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,238
+Pennington,5-2,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,310
+Pennington,5-3,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,510
+Pennington,5-4,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,576
+Pennington,5-5,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,883
+Pennington,AW,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,790
+Pennington,BE,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,693
+Pennington,CA,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,217
+Pennington,CL,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,253
+Pennington,DT,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,297
+Pennington,HC,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,437
+Pennington,HR,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,552
+Pennington,JS,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,480
+Pennington,KY,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,162
+Pennington,LS,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,159
+Pennington,NH,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,56
+Pennington,NU,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,210
+Pennington,QU,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,53
+Pennington,RK,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,20
+Pennington,RV,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,434
+Pennington,SR,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,80
+Pennington,VF,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,558
+Pennington,VV,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,436
+Pennington,WL,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,125
+Pennington,WP,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,537
+Pennington,WS,Judge of the Circuit Court,Position F Seventh Circuit,Craig A Pfeifle,NON,24
+Pennington,1-1,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,447
+Pennington,1-2,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,497
+Pennington,1-3,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,597
+Pennington,1-4,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,337
+Pennington,1-5,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,513
+Pennington,2-1,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,68
+Pennington,2-2,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,463
+Pennington,2-3,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,279
+Pennington,2-4,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,273
+Pennington,2-5,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,278
+Pennington,3-1,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,133
+Pennington,3-2,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,786
+Pennington,3-3,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,807
+Pennington,3-4,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,674
+Pennington,3-5,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,487
+Pennington,4-1,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,258
+Pennington,4-2,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,386
+Pennington,4-3,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,384
+Pennington,4-4,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,178
+Pennington,4-5,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,146
+Pennington,5-1,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,221
+Pennington,5-2,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,275
+Pennington,5-3,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,445
+Pennington,5-4,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,485
+Pennington,5-5,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,700
+Pennington,AW,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,808
+Pennington,BE,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,678
+Pennington,CA,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,197
+Pennington,CL,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,226
+Pennington,DT,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,253
+Pennington,HC,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,427
+Pennington,HR,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,503
+Pennington,JS,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,435
+Pennington,KY,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,150
+Pennington,LS,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,147
+Pennington,NH,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,56
+Pennington,NU,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,200
+Pennington,QU,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,54
+Pennington,RK,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,16
+Pennington,RV,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,422
+Pennington,SR,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,78
+Pennington,VF,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,528
+Pennington,VV,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,417
+Pennington,WL,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,118
+Pennington,WP,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,468
+Pennington,WS,Judge of the Circuit Court,Position G Seventh Circuit,Robert Gusinsky,NON,24
+Pennington,1-1,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,442
+Pennington,1-2,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,507
+Pennington,1-3,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,587
+Pennington,1-4,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,325
+Pennington,1-5,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,526
+Pennington,2-1,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,71
+Pennington,2-2,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,454
+Pennington,2-3,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,295
+Pennington,2-4,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,270
+Pennington,2-5,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,284
+Pennington,3-1,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,130
+Pennington,3-2,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,773
+Pennington,3-3,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,821
+Pennington,3-4,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,677
+Pennington,3-5,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,485
+Pennington,4-1,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,271
+Pennington,4-2,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,397
+Pennington,4-3,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,387
+Pennington,4-4,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,189
+Pennington,4-5,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,144
+Pennington,5-1,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,227
+Pennington,5-2,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,278
+Pennington,5-3,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,440
+Pennington,5-4,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,472
+Pennington,5-5,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,701
+Pennington,AW,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,797
+Pennington,BE,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,703
+Pennington,CA,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,207
+Pennington,CL,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,212
+Pennington,DT,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,258
+Pennington,HC,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,450
+Pennington,HR,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,504
+Pennington,JS,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,442
+Pennington,KY,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,161
+Pennington,LS,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,154
+Pennington,NH,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,56
+Pennington,NU,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,199
+Pennington,QU,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,54
+Pennington,RK,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,18
+Pennington,RV,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,410
+Pennington,SR,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,77
+Pennington,VF,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,531
+Pennington,VV,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,414
+Pennington,WL,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,122
+Pennington,WP,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,459
+Pennington,WS,Judge of the Circuit Court,Position H Seventh Circuit,Matthew M. Brown,NON,25
+Pennington,1-1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,761
+Pennington,1-1,Supreme Court Retention,3,Patricia J. DeVaney - No,,213
+Pennington,1-2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,836
+Pennington,1-2,Supreme Court Retention,3,Patricia J. DeVaney - No,,233
+Pennington,1-3,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,987
+Pennington,1-3,Supreme Court Retention,3,Patricia J. DeVaney - No,,213
+Pennington,1-4,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,542
+Pennington,1-4,Supreme Court Retention,3,Patricia J. DeVaney - No,,115
+Pennington,1-5,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,950
+Pennington,1-5,Supreme Court Retention,3,Patricia J. DeVaney - No,,287
+Pennington,2-1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,135
+Pennington,2-1,Supreme Court Retention,3,Patricia J. DeVaney - No,,86
+Pennington,2-2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,791
+Pennington,2-2,Supreme Court Retention,3,Patricia J. DeVaney - No,,233
+Pennington,2-3,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,447
+Pennington,2-3,Supreme Court Retention,3,Patricia J. DeVaney - No,,185
+Pennington,2-4,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,519
+Pennington,2-4,Supreme Court Retention,3,Patricia J. DeVaney - No,,201
+Pennington,2-5,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,530
+Pennington,2-5,Supreme Court Retention,3,Patricia J. DeVaney - No,,137
+Pennington,3-1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,228
+Pennington,3-1,Supreme Court Retention,3,Patricia J. DeVaney - No,,65
+Pennington,3-2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1348
+Pennington,3-2,Supreme Court Retention,3,Patricia J. DeVaney - No,,409
+Pennington,3-3,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1438
+Pennington,3-3,Supreme Court Retention,3,Patricia J. DeVaney - No,,320
+Pennington,3-4,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1122
+Pennington,3-4,Supreme Court Retention,3,Patricia J. DeVaney - No,,272
+Pennington,3-5,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,848
+Pennington,3-5,Supreme Court Retention,3,Patricia J. DeVaney - No,,151
+Pennington,4-1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,476
+Pennington,4-1,Supreme Court Retention,3,Patricia J. DeVaney - No,,203
+Pennington,4-2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,622
+Pennington,4-2,Supreme Court Retention,3,Patricia J. DeVaney - No,,293
+Pennington,4-3,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,668
+Pennington,4-3,Supreme Court Retention,3,Patricia J. DeVaney - No,,225
+Pennington,4-4,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,364
+Pennington,4-4,Supreme Court Retention,3,Patricia J. DeVaney - No,,158
+Pennington,4-5,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,255
+Pennington,4-5,Supreme Court Retention,3,Patricia J. DeVaney - No,,105
+Pennington,5-1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,390
+Pennington,5-1,Supreme Court Retention,3,Patricia J. DeVaney - No,,129
+Pennington,5-2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,483
+Pennington,5-2,Supreme Court Retention,3,Patricia J. DeVaney - No,,205
+Pennington,5-3,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,753
+Pennington,5-3,Supreme Court Retention,3,Patricia J. DeVaney - No,,277
+Pennington,5-4,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,847
+Pennington,5-4,Supreme Court Retention,3,Patricia J. DeVaney - No,,362
+Pennington,5-5,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1223
+Pennington,5-5,Supreme Court Retention,3,Patricia J. DeVaney - No,,331
+Pennington,AW,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1515
+Pennington,AW,Supreme Court Retention,3,Patricia J. DeVaney - No,,414
+Pennington,BE,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,1198
+Pennington,BE,Supreme Court Retention,3,Patricia J. DeVaney - No,,378
+Pennington,CA,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,374
+Pennington,CA,Supreme Court Retention,3,Patricia J. DeVaney - No,,91
+Pennington,CL,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,377
+Pennington,CL,Supreme Court Retention,3,Patricia J. DeVaney - No,,92
+Pennington,DT,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,435
+Pennington,DT,Supreme Court Retention,3,Patricia J. DeVaney - No,,94
+Pennington,HC,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,785
+Pennington,HC,Supreme Court Retention,3,Patricia J. DeVaney - No,,188
+Pennington,HR,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,863
+Pennington,HR,Supreme Court Retention,3,Patricia J. DeVaney - No,,152
+Pennington,JS,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,819
+Pennington,JS,Supreme Court Retention,3,Patricia J. DeVaney - No,,217
+Pennington,KY,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,312
+Pennington,KY,Supreme Court Retention,3,Patricia J. DeVaney - No,,97
+Pennington,LS,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,261
+Pennington,LS,Supreme Court Retention,3,Patricia J. DeVaney - No,,65
+Pennington,NH,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,93
+Pennington,NH,Supreme Court Retention,3,Patricia J. DeVaney - No,,36
+Pennington,NU,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,368
+Pennington,NU,Supreme Court Retention,3,Patricia J. DeVaney - No,,100
+Pennington,QU,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,126
+Pennington,QU,Supreme Court Retention,3,Patricia J. DeVaney - No,,43
+Pennington,RK,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,24
+Pennington,RK,Supreme Court Retention,3,Patricia J. DeVaney - No,,3
+Pennington,RV,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,697
+Pennington,RV,Supreme Court Retention,3,Patricia J. DeVaney - No,,197
+Pennington,SR,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,136
+Pennington,SR,Supreme Court Retention,3,Patricia J. DeVaney - No,,51
+Pennington,VF,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,928
+Pennington,VF,Supreme Court Retention,3,Patricia J. DeVaney - No,,233
+Pennington,VV,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,696
+Pennington,VV,Supreme Court Retention,3,Patricia J. DeVaney - No,,182
+Pennington,WL,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,246
+Pennington,WL,Supreme Court Retention,3,Patricia J. DeVaney - No,,59
+Pennington,WP,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,773
+Pennington,WP,Supreme Court Retention,3,Patricia J. DeVaney - No,,171
+Pennington,WS,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,57
+Pennington,WS,Supreme Court Retention,3,Patricia J. DeVaney - No,,13
+Pennington,1-1,Supreme Court Retention,2,Mark E. Salter - Yes,,744
+Pennington,1-1,Supreme Court Retention,2,Mark E. Salter - No,,219
+Pennington,1-2,Supreme Court Retention,2,Mark E. Salter - Yes,,847
+Pennington,1-2,Supreme Court Retention,2,Mark E. Salter - No,,219
+Pennington,1-3,Supreme Court Retention,2,Mark E. Salter - Yes,,1004
+Pennington,1-3,Supreme Court Retention,2,Mark E. Salter - No,,192
+Pennington,1-4,Supreme Court Retention,2,Mark E. Salter - Yes,,541
+Pennington,1-4,Supreme Court Retention,2,Mark E. Salter - No,,116
+Pennington,1-5,Supreme Court Retention,2,Mark E. Salter - Yes,,945
+Pennington,1-5,Supreme Court Retention,2,Mark E. Salter - No,,280
+Pennington,2-1,Supreme Court Retention,2,Mark E. Salter - Yes,,123
+Pennington,2-1,Supreme Court Retention,2,Mark E. Salter - No,,95
+Pennington,2-2,Supreme Court Retention,2,Mark E. Salter - Yes,,791
+Pennington,2-2,Supreme Court Retention,2,Mark E. Salter - No,,229
+Pennington,2-3,Supreme Court Retention,2,Mark E. Salter - Yes,,442
+Pennington,2-3,Supreme Court Retention,2,Mark E. Salter - No,,189
+Pennington,2-4,Supreme Court Retention,2,Mark E. Salter - Yes,,511
+Pennington,2-4,Supreme Court Retention,2,Mark E. Salter - No,,212
+Pennington,2-5,Supreme Court Retention,2,Mark E. Salter - Yes,,517
+Pennington,2-5,Supreme Court Retention,2,Mark E. Salter - No,,141
+Pennington,3-1,Supreme Court Retention,2,Mark E. Salter - Yes,,224
+Pennington,3-1,Supreme Court Retention,2,Mark E. Salter - No,,65
+Pennington,3-2,Supreme Court Retention,2,Mark E. Salter - Yes,,1351
+Pennington,3-2,Supreme Court Retention,2,Mark E. Salter - No,,398
+Pennington,3-3,Supreme Court Retention,2,Mark E. Salter - Yes,,1430
+Pennington,3-3,Supreme Court Retention,2,Mark E. Salter - No,,317
+Pennington,3-4,Supreme Court Retention,2,Mark E. Salter - Yes,,1138
+Pennington,3-4,Supreme Court Retention,2,Mark E. Salter - No,,254
+Pennington,3-5,Supreme Court Retention,2,Mark E. Salter - Yes,,847
+Pennington,3-5,Supreme Court Retention,2,Mark E. Salter - No,,145
+Pennington,4-1,Supreme Court Retention,2,Mark E. Salter - Yes,,469
+Pennington,4-1,Supreme Court Retention,2,Mark E. Salter - No,,208
+Pennington,4-2,Supreme Court Retention,2,Mark E. Salter - Yes,,627
+Pennington,4-2,Supreme Court Retention,2,Mark E. Salter - No,,285
+Pennington,4-3,Supreme Court Retention,2,Mark E. Salter - Yes,,673
+Pennington,4-3,Supreme Court Retention,2,Mark E. Salter - No,,216
+Pennington,4-4,Supreme Court Retention,2,Mark E. Salter - Yes,,358
+Pennington,4-4,Supreme Court Retention,2,Mark E. Salter - No,,160
+Pennington,4-5,Supreme Court Retention,2,Mark E. Salter - Yes,,257
+Pennington,4-5,Supreme Court Retention,2,Mark E. Salter - No,,101
+Pennington,5-1,Supreme Court Retention,2,Mark E. Salter - Yes,,389
+Pennington,5-1,Supreme Court Retention,2,Mark E. Salter - No,,127
+Pennington,5-2,Supreme Court Retention,2,Mark E. Salter - Yes,,489
+Pennington,5-2,Supreme Court Retention,2,Mark E. Salter - No,,202
+Pennington,5-3,Supreme Court Retention,2,Mark E. Salter - Yes,,754
+Pennington,5-3,Supreme Court Retention,2,Mark E. Salter - No,,266
+Pennington,5-4,Supreme Court Retention,2,Mark E. Salter - Yes,,850
+Pennington,5-4,Supreme Court Retention,2,Mark E. Salter - No,,355
+Pennington,5-5,Supreme Court Retention,2,Mark E. Salter - Yes,,1216
+Pennington,5-5,Supreme Court Retention,2,Mark E. Salter - No,,332
+Pennington,AW,Supreme Court Retention,2,Mark E. Salter - Yes,,1508
+Pennington,AW,Supreme Court Retention,2,Mark E. Salter - No,,398
+Pennington,BE,Supreme Court Retention,2,Mark E. Salter - Yes,,1188
+Pennington,BE,Supreme Court Retention,2,Mark E. Salter - No,,378
+Pennington,CA,Supreme Court Retention,2,Mark E. Salter - Yes,,368
+Pennington,CA,Supreme Court Retention,2,Mark E. Salter - No,,96
+Pennington,CL,Supreme Court Retention,2,Mark E. Salter - Yes,,375
+Pennington,CL,Supreme Court Retention,2,Mark E. Salter - No,,87
+Pennington,DT,Supreme Court Retention,2,Mark E. Salter - Yes,,441
+Pennington,DT,Supreme Court Retention,2,Mark E. Salter - No,,83
+Pennington,HC,Supreme Court Retention,2,Mark E. Salter - Yes,,769
+Pennington,HC,Supreme Court Retention,2,Mark E. Salter - No,,189
+Pennington,HR,Supreme Court Retention,2,Mark E. Salter - Yes,,854
+Pennington,HR,Supreme Court Retention,2,Mark E. Salter - No,,155
+Pennington,JS,Supreme Court Retention,2,Mark E. Salter - Yes,,814
+Pennington,JS,Supreme Court Retention,2,Mark E. Salter - No,,215
+Pennington,KY,Supreme Court Retention,2,Mark E. Salter - Yes,,320
+Pennington,KY,Supreme Court Retention,2,Mark E. Salter - No,,88
+Pennington,LS,Supreme Court Retention,2,Mark E. Salter - Yes,,259
+Pennington,LS,Supreme Court Retention,2,Mark E. Salter - No,,68
+Pennington,NH,Supreme Court Retention,2,Mark E. Salter - Yes,,96
+Pennington,NH,Supreme Court Retention,2,Mark E. Salter - No,,36
+Pennington,NU,Supreme Court Retention,2,Mark E. Salter - Yes,,371
+Pennington,NU,Supreme Court Retention,2,Mark E. Salter - No,,97
+Pennington,QU,Supreme Court Retention,2,Mark E. Salter - Yes,,126
+Pennington,QU,Supreme Court Retention,2,Mark E. Salter - No,,40
+Pennington,RK,Supreme Court Retention,2,Mark E. Salter - Yes,,25
+Pennington,RK,Supreme Court Retention,2,Mark E. Salter - No,,3
+Pennington,RV,Supreme Court Retention,2,Mark E. Salter - Yes,,674
+Pennington,RV,Supreme Court Retention,2,Mark E. Salter - No,,212
+Pennington,SR,Supreme Court Retention,2,Mark E. Salter - Yes,,134
+Pennington,SR,Supreme Court Retention,2,Mark E. Salter - No,,51
+Pennington,VF,Supreme Court Retention,2,Mark E. Salter - Yes,,912
+Pennington,VF,Supreme Court Retention,2,Mark E. Salter - No,,242
+Pennington,VV,Supreme Court Retention,2,Mark E. Salter - Yes,,692
+Pennington,VV,Supreme Court Retention,2,Mark E. Salter - No,,184
+Pennington,WL,Supreme Court Retention,2,Mark E. Salter - Yes,,253
+Pennington,WL,Supreme Court Retention,2,Mark E. Salter - No,,51
+Pennington,WP,Supreme Court Retention,2,Mark E. Salter - Yes,,773
+Pennington,WP,Supreme Court Retention,2,Mark E. Salter - No,,165
+Pennington,WS,Supreme Court Retention,2,Mark E. Salter - Yes,,54
+Pennington,WS,Supreme Court Retention,2,Mark E. Salter - No,,14
+Pennington,1-1,Constitutional Amendment D,,Yes,,638
+Pennington,1-1,Constitutional Amendment D,,No,,517
+Pennington,1-2,Constitutional Amendment D,,Yes,,742
+Pennington,1-2,Constitutional Amendment D,,No,,543
+Pennington,1-3,Constitutional Amendment D,,Yes,,765
+Pennington,1-3,Constitutional Amendment D,,No,,695
+Pennington,1-4,Constitutional Amendment D,,Yes,,406
+Pennington,1-4,Constitutional Amendment D,,No,,388
+Pennington,1-5,Constitutional Amendment D,,Yes,,847
+Pennington,1-5,Constitutional Amendment D,,No,,582
+Pennington,2-1,Constitutional Amendment D,,Yes,,196
+Pennington,2-1,Constitutional Amendment D,,No,,75
+Pennington,2-2,Constitutional Amendment D,,Yes,,690
+Pennington,2-2,Constitutional Amendment D,,No,,530
+Pennington,2-3,Constitutional Amendment D,,Yes,,524
+Pennington,2-3,Constitutional Amendment D,,No,,255
+Pennington,2-4,Constitutional Amendment D,,Yes,,589
+Pennington,2-4,Constitutional Amendment D,,No,,274
+Pennington,2-5,Constitutional Amendment D,,Yes,,495
+Pennington,2-5,Constitutional Amendment D,,No,,308
+Pennington,3-1,Constitutional Amendment D,,Yes,,202
+Pennington,3-1,Constitutional Amendment D,,No,,136
+Pennington,3-2,Constitutional Amendment D,,Yes,,1270
+Pennington,3-2,Constitutional Amendment D,,No,,904
+Pennington,3-3,Constitutional Amendment D,,Yes,,1139
+Pennington,3-3,Constitutional Amendment D,,No,,981
+Pennington,3-4,Constitutional Amendment D,,Yes,,969
+Pennington,3-4,Constitutional Amendment D,,No,,790
+Pennington,3-5,Constitutional Amendment D,,Yes,,607
+Pennington,3-5,Constitutional Amendment D,,No,,604
+Pennington,4-1,Constitutional Amendment D,,Yes,,595
+Pennington,4-1,Constitutional Amendment D,,No,,216
+Pennington,4-2,Constitutional Amendment D,,Yes,,740
+Pennington,4-2,Constitutional Amendment D,,No,,316
+Pennington,4-3,Constitutional Amendment D,,Yes,,638
+Pennington,4-3,Constitutional Amendment D,,No,,412
+Pennington,4-4,Constitutional Amendment D,,Yes,,437
+Pennington,4-4,Constitutional Amendment D,,No,,166
+Pennington,4-5,Constitutional Amendment D,,Yes,,265
+Pennington,4-5,Constitutional Amendment D,,No,,176
+Pennington,5-1,Constitutional Amendment D,,Yes,,380
+Pennington,5-1,Constitutional Amendment D,,No,,223
+Pennington,5-2,Constitutional Amendment D,,Yes,,583
+Pennington,5-2,Constitutional Amendment D,,No,,265
+Pennington,5-3,Constitutional Amendment D,,Yes,,786
+Pennington,5-3,Constitutional Amendment D,,No,,466
+Pennington,5-4,Constitutional Amendment D,,Yes,,1116
+Pennington,5-4,Constitutional Amendment D,,No,,407
+Pennington,5-5,Constitutional Amendment D,,Yes,,1124
+Pennington,5-5,Constitutional Amendment D,,No,,763
+Pennington,AW,Constitutional Amendment D,,Yes,,1005
+Pennington,AW,Constitutional Amendment D,,No,,1247
+Pennington,BE,Constitutional Amendment D,,Yes,,1069
+Pennington,BE,Constitutional Amendment D,,No,,736
+Pennington,CA,Constitutional Amendment D,,Yes,,224
+Pennington,CA,Constitutional Amendment D,,No,,351
+Pennington,CL,Constitutional Amendment D,,Yes,,285
+Pennington,CL,Constitutional Amendment D,,No,,288
+Pennington,DT,Constitutional Amendment D,,Yes,,298
+Pennington,DT,Constitutional Amendment D,,No,,314
+Pennington,HC,Constitutional Amendment D,,Yes,,633
+Pennington,HC,Constitutional Amendment D,,No,,554
+Pennington,HR,Constitutional Amendment D,,Yes,,543
+Pennington,HR,Constitutional Amendment D,,No,,672
+Pennington,JS,Constitutional Amendment D,,Yes,,619
+Pennington,JS,Constitutional Amendment D,,No,,637
+Pennington,KY,Constitutional Amendment D,,Yes,,262
+Pennington,KY,Constitutional Amendment D,,No,,248
+Pennington,LS,Constitutional Amendment D,,Yes,,156
+Pennington,LS,Constitutional Amendment D,,No,,242
+Pennington,NH,Constitutional Amendment D,,Yes,,84
+Pennington,NH,Constitutional Amendment D,,No,,68
+Pennington,NU,Constitutional Amendment D,,Yes,,245
+Pennington,NU,Constitutional Amendment D,,No,,328
+Pennington,QU,Constitutional Amendment D,,Yes,,62
+Pennington,QU,Constitutional Amendment D,,No,,161
+Pennington,RK,Constitutional Amendment D,,Yes,,14
+Pennington,RK,Constitutional Amendment D,,No,,17
+Pennington,RV,Constitutional Amendment D,,Yes,,624
+Pennington,RV,Constitutional Amendment D,,No,,450
+Pennington,SR,Constitutional Amendment D,,Yes,,130
+Pennington,SR,Constitutional Amendment D,,No,,93
+Pennington,VF,Constitutional Amendment D,,Yes,,768
+Pennington,VF,Constitutional Amendment D,,No,,633
+Pennington,VV,Constitutional Amendment D,,Yes,,570
+Pennington,VV,Constitutional Amendment D,,No,,490
+Pennington,WL,Constitutional Amendment D,,Yes,,159
+Pennington,WL,Constitutional Amendment D,,No,,204
+Pennington,WP,Constitutional Amendment D,,Yes,,587
+Pennington,WP,Constitutional Amendment D,,No,,585
+Pennington,WS,Constitutional Amendment D,,Yes,,33
+Pennington,WS,Constitutional Amendment D,,No,,49
+Pennington,1-1,Initiated Measure 27,,Yes,,552
+Pennington,1-1,Initiated Measure 27,,No,,636
+Pennington,1-2,Initiated Measure 27,,Yes,,576
+Pennington,1-2,Initiated Measure 27,,No,,738
+Pennington,1-3,Initiated Measure 27,,Yes,,543
+Pennington,1-3,Initiated Measure 27,,No,,929
+Pennington,1-4,Initiated Measure 27,,Yes,,349
+Pennington,1-4,Initiated Measure 27,,No,,457
+Pennington,1-5,Initiated Measure 27,,Yes,,718
+Pennington,1-5,Initiated Measure 27,,No,,746
+Pennington,2-1,Initiated Measure 27,,Yes,,202
+Pennington,2-1,Initiated Measure 27,,No,,73
+Pennington,2-2,Initiated Measure 27,,Yes,,655
+Pennington,2-2,Initiated Measure 27,,No,,582
+Pennington,2-3,Initiated Measure 27,,Yes,,509
+Pennington,2-3,Initiated Measure 27,,No,,277
+Pennington,2-4,Initiated Measure 27,,Yes,,565
+Pennington,2-4,Initiated Measure 27,,No,,313
+Pennington,2-5,Initiated Measure 27,,Yes,,478
+Pennington,2-5,Initiated Measure 27,,No,,332
+Pennington,3-1,Initiated Measure 27,,Yes,,179
+Pennington,3-1,Initiated Measure 27,,No,,161
+Pennington,3-2,Initiated Measure 27,,Yes,,1145
+Pennington,3-2,Initiated Measure 27,,No,,1066
+Pennington,3-3,Initiated Measure 27,,Yes,,965
+Pennington,3-3,Initiated Measure 27,,No,,1191
+Pennington,3-4,Initiated Measure 27,,Yes,,767
+Pennington,3-4,Initiated Measure 27,,No,,1019
+Pennington,3-5,Initiated Measure 27,,Yes,,472
+Pennington,3-5,Initiated Measure 27,,No,,752
+Pennington,4-1,Initiated Measure 27,,Yes,,550
+Pennington,4-1,Initiated Measure 27,,No,,272
+Pennington,4-2,Initiated Measure 27,,Yes,,689
+Pennington,4-2,Initiated Measure 27,,No,,380
+Pennington,4-3,Initiated Measure 27,,Yes,,548
+Pennington,4-3,Initiated Measure 27,,No,,515
+Pennington,4-4,Initiated Measure 27,,Yes,,394
+Pennington,4-4,Initiated Measure 27,,No,,219
+Pennington,4-5,Initiated Measure 27,,Yes,,254
+Pennington,4-5,Initiated Measure 27,,No,,196
+Pennington,5-1,Initiated Measure 27,,Yes,,345
+Pennington,5-1,Initiated Measure 27,,No,,264
+Pennington,5-2,Initiated Measure 27,,Yes,,546
+Pennington,5-2,Initiated Measure 27,,No,,309
+Pennington,5-3,Initiated Measure 27,,Yes,,735
+Pennington,5-3,Initiated Measure 27,,No,,542
+Pennington,5-4,Initiated Measure 27,,Yes,,1060
+Pennington,5-4,Initiated Measure 27,,No,,497
+Pennington,5-5,Initiated Measure 27,,Yes,,920
+Pennington,5-5,Initiated Measure 27,,No,,1005
+Pennington,AW,Initiated Measure 27,,Yes,,1151
+Pennington,AW,Initiated Measure 27,,No,,1157
+Pennington,BE,Initiated Measure 27,,Yes,,1041
+Pennington,BE,Initiated Measure 27,,No,,791
+Pennington,CA,Initiated Measure 27,,Yes,,212
+Pennington,CA,Initiated Measure 27,,No,,371
+Pennington,CL,Initiated Measure 27,,Yes,,269
+Pennington,CL,Initiated Measure 27,,No,,313
+Pennington,DT,Initiated Measure 27,,Yes,,254
+Pennington,DT,Initiated Measure 27,,No,,375
+Pennington,HC,Initiated Measure 27,,Yes,,517
+Pennington,HC,Initiated Measure 27,,No,,689
+Pennington,HR,Initiated Measure 27,,Yes,,460
+Pennington,HR,Initiated Measure 27,,No,,772
+Pennington,JS,Initiated Measure 27,,Yes,,581
+Pennington,JS,Initiated Measure 27,,No,,687
+Pennington,KY,Initiated Measure 27,,Yes,,238
+Pennington,KY,Initiated Measure 27,,No,,282
+Pennington,LS,Initiated Measure 27,,Yes,,129
+Pennington,LS,Initiated Measure 27,,No,,270
+Pennington,NH,Initiated Measure 27,,Yes,,82
+Pennington,NH,Initiated Measure 27,,No,,73
+Pennington,NU,Initiated Measure 27,,Yes,,197
+Pennington,NU,Initiated Measure 27,,No,,387
+Pennington,QU,Initiated Measure 27,,Yes,,38
+Pennington,QU,Initiated Measure 27,,No,,191
+Pennington,RK,Initiated Measure 27,,Yes,,7
+Pennington,RK,Initiated Measure 27,,No,,25
+Pennington,RV,Initiated Measure 27,,Yes,,584
+Pennington,RV,Initiated Measure 27,,No,,501
+Pennington,SR,Initiated Measure 27,,Yes,,120
+Pennington,SR,Initiated Measure 27,,No,,105
+Pennington,VF,Initiated Measure 27,,Yes,,776
+Pennington,VF,Initiated Measure 27,,No,,651
+Pennington,VV,Initiated Measure 27,,Yes,,546
+Pennington,VV,Initiated Measure 27,,No,,534
+Pennington,WL,Initiated Measure 27,,Yes,,110
+Pennington,WL,Initiated Measure 27,,No,,259
+Pennington,WP,Initiated Measure 27,,Yes,,486
+Pennington,WP,Initiated Measure 27,,No,,698
+Pennington,WS,Initiated Measure 27,,Yes,,28
+Pennington,WS,Initiated Measure 27,,No,,54
+Pennington,1-1,State Senate,33,Darren Freidel,LIB,283
+Pennington,1-1,State Senate,33,David Johnson,REP,776
+Pennington,1-2,State Senate,33,Darren Freidel,LIB,282
+Pennington,1-2,State Senate,33,David Johnson,REP,856
+Pennington,1-3,State Senate,33,Darren Freidel,LIB,305
+Pennington,1-3,State Senate,33,David Johnson,REP,1006
+Pennington,1-4,State Senate,35,Jessica Castleberry,REP,569
+Pennington,1-5,State Senate,32,Nicole A. Heenan,DEM,536
+Pennington,1-5,State Senate,32,Helene Duhamel,REP,912
+Pennington,2-1,State Senate,32,Nicole A. Heenan,DEM,134
+Pennington,2-1,State Senate,32,Helene Duhamel,REP,132
+Pennington,2-2,State Senate,35,Jessica Castleberry,REP,819
+Pennington,2-3,State Senate,35,Jessica Castleberry,REP,456
+Pennington,2-4,State Senate,32,Nicole A. Heenan,DEM,368
+Pennington,2-4,State Senate,32,Helene Duhamel,REP,474
+Pennington,2-5,State Senate,32,Nicole A. Heenan,DEM,296
+Pennington,2-5,State Senate,32,Helene Duhamel,REP,483
+Pennington,3-1,State Senate,32,Nicole A. Heenan,DEM,124
+Pennington,3-1,State Senate,32,Helene Duhamel,REP,203
+Pennington,3-2,State Senate,34,Michael Diedrich,REP,1430
+Pennington,3-3,State Senate,34,Michael Diedrich,REP,1500
+Pennington,3-4,State Senate,34,Michael Diedrich,REP,1281
+Pennington,3-5,State Senate,33,Darren Freidel,LIB,197
+Pennington,3-5,State Senate,33,David Johnson,REP,898
+Pennington,4-1,State Senate,32,Nicole A. Heenan,DEM,378
+Pennington,4-1,State Senate,32,Helene Duhamel,REP,419
+Pennington,4-2,State Senate,32,Nicole A. Heenan,DEM,441
+Pennington,4-2,State Senate,32,Helene Duhamel,REP,590
+Pennington,4-3,State Senate,33,Darren Freidel,LIB,287
+Pennington,4-3,State Senate,33,David Johnson,REP,660
+Pennington,4-4,State Senate,32,Nicole A. Heenan,DEM,268
+Pennington,4-4,State Senate,32,Helene Duhamel,REP,322
+Pennington,4-5,State Senate,35,Jessica Castleberry,REP,293
+Pennington,5-1,State Senate,34,Michael Diedrich,REP,376
+Pennington,5-2,State Senate,34,Michael Diedrich,REP,503
+Pennington,5-3,State Senate,34,Michael Diedrich,REP,785
+Pennington,5-4,State Senate,32,Nicole A. Heenan,DEM,778
+Pennington,5-4,State Senate,32,Helene Duhamel,REP,722
+Pennington,5-5,State Senate,34,Michael Diedrich,REP,1235
+Pennington,AW,State Senate,35,Jessica Castleberry,REP,1747
+Pennington,BE,State Senate,35,Jessica Castleberry,REP,1294
+Pennington,CA,State Senate,27,Red Dawn Foster,DEM,83
+Pennington,CA,State Senate,27,David Jones,REP,477
+Pennington,CL,State Senate,34,Michael Diedrich,REP,395
+Pennington,DT,State Senate,33,Darren Freidel,LIB,118
+Pennington,DT,State Senate,33,David Johnson,REP,448
+Pennington,HC,State Senate,30,Julie Frye-Mueller,REP,816
+Pennington,HR,State Senate,30,Julie Frye-Mueller,REP,858
+Pennington,JS,State Senate,33,Darren Freidel,LIB,283
+Pennington,JS,State Senate,33,David Johnson,REP,895
+Pennington,KY,State Senate,30,Julie Frye-Mueller,REP,332
+Pennington,LS,State Senate,30,Julie Frye-Mueller,REP,288
+Pennington,NH,State Senate,35,Jessica Castleberry,REP,110
+Pennington,NU,State Senate,27,Red Dawn Foster,DEM,83
+Pennington,NU,State Senate,27,David Jones,REP,484
+Pennington,QU,State Senate,27,Red Dawn Foster,DEM,16
+Pennington,QU,State Senate,27,David Jones,REP,212
+Pennington,RK,State Senate,30,Julie Frye-Mueller,REP,26
+Pennington,RV,State Senate,35,Jessica Castleberry,REP,739
+Pennington,SR,State Senate,33,Darren Freidel,LIB,52
+Pennington,SR,State Senate,33,David Johnson,REP,148
+Pennington,VF,State Senate,30,Julie Frye-Mueller,REP,949
+Pennington,VV,State Senate,35,Jessica Castleberry,REP,757
+Pennington,WL,State Senate,27,Red Dawn Foster,DEM,55
+Pennington,WL,State Senate,27,David Jones,REP,293
+Pennington,WP,State Senate,33,Darren Freidel,LIB,267
+Pennington,WP,State Senate,33,David Johnson,REP,790
+Pennington,WS 10 of 25,State Senate,27,Red Dawn Foster,DEM,8
+Pennington,WS 10 of 25,State Senate,27,David Jones,REP,74
+Pennington,1-1 Precinct 1-2 Precinct 1-3 Precinct 1-4 Precinct 1-5 Precinct 2-1 Precinct 2-2 Precinct 2-3 Precinct 2-4 Precinct 2-5 Precinct 3-1 Precinct 3-2 Precinct 3-3 Precinct 3-4 Precinct 3-5 Precinct 4-1 Precinct 4-2 Precinct 4-3 Precinct 4-4 Precinct 4-5 Precinct 5-1 Precinct 5-2 Precinct 5-3 Precinct 5-4 Precinct 5-5 Precinct AW Precinct BE Precinct CA Precinct CL,State House,27,Peri Pourier,DEM,93
+Pennington,1-1 Precinct 1-2 Precinct 1-3 Precinct 1-4 Precinct 1-5 Precinct 2-1 Precinct 2-2 Precinct 2-3 Precinct 2-4 Precinct 2-5 Precinct 3-1 Precinct 3-2 Precinct 3-3 Precinct 3-4 Precinct 3-5 Precinct 4-1 Precinct 4-2 Precinct 4-3 Precinct 4-4 Precinct 4-5 Precinct 5-1 Precinct 5-2 Precinct 5-3 Precinct 5-4 Precinct 5-5 Precinct AW Precinct BE Precinct CA Precinct CL,State House,27,Norma Rendon,DEM,65
+Pennington,1-1 Precinct 1-2 Precinct 1-3 Precinct 1-4 Precinct 1-5 Precinct 2-1 Precinct 2-2 Precinct 2-3 Precinct 2-4 Precinct 2-5 Precinct 3-1 Precinct 3-2 Precinct 3-3 Precinct 3-4 Precinct 3-5 Precinct 4-1 Precinct 4-2 Precinct 4-3 Precinct 4-4 Precinct 4-5 Precinct 5-1 Precinct 5-2 Precinct 5-3 Precinct 5-4 Precinct 5-5 Precinct AW Precinct BE Precinct CA Precinct CL,State House,27,Liz May,REP,412
+Pennington,1-1 Precinct 1-2 Precinct 1-3 Precinct 1-4 Precinct 1-5 Precinct 2-1 Precinct 2-2 Precinct 2-3 Precinct 2-4 Precinct 2-5 Precinct 3-1 Precinct 3-2 Precinct 3-3 Precinct 3-4 Precinct 3-5 Precinct 4-1 Precinct 4-2 Precinct 4-3 Precinct 4-4 Precinct 4-5 Precinct 5-1 Precinct 5-2 Precinct 5-3 Precinct 5-4 Precinct 5-5 Precinct AW Precinct BE Precinct CA Precinct CL,State House,27,Bud May,REP,420
+Pennington,DT Precinct HC,State House,30,Bret Swanson,DEM,301
+Pennington,DT Precinct HC,State House,30,Dennis Krull,REP,876
+Pennington,DT Precinct HC,State House,30,Trish Ladner,REP,544
+Pennington,HR Precinct JS,State House,30,Bret Swanson,DEM,270
+Pennington,HR Precinct JS,State House,30,Dennis Krull,REP,717
+Pennington,HR Precinct JS,State House,30,Trish Ladner,REP,782
+Pennington,KY,State House,30,Bret Swanson,DEM,140
+Pennington,KY,State House,30,Dennis Krull,REP,312
+Pennington,KY,State House,30,Trish Ladner,REP,254
+Pennington,LS Precinct NH,State House,30,Bret Swanson,DEM,83
+Pennington,LS Precinct NH,State House,30,Dennis Krull,REP,226
+Pennington,LS Precinct NH,State House,30,Trish Ladner,REP,271
+Pennington,NU,State House,27,Peri Pourier,DEM,81
+Pennington,NU,State House,27,Norma Rendon,DEM,64
+Pennington,NU,State House,27,Liz May,REP,438
+Pennington,NU,State House,27,Bud May,REP,414
+Pennington,QU,State House,27,Peri Pourier,DEM,18
+Pennington,QU,State House,27,Norma Rendon,DEM,18
+Pennington,QU,State House,27,Liz May,REP,191
+Pennington,QU,State House,27,Bud May,REP,190
+Pennington,RK Precinct RV,State House,30,Bret Swanson,DEM,5
+Pennington,RK Precinct RV,State House,30,Dennis Krull,REP,20
+Pennington,RK Precinct RV,State House,30,Trish Ladner,REP,24
+Pennington,SR Precinct VF,State House,30,Bret Swanson,DEM,372
+Pennington,SR Precinct VF,State House,30,Dennis Krull,REP,666
+Pennington,SR Precinct VF,State House,30,Trish Ladner,REP,817
+Pennington,VV Precinct WL Precinct WP,State House,27,Peri Pourier,DEM,61
+Pennington,VV Precinct WL Precinct WP,State House,27,Norma Rendon,DEM,44
+Pennington,VV Precinct WL Precinct WP,State House,27,Liz May,REP,268
+Pennington,VV Precinct WL Precinct WP,State House,27,Bud May,REP,260
+Pennington,WS 11 of 25,State House,27,Peri Pourier,DEM,6
+Pennington,WS 11 of 25,State House,27,Norma Rendon,DEM,9
+Pennington,WS 11 of 25,State House,27,Liz May,REP,65
+Pennington,WS 11 of 25,State House,27,Bud May,REP,66
+Pennington,1-1,State House,33,Vince Vidal,DEM,430
+Pennington,1-1,State House,33,Curt Massie,REP,532
+Pennington,1-1,State House,33,Phil Jensen,REP,636
+Pennington,1-2,State House,33,Vince Vidal,DEM,482
+Pennington,1-2,State House,33,Curt Massie,REP,614
+Pennington,1-2,State House,33,Phil Jensen,REP,687
+Pennington,1-3,State House,33,Vince Vidal,DEM,533
+Pennington,1-3,State House,33,Curt Massie,REP,712
+Pennington,1-3,State House,33,Phil Jensen,REP,802
+Pennington,1-4 Precinct 1-5,State House,32,Jonathan M. Old Horse,DEM,426
+Pennington,1-4 Precinct 1-5,State House,32,Christine Stephenson,DEM,542
+Pennington,1-4 Precinct 1-5,State House,32,Becky J. Drury,REP,740
+Pennington,1-4 Precinct 1-5,State House,32,Steve Duffy,REP,723
+Pennington,2-1 Precinct 2-2,State House,32,Jonathan M. Old Horse,DEM,121
+Pennington,2-1 Precinct 2-2,State House,32,Christine Stephenson,DEM,113
+Pennington,2-1 Precinct 2-2,State House,32,Becky J. Drury,REP,91
+Pennington,2-1 Precinct 2-2,State House,32,Steve Duffy,REP,104
+Pennington,2-3 Precinct 2-4,State House,32,Jonathan M. Old Horse,DEM,291
+Pennington,2-3 Precinct 2-4,State House,32,Christine Stephenson,DEM,362
+Pennington,2-3 Precinct 2-4,State House,32,Becky J. Drury,REP,337
+Pennington,2-3 Precinct 2-4,State House,32,Steve Duffy,REP,364
+Pennington,2-5,State House,32,Jonathan M. Old Horse,DEM,250
+Pennington,2-5,State House,32,Christine Stephenson,DEM,283
+Pennington,2-5,State House,32,Becky J. Drury,REP,398
+Pennington,2-5,State House,32,Steve Duffy,REP,395
+Pennington,3-1 Precinct 3-2,State House,32,Jonathan M. Old Horse,DEM,109
+Pennington,3-1 Precinct 3-2,State House,32,Christine Stephenson,DEM,138
+Pennington,3-1 Precinct 3-2,State House,32,Becky J. Drury,REP,164
+Pennington,3-1 Precinct 3-2,State House,32,Steve Duffy,REP,155
+Pennington,3-3 Precinct 3-4 Precinct 3-5,State House,33,Vince Vidal,DEM,378
+Pennington,3-3 Precinct 3-4 Precinct 3-5,State House,33,Curt Massie,REP,679
+Pennington,3-3 Precinct 3-4 Precinct 3-5,State House,33,Phil Jensen,REP,673
+Pennington,4-1,State House,32,Jonathan M. Old Horse,DEM,365
+Pennington,4-1,State House,32,Christine Stephenson,DEM,302
+Pennington,4-1,State House,32,Becky J. Drury,REP,285
+Pennington,4-1,State House,32,Steve Duffy,REP,332
+Pennington,4-2,State House,32,Jonathan M. Old Horse,DEM,396
+Pennington,4-2,State House,32,Christine Stephenson,DEM,383
+Pennington,4-2,State House,32,Becky J. Drury,REP,457
+Pennington,4-2,State House,32,Steve Duffy,REP,463
+Pennington,4-3,State House,33,Vince Vidal,DEM,394
+Pennington,4-3,State House,33,Curt Massie,REP,456
+Pennington,4-3,State House,33,Phil Jensen,REP,537
+Pennington,4-4 Precinct 4-5 Precinct 5-1,State House,32,Jonathan M. Old Horse,DEM,251
+Pennington,4-4 Precinct 4-5 Precinct 5-1,State House,32,Christine Stephenson,DEM,200
+Pennington,4-4 Precinct 4-5 Precinct 5-1,State House,32,Becky J. Drury,REP,224
+Pennington,4-4 Precinct 4-5 Precinct 5-1,State House,32,Steve Duffy,REP,249
+Pennington,5-2 Precinct 5-3 Precinct 5-4 Precinct 5-5 Precinct AW Precinct BE,State House,32,Jonathan M. Old Horse,DEM,639
+Pennington,5-2 Precinct 5-3 Precinct 5-4 Precinct 5-5 Precinct AW Precinct BE,State House,32,Christine Stephenson,DEM,772
+Pennington,5-2 Precinct 5-3 Precinct 5-4 Precinct 5-5 Precinct AW Precinct BE,State House,32,Becky J. Drury,REP,534
+Pennington,5-2 Precinct 5-3 Precinct 5-4 Precinct 5-5 Precinct AW Precinct BE,State House,32,Steve Duffy,REP,589
+Pennington,CA Precinct CL Precinct DT Precinct HC,State House,33,Vince Vidal,DEM,168
+Pennington,CA Precinct CL Precinct DT Precinct HC,State House,33,Curt Massie,REP,332
+Pennington,CA Precinct CL Precinct DT Precinct HC,State House,33,Phil Jensen,REP,376
+Pennington,HR Precinct JS Precinct KY Precinct LS Precinct NH,State House,33,Vince Vidal,DEM,385
+Pennington,HR Precinct JS Precinct KY Precinct LS Precinct NH,State House,33,Curt Massie,REP,664
+Pennington,HR Precinct JS Precinct KY Precinct LS Precinct NH,State House,33,Phil Jensen,REP,712
+Pennington,NU Precinct QU Precinct RK Precinct RV Precinct SR Precinct VF,State House,33,Vince Vidal,DEM,63
+Pennington,NU Precinct QU Precinct RK Precinct RV Precinct SR Precinct VF,State House,33,Curt Massie,REP,95
+Pennington,NU Precinct QU Precinct RK Precinct RV Precinct SR Precinct VF,State House,33,Phil Jensen,REP,135
+Pennington,VV Precinct WL Precinct WP Precinct WS 12 of 25,State House,33,Vince Vidal,DEM,408
+Pennington,VV Precinct WL Precinct WP Precinct WS 12 of 25,State House,33,Curt Massie,REP,660
+Pennington,VV Precinct WL Precinct WP Precinct WS 12 of 25,State House,33,Phil Jensen,REP,609
+Pennington,1-1 Precinct 1-2 Precinct 1-3 Precinct 1-4 Precinct 1-5,State House,35,Pat Cromwell,DEM,211
+Pennington,1-1 Precinct 1-2 Precinct 1-3 Precinct 1-4 Precinct 1-5,State House,35,David A. Hubbard,DEM,213
+Pennington,1-1 Precinct 1-2 Precinct 1-3 Precinct 1-4 Precinct 1-5,State House,35,Tony Randolph,REP,462
+Pennington,1-1 Precinct 1-2 Precinct 1-3 Precinct 1-4 Precinct 1-5,State House,35,Tina L Mulally,REP,491
+Pennington,2-1 Precinct 2-2,State House,35,Pat Cromwell,DEM,343
+Pennington,2-1 Precinct 2-2,State House,35,David A. Hubbard,DEM,320
+Pennington,2-1 Precinct 2-2,State House,35,Tony Randolph,REP,680
+Pennington,2-1 Precinct 2-2,State House,35,Tina L Mulally,REP,705
+Pennington,2-3 Precinct 2-4,State House,35,Pat Cromwell,DEM,276
+Pennington,2-3 Precinct 2-4,State House,35,David A. Hubbard,DEM,261
+Pennington,2-3 Precinct 2-4,State House,35,Tony Randolph,REP,342
+Pennington,2-3 Precinct 2-4,State House,35,Tina L Mulally,REP,372
+Pennington,2-5 Precinct 3-1 Precinct 3-2,State House,34,Darla Drew,DEM,802
+Pennington,2-5 Precinct 3-1 Precinct 3-2,State House,34,Jay Shultz,DEM,598
+Pennington,2-5 Precinct 3-1 Precinct 3-2,State House,34,Jess Olson,REP,1144
+Pennington,2-5 Precinct 3-1 Precinct 3-2,State House,34,Mike Derby,REP,1227
+Pennington,3-3,State House,34,Darla Drew,DEM,668
+Pennington,3-3,State House,34,Jay Shultz,DEM,531
+Pennington,3-3,State House,34,Jess Olson,REP,1184
+Pennington,3-3,State House,34,Mike Derby,REP,1290
+Pennington,3-4 Precinct 3-5 Precinct 4-1 Precinct 4-2,State House,34,Darla Drew,DEM,568
+Pennington,3-4 Precinct 3-5 Precinct 4-1 Precinct 4-2,State House,34,Jay Shultz,DEM,428
+Pennington,3-4 Precinct 3-5 Precinct 4-1 Precinct 4-2,State House,34,Jess Olson,REP,1045
+Pennington,3-4 Precinct 3-5 Precinct 4-1 Precinct 4-2,State House,34,Mike Derby,REP,1050
+Pennington,4-3 Precinct 4-4 Precinct 4-5,State House,35,Pat Cromwell,DEM,138
+Pennington,4-3 Precinct 4-4 Precinct 4-5,State House,35,David A. Hubbard,DEM,124
+Pennington,4-3 Precinct 4-4 Precinct 4-5,State House,35,Tony Randolph,REP,239
+Pennington,4-3 Precinct 4-4 Precinct 4-5,State House,35,Tina L Mulally,REP,220
+Pennington,5-1,State House,34,Darla Drew,DEM,247
+Pennington,5-1,State House,34,Jay Shultz,DEM,192
+Pennington,5-1,State House,34,Jess Olson,REP,266
+Pennington,5-1,State House,34,Mike Derby,REP,303
+Pennington,5-2,State House,34,Darla Drew,DEM,391
+Pennington,5-2,State House,34,Jay Shultz,DEM,270
+Pennington,5-2,State House,34,Jess Olson,REP,350
+Pennington,5-2,State House,34,Mike Derby,REP,404
+Pennington,5-3 Precinct 5-4,State House,34,Darla Drew,DEM,562
+Pennington,5-3 Precinct 5-4,State House,34,Jay Shultz,DEM,365
+Pennington,5-3 Precinct 5-4,State House,34,Jess Olson,REP,590
+Pennington,5-3 Precinct 5-4,State House,34,Mike Derby,REP,625
+Pennington,5-5,State House,34,Darla Drew,DEM,730
+Pennington,5-5,State House,34,Jay Shultz,DEM,483
+Pennington,5-5,State House,34,Jess Olson,REP,974
+Pennington,5-5,State House,34,Mike Derby,REP,1082
+Pennington,AW,State House,35,Pat Cromwell,DEM,601
+Pennington,AW,State House,35,David A. Hubbard,DEM,509
+Pennington,AW,State House,35,Tony Randolph,REP,1514
+Pennington,AW,State House,35,Tina L Mulally,REP,1685
+Pennington,BE,State House,35,Pat Cromwell,DEM,482
+Pennington,BE,State House,35,David A. Hubbard,DEM,446
+Pennington,BE,State House,35,Tony Randolph,REP,1013
+Pennington,BE,State House,35,Tina L Mulally,REP,1095
+Pennington,CA Precinct CL Precinct DT Precinct HC Precinct HR,State House,34,Darla Drew,DEM,181
+Pennington,CA Precinct CL Precinct DT Precinct HC Precinct HR,State House,34,Jay Shultz,DEM,133
+Pennington,CA Precinct CL Precinct DT Precinct HC Precinct HR,State House,34,Jess Olson,REP,316
+Pennington,CA Precinct CL Precinct DT Precinct HC Precinct HR,State House,34,Mike Derby,REP,369
+Pennington,JS Precinct KY Precinct LS Precinct NH Precinct NU Precinct QU,State House,35,Pat Cromwell,DEM,36
+Pennington,JS Precinct KY Precinct LS Precinct NH Precinct NU Precinct QU,State House,35,David A. Hubbard,DEM,33
+Pennington,JS Precinct KY Precinct LS Precinct NH Precinct NU Precinct QU,State House,35,Tony Randolph,REP,95
+Pennington,JS Precinct KY Precinct LS Precinct NH Precinct NU Precinct QU,State House,35,Tina L Mulally,REP,99
+Pennington,RK Precinct RV Precinct SR,State House,35,Pat Cromwell,DEM,294
+Pennington,RK Precinct RV Precinct SR,State House,35,David A. Hubbard,DEM,262
+Pennington,RK Precinct RV Precinct SR,State House,35,Tony Randolph,REP,610
+Pennington,RK Precinct RV Precinct SR,State House,35,Tina L Mulally,REP,616
+Pennington,VF Precinct VV Precinct WL Precinct WP Precinct WS 13 of 25,State House,35,Pat Cromwell,DEM,266
+Pennington,VF Precinct VV Precinct WL Precinct WP Precinct WS 13 of 25,State House,35,David A. Hubbard,DEM,234
+Pennington,VF Precinct VV Precinct WL Precinct WP Precinct WS 13 of 25,State House,35,Tony Randolph,REP,618
+Pennington,VF Precinct VV Precinct WL Precinct WP Precinct WS 13 of 25,State House,35,Tina L Mulally,REP,625

--- a/2022/counties/20221108__sd__general__perkins__precinct.csv
+++ b/2022/counties/20221108__sd__general__perkins__precinct.csv
@@ -1,0 +1,391 @@
+county,precinct,office,district,candidate,party,votes
+Perkins,01,U.S. Senate,,Brian L. Bengs,DEM,32
+Perkins,01,U.S. Senate,,Tamara J Lesnar,LIB,18
+Perkins,01,U.S. Senate,,John R. Thune,REP,191
+Perkins,02,U.S. Senate,,Brian L. Bengs,DEM,13
+Perkins,02,U.S. Senate,,Tamara J Lesnar,LIB,4
+Perkins,02,U.S. Senate,,John R. Thune,REP,67
+Perkins,03,U.S. Senate,,Brian L. Bengs,DEM,20
+Perkins,03,U.S. Senate,,Tamara J Lesnar,LIB,17
+Perkins,03,U.S. Senate,,John R. Thune,REP,218
+Perkins,04,U.S. Senate,,Brian L. Bengs,DEM,5
+Perkins,04,U.S. Senate,,Tamara J Lesnar,LIB,5
+Perkins,04,U.S. Senate,,John R. Thune,REP,44
+Perkins,05,U.S. Senate,,Brian L. Bengs,DEM,10
+Perkins,05,U.S. Senate,,Tamara J Lesnar,LIB,11
+Perkins,05,U.S. Senate,,John R. Thune,REP,100
+Perkins,06,U.S. Senate,,Brian L. Bengs,DEM,11
+Perkins,06,U.S. Senate,,Tamara J Lesnar,LIB,7
+Perkins,06,U.S. Senate,,John R. Thune,REP,93
+Perkins,07,U.S. Senate,,Brian L. Bengs,DEM,2
+Perkins,07,U.S. Senate,,Tamara J Lesnar,LIB,8
+Perkins,07,U.S. Senate,,John R. Thune,REP,95
+Perkins,08,U.S. Senate,,Brian L. Bengs,DEM,2
+Perkins,08,U.S. Senate,,Tamara J Lesnar,LIB,5
+Perkins,08,U.S. Senate,,John R. Thune,REP,50
+Perkins,09,U.S. Senate,,Brian L. Bengs,DEM,6
+Perkins,09,U.S. Senate,,Tamara J Lesnar,LIB,6
+Perkins,09,U.S. Senate,,John R. Thune,REP,63
+Perkins,12,U.S. Senate,,Brian L. Bengs,DEM,32
+Perkins,12,U.S. Senate,,Tamara J Lesnar,LIB,14
+Perkins,12,U.S. Senate,,John R. Thune,REP,220
+Perkins,01,U.S. House,1,Collin Duprel,LIB,47
+Perkins,01,U.S. House,1,Dusty Johnson,REP,189
+Perkins,02,U.S. House,1,Collin Duprel,LIB,17
+Perkins,02,U.S. House,1,Dusty Johnson,REP,62
+Perkins,03,U.S. House,1,Collin Duprel,LIB,35
+Perkins,03,U.S. House,1,Dusty Johnson,REP,213
+Perkins,04,U.S. House,1,Collin Duprel,LIB,11
+Perkins,04,U.S. House,1,Dusty Johnson,REP,41
+Perkins,05,U.S. House,1,Collin Duprel,LIB,26
+Perkins,05,U.S. House,1,Dusty Johnson,REP,94
+Perkins,06,U.S. House,1,Collin Duprel,LIB,26
+Perkins,06,U.S. House,1,Dusty Johnson,REP,84
+Perkins,07,U.S. House,1,Collin Duprel,LIB,31
+Perkins,07,U.S. House,1,Dusty Johnson,REP,76
+Perkins,08,U.S. House,1,Collin Duprel,LIB,17
+Perkins,08,U.S. House,1,Dusty Johnson,REP,39
+Perkins,09,U.S. House,1,Collin Duprel,LIB,25
+Perkins,09,U.S. House,1,Dusty Johnson,REP,49
+Perkins,12,U.S. House,1,Collin Duprel,LIB,47
+Perkins,12,U.S. House,1,Dusty Johnson,REP,213
+Perkins,01,Governor,,Jamie Smith and Jennifer Keintz,DEM,42
+Perkins,01,Governor,,Tracey Quint and Ashley Strand,LIB,12
+Perkins,01,Governor,,Kristi Noem and Larry Rhoden,REP,184
+Perkins,02,Governor,,Jamie Smith and Jennifer Keintz,DEM,16
+Perkins,02,Governor,,Tracey Quint and Ashley Strand,LIB,0
+Perkins,02,Governor,,Kristi Noem and Larry Rhoden,REP,68
+Perkins,03,Governor,,Jamie Smith and Jennifer Keintz,DEM,27
+Perkins,03,Governor,,Tracey Quint and Ashley Strand,LIB,19
+Perkins,03,Governor,,Kristi Noem and Larry Rhoden,REP,209
+Perkins,04,Governor,,Jamie Smith and Jennifer Keintz,DEM,6
+Perkins,04,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Perkins,04,Governor,,Kristi Noem and Larry Rhoden,REP,43
+Perkins,05,Governor,,Jamie Smith and Jennifer Keintz,DEM,14
+Perkins,05,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Perkins,05,Governor,,Kristi Noem and Larry Rhoden,REP,107
+Perkins,06,Governor,,Jamie Smith and Jennifer Keintz,DEM,10
+Perkins,06,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Perkins,06,Governor,,Kristi Noem and Larry Rhoden,REP,98
+Perkins,07,Governor,,Jamie Smith and Jennifer Keintz,DEM,5
+Perkins,07,Governor,,Tracey Quint and Ashley Strand,LIB,6
+Perkins,07,Governor,,Kristi Noem and Larry Rhoden,REP,99
+Perkins,08,Governor,,Jamie Smith and Jennifer Keintz,DEM,5
+Perkins,08,Governor,,Tracey Quint and Ashley Strand,LIB,0
+Perkins,08,Governor,,Kristi Noem and Larry Rhoden,REP,52
+Perkins,09,Governor,,Jamie Smith and Jennifer Keintz,DEM,4
+Perkins,09,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Perkins,09,Governor,,Kristi Noem and Larry Rhoden,REP,70
+Perkins,12,Governor,,Jamie Smith and Jennifer Keintz,DEM,48
+Perkins,12,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Perkins,12,Governor,,Kristi Noem and Larry Rhoden,REP,212
+Perkins,01,Secretary of State,,Thomas A Cool,DEM,49
+Perkins,01,Secretary of State,,Monae Johnson,REP,170
+Perkins,02,Secretary of State,,Thomas A Cool,DEM,16
+Perkins,02,Secretary of State,,Monae Johnson,REP,68
+Perkins,03,Secretary of State,,Thomas A Cool,DEM,39
+Perkins,03,Secretary of State,,Monae Johnson,REP,204
+Perkins,04,Secretary of State,,Thomas A Cool,DEM,5
+Perkins,04,Secretary of State,,Monae Johnson,REP,47
+Perkins,05,Secretary of State,,Thomas A Cool,DEM,13
+Perkins,05,Secretary of State,,Monae Johnson,REP,108
+Perkins,06,Secretary of State,,Thomas A Cool,DEM,12
+Perkins,06,Secretary of State,,Monae Johnson,REP,95
+Perkins,07,Secretary of State,,Thomas A Cool,DEM,5
+Perkins,07,Secretary of State,,Monae Johnson,REP,97
+Perkins,08,Secretary of State,,Thomas A Cool,DEM,6
+Perkins,08,Secretary of State,,Monae Johnson,REP,47
+Perkins,09,Secretary of State,,Thomas A Cool,DEM,6
+Perkins,09,Secretary of State,,Monae Johnson,REP,65
+Perkins,12,Secretary of State,,Thomas A Cool,DEM,45
+Perkins,12,Secretary of State,,Monae Johnson,REP,209
+Perkins,01,Attorney General,,Marty J. Jackley,REP,183
+Perkins,02,Attorney General,,Marty J. Jackley,REP,68
+Perkins,03,Attorney General,,Marty J. Jackley,REP,217
+Perkins,04,Attorney General,,Marty J. Jackley,REP,44
+Perkins,05,Attorney General,,Marty J. Jackley,REP,103
+Perkins,06,Attorney General,,Marty J. Jackley,REP,92
+Perkins,07,Attorney General,,Marty J. Jackley,REP,91
+Perkins,08,Attorney General,,Marty J. Jackley,REP,46
+Perkins,09,Attorney General,,Marty J. Jackley,REP,60
+Perkins,12,Attorney General,,Marty J. Jackley,REP,215
+Perkins,01,State Auditor,,Stephanie Marty,DEM,45
+Perkins,01,State Auditor,,Rene Meyer,LIB,16
+Perkins,01,State Auditor,,Richard Sattgast,REP,160
+Perkins,02,State Auditor,,Stephanie Marty,DEM,17
+Perkins,02,State Auditor,,Rene Meyer,LIB,6
+Perkins,02,State Auditor,,Richard Sattgast,REP,58
+Perkins,03,State Auditor,,Stephanie Marty,DEM,41
+Perkins,03,State Auditor,,Rene Meyer,LIB,20
+Perkins,03,State Auditor,,Richard Sattgast,REP,184
+Perkins,04,State Auditor,,Stephanie Marty,DEM,8
+Perkins,04,State Auditor,,Rene Meyer,LIB,4
+Perkins,04,State Auditor,,Richard Sattgast,REP,38
+Perkins,05,State Auditor,,Stephanie Marty,DEM,12
+Perkins,05,State Auditor,,Rene Meyer,LIB,5
+Perkins,05,State Auditor,,Richard Sattgast,REP,103
+Perkins,06,State Auditor,,Stephanie Marty,DEM,13
+Perkins,06,State Auditor,,Rene Meyer,LIB,7
+Perkins,06,State Auditor,,Richard Sattgast,REP,85
+Perkins,07,State Auditor,,Stephanie Marty,DEM,5
+Perkins,07,State Auditor,,Rene Meyer,LIB,1
+Perkins,07,State Auditor,,Richard Sattgast,REP,93
+Perkins,08,State Auditor,,Stephanie Marty,DEM,4
+Perkins,08,State Auditor,,Rene Meyer,LIB,6
+Perkins,08,State Auditor,,Richard Sattgast,REP,43
+Perkins,09,State Auditor,,Stephanie Marty,DEM,7
+Perkins,09,State Auditor,,Rene Meyer,LIB,7
+Perkins,09,State Auditor,,Richard Sattgast,REP,57
+Perkins,12,State Auditor,,Stephanie Marty,DEM,45
+Perkins,12,State Auditor,,Rene Meyer,LIB,9
+Perkins,12,State Auditor,,Richard Sattgast,REP,198
+Perkins,01,State Treasurer,,John Cunningham,DEM,43
+Perkins,01,State Treasurer,,Josh Haeder,REP,169
+Perkins,02,State Treasurer,,John Cunningham,DEM,15
+Perkins,02,State Treasurer,,Josh Haeder,REP,64
+Perkins,03,State Treasurer,,John Cunningham,DEM,34
+Perkins,03,State Treasurer,,Josh Haeder,REP,208
+Perkins,04,State Treasurer,,John Cunningham,DEM,7
+Perkins,04,State Treasurer,,Josh Haeder,REP,45
+Perkins,05,State Treasurer,,John Cunningham,DEM,10
+Perkins,05,State Treasurer,,Josh Haeder,REP,109
+Perkins,06,State Treasurer,,John Cunningham,DEM,10
+Perkins,06,State Treasurer,,Josh Haeder,REP,94
+Perkins,07,State Treasurer,,John Cunningham,DEM,5
+Perkins,07,State Treasurer,,Josh Haeder,REP,95
+Perkins,08,State Treasurer,,John Cunningham,DEM,6
+Perkins,08,State Treasurer,,Josh Haeder,REP,47
+Perkins,09,State Treasurer,,John Cunningham,DEM,5
+Perkins,09,State Treasurer,,Josh Haeder,REP,62
+Perkins,12,State Treasurer,,John Cunningham,DEM,38
+Perkins,12,State Treasurer,,Josh Haeder,REP,205
+Perkins,01,Commissioner of School and Public Lands,,Timothy Azure,DEM,43
+Perkins,01,Commissioner of School and Public Lands,,Brock Greenfield,REP,172
+Perkins,02,Commissioner of School and Public Lands,,Timothy Azure,DEM,15
+Perkins,02,Commissioner of School and Public Lands,,Brock Greenfield,REP,66
+Perkins,03,Commissioner of School and Public Lands,,Timothy Azure,DEM,34
+Perkins,03,Commissioner of School and Public Lands,,Brock Greenfield,REP,205
+Perkins,04,Commissioner of School and Public Lands,,Timothy Azure,DEM,5
+Perkins,04,Commissioner of School and Public Lands,,Brock Greenfield,REP,45
+Perkins,05,Commissioner of School and Public Lands,,Timothy Azure,DEM,14
+Perkins,05,Commissioner of School and Public Lands,,Brock Greenfield,REP,104
+Perkins,06,Commissioner of School and Public Lands,,Timothy Azure,DEM,11
+Perkins,06,Commissioner of School and Public Lands,,Brock Greenfield,REP,93
+Perkins,07,Commissioner of School and Public Lands,,Timothy Azure,DEM,2
+Perkins,07,Commissioner of School and Public Lands,,Brock Greenfield,REP,98
+Perkins,08,Commissioner of School and Public Lands,,Timothy Azure,DEM,4
+Perkins,08,Commissioner of School and Public Lands,,Brock Greenfield,REP,50
+Perkins,09,Commissioner of School and Public Lands,,Timothy Azure,DEM,5
+Perkins,09,Commissioner of School and Public Lands,,Brock Greenfield,REP,64
+Perkins,12,Commissioner of School and Public Lands,,Timothy Azure,DEM,38
+Perkins,12,Commissioner of School and Public Lands,,Brock Greenfield,REP,208
+Perkins,01,Public Utilities Commissioner,,Jeffrey Barth,DEM,41
+Perkins,01,Public Utilities Commissioner,,Chris Nelson,REP,180
+Perkins,02,Public Utilities Commissioner,,Jeffrey Barth,DEM,13
+Perkins,02,Public Utilities Commissioner,,Chris Nelson,REP,67
+Perkins,03,Public Utilities Commissioner,,Jeffrey Barth,DEM,27
+Perkins,03,Public Utilities Commissioner,,Chris Nelson,REP,214
+Perkins,04,Public Utilities Commissioner,,Jeffrey Barth,DEM,5
+Perkins,04,Public Utilities Commissioner,,Chris Nelson,REP,45
+Perkins,05,Public Utilities Commissioner,,Jeffrey Barth,DEM,10
+Perkins,05,Public Utilities Commissioner,,Chris Nelson,REP,110
+Perkins,06,Public Utilities Commissioner,,Jeffrey Barth,DEM,12
+Perkins,06,Public Utilities Commissioner,,Chris Nelson,REP,93
+Perkins,07,Public Utilities Commissioner,,Jeffrey Barth,DEM,4
+Perkins,07,Public Utilities Commissioner,,Chris Nelson,REP,98
+Perkins,08,Public Utilities Commissioner,,Jeffrey Barth,DEM,3
+Perkins,08,Public Utilities Commissioner,,Chris Nelson,REP,52
+Perkins,09,Public Utilities Commissioner,,Jeffrey Barth,DEM,6
+Perkins,09,Public Utilities Commissioner,,Chris Nelson,REP,64
+Perkins,12,Public Utilities Commissioner,,Jeffrey Barth,DEM,39
+Perkins,12,Public Utilities Commissioner,,Chris Nelson,REP,209
+Perkins,01,State Senate,28,Ryan M. Maher,REP,186
+Perkins,02,State Senate,28,Ryan M. Maher,REP,73
+Perkins,03,State Senate,28,Ryan M. Maher,REP,224
+Perkins,04,State Senate,28,Ryan M. Maher,REP,46
+Perkins,05,State Senate,28,Ryan M. Maher,REP,105
+Perkins,06,State Senate,28,Ryan M. Maher,REP,93
+Perkins,07,State Senate,28,Ryan M. Maher,REP,101
+Perkins,08,State Senate,28,Ryan M. Maher,REP,51
+Perkins,09,State Senate,28,Ryan M. Maher,REP,66
+Perkins,12,State Senate,28,Ryan M. Maher,REP,233
+Perkins,01,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,116
+Perkins,02,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,42
+Perkins,03,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,140
+Perkins,04,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,20
+Perkins,05,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,51
+Perkins,06,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,37
+Perkins,07,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,41
+Perkins,08,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,26
+Perkins,09,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,36
+Perkins,12,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,114
+Perkins,01,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,114
+Perkins,02,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,45
+Perkins,03,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,140
+Perkins,04,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,24
+Perkins,05,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,51
+Perkins,06,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,38
+Perkins,07,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,41
+Perkins,08,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,26
+Perkins,09,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,33
+Perkins,12,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,113
+Perkins,01,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,112
+Perkins,02,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,44
+Perkins,03,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,141
+Perkins,04,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,24
+Perkins,05,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,50
+Perkins,06,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,37
+Perkins,07,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,41
+Perkins,08,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,26
+Perkins,09,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,32
+Perkins,12,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,103
+Perkins,01,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,9
+Perkins,01,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,26
+Perkins,01,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,68
+Perkins,01,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,21
+Perkins,01,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,33
+Perkins,02,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,4
+Perkins,02,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,4
+Perkins,02,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,21
+Perkins,02,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,10
+Perkins,02,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,12
+Perkins,03,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,18
+Perkins,03,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,38
+Perkins,03,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,66
+Perkins,03,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,19
+Perkins,03,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,30
+Perkins,04,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,2
+Perkins,04,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,7
+Perkins,04,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,15
+Perkins,04,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,4
+Perkins,04,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,10
+Perkins,05,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,2
+Perkins,05,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,23
+Perkins,05,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,20
+Perkins,05,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,8
+Perkins,05,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,13
+Perkins,06,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,3
+Perkins,06,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,14
+Perkins,06,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,17
+Perkins,06,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,7
+Perkins,06,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,19
+Perkins,07,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,3
+Perkins,07,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,16
+Perkins,07,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,11
+Perkins,07,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,10
+Perkins,07,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,28
+Perkins,08,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,1
+Perkins,08,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,13
+Perkins,08,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,6
+Perkins,08,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,4
+Perkins,08,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,12
+Perkins,09,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,1
+Perkins,09,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,9
+Perkins,09,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,7
+Perkins,09,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,13
+Perkins,09,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,15
+Perkins,12,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,8
+Perkins,12,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,45
+Perkins,12,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,35
+Perkins,12,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,29
+Perkins,12,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,56
+Perkins,01,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,165
+Perkins,01,Supreme Court Retention,3,Patricia J. DeVaney - No,,35
+Perkins,02,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,56
+Perkins,02,Supreme Court Retention,3,Patricia J. DeVaney - No,,13
+Perkins,03,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,185
+Perkins,03,Supreme Court Retention,3,Patricia J. DeVaney - No,,31
+Perkins,04,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,30
+Perkins,04,Supreme Court Retention,3,Patricia J. DeVaney - No,,9
+Perkins,05,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,89
+Perkins,05,Supreme Court Retention,3,Patricia J. DeVaney - No,,8
+Perkins,06,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,66
+Perkins,06,Supreme Court Retention,3,Patricia J. DeVaney - No,,18
+Perkins,07,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,78
+Perkins,07,Supreme Court Retention,3,Patricia J. DeVaney - No,,12
+Perkins,08,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,36
+Perkins,08,Supreme Court Retention,3,Patricia J. DeVaney - No,,6
+Perkins,09,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,42
+Perkins,09,Supreme Court Retention,3,Patricia J. DeVaney - No,,15
+Perkins,12,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,163
+Perkins,12,Supreme Court Retention,3,Patricia J. DeVaney - No,,42
+Perkins,01,Supreme Court Retention,2,Mark E. Salter - Yes,,162
+Perkins,01,Supreme Court Retention,2,Mark E. Salter - No,,37
+Perkins,02,Supreme Court Retention,2,Mark E. Salter - Yes,,56
+Perkins,02,Supreme Court Retention,2,Mark E. Salter - No,,11
+Perkins,03,Supreme Court Retention,2,Mark E. Salter - Yes,,181
+Perkins,03,Supreme Court Retention,2,Mark E. Salter - No,,35
+Perkins,04,Supreme Court Retention,2,Mark E. Salter - Yes,,29
+Perkins,04,Supreme Court Retention,2,Mark E. Salter - No,,9
+Perkins,05,Supreme Court Retention,2,Mark E. Salter - Yes,,91
+Perkins,05,Supreme Court Retention,2,Mark E. Salter - No,,7
+Perkins,06,Supreme Court Retention,2,Mark E. Salter - Yes,,71
+Perkins,06,Supreme Court Retention,2,Mark E. Salter - No,,13
+Perkins,07,Supreme Court Retention,2,Mark E. Salter - Yes,,78
+Perkins,07,Supreme Court Retention,2,Mark E. Salter - No,,13
+Perkins,08,Supreme Court Retention,2,Mark E. Salter - Yes,,36
+Perkins,08,Supreme Court Retention,2,Mark E. Salter - No,,5
+Perkins,09,Supreme Court Retention,2,Mark E. Salter - Yes,,46
+Perkins,09,Supreme Court Retention,2,Mark E. Salter - No,,11
+Perkins,12,Supreme Court Retention,2,Mark E. Salter - Yes,,167
+Perkins,12,Supreme Court Retention,2,Mark E. Salter - No,,38
+Perkins,01,Constitutional Amendment D,,Yes,,141
+Perkins,01,Constitutional Amendment D,,No,,92
+Perkins,02,Constitutional Amendment D,,Yes,,34
+Perkins,02,Constitutional Amendment D,,No,,49
+Perkins,03,Constitutional Amendment D,,Yes,,122
+Perkins,03,Constitutional Amendment D,,No,,128
+Perkins,04,Constitutional Amendment D,,Yes,,22
+Perkins,04,Constitutional Amendment D,,No,,31
+Perkins,05,Constitutional Amendment D,,Yes,,46
+Perkins,05,Constitutional Amendment D,,No,,72
+Perkins,06,Constitutional Amendment D,,Yes,,35
+Perkins,06,Constitutional Amendment D,,No,,72
+Perkins,07,Constitutional Amendment D,,Yes,,26
+Perkins,07,Constitutional Amendment D,,No,,81
+Perkins,08,Constitutional Amendment D,,Yes,,12
+Perkins,08,Constitutional Amendment D,,No,,44
+Perkins,09,Constitutional Amendment D,,Yes,,24
+Perkins,09,Constitutional Amendment D,,No,,50
+Perkins,12,Constitutional Amendment D,,Yes,,81
+Perkins,12,Constitutional Amendment D,,No,,178
+Perkins,01,Initiated Measure 27,,Yes,,90
+Perkins,01,Initiated Measure 27,,No,,147
+Perkins,02,Initiated Measure 27,,Yes,,26
+Perkins,02,Initiated Measure 27,,No,,59
+Perkins,03,Initiated Measure 27,,Yes,,66
+Perkins,03,Initiated Measure 27,,No,,185
+Perkins,04,Initiated Measure 27,,Yes,,13
+Perkins,04,Initiated Measure 27,,No,,40
+Perkins,05,Initiated Measure 27,,Yes,,26
+Perkins,05,Initiated Measure 27,,No,,93
+Perkins,06,Initiated Measure 27,,Yes,,22
+Perkins,06,Initiated Measure 27,,No,,89
+Perkins,07,Initiated Measure 27,,Yes,,15
+Perkins,07,Initiated Measure 27,,No,,94
+Perkins,08,Initiated Measure 27,,Yes,,2
+Perkins,08,Initiated Measure 27,,No,,54
+Perkins,09,Initiated Measure 27,,Yes,,12
+Perkins,09,Initiated Measure 27,,No,,62
+Perkins,12,Initiated Measure 27,,Yes,,64
+Perkins,12,Initiated Measure 27,,No,,198
+Perkins,01,State House,28B,Neal Pinnow,REP,188
+Perkins,01,State House,28B,Calvin Reilly,IND,43
+Perkins,02,State House,28B,Neal Pinnow,REP,69
+Perkins,02,State House,28B,Calvin Reilly,IND,12
+Perkins,03,State House,28B,Neal Pinnow,REP,221
+Perkins,03,State House,28B,Calvin Reilly,IND,30
+Perkins,04,State House,28B,Neal Pinnow,REP,39
+Perkins,04,State House,28B,Calvin Reilly,IND,10
+Perkins,05,State House,28B,Neal Pinnow,REP,112
+Perkins,05,State House,28B,Calvin Reilly,IND,11
+Perkins,06,State House,28A,Oren L Lesmeister,DEM,9
+Perkins,06,State House,28A,Ralph Lyon,REP,104
+Perkins,07,State House,28A,Oren L Lesmeister,DEM,4
+Perkins,07,State House,28A,Ralph Lyon,REP,98
+Perkins,08,State House,28A,Oren L Lesmeister,DEM,8
+Perkins,08,State House,28A,Ralph Lyon,REP,47
+Perkins,09,State House,28A,Oren L Lesmeister,DEM,8
+Perkins,09,State House,28A,Ralph Lyon,REP,66
+Perkins,12 11 of 19,State House,28A,Oren L Lesmeister,DEM,41
+Perkins,12 11 of 19,State House,28A,Ralph Lyon,REP,223

--- a/2022/counties/20221108__sd__general__potter__precinct.csv
+++ b/2022/counties/20221108__sd__general__potter__precinct.csv
@@ -1,0 +1,106 @@
+county,precinct,office,district,candidate,party,votes
+Potter,Absentee Precinct,U.S. Senate,,Brian L. Bengs,DEM,56
+Potter,Absentee Precinct,U.S. Senate,,Tamara J Lesnar,LIB,7
+Potter,Absentee Precinct,U.S. Senate,,John R. Thune,REP,140
+Potter,Gettysburg Legion Annex,U.S. Senate,,Brian L. Bengs,DEM,52
+Potter,Gettysburg Legion Annex,U.S. Senate,,Tamara J Lesnar,LIB,19
+Potter,Gettysburg Legion Annex,U.S. Senate,,John R. Thune,REP,569
+Potter,Hoven American Legion,U.S. Senate,,Brian L. Bengs,DEM,15
+Potter,Hoven American Legion,U.S. Senate,,Tamara J Lesnar,LIB,7
+Potter,Hoven American Legion,U.S. Senate,,John R. Thune,REP,228
+Potter,Absentee Precinct,U.S. House,1,Collin Duprel,LIB,49
+Potter,Absentee Precinct,U.S. House,1,Dusty Johnson,REP,156
+Potter,Gettysburg Legion Annex,U.S. House,1,Collin Duprel,LIB,62
+Potter,Gettysburg Legion Annex,U.S. House,1,Dusty Johnson,REP,565
+Potter,Hoven American Legion,U.S. House,1,Collin Duprel,LIB,25
+Potter,Hoven American Legion,U.S. House,1,Dusty Johnson,REP,223
+Potter,Absentee Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,68
+Potter,Absentee Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Potter,Absentee Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,137
+Potter,Gettysburg Legion Annex,Governor,,Jamie Smith and Jennifer Keintz,DEM,96
+Potter,Gettysburg Legion Annex,Governor,,Tracey Quint and Ashley Strand,LIB,16
+Potter,Gettysburg Legion Annex,Governor,,Kristi Noem and Larry Rhoden,REP,528
+Potter,Hoven American Legion,Governor,,Jamie Smith and Jennifer Keintz,DEM,23
+Potter,Hoven American Legion,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Potter,Hoven American Legion,Governor,,Kristi Noem and Larry Rhoden,REP,227
+Potter,Absentee Precinct,Secretary of State,,Thomas A Cool,DEM,62
+Potter,Absentee Precinct,Secretary of State,,Monae Johnson,REP,139
+Potter,Gettysburg Legion Annex,Secretary of State,,Thomas A Cool,DEM,106
+Potter,Gettysburg Legion Annex,Secretary of State,,Monae Johnson,REP,508
+Potter,Hoven American Legion,Secretary of State,,Thomas A Cool,DEM,33
+Potter,Hoven American Legion,Secretary of State,,Monae Johnson,REP,204
+Potter,Absentee Precinct,Attorney General,,Marty J. Jackley,REP,157
+Potter,Gettysburg Legion Annex,Attorney General,,Marty J. Jackley,REP,562
+Potter,Hoven American Legion,Attorney General,,Marty J. Jackley,REP,215
+Potter,Absentee Precinct,State Auditor,,Stephanie Marty,DEM,55
+Potter,Absentee Precinct,State Auditor,,Rene Meyer,LIB,7
+Potter,Absentee Precinct,State Auditor,,Richard Sattgast,REP,139
+Potter,Gettysburg Legion Annex,State Auditor,,Stephanie Marty,DEM,75
+Potter,Gettysburg Legion Annex,State Auditor,,Rene Meyer,LIB,23
+Potter,Gettysburg Legion Annex,State Auditor,,Richard Sattgast,REP,510
+Potter,Hoven American Legion,State Auditor,,Stephanie Marty,DEM,23
+Potter,Hoven American Legion,State Auditor,,Rene Meyer,LIB,9
+Potter,Hoven American Legion,State Auditor,,Richard Sattgast,REP,204
+Potter,Absentee Precinct,State Treasurer,,John Cunningham,DEM,60
+Potter,Absentee Precinct,State Treasurer,,Josh Haeder,REP,138
+Potter,Gettysburg Legion Annex,State Treasurer,,John Cunningham,DEM,79
+Potter,Gettysburg Legion Annex,State Treasurer,,Josh Haeder,REP,525
+Potter,Hoven American Legion,State Treasurer,,John Cunningham,DEM,26
+Potter,Hoven American Legion,State Treasurer,,Josh Haeder,REP,208
+Potter,Absentee Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,55
+Potter,Absentee Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,140
+Potter,Gettysburg Legion Annex,Commissioner of School and Public Lands,,Timothy Azure,DEM,77
+Potter,Gettysburg Legion Annex,Commissioner of School and Public Lands,,Brock Greenfield,REP,519
+Potter,Hoven American Legion,Commissioner of School and Public Lands,,Timothy Azure,DEM,17
+Potter,Hoven American Legion,Commissioner of School and Public Lands,,Brock Greenfield,REP,222
+Potter,Absentee Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,52
+Potter,Absentee Precinct,Public Utilities Commissioner,,Chris Nelson,REP,148
+Potter,Gettysburg Legion Annex,Public Utilities Commissioner,,Jeffrey Barth,DEM,73
+Potter,Gettysburg Legion Annex,Public Utilities Commissioner,,Chris Nelson,REP,544
+Potter,Hoven American Legion,Public Utilities Commissioner,,Jeffrey Barth,DEM,19
+Potter,Hoven American Legion,Public Utilities Commissioner,,Chris Nelson,REP,222
+Potter,Absentee Precinct,State Senate,23,Bryan J. Breitling,REP,148
+Potter,Gettysburg Legion Annex,State Senate,23,Bryan J. Breitling,REP,529
+Potter,Hoven American Legion,State Senate,23,Bryan J. Breitling,REP,211
+Potter,Absentee Precinct,State House,23,James D. Wangsness,REP,96
+Potter,Absentee Precinct,State House,23,Scott Moore,REP,128
+Potter,Gettysburg Legion Annex,State House,23,James D. Wangsness,REP,326
+Potter,Gettysburg Legion Annex,State House,23,Scott Moore,REP,431
+Potter,Hoven American Legion,State House,23,James D. Wangsness,REP,128
+Potter,Hoven American Legion,State House,23,Scott Moore,REP,179
+Potter,Absentee Precinct,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,99
+Potter,Gettysburg Legion Annex,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,301
+Potter,Hoven American Legion,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,127
+Potter,Absentee Precinct,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,90
+Potter,Gettysburg Legion Annex,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,298
+Potter,Hoven American Legion,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,124
+Potter,Absentee Precinct,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,88
+Potter,Gettysburg Legion Annex,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,306
+Potter,Hoven American Legion,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,125
+Potter,Absentee Precinct,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,85
+Potter,Gettysburg Legion Annex,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,293
+Potter,Hoven American Legion,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,120
+Potter,Absentee Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,131
+Potter,Absentee Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,34
+Potter,Gettysburg Legion Annex,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,457
+Potter,Gettysburg Legion Annex,Supreme Court Retention,3,Patricia J. DeVaney - No,,95
+Potter,Hoven American Legion,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,187
+Potter,Hoven American Legion,Supreme Court Retention,3,Patricia J. DeVaney - No,,35
+Potter,Absentee Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,130
+Potter,Absentee Precinct,Supreme Court Retention,2,Mark E. Salter - No,,32
+Potter,Gettysburg Legion Annex,Supreme Court Retention,2,Mark E. Salter - Yes,,456
+Potter,Gettysburg Legion Annex,Supreme Court Retention,2,Mark E. Salter - No,,95
+Potter,Hoven American Legion,Supreme Court Retention,2,Mark E. Salter - Yes,,184
+Potter,Hoven American Legion,Supreme Court Retention,2,Mark E. Salter - No,,35
+Potter,Absentee Precinct,Constitutional Amendment D,,Yes,,102
+Potter,Absentee Precinct,Constitutional Amendment D,,No,,100
+Potter,Gettysburg Legion Annex,Constitutional Amendment D,,Yes,,291
+Potter,Gettysburg Legion Annex,Constitutional Amendment D,,No,,334
+Potter,Hoven American Legion,Constitutional Amendment D,,Yes,,118
+Potter,Hoven American Legion,Constitutional Amendment D,,No,,121
+Potter,Absentee Precinct,Initiated Measure 27,,Yes,,101
+Potter,Absentee Precinct,Initiated Measure 27,,No,,106
+Potter,Gettysburg Legion Annex,Initiated Measure 27,,Yes,,209
+Potter,Gettysburg Legion Annex,Initiated Measure 27,,No,,425
+Potter,Hoven American Legion,Initiated Measure 27,,Yes,,71
+Potter,Hoven American Legion,Initiated Measure 27,,No,,170

--- a/2022/counties/20221108__sd__general__roberts__precinct.csv
+++ b/2022/counties/20221108__sd__general__roberts__precinct.csv
@@ -1,0 +1,460 @@
+county,precinct,office,district,candidate,party,votes
+Roberts,01,U.S. Senate,,Brian L. Bengs,DEM,28
+Roberts,01,U.S. Senate,,Tamara J Lesnar,LIB,3
+Roberts,01,U.S. Senate,,John R. Thune,REP,107
+Roberts,02,U.S. Senate,,Brian L. Bengs,DEM,71
+Roberts,02,U.S. Senate,,Tamara J Lesnar,LIB,13
+Roberts,02,U.S. Senate,,John R. Thune,REP,367
+Roberts,03,U.S. Senate,,Brian L. Bengs,DEM,35
+Roberts,03,U.S. Senate,,Tamara J Lesnar,LIB,10
+Roberts,03,U.S. Senate,,John R. Thune,REP,140
+Roberts,04,U.S. Senate,,Brian L. Bengs,DEM,19
+Roberts,04,U.S. Senate,,Tamara J Lesnar,LIB,3
+Roberts,04,U.S. Senate,,John R. Thune,REP,49
+Roberts,05,U.S. Senate,,Brian L. Bengs,DEM,152
+Roberts,05,U.S. Senate,,Tamara J Lesnar,LIB,15
+Roberts,05,U.S. Senate,,John R. Thune,REP,168
+Roberts,06 (Precinct-07),U.S. Senate,,Brian L. Bengs,DEM,88
+Roberts,06 (Precinct-07),U.S. Senate,,Tamara J Lesnar,LIB,13
+Roberts,06 (Precinct-07),U.S. Senate,,John R. Thune,REP,377
+Roberts,08,U.S. Senate,,Brian L. Bengs,DEM,27
+Roberts,08,U.S. Senate,,Tamara J Lesnar,LIB,11
+Roberts,08,U.S. Senate,,John R. Thune,REP,75
+Roberts,09,U.S. Senate,,Brian L. Bengs,DEM,75
+Roberts,09,U.S. Senate,,Tamara J Lesnar,LIB,18
+Roberts,09,U.S. Senate,,John R. Thune,REP,312
+Roberts,10,U.S. Senate,,Brian L. Bengs,DEM,83
+Roberts,10,U.S. Senate,,Tamara J Lesnar,LIB,5
+Roberts,10,U.S. Senate,,John R. Thune,REP,94
+Roberts,11,U.S. Senate,,Brian L. Bengs,DEM,242
+Roberts,11,U.S. Senate,,Tamara J Lesnar,LIB,31
+Roberts,11,U.S. Senate,,John R. Thune,REP,415
+Roberts,12 (Precinct-14),U.S. Senate,,Brian L. Bengs,DEM,104
+Roberts,12 (Precinct-14),U.S. Senate,,Tamara J Lesnar,LIB,9
+Roberts,12 (Precinct-14),U.S. Senate,,John R. Thune,REP,153
+Roberts,13,U.S. Senate,,Brian L. Bengs,DEM,76
+Roberts,13,U.S. Senate,,Tamara J Lesnar,LIB,16
+Roberts,13,U.S. Senate,,John R. Thune,REP,127
+Roberts,01,U.S. House,1,Collin Duprel,LIB,16
+Roberts,01,U.S. House,1,Dusty Johnson,REP,120
+Roberts,02,U.S. House,1,Collin Duprel,LIB,60
+Roberts,02,U.S. House,1,Dusty Johnson,REP,376
+Roberts,03,U.S. House,1,Collin Duprel,LIB,27
+Roberts,03,U.S. House,1,Dusty Johnson,REP,145
+Roberts,04,U.S. House,1,Collin Duprel,LIB,15
+Roberts,04,U.S. House,1,Dusty Johnson,REP,57
+Roberts,05,U.S. House,1,Collin Duprel,LIB,102
+Roberts,05,U.S. House,1,Dusty Johnson,REP,205
+Roberts,06 (Precinct-07),U.S. House,1,Collin Duprel,LIB,63
+Roberts,06 (Precinct-07),U.S. House,1,Dusty Johnson,REP,393
+Roberts,08,U.S. House,1,Collin Duprel,LIB,26
+Roberts,08,U.S. House,1,Dusty Johnson,REP,80
+Roberts,09,U.S. House,1,Collin Duprel,LIB,61
+Roberts,09,U.S. House,1,Dusty Johnson,REP,318
+Roberts,10,U.S. House,1,Collin Duprel,LIB,62
+Roberts,10,U.S. House,1,Dusty Johnson,REP,107
+Roberts,11,U.S. House,1,Collin Duprel,LIB,175
+Roberts,11,U.S. House,1,Dusty Johnson,REP,464
+Roberts,12 (Precinct-14),U.S. House,1,Collin Duprel,LIB,77
+Roberts,12 (Precinct-14),U.S. House,1,Dusty Johnson,REP,172
+Roberts,13,U.S. House,1,Collin Duprel,LIB,54
+Roberts,13,U.S. House,1,Dusty Johnson,REP,153
+Roberts,01,Governor,,Jamie Smith and Jennifer Keintz,DEM,32
+Roberts,01,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Roberts,01,Governor,,Kristi Noem and Larry Rhoden,REP,108
+Roberts,02,Governor,,Jamie Smith and Jennifer Keintz,DEM,96
+Roberts,02,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Roberts,02,Governor,,Kristi Noem and Larry Rhoden,REP,348
+Roberts,03,Governor,,Jamie Smith and Jennifer Keintz,DEM,54
+Roberts,03,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Roberts,03,Governor,,Kristi Noem and Larry Rhoden,REP,131
+Roberts,04,Governor,,Jamie Smith and Jennifer Keintz,DEM,25
+Roberts,04,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Roberts,04,Governor,,Kristi Noem and Larry Rhoden,REP,43
+Roberts,05,Governor,,Jamie Smith and Jennifer Keintz,DEM,188
+Roberts,05,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Roberts,05,Governor,,Kristi Noem and Larry Rhoden,REP,148
+Roberts,06 (Precinct-07),Governor,,Jamie Smith and Jennifer Keintz,DEM,117
+Roberts,06 (Precinct-07),Governor,,Tracey Quint and Ashley Strand,LIB,13
+Roberts,06 (Precinct-07),Governor,,Kristi Noem and Larry Rhoden,REP,357
+Roberts,08,Governor,,Jamie Smith and Jennifer Keintz,DEM,43
+Roberts,08,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Roberts,08,Governor,,Kristi Noem and Larry Rhoden,REP,61
+Roberts,09,Governor,,Jamie Smith and Jennifer Keintz,DEM,106
+Roberts,09,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Roberts,09,Governor,,Kristi Noem and Larry Rhoden,REP,300
+Roberts,10,Governor,,Jamie Smith and Jennifer Keintz,DEM,106
+Roberts,10,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Roberts,10,Governor,,Kristi Noem and Larry Rhoden,REP,74
+Roberts,11,Governor,,Jamie Smith and Jennifer Keintz,DEM,306
+Roberts,11,Governor,,Tracey Quint and Ashley Strand,LIB,19
+Roberts,11,Governor,,Kristi Noem and Larry Rhoden,REP,362
+Roberts,12 (Precinct-14),Governor,,Jamie Smith and Jennifer Keintz,DEM,132
+Roberts,12 (Precinct-14),Governor,,Tracey Quint and Ashley Strand,LIB,8
+Roberts,12 (Precinct-14),Governor,,Kristi Noem and Larry Rhoden,REP,130
+Roberts,13,Governor,,Jamie Smith and Jennifer Keintz,DEM,110
+Roberts,13,Governor,,Tracey Quint and Ashley Strand,LIB,9
+Roberts,13,Governor,,Kristi Noem and Larry Rhoden,REP,102
+Roberts,01,Secretary of State,,Thomas A Cool,DEM,37
+Roberts,01,Secretary of State,,Monae Johnson,REP,94
+Roberts,02,Secretary of State,,Thomas A Cool,DEM,100
+Roberts,02,Secretary of State,,Monae Johnson,REP,334
+Roberts,03,Secretary of State,,Thomas A Cool,DEM,63
+Roberts,03,Secretary of State,,Monae Johnson,REP,107
+Roberts,04,Secretary of State,,Thomas A Cool,DEM,30
+Roberts,04,Secretary of State,,Monae Johnson,REP,38
+Roberts,05,Secretary of State,,Thomas A Cool,DEM,185
+Roberts,05,Secretary of State,,Monae Johnson,REP,143
+Roberts,06 (Precinct-07),Secretary of State,,Thomas A Cool,DEM,139
+Roberts,06 (Precinct-07),Secretary of State,,Monae Johnson,REP,322
+Roberts,08,Secretary of State,,Thomas A Cool,DEM,47
+Roberts,08,Secretary of State,,Monae Johnson,REP,62
+Roberts,09,Secretary of State,,Thomas A Cool,DEM,112
+Roberts,09,Secretary of State,,Monae Johnson,REP,275
+Roberts,10,Secretary of State,,Thomas A Cool,DEM,101
+Roberts,10,Secretary of State,,Monae Johnson,REP,74
+Roberts,11,Secretary of State,,Thomas A Cool,DEM,331
+Roberts,11,Secretary of State,,Monae Johnson,REP,317
+Roberts,12 (Precinct-14),Secretary of State,,Thomas A Cool,DEM,146
+Roberts,12 (Precinct-14),Secretary of State,,Monae Johnson,REP,112
+Roberts,13,Secretary of State,,Thomas A Cool,DEM,120
+Roberts,13,Secretary of State,,Monae Johnson,REP,92
+Roberts,01,Attorney General,,Marty J. Jackley,REP,116
+Roberts,02,Attorney General,,Marty J. Jackley,REP,365
+Roberts,03,Attorney General,,Marty J. Jackley,REP,138
+Roberts,04,Attorney General,,Marty J. Jackley,REP,52
+Roberts,05,Attorney General,,Marty J. Jackley,REP,192
+Roberts,06 (Precinct-07),Attorney General,,Marty J. Jackley,REP,377
+Roberts,08,Attorney General,,Marty J. Jackley,REP,85
+Roberts,09,Attorney General,,Marty J. Jackley,REP,327
+Roberts,10,Attorney General,,Marty J. Jackley,REP,115
+Roberts,11,Attorney General,,Marty J. Jackley,REP,468
+Roberts,12 (Precinct-14),Attorney General,,Marty J. Jackley,REP,179
+Roberts,13,Attorney General,,Marty J. Jackley,REP,142
+Roberts,01,State Auditor,,Stephanie Marty,DEM,31
+Roberts,01,State Auditor,,Rene Meyer,LIB,2
+Roberts,01,State Auditor,,Richard Sattgast,REP,94
+Roberts,02,State Auditor,,Stephanie Marty,DEM,95
+Roberts,02,State Auditor,,Rene Meyer,LIB,14
+Roberts,02,State Auditor,,Richard Sattgast,REP,323
+Roberts,03,State Auditor,,Stephanie Marty,DEM,57
+Roberts,03,State Auditor,,Rene Meyer,LIB,8
+Roberts,03,State Auditor,,Richard Sattgast,REP,99
+Roberts,04,State Auditor,,Stephanie Marty,DEM,23
+Roberts,04,State Auditor,,Rene Meyer,LIB,4
+Roberts,04,State Auditor,,Richard Sattgast,REP,38
+Roberts,05,State Auditor,,Stephanie Marty,DEM,190
+Roberts,05,State Auditor,,Rene Meyer,LIB,15
+Roberts,05,State Auditor,,Richard Sattgast,REP,124
+Roberts,06 (Precinct-07),State Auditor,,Stephanie Marty,DEM,136
+Roberts,06 (Precinct-07),State Auditor,,Rene Meyer,LIB,23
+Roberts,06 (Precinct-07),State Auditor,,Richard Sattgast,REP,306
+Roberts,08,State Auditor,,Stephanie Marty,DEM,44
+Roberts,08,State Auditor,,Rene Meyer,LIB,8
+Roberts,08,State Auditor,,Richard Sattgast,REP,57
+Roberts,09,State Auditor,,Stephanie Marty,DEM,97
+Roberts,09,State Auditor,,Rene Meyer,LIB,17
+Roberts,09,State Auditor,,Richard Sattgast,REP,274
+Roberts,10,State Auditor,,Stephanie Marty,DEM,98
+Roberts,10,State Auditor,,Rene Meyer,LIB,8
+Roberts,10,State Auditor,,Richard Sattgast,REP,69
+Roberts,11,State Auditor,,Stephanie Marty,DEM,314
+Roberts,11,State Auditor,,Rene Meyer,LIB,28
+Roberts,11,State Auditor,,Richard Sattgast,REP,296
+Roberts,12 (Precinct-14),State Auditor,,Stephanie Marty,DEM,139
+Roberts,12 (Precinct-14),State Auditor,,Rene Meyer,LIB,10
+Roberts,12 (Precinct-14),State Auditor,,Richard Sattgast,REP,108
+Roberts,13,State Auditor,,Stephanie Marty,DEM,107
+Roberts,13,State Auditor,,Rene Meyer,LIB,14
+Roberts,13,State Auditor,,Richard Sattgast,REP,85
+Roberts,01,State Treasurer,,John Cunningham,DEM,34
+Roberts,01,State Treasurer,,Josh Haeder,REP,95
+Roberts,02,State Treasurer,,John Cunningham,DEM,95
+Roberts,02,State Treasurer,,Josh Haeder,REP,332
+Roberts,03,State Treasurer,,John Cunningham,DEM,56
+Roberts,03,State Treasurer,,Josh Haeder,REP,108
+Roberts,04,State Treasurer,,John Cunningham,DEM,29
+Roberts,04,State Treasurer,,Josh Haeder,REP,38
+Roberts,05,State Treasurer,,John Cunningham,DEM,188
+Roberts,05,State Treasurer,,Josh Haeder,REP,139
+Roberts,06 (Precinct-07),State Treasurer,,John Cunningham,DEM,133
+Roberts,06 (Precinct-07),State Treasurer,,Josh Haeder,REP,322
+Roberts,08,State Treasurer,,John Cunningham,DEM,42
+Roberts,08,State Treasurer,,Josh Haeder,REP,66
+Roberts,09,State Treasurer,,John Cunningham,DEM,110
+Roberts,09,State Treasurer,,Josh Haeder,REP,274
+Roberts,10,State Treasurer,,John Cunningham,DEM,99
+Roberts,10,State Treasurer,,Josh Haeder,REP,73
+Roberts,11,State Treasurer,,John Cunningham,DEM,329
+Roberts,11,State Treasurer,,Josh Haeder,REP,307
+Roberts,12 (Precinct-14),State Treasurer,,John Cunningham,DEM,142
+Roberts,12 (Precinct-14),State Treasurer,,Josh Haeder,REP,109
+Roberts,13,State Treasurer,,John Cunningham,DEM,114
+Roberts,13,State Treasurer,,Josh Haeder,REP,93
+Roberts,01,Commissioner of School and Public Lands,,Timothy Azure,DEM,32
+Roberts,01,Commissioner of School and Public Lands,,Brock Greenfield,REP,93
+Roberts,02,Commissioner of School and Public Lands,,Timothy Azure,DEM,89
+Roberts,02,Commissioner of School and Public Lands,,Brock Greenfield,REP,324
+Roberts,03,Commissioner of School and Public Lands,,Timothy Azure,DEM,61
+Roberts,03,Commissioner of School and Public Lands,,Brock Greenfield,REP,107
+Roberts,04,Commissioner of School and Public Lands,,Timothy Azure,DEM,25
+Roberts,04,Commissioner of School and Public Lands,,Brock Greenfield,REP,43
+Roberts,05,Commissioner of School and Public Lands,,Timothy Azure,DEM,186
+Roberts,05,Commissioner of School and Public Lands,,Brock Greenfield,REP,136
+Roberts,06 (Precinct-07),Commissioner of School and Public Lands,,Timothy Azure,DEM,138
+Roberts,06 (Precinct-07),Commissioner of School and Public Lands,,Brock Greenfield,REP,316
+Roberts,08,Commissioner of School and Public Lands,,Timothy Azure,DEM,38
+Roberts,08,Commissioner of School and Public Lands,,Brock Greenfield,REP,70
+Roberts,09,Commissioner of School and Public Lands,,Timothy Azure,DEM,106
+Roberts,09,Commissioner of School and Public Lands,,Brock Greenfield,REP,266
+Roberts,10,Commissioner of School and Public Lands,,Timothy Azure,DEM,100
+Roberts,10,Commissioner of School and Public Lands,,Brock Greenfield,REP,71
+Roberts,11,Commissioner of School and Public Lands,,Timothy Azure,DEM,328
+Roberts,11,Commissioner of School and Public Lands,,Brock Greenfield,REP,309
+Roberts,12 (Precinct-14),Commissioner of School and Public Lands,,Timothy Azure,DEM,143
+Roberts,12 (Precinct-14),Commissioner of School and Public Lands,,Brock Greenfield,REP,106
+Roberts,13,Commissioner of School and Public Lands,,Timothy Azure,DEM,116
+Roberts,13,Commissioner of School and Public Lands,,Brock Greenfield,REP,92
+Roberts,01,Public Utilities Commissioner,,Jeffrey Barth,DEM,33
+Roberts,01,Public Utilities Commissioner,,Chris Nelson,REP,94
+Roberts,02,Public Utilities Commissioner,,Jeffrey Barth,DEM,82
+Roberts,02,Public Utilities Commissioner,,Chris Nelson,REP,348
+Roberts,03,Public Utilities Commissioner,,Jeffrey Barth,DEM,43
+Roberts,03,Public Utilities Commissioner,,Chris Nelson,REP,130
+Roberts,04,Public Utilities Commissioner,,Jeffrey Barth,DEM,27
+Roberts,04,Public Utilities Commissioner,,Chris Nelson,REP,41
+Roberts,05,Public Utilities Commissioner,,Jeffrey Barth,DEM,178
+Roberts,05,Public Utilities Commissioner,,Chris Nelson,REP,149
+Roberts,06 (Precinct-07),Public Utilities Commissioner,,Jeffrey Barth,DEM,121
+Roberts,06 (Precinct-07),Public Utilities Commissioner,,Chris Nelson,REP,340
+Roberts,08,Public Utilities Commissioner,,Jeffrey Barth,DEM,37
+Roberts,08,Public Utilities Commissioner,,Chris Nelson,REP,71
+Roberts,09,Public Utilities Commissioner,,Jeffrey Barth,DEM,89
+Roberts,09,Public Utilities Commissioner,,Chris Nelson,REP,296
+Roberts,10,Public Utilities Commissioner,,Jeffrey Barth,DEM,96
+Roberts,10,Public Utilities Commissioner,,Chris Nelson,REP,76
+Roberts,11,Public Utilities Commissioner,,Jeffrey Barth,DEM,299
+Roberts,11,Public Utilities Commissioner,,Chris Nelson,REP,340
+Roberts,12 (Precinct-14),Public Utilities Commissioner,,Jeffrey Barth,DEM,123
+Roberts,12 (Precinct-14),Public Utilities Commissioner,,Chris Nelson,REP,126
+Roberts,13,Public Utilities Commissioner,,Jeffrey Barth,DEM,96
+Roberts,13,Public Utilities Commissioner,,Chris Nelson,REP,111
+Roberts,01,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,62
+Roberts,02,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,206
+Roberts,03,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,76
+Roberts,04,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,36
+Roberts,05,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,117
+Roberts,06 (Precinct-07),Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,207
+Roberts,08,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,58
+Roberts,09,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,167
+Roberts,10,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,62
+Roberts,11,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,266
+Roberts,12 (Precinct-14),Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,95
+Roberts,13,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,85
+Roberts,01,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,67
+Roberts,02,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,201
+Roberts,03,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,70
+Roberts,04,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,31
+Roberts,05,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,121
+Roberts,06 (Precinct-07),Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,204
+Roberts,08,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,56
+Roberts,09,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,169
+Roberts,10,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,74
+Roberts,11,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,286
+Roberts,12 (Precinct-14),Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,100
+Roberts,13,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,96
+Roberts,01,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,63
+Roberts,02,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,201
+Roberts,03,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,66
+Roberts,04,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,32
+Roberts,05,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,110
+Roberts,06 (Precinct-07),Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,197
+Roberts,08,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,54
+Roberts,09,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,163
+Roberts,10,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,61
+Roberts,11,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,246
+Roberts,12 (Precinct-14),Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,91
+Roberts,13,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,81
+Roberts,01,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,68
+Roberts,02,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,209
+Roberts,03,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,73
+Roberts,04,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,34
+Roberts,05,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,121
+Roberts,06 (Precinct-07),Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,210
+Roberts,08,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,55
+Roberts,09,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,180
+Roberts,10,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,67
+Roberts,11,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,270
+Roberts,12 (Precinct-14),Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,104
+Roberts,13,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,91
+Roberts,01,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,105
+Roberts,01,Supreme Court Retention,3,Patricia J. DeVaney - No,,15
+Roberts,02,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,346
+Roberts,02,Supreme Court Retention,3,Patricia J. DeVaney - No,,51
+Roberts,03,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,131
+Roberts,03,Supreme Court Retention,3,Patricia J. DeVaney - No,,24
+Roberts,04,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,53
+Roberts,04,Supreme Court Retention,3,Patricia J. DeVaney - No,,12
+Roberts,05,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,225
+Roberts,05,Supreme Court Retention,3,Patricia J. DeVaney - No,,83
+Roberts,06 (Precinct-07),Supreme Court Retention,3,Patricia J. DeVaney - Yes,,337
+Roberts,06 (Precinct-07),Supreme Court Retention,3,Patricia J. DeVaney - No,,79
+Roberts,08,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,86
+Roberts,08,Supreme Court Retention,3,Patricia J. DeVaney - No,,17
+Roberts,09,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,282
+Roberts,09,Supreme Court Retention,3,Patricia J. DeVaney - No,,67
+Roberts,10,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,110
+Roberts,10,Supreme Court Retention,3,Patricia J. DeVaney - No,,50
+Roberts,11,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,442
+Roberts,11,Supreme Court Retention,3,Patricia J. DeVaney - No,,155
+Roberts,12 (Precinct-14),Supreme Court Retention,3,Patricia J. DeVaney - Yes,,167
+Roberts,12 (Precinct-14),Supreme Court Retention,3,Patricia J. DeVaney - No,,64
+Roberts,13,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,143
+Roberts,13,Supreme Court Retention,3,Patricia J. DeVaney - No,,47
+Roberts,01,Supreme Court Retention,2,Mark E. Salter - Yes,,102
+Roberts,01,Supreme Court Retention,2,Mark E. Salter - No,,17
+Roberts,02,Supreme Court Retention,2,Mark E. Salter - Yes,,342
+Roberts,02,Supreme Court Retention,2,Mark E. Salter - No,,51
+Roberts,03,Supreme Court Retention,2,Mark E. Salter - Yes,,127
+Roberts,03,Supreme Court Retention,2,Mark E. Salter - No,,24
+Roberts,04,Supreme Court Retention,2,Mark E. Salter - Yes,,51
+Roberts,04,Supreme Court Retention,2,Mark E. Salter - No,,13
+Roberts,05,Supreme Court Retention,2,Mark E. Salter - Yes,,212
+Roberts,05,Supreme Court Retention,2,Mark E. Salter - No,,94
+Roberts,06 (Precinct-07),Supreme Court Retention,2,Mark E. Salter - Yes,,336
+Roberts,06 (Precinct-07),Supreme Court Retention,2,Mark E. Salter - No,,81
+Roberts,08,Supreme Court Retention,2,Mark E. Salter - Yes,,82
+Roberts,08,Supreme Court Retention,2,Mark E. Salter - No,,20
+Roberts,09,Supreme Court Retention,2,Mark E. Salter - Yes,,281
+Roberts,09,Supreme Court Retention,2,Mark E. Salter - No,,63
+Roberts,10,Supreme Court Retention,2,Mark E. Salter - Yes,,101
+Roberts,10,Supreme Court Retention,2,Mark E. Salter - No,,57
+Roberts,11,Supreme Court Retention,2,Mark E. Salter - Yes,,438
+Roberts,11,Supreme Court Retention,2,Mark E. Salter - No,,158
+Roberts,12 (Precinct-14),Supreme Court Retention,2,Mark E. Salter - Yes,,164
+Roberts,12 (Precinct-14),Supreme Court Retention,2,Mark E. Salter - No,,66
+Roberts,13,Supreme Court Retention,2,Mark E. Salter - Yes,,140
+Roberts,13,Supreme Court Retention,2,Mark E. Salter - No,,47
+Roberts,01,Constitutional Amendment D,,Yes,,77
+Roberts,01,Constitutional Amendment D,,No,,62
+Roberts,02,Constitutional Amendment D,,Yes,,186
+Roberts,02,Constitutional Amendment D,,No,,259
+Roberts,03,Constitutional Amendment D,,Yes,,96
+Roberts,03,Constitutional Amendment D,,No,,83
+Roberts,04,Constitutional Amendment D,,Yes,,39
+Roberts,04,Constitutional Amendment D,,No,,29
+Roberts,05,Constitutional Amendment D,,Yes,,223
+Roberts,05,Constitutional Amendment D,,No,,113
+Roberts,06 (Precinct-07),Constitutional Amendment D,,Yes,,242
+Roberts,06 (Precinct-07),Constitutional Amendment D,,No,,221
+Roberts,08,Constitutional Amendment D,,Yes,,72
+Roberts,08,Constitutional Amendment D,,No,,40
+Roberts,09,Constitutional Amendment D,,Yes,,188
+Roberts,09,Constitutional Amendment D,,No,,212
+Roberts,10,Constitutional Amendment D,,Yes,,126
+Roberts,10,Constitutional Amendment D,,No,,55
+Roberts,11,Constitutional Amendment D,,Yes,,427
+Roberts,11,Constitutional Amendment D,,No,,247
+Roberts,12 (Precinct-14),Constitutional Amendment D,,Yes,,192
+Roberts,12 (Precinct-14),Constitutional Amendment D,,No,,69
+Roberts,13,Constitutional Amendment D,,Yes,,132
+Roberts,13,Constitutional Amendment D,,No,,78
+Roberts,01,Initiated Measure 27,,Yes,,44
+Roberts,01,Initiated Measure 27,,No,,94
+Roberts,02,Initiated Measure 27,,Yes,,183
+Roberts,02,Initiated Measure 27,,No,,266
+Roberts,03,Initiated Measure 27,,Yes,,68
+Roberts,03,Initiated Measure 27,,No,,112
+Roberts,04,Initiated Measure 27,,Yes,,30
+Roberts,04,Initiated Measure 27,,No,,41
+Roberts,05,Initiated Measure 27,,Yes,,182
+Roberts,05,Initiated Measure 27,,No,,152
+Roberts,06 (Precinct-07),Initiated Measure 27,,Yes,,179
+Roberts,06 (Precinct-07),Initiated Measure 27,,No,,294
+Roberts,08,Initiated Measure 27,,Yes,,60
+Roberts,08,Initiated Measure 27,,No,,53
+Roberts,09,Initiated Measure 27,,Yes,,148
+Roberts,09,Initiated Measure 27,,No,,255
+Roberts,10,Initiated Measure 27,,Yes,,105
+Roberts,10,Initiated Measure 27,,No,,78
+Roberts,11,Initiated Measure 27,,Yes,,308
+Roberts,11,Initiated Measure 27,,No,,381
+Roberts,12 (Precinct-14),Initiated Measure 27,,Yes,,136
+Roberts,12 (Precinct-14),Initiated Measure 27,,No,,127
+Roberts,13,Initiated Measure 27,,Yes,,109
+Roberts,13,Initiated Measure 27,,No,,106
+Roberts,01,State Senate,01,Michael H. Rohl,REP,96
+Roberts,01,State Senate,01,Susan Wismer,IND,42
+Roberts,02,State Senate,04,John Wiik,REP,339
+Roberts,03,State Senate,01,Michael H. Rohl,REP,100
+Roberts,03,State Senate,01,Susan Wismer,IND,76
+Roberts,04,State Senate,01,Michael H. Rohl,REP,41
+Roberts,04,State Senate,01,Susan Wismer,IND,27
+Roberts,05,State Senate,01,Michael H. Rohl,REP,109
+Roberts,05,State Senate,01,Susan Wismer,IND,154
+Roberts,05,State Senate,04,John Wiik,REP,28
+Roberts,06 (Precinct-07),State Senate,01,Michael H. Rohl,REP,289
+Roberts,06 (Precinct-07),State Senate,01,Susan Wismer,IND,170
+Roberts,08,State Senate,01,Michael H. Rohl,REP,58
+Roberts,08,State Senate,01,Susan Wismer,IND,45
+Roberts,09,State Senate,01,Michael H. Rohl,REP,2
+Roberts,09,State Senate,01,Susan Wismer,IND,4
+Roberts,09,State Senate,04,John Wiik,REP,304
+Roberts,10,State Senate,01,Michael H. Rohl,REP,67
+Roberts,10,State Senate,01,Susan Wismer,IND,100
+Roberts,11,State Senate,01,Michael H. Rohl,REP,305
+Roberts,11,State Senate,01,Susan Wismer,IND,343
+Roberts,12 (Precinct-14),State Senate,01,Michael H. Rohl,REP,101
+Roberts,12 (Precinct-14),State Senate,01,Susan Wismer,IND,150
+Roberts,13 10 of 19,State Senate,01,Michael H. Rohl,REP,90
+Roberts,13 10 of 19,State Senate,01,Susan Wismer,IND,112
+Roberts,01,State House,01,Steven D. McCleerey,DEM,52
+Roberts,01,State House,01,Kay F. Nikolas,DEM,42
+Roberts,01,State House,01,Joe Donnell,REP,73
+Roberts,01,State House,01,Tamara St John,REP,70
+Roberts,02,State House,04,Stephanie Sauder,REP,219
+Roberts,02,State House,04,Fred Deutsch,REP,297
+Roberts,03,State House,01,Steven D. McCleerey,DEM,86
+Roberts,03,State House,01,Kay F. Nikolas,DEM,59
+Roberts,03,State House,01,Joe Donnell,REP,83
+Roberts,03,State House,01,Tamara St John,REP,90
+Roberts,04,State House,01,Steven D. McCleerey,DEM,25
+Roberts,04,State House,01,Kay F. Nikolas,DEM,19
+Roberts,04,State House,01,Joe Donnell,REP,21
+Roberts,04,State House,01,Tamara St John,REP,30
+Roberts,05,State House,01,Steven D. McCleerey,DEM,138
+Roberts,05,State House,01,Kay F. Nikolas,DEM,78
+Roberts,05,State House,01,Joe Donnell,REP,104
+Roberts,05,State House,01,Tamara St John,REP,134
+Roberts,05,State House,04,Stephanie Sauder,REP,19
+Roberts,05,State House,04,Fred Deutsch,REP,21
+Roberts,06 (Precinct-07),State House,01,Steven D. McCleerey,DEM,154
+Roberts,06 (Precinct-07),State House,01,Kay F. Nikolas,DEM,133
+Roberts,06 (Precinct-07),State House,01,Joe Donnell,REP,234
+Roberts,06 (Precinct-07),State House,01,Tamara St John,REP,280
+Roberts,08,State House,01,Steven D. McCleerey,DEM,40
+Roberts,08,State House,01,Kay F. Nikolas,DEM,31
+Roberts,08,State House,01,Joe Donnell,REP,54
+Roberts,08,State House,01,Tamara St John,REP,56
+Roberts,09,State House,01,Steven D. McCleerey,DEM,3
+Roberts,09,State House,01,Kay F. Nikolas,DEM,1
+Roberts,09,State House,01,Joe Donnell,REP,2
+Roberts,09,State House,01,Tamara St John,REP,1
+Roberts,09,State House,04,Stephanie Sauder,REP,177
+Roberts,09,State House,04,Fred Deutsch,REP,238
+Roberts,10,State House,01,Steven D. McCleerey,DEM,81
+Roberts,10,State House,01,Kay F. Nikolas,DEM,42
+Roberts,10,State House,01,Joe Donnell,REP,72
+Roberts,10,State House,01,Tamara St John,REP,96
+Roberts,11,State House,01,Steven D. McCleerey,DEM,303
+Roberts,11,State House,01,Kay F. Nikolas,DEM,234
+Roberts,11,State House,01,Joe Donnell,REP,289
+Roberts,11,State House,01,Tamara St John,REP,332
+Roberts,12 (Precinct-14),State House,01,Steven D. McCleerey,DEM,136
+Roberts,12 (Precinct-14),State House,01,Kay F. Nikolas,DEM,112
+Roberts,12 (Precinct-14),State House,01,Joe Donnell,REP,96
+Roberts,12 (Precinct-14),State House,01,Tamara St John,REP,118
+Roberts,13 11 of 19,State House,01,Steven D. McCleerey,DEM,105
+Roberts,13 11 of 19,State House,01,Kay F. Nikolas,DEM,90
+Roberts,13 11 of 19,State House,01,Joe Donnell,REP,93
+Roberts,13 11 of 19,State House,01,Tamara St John,REP,97

--- a/2022/counties/20221108__sd__general__sanborn__precinct.csv
+++ b/2022/counties/20221108__sd__general__sanborn__precinct.csv
@@ -1,0 +1,153 @@
+county,precinct,office,district,candidate,party,votes
+Sanborn,1,U.S. Senate,,Brian L. Bengs,DEM,29
+Sanborn,1,U.S. Senate,,Tamara J Lesnar,LIB,7
+Sanborn,1,U.S. Senate,,John R. Thune,REP,176
+Sanborn,2,U.S. Senate,,Brian L. Bengs,DEM,49
+Sanborn,2,U.S. Senate,,Tamara J Lesnar,LIB,7
+Sanborn,2,U.S. Senate,,John R. Thune,REP,238
+Sanborn,4,U.S. Senate,,Brian L. Bengs,DEM,39
+Sanborn,4,U.S. Senate,,Tamara J Lesnar,LIB,5
+Sanborn,4,U.S. Senate,,John R. Thune,REP,226
+Sanborn,5,U.S. Senate,,Brian L. Bengs,DEM,37
+Sanborn,5,U.S. Senate,,Tamara J Lesnar,LIB,8
+Sanborn,5,U.S. Senate,,John R. Thune,REP,181
+Sanborn,1,U.S. House,1,Collin Duprel,LIB,31
+Sanborn,1,U.S. House,1,Dusty Johnson,REP,175
+Sanborn,2,U.S. House,1,Collin Duprel,LIB,40
+Sanborn,2,U.S. House,1,Dusty Johnson,REP,244
+Sanborn,4,U.S. House,1,Collin Duprel,LIB,21
+Sanborn,4,U.S. House,1,Dusty Johnson,REP,239
+Sanborn,5,U.S. House,1,Collin Duprel,LIB,32
+Sanborn,5,U.S. House,1,Dusty Johnson,REP,187
+Sanborn,1,Governor,,Jamie Smith and Jennifer Keintz,DEM,50
+Sanborn,1,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Sanborn,1,Governor,,Kristi Noem and Larry Rhoden,REP,165
+Sanborn,2,Governor,,Jamie Smith and Jennifer Keintz,DEM,64
+Sanborn,2,Governor,,Tracey Quint and Ashley Strand,LIB,9
+Sanborn,2,Governor,,Kristi Noem and Larry Rhoden,REP,222
+Sanborn,4,Governor,,Jamie Smith and Jennifer Keintz,DEM,52
+Sanborn,4,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Sanborn,4,Governor,,Kristi Noem and Larry Rhoden,REP,212
+Sanborn,5,Governor,,Jamie Smith and Jennifer Keintz,DEM,60
+Sanborn,5,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Sanborn,5,Governor,,Kristi Noem and Larry Rhoden,REP,158
+Sanborn,1,Secretary of State,,Thomas A Cool,DEM,53
+Sanborn,1,Secretary of State,,Monae Johnson,REP,142
+Sanborn,2,Secretary of State,,Thomas A Cool,DEM,72
+Sanborn,2,Secretary of State,,Monae Johnson,REP,208
+Sanborn,4,Secretary of State,,Thomas A Cool,DEM,67
+Sanborn,4,Secretary of State,,Monae Johnson,REP,190
+Sanborn,5,Secretary of State,,Thomas A Cool,DEM,63
+Sanborn,5,Secretary of State,,Monae Johnson,REP,152
+Sanborn,1,Attorney General,,Marty J. Jackley,REP,184
+Sanborn,2,Attorney General,,Marty J. Jackley,REP,230
+Sanborn,4,Attorney General,,Marty J. Jackley,REP,219
+Sanborn,5,Attorney General,,Marty J. Jackley,REP,177
+Sanborn,1,State Auditor,,Stephanie Marty,DEM,37
+Sanborn,1,State Auditor,,Rene Meyer,LIB,10
+Sanborn,1,State Auditor,,Richard Sattgast,REP,149
+Sanborn,2,State Auditor,,Stephanie Marty,DEM,61
+Sanborn,2,State Auditor,,Rene Meyer,LIB,7
+Sanborn,2,State Auditor,,Richard Sattgast,REP,207
+Sanborn,4,State Auditor,,Stephanie Marty,DEM,55
+Sanborn,4,State Auditor,,Rene Meyer,LIB,11
+Sanborn,4,State Auditor,,Richard Sattgast,REP,190
+Sanborn,5,State Auditor,,Stephanie Marty,DEM,48
+Sanborn,5,State Auditor,,Rene Meyer,LIB,15
+Sanborn,5,State Auditor,,Richard Sattgast,REP,154
+Sanborn,1,State Treasurer,,John Cunningham,DEM,39
+Sanborn,1,State Treasurer,,Josh Haeder,REP,157
+Sanborn,2,State Treasurer,,John Cunningham,DEM,60
+Sanborn,2,State Treasurer,,Josh Haeder,REP,220
+Sanborn,4,State Treasurer,,John Cunningham,DEM,46
+Sanborn,4,State Treasurer,,Josh Haeder,REP,216
+Sanborn,5,State Treasurer,,John Cunningham,DEM,48
+Sanborn,5,State Treasurer,,Josh Haeder,REP,169
+Sanborn,1,Commissioner of School and Public Lands,,Timothy Azure,DEM,34
+Sanborn,1,Commissioner of School and Public Lands,,Brock Greenfield,REP,152
+Sanborn,2,Commissioner of School and Public Lands,,Timothy Azure,DEM,55
+Sanborn,2,Commissioner of School and Public Lands,,Brock Greenfield,REP,216
+Sanborn,4,Commissioner of School and Public Lands,,Timothy Azure,DEM,53
+Sanborn,4,Commissioner of School and Public Lands,,Brock Greenfield,REP,196
+Sanborn,5,Commissioner of School and Public Lands,,Timothy Azure,DEM,55
+Sanborn,5,Commissioner of School and Public Lands,,Brock Greenfield,REP,154
+Sanborn,1,Public Utilities Commissioner,,Jeffrey Barth,DEM,44
+Sanborn,1,Public Utilities Commissioner,,Chris Nelson,REP,157
+Sanborn,2,Public Utilities Commissioner,,Jeffrey Barth,DEM,56
+Sanborn,2,Public Utilities Commissioner,,Chris Nelson,REP,222
+Sanborn,4,Public Utilities Commissioner,,Jeffrey Barth,DEM,43
+Sanborn,4,Public Utilities Commissioner,,Chris Nelson,REP,217
+Sanborn,5,Public Utilities Commissioner,,Jeffrey Barth,DEM,50
+Sanborn,5,Public Utilities Commissioner,,Chris Nelson,REP,163
+Sanborn,1,State Senate,20,Joshua Klumb,REP,169
+Sanborn,2,State Senate,20,Joshua Klumb,REP,230
+Sanborn,4,State Senate,20,Joshua Klumb,REP,208
+Sanborn,5,State Senate,20,Joshua Klumb,REP,157
+Sanborn,1,State House,20,Ben Krohmer,REP,109
+Sanborn,1,State House,20,Lance Koth,REP,127
+Sanborn,2,State House,20,Ben Krohmer,REP,160
+Sanborn,2,State House,20,Lance Koth,REP,186
+Sanborn,4,State House,20,Ben Krohmer,REP,128
+Sanborn,4,State House,20,Lance Koth,REP,177
+Sanborn,5,State House,20,Ben Krohmer,REP,97
+Sanborn,5,State House,20,Lance Koth,REP,130
+Sanborn,1,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,98
+Sanborn,2,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,129
+Sanborn,4,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,122
+Sanborn,5,Judge of the Circuit Court,Position A Third Circuit,Carmen Means,NON,104
+Sanborn,1,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,97
+Sanborn,2,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,125
+Sanborn,4,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,122
+Sanborn,5,Judge of the Circuit Court,Position B Third Circuit,Dawn M. Elshere,NON,96
+Sanborn,1,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,105
+Sanborn,2,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,125
+Sanborn,4,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,130
+Sanborn,5,Judge of the Circuit Court,Position C Third Circuit,Kent A Shelton,NON,108
+Sanborn,1,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,101
+Sanborn,2,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,123
+Sanborn,4,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,121
+Sanborn,5,Judge of the Circuit Court,Position D Third Circuit,Gregory J. Stoltenburg,NON,94
+Sanborn,1,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,33
+Sanborn,1,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,84
+Sanborn,2,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,38
+Sanborn,2,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,119
+Sanborn,4,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,70
+Sanborn,4,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,94
+Sanborn,5,Judge of the Circuit Court,Position E Third Circuit,Robert L. Spears,NON,49
+Sanborn,5,Judge of the Circuit Court,Position E Third Circuit,Michael R. Moore,NON,97
+Sanborn,1,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,110
+Sanborn,2,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,132
+Sanborn,4,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,133
+Sanborn,5,Judge of the Circuit Court,Position F Third Circuit,Patrick Pardy,NON,105
+Sanborn,1,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,148
+Sanborn,1,Supreme Court Retention,3,Patricia J. DeVaney - No,,25
+Sanborn,2,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,188
+Sanborn,2,Supreme Court Retention,3,Patricia J. DeVaney - No,,50
+Sanborn,4,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,194
+Sanborn,4,Supreme Court Retention,3,Patricia J. DeVaney - No,,32
+Sanborn,5,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,168
+Sanborn,5,Supreme Court Retention,3,Patricia J. DeVaney - No,,26
+Sanborn,1,Supreme Court Retention,2,Mark E. Salter - Yes,,148
+Sanborn,1,Supreme Court Retention,2,Mark E. Salter - No,,26
+Sanborn,2,Supreme Court Retention,2,Mark E. Salter - Yes,,192
+Sanborn,2,Supreme Court Retention,2,Mark E. Salter - No,,44
+Sanborn,4,Supreme Court Retention,2,Mark E. Salter - Yes,,197
+Sanborn,4,Supreme Court Retention,2,Mark E. Salter - No,,29
+Sanborn,5,Supreme Court Retention,2,Mark E. Salter - Yes,,158
+Sanborn,5,Supreme Court Retention,2,Mark E. Salter - No,,35
+Sanborn,1,Constitutional Amendment D,,Yes,,105
+Sanborn,1,Constitutional Amendment D,,No,,101
+Sanborn,2,Constitutional Amendment D,,Yes,,127
+Sanborn,2,Constitutional Amendment D,,No,,155
+Sanborn,4,Constitutional Amendment D,,Yes,,125
+Sanborn,4,Constitutional Amendment D,,No,,135
+Sanborn,5,Constitutional Amendment D,,Yes,,126
+Sanborn,5,Constitutional Amendment D,,No,,95
+Sanborn,1,Initiated Measure 27,,Yes,,73
+Sanborn,1,Initiated Measure 27,,No,,139
+Sanborn,2,Initiated Measure 27,,Yes,,100
+Sanborn,2,Initiated Measure 27,,No,,187
+Sanborn,4,Initiated Measure 27,,Yes,,101
+Sanborn,4,Initiated Measure 27,,No,,163
+Sanborn,5,Initiated Measure 27,,Yes,,85
+Sanborn,5,Initiated Measure 27,,No,,140

--- a/2022/counties/20221108__sd__general__spink__precinct.csv
+++ b/2022/counties/20221108__sd__general__spink__precinct.csv
@@ -1,0 +1,325 @@
+county,precinct,office,district,candidate,party,votes
+Spink,01,U.S. Senate,,Brian L. Bengs,DEM,60
+Spink,01,U.S. Senate,,Tamara J Lesnar,LIB,5
+Spink,01,U.S. Senate,,John R. Thune,REP,327
+Spink,03,U.S. Senate,,Brian L. Bengs,DEM,51
+Spink,03,U.S. Senate,,Tamara J Lesnar,LIB,11
+Spink,03,U.S. Senate,,John R. Thune,REP,250
+Spink,04,U.S. Senate,,Brian L. Bengs,DEM,52
+Spink,04,U.S. Senate,,Tamara J Lesnar,LIB,7
+Spink,04,U.S. Senate,,John R. Thune,REP,205
+Spink,05,U.S. Senate,,Brian L. Bengs,DEM,37
+Spink,05,U.S. Senate,,Tamara J Lesnar,LIB,6
+Spink,05,U.S. Senate,,John R. Thune,REP,158
+Spink,06,U.S. Senate,,Brian L. Bengs,DEM,17
+Spink,06,U.S. Senate,,Tamara J Lesnar,LIB,2
+Spink,06,U.S. Senate,,John R. Thune,REP,78
+Spink,07,U.S. Senate,,Brian L. Bengs,DEM,94
+Spink,07,U.S. Senate,,Tamara J Lesnar,LIB,22
+Spink,07,U.S. Senate,,John R. Thune,REP,310
+Spink,08,U.S. Senate,,Brian L. Bengs,DEM,21
+Spink,08,U.S. Senate,,Tamara J Lesnar,LIB,5
+Spink,08,U.S. Senate,,John R. Thune,REP,87
+Spink,09,U.S. Senate,,Brian L. Bengs,DEM,110
+Spink,09,U.S. Senate,,Tamara J Lesnar,LIB,11
+Spink,09,U.S. Senate,,John R. Thune,REP,326
+Spink,10,U.S. Senate,,Brian L. Bengs,DEM,104
+Spink,10,U.S. Senate,,Tamara J Lesnar,LIB,22
+Spink,10,U.S. Senate,,John R. Thune,REP,286
+Spink,01,U.S. House,1,Collin Duprel,LIB,46
+Spink,01,U.S. House,1,Dusty Johnson,REP,340
+Spink,03,U.S. House,1,Collin Duprel,LIB,45
+Spink,03,U.S. House,1,Dusty Johnson,REP,259
+Spink,04,U.S. House,1,Collin Duprel,LIB,41
+Spink,04,U.S. House,1,Dusty Johnson,REP,212
+Spink,05,U.S. House,1,Collin Duprel,LIB,29
+Spink,05,U.S. House,1,Dusty Johnson,REP,168
+Spink,06,U.S. House,1,Collin Duprel,LIB,15
+Spink,06,U.S. House,1,Dusty Johnson,REP,80
+Spink,07,U.S. House,1,Collin Duprel,LIB,69
+Spink,07,U.S. House,1,Dusty Johnson,REP,338
+Spink,08,U.S. House,1,Collin Duprel,LIB,18
+Spink,08,U.S. House,1,Dusty Johnson,REP,91
+Spink,09,U.S. House,1,Collin Duprel,LIB,76
+Spink,09,U.S. House,1,Dusty Johnson,REP,355
+Spink,10,U.S. House,1,Collin Duprel,LIB,71
+Spink,10,U.S. House,1,Dusty Johnson,REP,323
+Spink,01,Governor,,Jamie Smith and Jennifer Keintz,DEM,88
+Spink,01,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Spink,01,Governor,,Kristi Noem and Larry Rhoden,REP,296
+Spink,03,Governor,,Jamie Smith and Jennifer Keintz,DEM,67
+Spink,03,Governor,,Tracey Quint and Ashley Strand,LIB,14
+Spink,03,Governor,,Kristi Noem and Larry Rhoden,REP,234
+Spink,04,Governor,,Jamie Smith and Jennifer Keintz,DEM,69
+Spink,04,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Spink,04,Governor,,Kristi Noem and Larry Rhoden,REP,187
+Spink,05,Governor,,Jamie Smith and Jennifer Keintz,DEM,48
+Spink,05,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Spink,05,Governor,,Kristi Noem and Larry Rhoden,REP,152
+Spink,06,Governor,,Jamie Smith and Jennifer Keintz,DEM,28
+Spink,06,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Spink,06,Governor,,Kristi Noem and Larry Rhoden,REP,68
+Spink,07,Governor,,Jamie Smith and Jennifer Keintz,DEM,128
+Spink,07,Governor,,Tracey Quint and Ashley Strand,LIB,12
+Spink,07,Governor,,Kristi Noem and Larry Rhoden,REP,283
+Spink,08,Governor,,Jamie Smith and Jennifer Keintz,DEM,32
+Spink,08,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Spink,08,Governor,,Kristi Noem and Larry Rhoden,REP,81
+Spink,09,Governor,,Jamie Smith and Jennifer Keintz,DEM,158
+Spink,09,Governor,,Tracey Quint and Ashley Strand,LIB,13
+Spink,09,Governor,,Kristi Noem and Larry Rhoden,REP,277
+Spink,10,Governor,,Jamie Smith and Jennifer Keintz,DEM,147
+Spink,10,Governor,,Tracey Quint and Ashley Strand,LIB,15
+Spink,10,Governor,,Kristi Noem and Larry Rhoden,REP,254
+Spink,01,Secretary of State,,Thomas A Cool,DEM,95
+Spink,01,Secretary of State,,Monae Johnson,REP,287
+Spink,03,Secretary of State,,Thomas A Cool,DEM,75
+Spink,03,Secretary of State,,Monae Johnson,REP,225
+Spink,04,Secretary of State,,Thomas A Cool,DEM,75
+Spink,04,Secretary of State,,Monae Johnson,REP,177
+Spink,05,Secretary of State,,Thomas A Cool,DEM,57
+Spink,05,Secretary of State,,Monae Johnson,REP,132
+Spink,06,Secretary of State,,Thomas A Cool,DEM,30
+Spink,06,Secretary of State,,Monae Johnson,REP,62
+Spink,07,Secretary of State,,Thomas A Cool,DEM,143
+Spink,07,Secretary of State,,Monae Johnson,REP,267
+Spink,08,Secretary of State,,Thomas A Cool,DEM,38
+Spink,08,Secretary of State,,Monae Johnson,REP,68
+Spink,09,Secretary of State,,Thomas A Cool,DEM,161
+Spink,09,Secretary of State,,Monae Johnson,REP,265
+Spink,10,Secretary of State,,Thomas A Cool,DEM,150
+Spink,10,Secretary of State,,Monae Johnson,REP,240
+Spink,01,Attorney General,,Marty J. Jackley,REP,325
+Spink,03,Attorney General,,Marty J. Jackley,REP,271
+Spink,04,Attorney General,,Marty J. Jackley,REP,210
+Spink,05,Attorney General,,Marty J. Jackley,REP,157
+Spink,06,Attorney General,,Marty J. Jackley,REP,77
+Spink,07,Attorney General,,Marty J. Jackley,REP,352
+Spink,08,Attorney General,,Marty J. Jackley,REP,86
+Spink,09,Attorney General,,Marty J. Jackley,REP,346
+Spink,10,Attorney General,,Marty J. Jackley,REP,327
+Spink,01,State Auditor,,Stephanie Marty,DEM,76
+Spink,01,State Auditor,,Rene Meyer,LIB,13
+Spink,01,State Auditor,,Richard Sattgast,REP,289
+Spink,03,State Auditor,,Stephanie Marty,DEM,60
+Spink,03,State Auditor,,Rene Meyer,LIB,12
+Spink,03,State Auditor,,Richard Sattgast,REP,232
+Spink,04,State Auditor,,Stephanie Marty,DEM,60
+Spink,04,State Auditor,,Rene Meyer,LIB,10
+Spink,04,State Auditor,,Richard Sattgast,REP,181
+Spink,05,State Auditor,,Stephanie Marty,DEM,47
+Spink,05,State Auditor,,Rene Meyer,LIB,10
+Spink,05,State Auditor,,Richard Sattgast,REP,127
+Spink,06,State Auditor,,Stephanie Marty,DEM,30
+Spink,06,State Auditor,,Rene Meyer,LIB,2
+Spink,06,State Auditor,,Richard Sattgast,REP,56
+Spink,07,State Auditor,,Stephanie Marty,DEM,113
+Spink,07,State Auditor,,Rene Meyer,LIB,25
+Spink,07,State Auditor,,Richard Sattgast,REP,271
+Spink,08,State Auditor,,Stephanie Marty,DEM,34
+Spink,08,State Auditor,,Rene Meyer,LIB,4
+Spink,08,State Auditor,,Richard Sattgast,REP,67
+Spink,09,State Auditor,,Stephanie Marty,DEM,143
+Spink,09,State Auditor,,Rene Meyer,LIB,18
+Spink,09,State Auditor,,Richard Sattgast,REP,274
+Spink,10,State Auditor,,Stephanie Marty,DEM,128
+Spink,10,State Auditor,,Rene Meyer,LIB,22
+Spink,10,State Auditor,,Richard Sattgast,REP,246
+Spink,01,State Treasurer,,John Cunningham,DEM,72
+Spink,01,State Treasurer,,Josh Haeder,REP,307
+Spink,03,State Treasurer,,John Cunningham,DEM,64
+Spink,03,State Treasurer,,Josh Haeder,REP,240
+Spink,04,State Treasurer,,John Cunningham,DEM,66
+Spink,04,State Treasurer,,Josh Haeder,REP,180
+Spink,05,State Treasurer,,John Cunningham,DEM,50
+Spink,05,State Treasurer,,Josh Haeder,REP,138
+Spink,06,State Treasurer,,John Cunningham,DEM,27
+Spink,06,State Treasurer,,Josh Haeder,REP,62
+Spink,07,State Treasurer,,John Cunningham,DEM,123
+Spink,07,State Treasurer,,Josh Haeder,REP,284
+Spink,08,State Treasurer,,John Cunningham,DEM,32
+Spink,08,State Treasurer,,Josh Haeder,REP,72
+Spink,09,State Treasurer,,John Cunningham,DEM,140
+Spink,09,State Treasurer,,Josh Haeder,REP,288
+Spink,10,State Treasurer,,John Cunningham,DEM,130
+Spink,10,State Treasurer,,Josh Haeder,REP,266
+Spink,01,Commissioner of School and Public Lands,,Timothy Azure,DEM,57
+Spink,01,Commissioner of School and Public Lands,,Brock Greenfield,REP,327
+Spink,03,Commissioner of School and Public Lands,,Timothy Azure,DEM,63
+Spink,03,Commissioner of School and Public Lands,,Brock Greenfield,REP,240
+Spink,04,Commissioner of School and Public Lands,,Timothy Azure,DEM,69
+Spink,04,Commissioner of School and Public Lands,,Brock Greenfield,REP,175
+Spink,05,Commissioner of School and Public Lands,,Timothy Azure,DEM,48
+Spink,05,Commissioner of School and Public Lands,,Brock Greenfield,REP,142
+Spink,06,Commissioner of School and Public Lands,,Timothy Azure,DEM,24
+Spink,06,Commissioner of School and Public Lands,,Brock Greenfield,REP,64
+Spink,07,Commissioner of School and Public Lands,,Timothy Azure,DEM,116
+Spink,07,Commissioner of School and Public Lands,,Brock Greenfield,REP,294
+Spink,08,Commissioner of School and Public Lands,,Timothy Azure,DEM,22
+Spink,08,Commissioner of School and Public Lands,,Brock Greenfield,REP,91
+Spink,09,Commissioner of School and Public Lands,,Timothy Azure,DEM,147
+Spink,09,Commissioner of School and Public Lands,,Brock Greenfield,REP,285
+Spink,10,Commissioner of School and Public Lands,,Timothy Azure,DEM,119
+Spink,10,Commissioner of School and Public Lands,,Brock Greenfield,REP,273
+Spink,01,Public Utilities Commissioner,,Jeffrey Barth,DEM,79
+Spink,01,Public Utilities Commissioner,,Chris Nelson,REP,300
+Spink,03,Public Utilities Commissioner,,Jeffrey Barth,DEM,61
+Spink,03,Public Utilities Commissioner,,Chris Nelson,REP,245
+Spink,04,Public Utilities Commissioner,,Jeffrey Barth,DEM,56
+Spink,04,Public Utilities Commissioner,,Chris Nelson,REP,199
+Spink,05,Public Utilities Commissioner,,Jeffrey Barth,DEM,49
+Spink,05,Public Utilities Commissioner,,Chris Nelson,REP,143
+Spink,06,Public Utilities Commissioner,,Jeffrey Barth,DEM,21
+Spink,06,Public Utilities Commissioner,,Chris Nelson,REP,70
+Spink,07,Public Utilities Commissioner,,Jeffrey Barth,DEM,143
+Spink,07,Public Utilities Commissioner,,Chris Nelson,REP,265
+Spink,08,Public Utilities Commissioner,,Jeffrey Barth,DEM,35
+Spink,08,Public Utilities Commissioner,,Chris Nelson,REP,73
+Spink,09,Public Utilities Commissioner,,Jeffrey Barth,DEM,123
+Spink,09,Public Utilities Commissioner,,Chris Nelson,REP,311
+Spink,10,Public Utilities Commissioner,,Jeffrey Barth,DEM,113
+Spink,10,Public Utilities Commissioner,,Chris Nelson,REP,287
+Spink,01,State Senate,22,David Wheeler,REP,299
+Spink,03,State Senate,22,David Wheeler,REP,249
+Spink,04,State Senate,22,David Wheeler,REP,188
+Spink,05,State Senate,22,David Wheeler,REP,126
+Spink,06,State Senate,22,David Wheeler,REP,70
+Spink,07,State Senate,22,David Wheeler,REP,304
+Spink,08,State Senate,22,David Wheeler,REP,77
+Spink,09,State Senate,22,David Wheeler,REP,305
+Spink,10,State Senate,22,David Wheeler,REP,275
+Spink,01,State House,22,Shane Milne,DEM,83
+Spink,01,State House,22,Roger Chase,REP,195
+Spink,01,State House,22,Lynn Schneider,REP,290
+Spink,03,State House,22,Shane Milne,DEM,66
+Spink,03,State House,22,Roger Chase,REP,192
+Spink,03,State House,22,Lynn Schneider,REP,210
+Spink,04,State House,22,Shane Milne,DEM,68
+Spink,04,State House,22,Roger Chase,REP,130
+Spink,04,State House,22,Lynn Schneider,REP,163
+Spink,05,State House,22,Shane Milne,DEM,50
+Spink,05,State House,22,Roger Chase,REP,86
+Spink,05,State House,22,Lynn Schneider,REP,114
+Spink,06,State House,22,Shane Milne,DEM,29
+Spink,06,State House,22,Roger Chase,REP,33
+Spink,06,State House,22,Lynn Schneider,REP,58
+Spink,07,State House,22,Shane Milne,DEM,121
+Spink,07,State House,22,Roger Chase,REP,193
+Spink,07,State House,22,Lynn Schneider,REP,266
+Spink,08,State House,22,Shane Milne,DEM,34
+Spink,08,State House,22,Roger Chase,REP,44
+Spink,08,State House,22,Lynn Schneider,REP,68
+Spink,09,State House,22,Shane Milne,DEM,151
+Spink,09,State House,22,Roger Chase,REP,194
+Spink,09,State House,22,Lynn Schneider,REP,258
+Spink,10,State House,22,Shane Milne,DEM,141
+Spink,10,State House,22,Roger Chase,REP,160
+Spink,10,State House,22,Lynn Schneider,REP,242
+Spink,01,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,220
+Spink,03,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,173
+Spink,04,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,151
+Spink,05,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,71
+Spink,06,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,60
+Spink,07,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,271
+Spink,08,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,64
+Spink,09,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,258
+Spink,10,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,236
+Spink,01,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,216
+Spink,03,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,179
+Spink,04,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,155
+Spink,05,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,70
+Spink,06,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,60
+Spink,07,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,261
+Spink,08,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,61
+Spink,09,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,272
+Spink,10,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,257
+Spink,01,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,212
+Spink,03,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,169
+Spink,04,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,142
+Spink,05,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,66
+Spink,06,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,55
+Spink,07,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,242
+Spink,08,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,55
+Spink,09,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,243
+Spink,10,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,225
+Spink,01,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,212
+Spink,03,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,168
+Spink,04,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,144
+Spink,05,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,67
+Spink,06,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,58
+Spink,07,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,248
+Spink,08,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,57
+Spink,09,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,252
+Spink,10,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,235
+Spink,01,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,287
+Spink,01,Supreme Court Retention,3,Patricia J. DeVaney - No,,40
+Spink,03,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,229
+Spink,03,Supreme Court Retention,3,Patricia J. DeVaney - No,,44
+Spink,04,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,178
+Spink,04,Supreme Court Retention,3,Patricia J. DeVaney - No,,49
+Spink,05,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,100
+Spink,05,Supreme Court Retention,3,Patricia J. DeVaney - No,,39
+Spink,06,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,70
+Spink,06,Supreme Court Retention,3,Patricia J. DeVaney - No,,18
+Spink,07,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,324
+Spink,07,Supreme Court Retention,3,Patricia J. DeVaney - No,,51
+Spink,08,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,69
+Spink,08,Supreme Court Retention,3,Patricia J. DeVaney - No,,26
+Spink,09,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,330
+Spink,09,Supreme Court Retention,3,Patricia J. DeVaney - No,,76
+Spink,10,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,295
+Spink,10,Supreme Court Retention,3,Patricia J. DeVaney - No,,57
+Spink,01,Supreme Court Retention,2,Mark E. Salter - Yes,,284
+Spink,01,Supreme Court Retention,2,Mark E. Salter - No,,41
+Spink,03,Supreme Court Retention,2,Mark E. Salter - Yes,,228
+Spink,03,Supreme Court Retention,2,Mark E. Salter - No,,46
+Spink,04,Supreme Court Retention,2,Mark E. Salter - Yes,,174
+Spink,04,Supreme Court Retention,2,Mark E. Salter - No,,55
+Spink,05,Supreme Court Retention,2,Mark E. Salter - Yes,,102
+Spink,05,Supreme Court Retention,2,Mark E. Salter - No,,34
+Spink,06,Supreme Court Retention,2,Mark E. Salter - Yes,,72
+Spink,06,Supreme Court Retention,2,Mark E. Salter - No,,18
+Spink,07,Supreme Court Retention,2,Mark E. Salter - Yes,,317
+Spink,07,Supreme Court Retention,2,Mark E. Salter - No,,51
+Spink,08,Supreme Court Retention,2,Mark E. Salter - Yes,,70
+Spink,08,Supreme Court Retention,2,Mark E. Salter - No,,23
+Spink,09,Supreme Court Retention,2,Mark E. Salter - Yes,,321
+Spink,09,Supreme Court Retention,2,Mark E. Salter - No,,84
+Spink,10,Supreme Court Retention,2,Mark E. Salter - Yes,,290
+Spink,10,Supreme Court Retention,2,Mark E. Salter - No,,61
+Spink,01,Constitutional Amendment D,,Yes,,190
+Spink,01,Constitutional Amendment D,,No,,185
+Spink,03,Constitutional Amendment D,,Yes,,139
+Spink,03,Constitutional Amendment D,,No,,170
+Spink,04,Constitutional Amendment D,,Yes,,135
+Spink,04,Constitutional Amendment D,,No,,123
+Spink,05,Constitutional Amendment D,,Yes,,120
+Spink,05,Constitutional Amendment D,,No,,74
+Spink,06,Constitutional Amendment D,,Yes,,55
+Spink,06,Constitutional Amendment D,,No,,40
+Spink,07,Constitutional Amendment D,,Yes,,217
+Spink,07,Constitutional Amendment D,,No,,198
+Spink,08,Constitutional Amendment D,,Yes,,55
+Spink,08,Constitutional Amendment D,,No,,53
+Spink,09,Constitutional Amendment D,,Yes,,262
+Spink,09,Constitutional Amendment D,,No,,174
+Spink,10,Constitutional Amendment D,,Yes,,243
+Spink,10,Constitutional Amendment D,,No,,149
+Spink,01,Initiated Measure 27,,Yes,,98
+Spink,01,Initiated Measure 27,,No,,282
+Spink,03,Initiated Measure 27,,Yes,,107
+Spink,03,Initiated Measure 27,,No,,204
+Spink,04,Initiated Measure 27,,Yes,,85
+Spink,04,Initiated Measure 27,,No,,173
+Spink,05,Initiated Measure 27,,Yes,,49
+Spink,05,Initiated Measure 27,,No,,147
+Spink,06,Initiated Measure 27,,Yes,,45
+Spink,06,Initiated Measure 27,,No,,53
+Spink,07,Initiated Measure 27,,Yes,,187
+Spink,07,Initiated Measure 27,,No,,235
+Spink,08,Initiated Measure 27,,Yes,,50
+Spink,08,Initiated Measure 27,,No,,60
+Spink,09,Initiated Measure 27,,Yes,,198
+Spink,09,Initiated Measure 27,,No,,239
+Spink,10,Initiated Measure 27,,Yes,,180
+Spink,10,Initiated Measure 27,,No,,215

--- a/2022/counties/20221108__sd__general__stanley__precinct.csv
+++ b/2022/counties/20221108__sd__general__stanley__precinct.csv
@@ -1,0 +1,106 @@
+county,precinct,office,district,candidate,party,votes
+Stanley,01,U.S. Senate,,Brian L. Bengs,DEM,225
+Stanley,01,U.S. Senate,,Tamara J Lesnar,LIB,59
+Stanley,01,U.S. Senate,,John R. Thune,REP,997
+Stanley,02,U.S. Senate,,Brian L. Bengs,DEM,8
+Stanley,02,U.S. Senate,,Tamara J Lesnar,LIB,2
+Stanley,02,U.S. Senate,,John R. Thune,REP,67
+Stanley,03,U.S. Senate,,Brian L. Bengs,DEM,12
+Stanley,03,U.S. Senate,,Tamara J Lesnar,LIB,3
+Stanley,03,U.S. Senate,,John R. Thune,REP,74
+Stanley,01,U.S. House,1,Collin Duprel,LIB,251
+Stanley,01,U.S. House,1,Dusty Johnson,REP,990
+Stanley,02,U.S. House,1,Collin Duprel,LIB,13
+Stanley,02,U.S. House,1,Dusty Johnson,REP,62
+Stanley,03,U.S. House,1,Collin Duprel,LIB,8
+Stanley,03,U.S. House,1,Dusty Johnson,REP,77
+Stanley,01,Governor,,Jamie Smith and Jennifer Keintz,DEM,377
+Stanley,01,Governor,,Tracey Quint and Ashley Strand,LIB,38
+Stanley,01,Governor,,Kristi Noem and Larry Rhoden,REP,866
+Stanley,02,Governor,,Jamie Smith and Jennifer Keintz,DEM,13
+Stanley,02,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Stanley,02,Governor,,Kristi Noem and Larry Rhoden,REP,61
+Stanley,03,Governor,,Jamie Smith and Jennifer Keintz,DEM,17
+Stanley,03,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Stanley,03,Governor,,Kristi Noem and Larry Rhoden,REP,72
+Stanley,01,Secretary of State,,Thomas A Cool,DEM,363
+Stanley,01,Secretary of State,,Monae Johnson,REP,864
+Stanley,02,Secretary of State,,Thomas A Cool,DEM,18
+Stanley,02,Secretary of State,,Monae Johnson,REP,58
+Stanley,03,Secretary of State,,Thomas A Cool,DEM,14
+Stanley,03,Secretary of State,,Monae Johnson,REP,71
+Stanley,01,Attorney General,,Marty J. Jackley,REP,1055
+Stanley,02,Attorney General,,Marty J. Jackley,REP,66
+Stanley,03,Attorney General,,Marty J. Jackley,REP,77
+Stanley,01,State Auditor,,Stephanie Marty,DEM,268
+Stanley,01,State Auditor,,Rene Meyer,LIB,81
+Stanley,01,State Auditor,,Richard Sattgast,REP,894
+Stanley,02,State Auditor,,Stephanie Marty,DEM,13
+Stanley,02,State Auditor,,Rene Meyer,LIB,5
+Stanley,02,State Auditor,,Richard Sattgast,REP,58
+Stanley,03,State Auditor,,Stephanie Marty,DEM,13
+Stanley,03,State Auditor,,Rene Meyer,LIB,7
+Stanley,03,State Auditor,,Richard Sattgast,REP,68
+Stanley,01,State Treasurer,,John Cunningham,DEM,281
+Stanley,01,State Treasurer,,Josh Haeder,REP,954
+Stanley,02,State Treasurer,,John Cunningham,DEM,17
+Stanley,02,State Treasurer,,Josh Haeder,REP,58
+Stanley,03,State Treasurer,,John Cunningham,DEM,16
+Stanley,03,State Treasurer,,Josh Haeder,REP,70
+Stanley,01,Commissioner of School and Public Lands,,Timothy Azure,DEM,299
+Stanley,01,Commissioner of School and Public Lands,,Brock Greenfield,REP,909
+Stanley,02,Commissioner of School and Public Lands,,Timothy Azure,DEM,17
+Stanley,02,Commissioner of School and Public Lands,,Brock Greenfield,REP,56
+Stanley,03,Commissioner of School and Public Lands,,Timothy Azure,DEM,13
+Stanley,03,Commissioner of School and Public Lands,,Brock Greenfield,REP,68
+Stanley,01,Public Utilities Commissioner,,Jeffrey Barth,DEM,261
+Stanley,01,Public Utilities Commissioner,,Chris Nelson,REP,982
+Stanley,02,Public Utilities Commissioner,,Jeffrey Barth,DEM,13
+Stanley,02,Public Utilities Commissioner,,Chris Nelson,REP,61
+Stanley,03,Public Utilities Commissioner,,Jeffrey Barth,DEM,14
+Stanley,03,Public Utilities Commissioner,,Chris Nelson,REP,71
+Stanley,01,State Senate,24,Jim Mehlhaff,REP,963
+Stanley,02,State Senate,24,Jim Mehlhaff,REP,63
+Stanley,03,State Senate,24,Jim Mehlhaff,REP,71
+Stanley,01,State House,24,Mike Weisgram,REP,839
+Stanley,01,State House,24,Will D. Mortenson,REP,915
+Stanley,02,State House,24,Mike Weisgram,REP,38
+Stanley,02,State House,24,Will D. Mortenson,REP,63
+Stanley,03,State House,24,Mike Weisgram,REP,48
+Stanley,03,State House,24,Will D. Mortenson,REP,73
+Stanley,01,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,803
+Stanley,02,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,54
+Stanley,03,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,64
+Stanley,01,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,808
+Stanley,02,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,50
+Stanley,03,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,63
+Stanley,01,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,811
+Stanley,02,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,52
+Stanley,03,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,63
+Stanley,01,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,762
+Stanley,02,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,50
+Stanley,03,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,63
+Stanley,01,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,955
+Stanley,01,Supreme Court Retention,3,Patricia J. DeVaney - No,,191
+Stanley,02,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,60
+Stanley,02,Supreme Court Retention,3,Patricia J. DeVaney - No,,9
+Stanley,03,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,70
+Stanley,03,Supreme Court Retention,3,Patricia J. DeVaney - No,,7
+Stanley,01,Supreme Court Retention,2,Mark E. Salter - Yes,,947
+Stanley,01,Supreme Court Retention,2,Mark E. Salter - No,,184
+Stanley,02,Supreme Court Retention,2,Mark E. Salter - Yes,,57
+Stanley,02,Supreme Court Retention,2,Mark E. Salter - No,,11
+Stanley,03,Supreme Court Retention,2,Mark E. Salter - Yes,,70
+Stanley,03,Supreme Court Retention,2,Mark E. Salter - No,,6
+Stanley,01,Constitutional Amendment D,,Yes,,656
+Stanley,01,Constitutional Amendment D,,No,,618
+Stanley,02,Constitutional Amendment D,,Yes,,30
+Stanley,02,Constitutional Amendment D,,No,,43
+Stanley,03,Constitutional Amendment D,,Yes,,38
+Stanley,03,Constitutional Amendment D,,No,,49
+Stanley,01,Initiated Measure 27,,Yes,,579
+Stanley,01,Initiated Measure 27,,No,,705
+Stanley,02,Initiated Measure 27,,Yes,,26
+Stanley,02,Initiated Measure 27,,No,,48
+Stanley,03,Initiated Measure 27,,Yes,,23
+Stanley,03,Initiated Measure 27,,No,,65

--- a/2022/counties/20221108__sd__general__sully__precinct.csv
+++ b/2022/counties/20221108__sd__general__sully__precinct.csv
@@ -1,0 +1,141 @@
+county,precinct,office,district,candidate,party,votes
+Sully,Absentee Precinct,U.S. Senate,,Brian L. Bengs,DEM,35
+Sully,Absentee Precinct,U.S. Senate,,Tamara J Lesnar,LIB,7
+Sully,Absentee Precinct,U.S. Senate,,John R. Thune,REP,103
+Sully,Agar Fire Hall,U.S. Senate,,Brian L. Bengs,DEM,12
+Sully,Agar Fire Hall,U.S. Senate,,Tamara J Lesnar,LIB,4
+Sully,Agar Fire Hall,U.S. Senate,,John R. Thune,REP,67
+Sully,Bill Floyd Shop,U.S. Senate,,Brian L. Bengs,DEM,20
+Sully,Bill Floyd Shop,U.S. Senate,,Tamara J Lesnar,LIB,7
+Sully,Bill Floyd Shop,U.S. Senate,,John R. Thune,REP,103
+Sully,Phoenix Center,U.S. Senate,,Brian L. Bengs,DEM,47
+Sully,Phoenix Center,U.S. Senate,,Tamara J Lesnar,LIB,29
+Sully,Phoenix Center,U.S. Senate,,John R. Thune,REP,349
+Sully,Absentee Precinct,U.S. House,1,Collin Duprel,LIB,31
+Sully,Absentee Precinct,U.S. House,1,Dusty Johnson,REP,105
+Sully,Agar Fire Hall,U.S. House,1,Collin Duprel,LIB,11
+Sully,Agar Fire Hall,U.S. House,1,Dusty Johnson,REP,70
+Sully,Bill Floyd Shop,U.S. House,1,Collin Duprel,LIB,27
+Sully,Bill Floyd Shop,U.S. House,1,Dusty Johnson,REP,104
+Sully,Phoenix Center,U.S. House,1,Collin Duprel,LIB,60
+Sully,Phoenix Center,U.S. House,1,Dusty Johnson,REP,346
+Sully,Absentee Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,47
+Sully,Absentee Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Sully,Absentee Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,95
+Sully,Agar Fire Hall,Governor,,Jamie Smith and Jennifer Keintz,DEM,13
+Sully,Agar Fire Hall,Governor,,Tracey Quint and Ashley Strand,LIB,0
+Sully,Agar Fire Hall,Governor,,Kristi Noem and Larry Rhoden,REP,71
+Sully,Bill Floyd Shop,Governor,,Jamie Smith and Jennifer Keintz,DEM,33
+Sully,Bill Floyd Shop,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Sully,Bill Floyd Shop,Governor,,Kristi Noem and Larry Rhoden,REP,95
+Sully,Phoenix Center,Governor,,Jamie Smith and Jennifer Keintz,DEM,76
+Sully,Phoenix Center,Governor,,Tracey Quint and Ashley Strand,LIB,16
+Sully,Phoenix Center,Governor,,Kristi Noem and Larry Rhoden,REP,336
+Sully,Absentee Precinct,Secretary of State,,Thomas A Cool,DEM,43
+Sully,Absentee Precinct,Secretary of State,,Monae Johnson,REP,97
+Sully,Agar Fire Hall,Secretary of State,,Thomas A Cool,DEM,16
+Sully,Agar Fire Hall,Secretary of State,,Monae Johnson,REP,65
+Sully,Bill Floyd Shop,Secretary of State,,Thomas A Cool,DEM,23
+Sully,Bill Floyd Shop,Secretary of State,,Monae Johnson,REP,108
+Sully,Phoenix Center,Secretary of State,,Thomas A Cool,DEM,87
+Sully,Phoenix Center,Secretary of State,,Monae Johnson,REP,314
+Sully,Absentee Precinct,Attorney General,,Marty J. Jackley,REP,122
+Sully,Agar Fire Hall,Attorney General,,Marty J. Jackley,REP,72
+Sully,Bill Floyd Shop,Attorney General,,Marty J. Jackley,REP,112
+Sully,Phoenix Center,Attorney General,,Marty J. Jackley,REP,361
+Sully,Absentee Precinct,State Auditor,,Stephanie Marty,DEM,40
+Sully,Absentee Precinct,State Auditor,,Rene Meyer,LIB,4
+Sully,Absentee Precinct,State Auditor,,Richard Sattgast,REP,102
+Sully,Agar Fire Hall,State Auditor,,Stephanie Marty,DEM,12
+Sully,Agar Fire Hall,State Auditor,,Rene Meyer,LIB,1
+Sully,Agar Fire Hall,State Auditor,,Richard Sattgast,REP,68
+Sully,Bill Floyd Shop,State Auditor,,Stephanie Marty,DEM,20
+Sully,Bill Floyd Shop,State Auditor,,Rene Meyer,LIB,2
+Sully,Bill Floyd Shop,State Auditor,,Richard Sattgast,REP,107
+Sully,Phoenix Center,State Auditor,,Stephanie Marty,DEM,62
+Sully,Phoenix Center,State Auditor,,Rene Meyer,LIB,26
+Sully,Phoenix Center,State Auditor,,Richard Sattgast,REP,321
+Sully,Absentee Precinct,State Treasurer,,John Cunningham,DEM,40
+Sully,Absentee Precinct,State Treasurer,,Josh Haeder,REP,103
+Sully,Agar Fire Hall,State Treasurer,,John Cunningham,DEM,13
+Sully,Agar Fire Hall,State Treasurer,,Josh Haeder,REP,68
+Sully,Bill Floyd Shop,State Treasurer,,John Cunningham,DEM,22
+Sully,Bill Floyd Shop,State Treasurer,,Josh Haeder,REP,104
+Sully,Phoenix Center,State Treasurer,,John Cunningham,DEM,67
+Sully,Phoenix Center,State Treasurer,,Josh Haeder,REP,341
+Sully,Absentee Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,42
+Sully,Absentee Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,99
+Sully,Agar Fire Hall,Commissioner of School and Public Lands,,Timothy Azure,DEM,11
+Sully,Agar Fire Hall,Commissioner of School and Public Lands,,Brock Greenfield,REP,70
+Sully,Bill Floyd Shop,Commissioner of School and Public Lands,,Timothy Azure,DEM,27
+Sully,Bill Floyd Shop,Commissioner of School and Public Lands,,Brock Greenfield,REP,101
+Sully,Phoenix Center,Commissioner of School and Public Lands,,Timothy Azure,DEM,61
+Sully,Phoenix Center,Commissioner of School and Public Lands,,Brock Greenfield,REP,328
+Sully,Absentee Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,39
+Sully,Absentee Precinct,Public Utilities Commissioner,,Chris Nelson,REP,108
+Sully,Agar Fire Hall,Public Utilities Commissioner,,Jeffrey Barth,DEM,13
+Sully,Agar Fire Hall,Public Utilities Commissioner,,Chris Nelson,REP,68
+Sully,Bill Floyd Shop,Public Utilities Commissioner,,Jeffrey Barth,DEM,23
+Sully,Bill Floyd Shop,Public Utilities Commissioner,,Chris Nelson,REP,106
+Sully,Phoenix Center,Public Utilities Commissioner,,Jeffrey Barth,DEM,79
+Sully,Phoenix Center,Public Utilities Commissioner,,Chris Nelson,REP,337
+Sully,Absentee Precinct,State Senate,24,Jim Mehlhaff,REP,108
+Sully,Agar Fire Hall,State Senate,24,Jim Mehlhaff,REP,71
+Sully,Bill Floyd Shop,State Senate,24,Jim Mehlhaff,REP,109
+Sully,Phoenix Center,State Senate,24,Jim Mehlhaff,REP,338
+Sully,Absentee Precinct,State House,24,Mike Weisgram,REP,93
+Sully,Absentee Precinct,State House,24,Will D. Mortenson,REP,94
+Sully,Agar Fire Hall,State House,24,Mike Weisgram,REP,53
+Sully,Agar Fire Hall,State House,24,Will D. Mortenson,REP,60
+Sully,Bill Floyd Shop,State House,24,Mike Weisgram,REP,77
+Sully,Bill Floyd Shop,State House,24,Will D. Mortenson,REP,89
+Sully,Phoenix Center,State House,24,Mike Weisgram,REP,245
+Sully,Phoenix Center,State House,24,Will D. Mortenson,REP,299
+Sully,Absentee Precinct,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,86
+Sully,Agar Fire Hall,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,49
+Sully,Bill Floyd Shop,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,68
+Sully,Phoenix Center,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,242
+Sully,Absentee Precinct,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,84
+Sully,Agar Fire Hall,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,49
+Sully,Bill Floyd Shop,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,66
+Sully,Phoenix Center,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,255
+Sully,Absentee Precinct,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,82
+Sully,Agar Fire Hall,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,48
+Sully,Bill Floyd Shop,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,64
+Sully,Phoenix Center,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,246
+Sully,Absentee Precinct,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,80
+Sully,Agar Fire Hall,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,47
+Sully,Bill Floyd Shop,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,66
+Sully,Phoenix Center,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,234
+Sully,Absentee Precinct,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,106
+Sully,Absentee Precinct,Supreme Court Retention,3,Patricia J. DeVaney - No,,23
+Sully,Agar Fire Hall,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,66
+Sully,Agar Fire Hall,Supreme Court Retention,3,Patricia J. DeVaney - No,,7
+Sully,Bill Floyd Shop,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,90
+Sully,Bill Floyd Shop,Supreme Court Retention,3,Patricia J. DeVaney - No,,19
+Sully,Phoenix Center,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,321
+Sully,Phoenix Center,Supreme Court Retention,3,Patricia J. DeVaney - No,,58
+Sully,Absentee Precinct,Supreme Court Retention,2,Mark E. Salter - Yes,,107
+Sully,Absentee Precinct,Supreme Court Retention,2,Mark E. Salter - No,,22
+Sully,Agar Fire Hall,Supreme Court Retention,2,Mark E. Salter - Yes,,65
+Sully,Agar Fire Hall,Supreme Court Retention,2,Mark E. Salter - No,,7
+Sully,Bill Floyd Shop,Supreme Court Retention,2,Mark E. Salter - Yes,,93
+Sully,Bill Floyd Shop,Supreme Court Retention,2,Mark E. Salter - No,,15
+Sully,Phoenix Center,Supreme Court Retention,2,Mark E. Salter - Yes,,318
+Sully,Phoenix Center,Supreme Court Retention,2,Mark E. Salter - No,,55
+Sully,Absentee Precinct,Constitutional Amendment D,,Yes,,71
+Sully,Absentee Precinct,Constitutional Amendment D,,No,,73
+Sully,Agar Fire Hall,Constitutional Amendment D,,Yes,,30
+Sully,Agar Fire Hall,Constitutional Amendment D,,No,,50
+Sully,Bill Floyd Shop,Constitutional Amendment D,,Yes,,50
+Sully,Bill Floyd Shop,Constitutional Amendment D,,No,,82
+Sully,Phoenix Center,Constitutional Amendment D,,Yes,,189
+Sully,Phoenix Center,Constitutional Amendment D,,No,,238
+Sully,Absentee Precinct,Initiated Measure 27,,Yes,,56
+Sully,Absentee Precinct,Initiated Measure 27,,No,,92
+Sully,Agar Fire Hall,Initiated Measure 27,,Yes,,25
+Sully,Agar Fire Hall,Initiated Measure 27,,No,,57
+Sully,Bill Floyd Shop,Initiated Measure 27,,Yes,,61
+Sully,Bill Floyd Shop,Initiated Measure 27,,No,,75
+Sully,Phoenix Center,Initiated Measure 27,,Yes,,142
+Sully,Phoenix Center,Initiated Measure 27,,No,,284

--- a/2022/counties/20221108__sd__general__todd__precinct.csv
+++ b/2022/counties/20221108__sd__general__todd__precinct.csv
@@ -1,0 +1,361 @@
+county,precinct,office,district,candidate,party,votes
+Todd,Bordeaux,U.S. Senate,,Brian L. Bengs,DEM,42
+Todd,Bordeaux,U.S. Senate,,Tamara J Lesnar,LIB,2
+Todd,Bordeaux,U.S. Senate,,John R. Thune,REP,16
+Todd,Fairgrounds-10,U.S. Senate,,Brian L. Bengs,DEM,37
+Todd,Fairgrounds-10,U.S. Senate,,Tamara J Lesnar,LIB,0
+Todd,Fairgrounds-10,U.S. Senate,,John R. Thune,REP,8
+Todd,Jeanette,U.S. Senate,,Brian L. Bengs,DEM,7
+Todd,Jeanette,U.S. Senate,,Tamara J Lesnar,LIB,4
+Todd,Jeanette,U.S. Senate,,John R. Thune,REP,47
+Todd,Lakeview,U.S. Senate,,Brian L. Bengs,DEM,12
+Todd,Lakeview,U.S. Senate,,Tamara J Lesnar,LIB,7
+Todd,Lakeview,U.S. Senate,,John R. Thune,REP,76
+Todd,Mission-N. Antelope,U.S. Senate,,Brian L. Bengs,DEM,288
+Todd,Mission-N. Antelope,U.S. Senate,,Tamara J Lesnar,LIB,19
+Todd,Mission-N. Antelope,U.S. Senate,,John R. Thune,REP,86
+Todd,OKreek,U.S. Senate,,Brian L. Bengs,DEM,49
+Todd,OKreek,U.S. Senate,,Tamara J Lesnar,LIB,6
+Todd,OKreek,U.S. Senate,,John R. Thune,REP,31
+Todd,Parmelee,U.S. Senate,,Brian L. Bengs,DEM,193
+Todd,Parmelee,U.S. Senate,,Tamara J Lesnar,LIB,17
+Todd,Parmelee,U.S. Senate,,John R. Thune,REP,47
+Todd,Rosebud,U.S. Senate,,Brian L. Bengs,DEM,313
+Todd,Rosebud,U.S. Senate,,Tamara J Lesnar,LIB,17
+Todd,Rosebud,U.S. Senate,,John R. Thune,REP,67
+Todd,S. Antelope,U.S. Senate,,Brian L. Bengs,DEM,172
+Todd,S. Antelope,U.S. Senate,,Tamara J Lesnar,LIB,18
+Todd,S. Antelope,U.S. Senate,,John R. Thune,REP,67
+Todd,Saint Francis,U.S. Senate,,Brian L. Bengs,DEM,195
+Todd,Saint Francis,U.S. Senate,,Tamara J Lesnar,LIB,11
+Todd,Saint Francis,U.S. Senate,,John R. Thune,REP,57
+Todd,Bordeaux,U.S. House,1,Collin Duprel,LIB,28
+Todd,Bordeaux,U.S. House,1,Dusty Johnson,REP,23
+Todd,Fairgrounds-10,U.S. House,1,Collin Duprel,LIB,18
+Todd,Fairgrounds-10,U.S. House,1,Dusty Johnson,REP,18
+Todd,Jeanette,U.S. House,1,Collin Duprel,LIB,7
+Todd,Jeanette,U.S. House,1,Dusty Johnson,REP,52
+Todd,Lakeview,U.S. House,1,Collin Duprel,LIB,15
+Todd,Lakeview,U.S. House,1,Dusty Johnson,REP,78
+Todd,Mission-N. Antelope,U.S. House,1,Collin Duprel,LIB,205
+Todd,Mission-N. Antelope,U.S. House,1,Dusty Johnson,REP,130
+Todd,OKreek,U.S. House,1,Collin Duprel,LIB,34
+Todd,OKreek,U.S. House,1,Dusty Johnson,REP,40
+Todd,Parmelee,U.S. House,1,Collin Duprel,LIB,141
+Todd,Parmelee,U.S. House,1,Dusty Johnson,REP,71
+Todd,Rosebud,U.S. House,1,Collin Duprel,LIB,218
+Todd,Rosebud,U.S. House,1,Dusty Johnson,REP,113
+Todd,S. Antelope,U.S. House,1,Collin Duprel,LIB,140
+Todd,S. Antelope,U.S. House,1,Dusty Johnson,REP,85
+Todd,Saint Francis,U.S. House,1,Collin Duprel,LIB,141
+Todd,Saint Francis,U.S. House,1,Dusty Johnson,REP,67
+Todd,Bordeaux,Governor,,Jamie Smith and Jennifer Keintz,DEM,45
+Todd,Bordeaux,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Todd,Bordeaux,Governor,,Kristi Noem and Larry Rhoden,REP,15
+Todd,Fairgrounds-10,Governor,,Jamie Smith and Jennifer Keintz,DEM,39
+Todd,Fairgrounds-10,Governor,,Tracey Quint and Ashley Strand,LIB,0
+Todd,Fairgrounds-10,Governor,,Kristi Noem and Larry Rhoden,REP,7
+Todd,Jeanette,Governor,,Jamie Smith and Jennifer Keintz,DEM,5
+Todd,Jeanette,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Todd,Jeanette,Governor,,Kristi Noem and Larry Rhoden,REP,55
+Todd,Lakeview,Governor,,Jamie Smith and Jennifer Keintz,DEM,15
+Todd,Lakeview,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Todd,Lakeview,Governor,,Kristi Noem and Larry Rhoden,REP,80
+Todd,Mission-N. Antelope,Governor,,Jamie Smith and Jennifer Keintz,DEM,313
+Todd,Mission-N. Antelope,Governor,,Tracey Quint and Ashley Strand,LIB,21
+Todd,Mission-N. Antelope,Governor,,Kristi Noem and Larry Rhoden,REP,61
+Todd,OKreek,Governor,,Jamie Smith and Jennifer Keintz,DEM,53
+Todd,OKreek,Governor,,Tracey Quint and Ashley Strand,LIB,6
+Todd,OKreek,Governor,,Kristi Noem and Larry Rhoden,REP,31
+Todd,Parmelee,Governor,,Jamie Smith and Jennifer Keintz,DEM,215
+Todd,Parmelee,Governor,,Tracey Quint and Ashley Strand,LIB,12
+Todd,Parmelee,Governor,,Kristi Noem and Larry Rhoden,REP,28
+Todd,Rosebud,Governor,,Jamie Smith and Jennifer Keintz,DEM,352
+Todd,Rosebud,Governor,,Tracey Quint and Ashley Strand,LIB,12
+Todd,Rosebud,Governor,,Kristi Noem and Larry Rhoden,REP,39
+Todd,S. Antelope,Governor,,Jamie Smith and Jennifer Keintz,DEM,193
+Todd,S. Antelope,Governor,,Tracey Quint and Ashley Strand,LIB,11
+Todd,S. Antelope,Governor,,Kristi Noem and Larry Rhoden,REP,54
+Todd,Saint Francis,Governor,,Jamie Smith and Jennifer Keintz,DEM,214
+Todd,Saint Francis,Governor,,Tracey Quint and Ashley Strand,LIB,13
+Todd,Saint Francis,Governor,,Kristi Noem and Larry Rhoden,REP,32
+Todd,Bordeaux,Secretary of State,,Thomas A Cool,DEM,43
+Todd,Bordeaux,Secretary of State,,Monae Johnson,REP,17
+Todd,Fairgrounds-10,Secretary of State,,Thomas A Cool,DEM,38
+Todd,Fairgrounds-10,Secretary of State,,Monae Johnson,REP,7
+Todd,Jeanette,Secretary of State,,Thomas A Cool,DEM,5
+Todd,Jeanette,Secretary of State,,Monae Johnson,REP,50
+Todd,Lakeview,Secretary of State,,Thomas A Cool,DEM,15
+Todd,Lakeview,Secretary of State,,Monae Johnson,REP,76
+Todd,Mission-N. Antelope,Secretary of State,,Thomas A Cool,DEM,322
+Todd,Mission-N. Antelope,Secretary of State,,Monae Johnson,REP,71
+Todd,OKreek,Secretary of State,,Thomas A Cool,DEM,53
+Todd,OKreek,Secretary of State,,Monae Johnson,REP,31
+Todd,Parmelee,Secretary of State,,Thomas A Cool,DEM,221
+Todd,Parmelee,Secretary of State,,Monae Johnson,REP,31
+Todd,Rosebud,Secretary of State,,Thomas A Cool,DEM,342
+Todd,Rosebud,Secretary of State,,Monae Johnson,REP,47
+Todd,S. Antelope,Secretary of State,,Thomas A Cool,DEM,188
+Todd,S. Antelope,Secretary of State,,Monae Johnson,REP,66
+Todd,Saint Francis,Secretary of State,,Thomas A Cool,DEM,221
+Todd,Saint Francis,Secretary of State,,Monae Johnson,REP,39
+Todd,Bordeaux,Attorney General,,Marty J. Jackley,REP,27
+Todd,Fairgrounds-10,Attorney General,,Marty J. Jackley,REP,23
+Todd,Jeanette,Attorney General,,Marty J. Jackley,REP,53
+Todd,Lakeview,Attorney General,,Marty J. Jackley,REP,79
+Todd,Mission-N. Antelope,Attorney General,,Marty J. Jackley,REP,146
+Todd,OKreek,Attorney General,,Marty J. Jackley,REP,38
+Todd,Parmelee,Attorney General,,Marty J. Jackley,REP,86
+Todd,Rosebud,Attorney General,,Marty J. Jackley,REP,138
+Todd,S. Antelope,Attorney General,,Marty J. Jackley,REP,122
+Todd,Saint Francis,Attorney General,,Marty J. Jackley,REP,84
+Todd,Bordeaux,State Auditor,,Stephanie Marty,DEM,41
+Todd,Bordeaux,State Auditor,,Rene Meyer,LIB,2
+Todd,Bordeaux,State Auditor,,Richard Sattgast,REP,14
+Todd,Fairgrounds-10,State Auditor,,Stephanie Marty,DEM,36
+Todd,Fairgrounds-10,State Auditor,,Rene Meyer,LIB,0
+Todd,Fairgrounds-10,State Auditor,,Richard Sattgast,REP,8
+Todd,Jeanette,State Auditor,,Stephanie Marty,DEM,7
+Todd,Jeanette,State Auditor,,Rene Meyer,LIB,3
+Todd,Jeanette,State Auditor,,Richard Sattgast,REP,47
+Todd,Lakeview,State Auditor,,Stephanie Marty,DEM,17
+Todd,Lakeview,State Auditor,,Rene Meyer,LIB,10
+Todd,Lakeview,State Auditor,,Richard Sattgast,REP,63
+Todd,Mission-N. Antelope,State Auditor,,Stephanie Marty,DEM,293
+Todd,Mission-N. Antelope,State Auditor,,Rene Meyer,LIB,35
+Todd,Mission-N. Antelope,State Auditor,,Richard Sattgast,REP,60
+Todd,OKreek,State Auditor,,Stephanie Marty,DEM,52
+Todd,OKreek,State Auditor,,Rene Meyer,LIB,5
+Todd,OKreek,State Auditor,,Richard Sattgast,REP,28
+Todd,Parmelee,State Auditor,,Stephanie Marty,DEM,206
+Todd,Parmelee,State Auditor,,Rene Meyer,LIB,21
+Todd,Parmelee,State Auditor,,Richard Sattgast,REP,24
+Todd,Rosebud,State Auditor,,Stephanie Marty,DEM,334
+Todd,Rosebud,State Auditor,,Rene Meyer,LIB,20
+Todd,Rosebud,State Auditor,,Richard Sattgast,REP,35
+Todd,S. Antelope,State Auditor,,Stephanie Marty,DEM,181
+Todd,S. Antelope,State Auditor,,Rene Meyer,LIB,20
+Todd,S. Antelope,State Auditor,,Richard Sattgast,REP,53
+Todd,Saint Francis,State Auditor,,Stephanie Marty,DEM,213
+Todd,Saint Francis,State Auditor,,Rene Meyer,LIB,15
+Todd,Saint Francis,State Auditor,,Richard Sattgast,REP,32
+Todd,Bordeaux,State Treasurer,,John Cunningham,DEM,44
+Todd,Bordeaux,State Treasurer,,Josh Haeder,REP,17
+Todd,Fairgrounds-10,State Treasurer,,John Cunningham,DEM,37
+Todd,Fairgrounds-10,State Treasurer,,Josh Haeder,REP,8
+Todd,Jeanette,State Treasurer,,John Cunningham,DEM,7
+Todd,Jeanette,State Treasurer,,Josh Haeder,REP,50
+Todd,Lakeview,State Treasurer,,John Cunningham,DEM,16
+Todd,Lakeview,State Treasurer,,Josh Haeder,REP,76
+Todd,Mission-N. Antelope,State Treasurer,,John Cunningham,DEM,318
+Todd,Mission-N. Antelope,State Treasurer,,Josh Haeder,REP,68
+Todd,OKreek,State Treasurer,,John Cunningham,DEM,53
+Todd,OKreek,State Treasurer,,Josh Haeder,REP,30
+Todd,Parmelee,State Treasurer,,John Cunningham,DEM,218
+Todd,Parmelee,State Treasurer,,Josh Haeder,REP,33
+Todd,Rosebud,State Treasurer,,John Cunningham,DEM,350
+Todd,Rosebud,State Treasurer,,Josh Haeder,REP,43
+Todd,S. Antelope,State Treasurer,,John Cunningham,DEM,188
+Todd,S. Antelope,State Treasurer,,Josh Haeder,REP,62
+Todd,Saint Francis,State Treasurer,,John Cunningham,DEM,216
+Todd,Saint Francis,State Treasurer,,Josh Haeder,REP,42
+Todd,Bordeaux,Commissioner of School and Public Lands,,Timothy Azure,DEM,44
+Todd,Bordeaux,Commissioner of School and Public Lands,,Brock Greenfield,REP,17
+Todd,Fairgrounds-10,Commissioner of School and Public Lands,,Timothy Azure,DEM,37
+Todd,Fairgrounds-10,Commissioner of School and Public Lands,,Brock Greenfield,REP,7
+Todd,Jeanette,Commissioner of School and Public Lands,,Timothy Azure,DEM,6
+Todd,Jeanette,Commissioner of School and Public Lands,,Brock Greenfield,REP,49
+Todd,Lakeview,Commissioner of School and Public Lands,,Timothy Azure,DEM,16
+Todd,Lakeview,Commissioner of School and Public Lands,,Brock Greenfield,REP,73
+Todd,Mission-N. Antelope,Commissioner of School and Public Lands,,Timothy Azure,DEM,315
+Todd,Mission-N. Antelope,Commissioner of School and Public Lands,,Brock Greenfield,REP,70
+Todd,OKreek,Commissioner of School and Public Lands,,Timothy Azure,DEM,53
+Todd,OKreek,Commissioner of School and Public Lands,,Brock Greenfield,REP,30
+Todd,Parmelee,Commissioner of School and Public Lands,,Timothy Azure,DEM,213
+Todd,Parmelee,Commissioner of School and Public Lands,,Brock Greenfield,REP,35
+Todd,Rosebud,Commissioner of School and Public Lands,,Timothy Azure,DEM,348
+Todd,Rosebud,Commissioner of School and Public Lands,,Brock Greenfield,REP,42
+Todd,S. Antelope,Commissioner of School and Public Lands,,Timothy Azure,DEM,189
+Todd,S. Antelope,Commissioner of School and Public Lands,,Brock Greenfield,REP,64
+Todd,Saint Francis,Commissioner of School and Public Lands,,Timothy Azure,DEM,218
+Todd,Saint Francis,Commissioner of School and Public Lands,,Brock Greenfield,REP,33
+Todd,Bordeaux,Public Utilities Commissioner,,Jeffrey Barth,DEM,43
+Todd,Bordeaux,Public Utilities Commissioner,,Chris Nelson,REP,15
+Todd,Fairgrounds-10,Public Utilities Commissioner,,Jeffrey Barth,DEM,36
+Todd,Fairgrounds-10,Public Utilities Commissioner,,Chris Nelson,REP,9
+Todd,Jeanette,Public Utilities Commissioner,,Jeffrey Barth,DEM,5
+Todd,Jeanette,Public Utilities Commissioner,,Chris Nelson,REP,54
+Todd,Lakeview,Public Utilities Commissioner,,Jeffrey Barth,DEM,12
+Todd,Lakeview,Public Utilities Commissioner,,Chris Nelson,REP,79
+Todd,Mission-N. Antelope,Public Utilities Commissioner,,Jeffrey Barth,DEM,299
+Todd,Mission-N. Antelope,Public Utilities Commissioner,,Chris Nelson,REP,80
+Todd,OKreek,Public Utilities Commissioner,,Jeffrey Barth,DEM,52
+Todd,OKreek,Public Utilities Commissioner,,Chris Nelson,REP,32
+Todd,Parmelee,Public Utilities Commissioner,,Jeffrey Barth,DEM,204
+Todd,Parmelee,Public Utilities Commissioner,,Chris Nelson,REP,45
+Todd,Rosebud,Public Utilities Commissioner,,Jeffrey Barth,DEM,336
+Todd,Rosebud,Public Utilities Commissioner,,Chris Nelson,REP,54
+Todd,S. Antelope,Public Utilities Commissioner,,Jeffrey Barth,DEM,186
+Todd,S. Antelope,Public Utilities Commissioner,,Chris Nelson,REP,66
+Todd,Saint Francis,Public Utilities Commissioner,,Jeffrey Barth,DEM,206
+Todd,Saint Francis,Public Utilities Commissioner,,Chris Nelson,REP,42
+Todd,Bordeaux,State Senate,26,Shawn Bordeaux,DEM,45
+Todd,Bordeaux,State Senate,26,Joel Koskan,REP,16
+Todd,Fairgrounds-10,State Senate,26,Shawn Bordeaux,DEM,35
+Todd,Fairgrounds-10,State Senate,26,Joel Koskan,REP,8
+Todd,Jeanette,State Senate,26,Shawn Bordeaux,DEM,9
+Todd,Jeanette,State Senate,26,Joel Koskan,REP,37
+Todd,Lakeview,State Senate,26,Shawn Bordeaux,DEM,21
+Todd,Lakeview,State Senate,26,Joel Koskan,REP,68
+Todd,Mission-N. Antelope,State Senate,26,Shawn Bordeaux,DEM,319
+Todd,Mission-N. Antelope,State Senate,26,Joel Koskan,REP,54
+Todd,OKreek,State Senate,26,Shawn Bordeaux,DEM,54
+Todd,OKreek,State Senate,26,Joel Koskan,REP,20
+Todd,Parmelee,State Senate,26,Shawn Bordeaux,DEM,227
+Todd,Parmelee,State Senate,26,Joel Koskan,REP,23
+Todd,Rosebud,State Senate,26,Shawn Bordeaux,DEM,359
+Todd,Rosebud,State Senate,26,Joel Koskan,REP,32
+Todd,S. Antelope,State Senate,26,Shawn Bordeaux,DEM,198
+Todd,S. Antelope,State Senate,26,Joel Koskan,REP,46
+Todd,Saint Francis,State Senate,26,Shawn Bordeaux,DEM,218
+Todd,Saint Francis,State Senate,26,Joel Koskan,REP,35
+Todd,Bordeaux,State House,26A,Eric Emery,DEM,47
+Todd,Bordeaux,State House,26A,Joyce Glynn,REP,15
+Todd,Fairgrounds-10,State House,26A,Eric Emery,DEM,38
+Todd,Fairgrounds-10,State House,26A,Joyce Glynn,REP,8
+Todd,Jeanette,State House,26A,Eric Emery,DEM,3
+Todd,Jeanette,State House,26A,Joyce Glynn,REP,55
+Todd,Lakeview,State House,26A,Eric Emery,DEM,18
+Todd,Lakeview,State House,26A,Joyce Glynn,REP,77
+Todd,Mission-N. Antelope,State House,26A,Eric Emery,DEM,324
+Todd,Mission-N. Antelope,State House,26A,Joyce Glynn,REP,67
+Todd,OKreek,State House,26A,Eric Emery,DEM,53
+Todd,OKreek,State House,26A,Joyce Glynn,REP,30
+Todd,Parmelee,State House,26A,Eric Emery,DEM,217
+Todd,Parmelee,State House,26A,Joyce Glynn,REP,31
+Todd,Rosebud,State House,26A,Eric Emery,DEM,360
+Todd,Rosebud,State House,26A,Joyce Glynn,REP,38
+Todd,S. Antelope,State House,26A,Eric Emery,DEM,194
+Todd,S. Antelope,State House,26A,Joyce Glynn,REP,59
+Todd,Saint Francis,State House,26A,Eric Emery,DEM,230
+Todd,Saint Francis,State House,26A,Joyce Glynn,REP,32
+Todd,Bordeaux,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,20
+Todd,Fairgrounds-10,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,17
+Todd,Jeanette,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,11
+Todd,Lakeview,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,35
+Todd,Mission-N. Antelope,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,110
+Todd,OKreek,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,18
+Todd,Parmelee,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,76
+Todd,Rosebud,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,121
+Todd,S. Antelope,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,79
+Todd,Saint Francis,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,53
+Todd,Bordeaux,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,20
+Todd,Fairgrounds-10,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,16
+Todd,Jeanette,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,12
+Todd,Lakeview,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,33
+Todd,Mission-N. Antelope,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,99
+Todd,OKreek,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,19
+Todd,Parmelee,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,69
+Todd,Rosebud,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,109
+Todd,S. Antelope,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,68
+Todd,Saint Francis,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,52
+Todd,Bordeaux,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,18
+Todd,Fairgrounds-10,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,17
+Todd,Jeanette,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,14
+Todd,Lakeview,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,31
+Todd,Mission-N. Antelope,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,103
+Todd,OKreek,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,17
+Todd,Parmelee,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,65
+Todd,Rosebud,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,116
+Todd,S. Antelope,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,69
+Todd,Saint Francis,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,53
+Todd,Bordeaux,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,20
+Todd,Fairgrounds-10,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,15
+Todd,Jeanette,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,20
+Todd,Lakeview,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,35
+Todd,Mission-N. Antelope,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,112
+Todd,OKreek,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,27
+Todd,Parmelee,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,69
+Todd,Rosebud,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,113
+Todd,S. Antelope,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,79
+Todd,Saint Francis,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,54
+Todd,Bordeaux,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,41
+Todd,Bordeaux,Supreme Court Retention,3,Patricia J. DeVaney - No,,13
+Todd,Fairgrounds-10,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,23
+Todd,Fairgrounds-10,Supreme Court Retention,3,Patricia J. DeVaney - No,,12
+Todd,Jeanette,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,32
+Todd,Jeanette,Supreme Court Retention,3,Patricia J. DeVaney - No,,10
+Todd,Lakeview,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,61
+Todd,Lakeview,Supreme Court Retention,3,Patricia J. DeVaney - No,,21
+Todd,Mission-N. Antelope,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,179
+Todd,Mission-N. Antelope,Supreme Court Retention,3,Patricia J. DeVaney - No,,159
+Todd,OKreek,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,39
+Todd,OKreek,Supreme Court Retention,3,Patricia J. DeVaney - No,,34
+Todd,Parmelee,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,119
+Todd,Parmelee,Supreme Court Retention,3,Patricia J. DeVaney - No,,109
+Todd,Rosebud,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,189
+Todd,Rosebud,Supreme Court Retention,3,Patricia J. DeVaney - No,,153
+Todd,S. Antelope,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,114
+Todd,S. Antelope,Supreme Court Retention,3,Patricia J. DeVaney - No,,111
+Todd,Saint Francis,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,120
+Todd,Saint Francis,Supreme Court Retention,3,Patricia J. DeVaney - No,,88
+Todd,Bordeaux,Supreme Court Retention,2,Mark E. Salter - Yes,,34
+Todd,Bordeaux,Supreme Court Retention,2,Mark E. Salter - No,,20
+Todd,Fairgrounds-10,Supreme Court Retention,2,Mark E. Salter - Yes,,24
+Todd,Fairgrounds-10,Supreme Court Retention,2,Mark E. Salter - No,,12
+Todd,Jeanette,Supreme Court Retention,2,Mark E. Salter - Yes,,31
+Todd,Jeanette,Supreme Court Retention,2,Mark E. Salter - No,,9
+Todd,Lakeview,Supreme Court Retention,2,Mark E. Salter - Yes,,57
+Todd,Lakeview,Supreme Court Retention,2,Mark E. Salter - No,,21
+Todd,Mission-N. Antelope,Supreme Court Retention,2,Mark E. Salter - Yes,,170
+Todd,Mission-N. Antelope,Supreme Court Retention,2,Mark E. Salter - No,,166
+Todd,OKreek,Supreme Court Retention,2,Mark E. Salter - Yes,,40
+Todd,OKreek,Supreme Court Retention,2,Mark E. Salter - No,,33
+Todd,Parmelee,Supreme Court Retention,2,Mark E. Salter - Yes,,103
+Todd,Parmelee,Supreme Court Retention,2,Mark E. Salter - No,,121
+Todd,Rosebud,Supreme Court Retention,2,Mark E. Salter - Yes,,166
+Todd,Rosebud,Supreme Court Retention,2,Mark E. Salter - No,,175
+Todd,S. Antelope,Supreme Court Retention,2,Mark E. Salter - Yes,,115
+Todd,S. Antelope,Supreme Court Retention,2,Mark E. Salter - No,,110
+Todd,Saint Francis,Supreme Court Retention,2,Mark E. Salter - Yes,,115
+Todd,Saint Francis,Supreme Court Retention,2,Mark E. Salter - No,,95
+Todd,Bordeaux,Constitutional Amendment D,,Yes,,43
+Todd,Bordeaux,Constitutional Amendment D,,No,,16
+Todd,Fairgrounds-10,Constitutional Amendment D,,Yes,,37
+Todd,Fairgrounds-10,Constitutional Amendment D,,No,,6
+Todd,Jeanette,Constitutional Amendment D,,Yes,,14
+Todd,Jeanette,Constitutional Amendment D,,No,,41
+Todd,Lakeview,Constitutional Amendment D,,Yes,,40
+Todd,Lakeview,Constitutional Amendment D,,No,,55
+Todd,Mission-N. Antelope,Constitutional Amendment D,,Yes,,348
+Todd,Mission-N. Antelope,Constitutional Amendment D,,No,,47
+Todd,OKreek,Constitutional Amendment D,,Yes,,64
+Todd,OKreek,Constitutional Amendment D,,No,,21
+Todd,Parmelee,Constitutional Amendment D,,Yes,,224
+Todd,Parmelee,Constitutional Amendment D,,No,,32
+Todd,Rosebud,Constitutional Amendment D,,Yes,,357
+Todd,Rosebud,Constitutional Amendment D,,No,,40
+Todd,S. Antelope,Constitutional Amendment D,,Yes,,200
+Todd,S. Antelope,Constitutional Amendment D,,No,,54
+Todd,Saint Francis,Constitutional Amendment D,,Yes,,208
+Todd,Saint Francis,Constitutional Amendment D,,No,,35
+Todd,Bordeaux,Initiated Measure 27,,Yes,,43
+Todd,Bordeaux,Initiated Measure 27,,No,,18
+Todd,Fairgrounds-10,Initiated Measure 27,,Yes,,36
+Todd,Fairgrounds-10,Initiated Measure 27,,No,,8
+Todd,Jeanette,Initiated Measure 27,,Yes,,9
+Todd,Jeanette,Initiated Measure 27,,No,,46
+Todd,Lakeview,Initiated Measure 27,,Yes,,23
+Todd,Lakeview,Initiated Measure 27,,No,,73
+Todd,Mission-N. Antelope,Initiated Measure 27,,Yes,,311
+Todd,Mission-N. Antelope,Initiated Measure 27,,No,,83
+Todd,OKreek,Initiated Measure 27,,Yes,,57
+Todd,OKreek,Initiated Measure 27,,No,,30
+Todd,Parmelee,Initiated Measure 27,,Yes,,204
+Todd,Parmelee,Initiated Measure 27,,No,,52
+Todd,Rosebud,Initiated Measure 27,,Yes,,343
+Todd,Rosebud,Initiated Measure 27,,No,,55
+Todd,S. Antelope,Initiated Measure 27,,Yes,,204
+Todd,S. Antelope,Initiated Measure 27,,No,,53
+Todd,Saint Francis,Initiated Measure 27,,Yes,,194
+Todd,Saint Francis,Initiated Measure 27,,No,,54

--- a/2022/counties/20221108__sd__general__tripp__precinct.csv
+++ b/2022/counties/20221108__sd__general__tripp__precinct.csv
@@ -1,0 +1,469 @@
+county,precinct,office,district,candidate,party,votes
+Tripp,Clearfield Consolidated,U.S. Senate,,Brian L. Bengs,DEM,19
+Tripp,Clearfield Consolidated,U.S. Senate,,Tamara J Lesnar,LIB,12
+Tripp,Clearfield Consolidated,U.S. Senate,,John R. Thune,REP,101
+Tripp,Colome Consolidated,U.S. Senate,,Brian L. Bengs,DEM,43
+Tripp,Colome Consolidated,U.S. Senate,,Tamara J Lesnar,LIB,17
+Tripp,Colome Consolidated,U.S. Senate,,John R. Thune,REP,285
+Tripp,Hamill Consolidated,U.S. Senate,,Brian L. Bengs,DEM,5
+Tripp,Hamill Consolidated,U.S. Senate,,Tamara J Lesnar,LIB,3
+Tripp,Hamill Consolidated,U.S. Senate,,John R. Thune,REP,73
+Tripp,Ideal Consolidated,U.S. Senate,,Brian L. Bengs,DEM,8
+Tripp,Ideal Consolidated,U.S. Senate,,Tamara J Lesnar,LIB,0
+Tripp,Ideal Consolidated,U.S. Senate,,John R. Thune,REP,57
+Tripp,Lake Consolidated,U.S. Senate,,Brian L. Bengs,DEM,15
+Tripp,Lake Consolidated,U.S. Senate,,Tamara J Lesnar,LIB,9
+Tripp,Lake Consolidated,U.S. Senate,,John R. Thune,REP,115
+Tripp,Lamro Consolidated,U.S. Senate,,Brian L. Bengs,DEM,34
+Tripp,Lamro Consolidated,U.S. Senate,,Tamara J Lesnar,LIB,19
+Tripp,Lamro Consolidated,U.S. Senate,,John R. Thune,REP,242
+Tripp,Sully Consolidated,U.S. Senate,,Brian L. Bengs,DEM,13
+Tripp,Sully Consolidated,U.S. Senate,,Tamara J Lesnar,LIB,4
+Tripp,Sully Consolidated,U.S. Senate,,John R. Thune,REP,69
+Tripp,?,U.S. Senate,,Brian L. Bengs,DEM,8
+Tripp,?,U.S. Senate,,Tamara J Lesnar,LIB,4
+Tripp,?,U.S. Senate,,John R. Thune,REP,98
+Tripp,?,U.S. Senate,,Brian L. Bengs,DEM,25
+Tripp,?,U.S. Senate,,Tamara J Lesnar,LIB,11
+Tripp,?,U.S. Senate,,John R. Thune,REP,198
+Tripp,?,U.S. Senate,,Brian L. Bengs,DEM,25
+Tripp,?,U.S. Senate,,Tamara J Lesnar,LIB,11
+Tripp,?,U.S. Senate,,John R. Thune,REP,205
+Tripp,?,U.S. Senate,,Brian L. Bengs,DEM,38
+Tripp,?,U.S. Senate,,Tamara J Lesnar,LIB,10
+Tripp,?,U.S. Senate,,John R. Thune,REP,214
+Tripp,?,U.S. Senate,,Brian L. Bengs,DEM,19
+Tripp,?,U.S. Senate,,Tamara J Lesnar,LIB,8
+Tripp,?,U.S. Senate,,John R. Thune,REP,129
+Tripp,Witten Consolidated,U.S. Senate,,Brian L. Bengs,DEM,11
+Tripp,Witten Consolidated,U.S. Senate,,Tamara J Lesnar,LIB,5
+Tripp,Witten Consolidated,U.S. Senate,,John R. Thune,REP,75
+Tripp,Clearfield Consolidated,U.S. House,1,Collin Duprel,LIB,24
+Tripp,Clearfield Consolidated,U.S. House,1,Dusty Johnson,REP,105
+Tripp,Colome Consolidated,U.S. House,1,Collin Duprel,LIB,54
+Tripp,Colome Consolidated,U.S. House,1,Dusty Johnson,REP,292
+Tripp,Hamill Consolidated,U.S. House,1,Collin Duprel,LIB,7
+Tripp,Hamill Consolidated,U.S. House,1,Dusty Johnson,REP,73
+Tripp,Ideal Consolidated,U.S. House,1,Collin Duprel,LIB,7
+Tripp,Ideal Consolidated,U.S. House,1,Dusty Johnson,REP,54
+Tripp,Lake Consolidated,U.S. House,1,Collin Duprel,LIB,19
+Tripp,Lake Consolidated,U.S. House,1,Dusty Johnson,REP,117
+Tripp,Lamro Consolidated,U.S. House,1,Collin Duprel,LIB,46
+Tripp,Lamro Consolidated,U.S. House,1,Dusty Johnson,REP,239
+Tripp,Sully Consolidated,U.S. House,1,Collin Duprel,LIB,20
+Tripp,Sully Consolidated,U.S. House,1,Dusty Johnson,REP,63
+Tripp,?,U.S. House,1,Collin Duprel,LIB,7
+Tripp,?,U.S. House,1,Dusty Johnson,REP,100
+Tripp,?,U.S. House,1,Collin Duprel,LIB,33
+Tripp,?,U.S. House,1,Dusty Johnson,REP,196
+Tripp,?,U.S. House,1,Collin Duprel,LIB,35
+Tripp,?,U.S. House,1,Dusty Johnson,REP,204
+Tripp,?,U.S. House,1,Collin Duprel,LIB,32
+Tripp,?,U.S. House,1,Dusty Johnson,REP,226
+Tripp,?,U.S. House,1,Collin Duprel,LIB,20
+Tripp,?,U.S. House,1,Dusty Johnson,REP,126
+Tripp,Witten Consolidated,U.S. House,1,Collin Duprel,LIB,21
+Tripp,Witten Consolidated,U.S. House,1,Dusty Johnson,REP,70
+Tripp,Clearfield Consolidated,Governor,,Jamie Smith and Jennifer Keintz,DEM,28
+Tripp,Clearfield Consolidated,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Tripp,Clearfield Consolidated,Governor,,Kristi Noem and Larry Rhoden,REP,108
+Tripp,Colome Consolidated,Governor,,Jamie Smith and Jennifer Keintz,DEM,49
+Tripp,Colome Consolidated,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Tripp,Colome Consolidated,Governor,,Kristi Noem and Larry Rhoden,REP,299
+Tripp,Hamill Consolidated,Governor,,Jamie Smith and Jennifer Keintz,DEM,9
+Tripp,Hamill Consolidated,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Tripp,Hamill Consolidated,Governor,,Kristi Noem and Larry Rhoden,REP,73
+Tripp,Ideal Consolidated,Governor,,Jamie Smith and Jennifer Keintz,DEM,12
+Tripp,Ideal Consolidated,Governor,,Tracey Quint and Ashley Strand,LIB,0
+Tripp,Ideal Consolidated,Governor,,Kristi Noem and Larry Rhoden,REP,53
+Tripp,Lake Consolidated,Governor,,Jamie Smith and Jennifer Keintz,DEM,19
+Tripp,Lake Consolidated,Governor,,Tracey Quint and Ashley Strand,LIB,0
+Tripp,Lake Consolidated,Governor,,Kristi Noem and Larry Rhoden,REP,117
+Tripp,Lamro Consolidated,Governor,,Jamie Smith and Jennifer Keintz,DEM,49
+Tripp,Lamro Consolidated,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Tripp,Lamro Consolidated,Governor,,Kristi Noem and Larry Rhoden,REP,250
+Tripp,Sully Consolidated,Governor,,Jamie Smith and Jennifer Keintz,DEM,16
+Tripp,Sully Consolidated,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Tripp,Sully Consolidated,Governor,,Kristi Noem and Larry Rhoden,REP,67
+Tripp,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,15
+Tripp,?,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Tripp,?,Governor,,Kristi Noem and Larry Rhoden,REP,93
+Tripp,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,40
+Tripp,?,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Tripp,?,Governor,,Kristi Noem and Larry Rhoden,REP,189
+Tripp,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,32
+Tripp,?,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Tripp,?,Governor,,Kristi Noem and Larry Rhoden,REP,208
+Tripp,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,46
+Tripp,?,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Tripp,?,Governor,,Kristi Noem and Larry Rhoden,REP,220
+Tripp,?,Governor,,Jamie Smith and Jennifer Keintz,DEM,33
+Tripp,?,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Tripp,?,Governor,,Kristi Noem and Larry Rhoden,REP,123
+Tripp,Witten Consolidated,Governor,,Jamie Smith and Jennifer Keintz,DEM,16
+Tripp,Witten Consolidated,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Tripp,Witten Consolidated,Governor,,Kristi Noem and Larry Rhoden,REP,73
+Tripp,Clearfield Consolidated,Secretary of State,,Thomas A Cool,DEM,29
+Tripp,Clearfield Consolidated,Secretary of State,,Monae Johnson,REP,107
+Tripp,Colome Consolidated,Secretary of State,,Thomas A Cool,DEM,62
+Tripp,Colome Consolidated,Secretary of State,,Monae Johnson,REP,278
+Tripp,Hamill Consolidated,Secretary of State,,Thomas A Cool,DEM,12
+Tripp,Hamill Consolidated,Secretary of State,,Monae Johnson,REP,70
+Tripp,Ideal Consolidated,Secretary of State,,Thomas A Cool,DEM,9
+Tripp,Ideal Consolidated,Secretary of State,,Monae Johnson,REP,55
+Tripp,Lake Consolidated,Secretary of State,,Thomas A Cool,DEM,24
+Tripp,Lake Consolidated,Secretary of State,,Monae Johnson,REP,115
+Tripp,Lamro Consolidated,Secretary of State,,Thomas A Cool,DEM,59
+Tripp,Lamro Consolidated,Secretary of State,,Monae Johnson,REP,231
+Tripp,Sully Consolidated,Secretary of State,,Thomas A Cool,DEM,20
+Tripp,Sully Consolidated,Secretary of State,,Monae Johnson,REP,64
+Tripp,?,Secretary of State,,Thomas A Cool,DEM,13
+Tripp,?,Secretary of State,,Monae Johnson,REP,95
+Tripp,?,Secretary of State,,Thomas A Cool,DEM,39
+Tripp,?,Secretary of State,,Monae Johnson,REP,186
+Tripp,?,Secretary of State,,Thomas A Cool,DEM,40
+Tripp,?,Secretary of State,,Monae Johnson,REP,204
+Tripp,?,Secretary of State,,Thomas A Cool,DEM,54
+Tripp,?,Secretary of State,,Monae Johnson,REP,207
+Tripp,?,Secretary of State,,Thomas A Cool,DEM,34
+Tripp,?,Secretary of State,,Monae Johnson,REP,119
+Tripp,Witten Consolidated,Secretary of State,,Thomas A Cool,DEM,22
+Tripp,Witten Consolidated,Secretary of State,,Monae Johnson,REP,69
+Tripp,Clearfield Consolidated,Attorney General,,Marty J. Jackley,REP,101
+Tripp,Colome Consolidated,Attorney General,,Marty J. Jackley,REP,302
+Tripp,Hamill Consolidated,Attorney General,,Marty J. Jackley,REP,70
+Tripp,Ideal Consolidated,Attorney General,,Marty J. Jackley,REP,55
+Tripp,Lake Consolidated,Attorney General,,Marty J. Jackley,REP,114
+Tripp,Lamro Consolidated,Attorney General,,Marty J. Jackley,REP,239
+Tripp,Sully Consolidated,Attorney General,,Marty J. Jackley,REP,80
+Tripp,?,Attorney General,,Marty J. Jackley,REP,97
+Tripp,?,Attorney General,,Marty J. Jackley,REP,198
+Tripp,?,Attorney General,,Marty J. Jackley,REP,206
+Tripp,?,Attorney General,,Marty J. Jackley,REP,222
+Tripp,?,Attorney General,,Marty J. Jackley,REP,122
+Tripp,Witten Consolidated,Attorney General,,Marty J. Jackley,REP,70
+Tripp,Clearfield Consolidated,State Auditor,,Stephanie Marty,DEM,25
+Tripp,Clearfield Consolidated,State Auditor,,Rene Meyer,LIB,5
+Tripp,Clearfield Consolidated,State Auditor,,Richard Sattgast,REP,103
+Tripp,Colome Consolidated,State Auditor,,Stephanie Marty,DEM,50
+Tripp,Colome Consolidated,State Auditor,,Rene Meyer,LIB,19
+Tripp,Colome Consolidated,State Auditor,,Richard Sattgast,REP,263
+Tripp,Hamill Consolidated,State Auditor,,Stephanie Marty,DEM,8
+Tripp,Hamill Consolidated,State Auditor,,Rene Meyer,LIB,4
+Tripp,Hamill Consolidated,State Auditor,,Richard Sattgast,REP,69
+Tripp,Ideal Consolidated,State Auditor,,Stephanie Marty,DEM,10
+Tripp,Ideal Consolidated,State Auditor,,Rene Meyer,LIB,0
+Tripp,Ideal Consolidated,State Auditor,,Richard Sattgast,REP,52
+Tripp,Lake Consolidated,State Auditor,,Stephanie Marty,DEM,21
+Tripp,Lake Consolidated,State Auditor,,Rene Meyer,LIB,4
+Tripp,Lake Consolidated,State Auditor,,Richard Sattgast,REP,111
+Tripp,Lamro Consolidated,State Auditor,,Stephanie Marty,DEM,53
+Tripp,Lamro Consolidated,State Auditor,,Rene Meyer,LIB,13
+Tripp,Lamro Consolidated,State Auditor,,Richard Sattgast,REP,221
+Tripp,Sully Consolidated,State Auditor,,Stephanie Marty,DEM,17
+Tripp,Sully Consolidated,State Auditor,,Rene Meyer,LIB,6
+Tripp,Sully Consolidated,State Auditor,,Richard Sattgast,REP,61
+Tripp,?,State Auditor,,Stephanie Marty,DEM,12
+Tripp,?,State Auditor,,Rene Meyer,LIB,3
+Tripp,?,State Auditor,,Richard Sattgast,REP,92
+Tripp,?,State Auditor,,Stephanie Marty,DEM,40
+Tripp,?,State Auditor,,Rene Meyer,LIB,9
+Tripp,?,State Auditor,,Richard Sattgast,REP,174
+Tripp,?,State Auditor,,Stephanie Marty,DEM,31
+Tripp,?,State Auditor,,Rene Meyer,LIB,15
+Tripp,?,State Auditor,,Richard Sattgast,REP,96
+Tripp,?,State Auditor,,Stephanie Marty,DEM,48
+Tripp,?,State Auditor,,Rene Meyer,LIB,14
+Tripp,?,State Auditor,,Richard Sattgast,REP,193
+Tripp,?,State Auditor,,Stephanie Marty,DEM,34
+Tripp,?,State Auditor,,Rene Meyer,LIB,8
+Tripp,?,State Auditor,,Richard Sattgast,REP,112
+Tripp,Witten Consolidated,State Auditor,,Stephanie Marty,DEM,15
+Tripp,Witten Consolidated,State Auditor,,Rene Meyer,LIB,8
+Tripp,Witten Consolidated,State Auditor,,Richard Sattgast,REP,65
+Tripp,Clearfield Consolidated,State Treasurer,,John Cunningham,DEM,25
+Tripp,Clearfield Consolidated,State Treasurer,,Josh Haeder,REP,109
+Tripp,Colome Consolidated,State Treasurer,,John Cunningham,DEM,56
+Tripp,Colome Consolidated,State Treasurer,,Josh Haeder,REP,276
+Tripp,Hamill Consolidated,State Treasurer,,John Cunningham,DEM,9
+Tripp,Hamill Consolidated,State Treasurer,,Josh Haeder,REP,71
+Tripp,Ideal Consolidated,State Treasurer,,John Cunningham,DEM,9
+Tripp,Ideal Consolidated,State Treasurer,,Josh Haeder,REP,54
+Tripp,Lake Consolidated,State Treasurer,,John Cunningham,DEM,23
+Tripp,Lake Consolidated,State Treasurer,,Josh Haeder,REP,108
+Tripp,Lamro Consolidated,State Treasurer,,John Cunningham,DEM,57
+Tripp,Lamro Consolidated,State Treasurer,,Josh Haeder,REP,229
+Tripp,Sully Consolidated,State Treasurer,,John Cunningham,DEM,19
+Tripp,Sully Consolidated,State Treasurer,,Josh Haeder,REP,64
+Tripp,?,State Treasurer,,John Cunningham,DEM,14
+Tripp,?,State Treasurer,,Josh Haeder,REP,87
+Tripp,?,State Treasurer,,John Cunningham,DEM,37
+Tripp,?,State Treasurer,,Josh Haeder,REP,183
+Tripp,?,State Treasurer,,John Cunningham,DEM,38
+Tripp,?,State Treasurer,,Josh Haeder,REP,203
+Tripp,?,State Treasurer,,John Cunningham,DEM,55
+Tripp,?,State Treasurer,,Josh Haeder,REP,196
+Tripp,?,State Treasurer,,John Cunningham,DEM,33
+Tripp,?,State Treasurer,,Josh Haeder,REP,117
+Tripp,Witten Consolidated,State Treasurer,,John Cunningham,DEM,23
+Tripp,Witten Consolidated,State Treasurer,,Josh Haeder,REP,63
+Tripp,Clearfield Consolidated,Commissioner of School and Public Lands,,Timothy Azure,DEM,23
+Tripp,Clearfield Consolidated,Commissioner of School and Public Lands,,Brock Greenfield,REP,109
+Tripp,Colome Consolidated,Commissioner of School and Public Lands,,Timothy Azure,DEM,42
+Tripp,Colome Consolidated,Commissioner of School and Public Lands,,Brock Greenfield,REP,287
+Tripp,Hamill Consolidated,Commissioner of School and Public Lands,,Timothy Azure,DEM,8
+Tripp,Hamill Consolidated,Commissioner of School and Public Lands,,Brock Greenfield,REP,72
+Tripp,Ideal Consolidated,Commissioner of School and Public Lands,,Timothy Azure,DEM,7
+Tripp,Ideal Consolidated,Commissioner of School and Public Lands,,Brock Greenfield,REP,54
+Tripp,Lake Consolidated,Commissioner of School and Public Lands,,Timothy Azure,DEM,21
+Tripp,Lake Consolidated,Commissioner of School and Public Lands,,Brock Greenfield,REP,110
+Tripp,Lamro Consolidated,Commissioner of School and Public Lands,,Timothy Azure,DEM,50
+Tripp,Lamro Consolidated,Commissioner of School and Public Lands,,Brock Greenfield,REP,234
+Tripp,Sully Consolidated,Commissioner of School and Public Lands,,Timothy Azure,DEM,16
+Tripp,Sully Consolidated,Commissioner of School and Public Lands,,Brock Greenfield,REP,66
+Tripp,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,11
+Tripp,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,88
+Tripp,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,38
+Tripp,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,184
+Tripp,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,36
+Tripp,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,198
+Tripp,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,48
+Tripp,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,201
+Tripp,?,Commissioner of School and Public Lands,,Timothy Azure,DEM,30
+Tripp,?,Commissioner of School and Public Lands,,Brock Greenfield,REP,118
+Tripp,Witten Consolidated,Commissioner of School and Public Lands,,Timothy Azure,DEM,20
+Tripp,Witten Consolidated,Commissioner of School and Public Lands,,Brock Greenfield,REP,67
+Tripp,Clearfield Consolidated,Public Utilities Commissioner,,Jeffrey Barth,DEM,27
+Tripp,Clearfield Consolidated,Public Utilities Commissioner,,Chris Nelson,REP,108
+Tripp,Colome Consolidated,Public Utilities Commissioner,,Jeffrey Barth,DEM,41
+Tripp,Colome Consolidated,Public Utilities Commissioner,,Chris Nelson,REP,291
+Tripp,Hamill Consolidated,Public Utilities Commissioner,,Jeffrey Barth,DEM,7
+Tripp,Hamill Consolidated,Public Utilities Commissioner,,Chris Nelson,REP,74
+Tripp,Ideal Consolidated,Public Utilities Commissioner,,Jeffrey Barth,DEM,8
+Tripp,Ideal Consolidated,Public Utilities Commissioner,,Chris Nelson,REP,55
+Tripp,Lake Consolidated,Public Utilities Commissioner,,Jeffrey Barth,DEM,22
+Tripp,Lake Consolidated,Public Utilities Commissioner,,Chris Nelson,REP,112
+Tripp,Lamro Consolidated,Public Utilities Commissioner,,Jeffrey Barth,DEM,48
+Tripp,Lamro Consolidated,Public Utilities Commissioner,,Chris Nelson,REP,241
+Tripp,Sully Consolidated,Public Utilities Commissioner,,Jeffrey Barth,DEM,14
+Tripp,Sully Consolidated,Public Utilities Commissioner,,Chris Nelson,REP,70
+Tripp,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,14
+Tripp,?,Public Utilities Commissioner,,Chris Nelson,REP,93
+Tripp,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,32
+Tripp,?,Public Utilities Commissioner,,Chris Nelson,REP,192
+Tripp,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,29
+Tripp,?,Public Utilities Commissioner,,Chris Nelson,REP,209
+Tripp,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,44
+Tripp,?,Public Utilities Commissioner,,Chris Nelson,REP,212
+Tripp,?,Public Utilities Commissioner,,Jeffrey Barth,DEM,30
+Tripp,?,Public Utilities Commissioner,,Chris Nelson,REP,124
+Tripp,Witten Consolidated,Public Utilities Commissioner,,Jeffrey Barth,DEM,15
+Tripp,Witten Consolidated,Public Utilities Commissioner,,Chris Nelson,REP,76
+Tripp,Clearfield Consolidated,State Senate,21,Dan Andersson,DEM,24
+Tripp,Clearfield Consolidated,State Senate,21,Erin Tobin,REP,114
+Tripp,Colome Consolidated,State Senate,21,Dan Andersson,DEM,49
+Tripp,Colome Consolidated,State Senate,21,Erin Tobin,REP,287
+Tripp,Hamill Consolidated,State Senate,21,Dan Andersson,DEM,8
+Tripp,Hamill Consolidated,State Senate,21,Erin Tobin,REP,69
+Tripp,Ideal Consolidated,State Senate,21,Dan Andersson,DEM,9
+Tripp,Ideal Consolidated,State Senate,21,Erin Tobin,REP,54
+Tripp,Lake Consolidated,State Senate,21,Dan Andersson,DEM,23
+Tripp,Lake Consolidated,State Senate,21,Erin Tobin,REP,110
+Tripp,Lamro Consolidated,State Senate,21,Dan Andersson,DEM,44
+Tripp,Lamro Consolidated,State Senate,21,Erin Tobin,REP,252
+Tripp,Sully Consolidated,State Senate,21,Dan Andersson,DEM,18
+Tripp,Sully Consolidated,State Senate,21,Erin Tobin,REP,68
+Tripp,?,State Senate,21,Dan Andersson,DEM,16
+Tripp,?,State Senate,21,Erin Tobin,REP,94
+Tripp,?,State Senate,21,Dan Andersson,DEM,33
+Tripp,?,State Senate,21,Erin Tobin,REP,196
+Tripp,?,State Senate,21,Dan Andersson,DEM,26
+Tripp,?,State Senate,21,Erin Tobin,REP,211
+Tripp,?,State Senate,21,Dan Andersson,DEM,34
+Tripp,?,State Senate,21,Erin Tobin,REP,226
+Tripp,?,State Senate,21,Dan Andersson,DEM,30
+Tripp,?,State Senate,21,Erin Tobin,REP,126
+Tripp,Witten Consolidated,State Senate,21,Dan Andersson,DEM,12
+Tripp,Witten Consolidated,State Senate,21,Erin Tobin,REP,75
+Tripp,Clearfield Consolidated,State House,21,Rocky Blare,REP,106
+Tripp,Clearfield Consolidated,State House,21,Marty Overweg,REP,59
+Tripp,Colome Consolidated,State House,21,Rocky Blare,REP,277
+Tripp,Colome Consolidated,State House,21,Marty Overweg,REP,162
+Tripp,Hamill Consolidated,State House,21,Rocky Blare,REP,66
+Tripp,Hamill Consolidated,State House,21,Marty Overweg,REP,42
+Tripp,Ideal Consolidated,State House,21,Rocky Blare,REP,52
+Tripp,Ideal Consolidated,State House,21,Marty Overweg,REP,30
+Tripp,Lake Consolidated,State House,21,Rocky Blare,REP,106
+Tripp,Lake Consolidated,State House,21,Marty Overweg,REP,59
+Tripp,Lamro Consolidated,State House,21,Rocky Blare,REP,249
+Tripp,Lamro Consolidated,State House,21,Marty Overweg,REP,118
+Tripp,Sully Consolidated,State House,21,Rocky Blare,REP,74
+Tripp,Sully Consolidated,State House,21,Marty Overweg,REP,41
+Tripp,?,State House,21,Rocky Blare,REP,92
+Tripp,?,State House,21,Marty Overweg,REP,37
+Tripp,?,State House,21,Rocky Blare,REP,187
+Tripp,?,State House,21,Marty Overweg,REP,92
+Tripp,?,State House,21,Rocky Blare,REP,211
+Tripp,?,State House,21,Marty Overweg,REP,102
+Tripp,?,State House,21,Rocky Blare,REP,218
+Tripp,?,State House,21,Marty Overweg,REP,112
+Tripp,?,State House,21,Rocky Blare,REP,124
+Tripp,?,State House,21,Marty Overweg,REP,58
+Tripp,Witten Consolidated,State House,21,Rocky Blare,REP,75
+Tripp,Witten Consolidated,State House,21,Marty Overweg,REP,28
+Tripp,Clearfield Consolidated,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,53
+Tripp,Colome Consolidated,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,156
+Tripp,Hamill Consolidated,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,50
+Tripp,Ideal Consolidated,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,33
+Tripp,Lake Consolidated,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,51
+Tripp,Lamro Consolidated,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,148
+Tripp,Sully Consolidated,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,49
+Tripp,?,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,54
+Tripp,?,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,131
+Tripp,?,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,119
+Tripp,?,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,141
+Tripp,?,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,65
+Tripp,Witten Consolidated,Judge of the Circuit Court,Position A Sixth Circuit,Christina Klinger,NON,37
+Tripp,Clearfield Consolidated,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,50
+Tripp,Colome Consolidated,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,150
+Tripp,Hamill Consolidated,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,47
+Tripp,Ideal Consolidated,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,33
+Tripp,Lake Consolidated,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,49
+Tripp,Lamro Consolidated,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,142
+Tripp,Sully Consolidated,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,47
+Tripp,?,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,55
+Tripp,?,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,129
+Tripp,?,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,115
+Tripp,?,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,142
+Tripp,?,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,61
+Tripp,Witten Consolidated,Judge of the Circuit Court,Position B Sixth Circuit,Margo Northrup,NON,36
+Tripp,Clearfield Consolidated,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,55
+Tripp,Colome Consolidated,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,148
+Tripp,Hamill Consolidated,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,47
+Tripp,Ideal Consolidated,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,36
+Tripp,Lake Consolidated,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,49
+Tripp,Lamro Consolidated,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,143
+Tripp,Sully Consolidated,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,48
+Tripp,?,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,53
+Tripp,?,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,127
+Tripp,?,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,125
+Tripp,?,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,188
+Tripp,?,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,63
+Tripp,Witten Consolidated,Judge of the Circuit Court,Position C Sixth Circuit,M. Bridget Mayer,NON,37
+Tripp,Clearfield Consolidated,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,85
+Tripp,Colome Consolidated,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,93
+Tripp,Hamill Consolidated,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,61
+Tripp,Ideal Consolidated,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,48
+Tripp,Lake Consolidated,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,81
+Tripp,Lamro Consolidated,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,232
+Tripp,Sully Consolidated,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,62
+Tripp,?,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,81
+Tripp,?,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,183
+Tripp,?,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,172
+Tripp,?,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,114
+Tripp,?,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,105
+Tripp,Witten Consolidated,Judge of the Circuit Court,Position D Sixth Circuit,Bobbi J. Rank,NON,58
+Tripp,Clearfield Consolidated,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,90
+Tripp,Clearfield Consolidated,Supreme Court Retention,3,Patricia J. DeVaney - No,,15
+Tripp,Colome Consolidated,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,248
+Tripp,Colome Consolidated,Supreme Court Retention,3,Patricia J. DeVaney - No,,49
+Tripp,Hamill Consolidated,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,55
+Tripp,Hamill Consolidated,Supreme Court Retention,3,Patricia J. DeVaney - No,,17
+Tripp,Ideal Consolidated,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,49
+Tripp,Ideal Consolidated,Supreme Court Retention,3,Patricia J. DeVaney - No,,9
+Tripp,Lake Consolidated,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,96
+Tripp,Lake Consolidated,Supreme Court Retention,3,Patricia J. DeVaney - No,,28
+Tripp,Lamro Consolidated,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,225
+Tripp,Lamro Consolidated,Supreme Court Retention,3,Patricia J. DeVaney - No,,39
+Tripp,Sully Consolidated,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,75
+Tripp,Sully Consolidated,Supreme Court Retention,3,Patricia J. DeVaney - No,,8
+Tripp,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,78
+Tripp,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,17
+Tripp,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,171
+Tripp,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,29
+Tripp,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,190
+Tripp,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,38
+Tripp,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,199
+Tripp,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,44
+Tripp,?,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,124
+Tripp,?,Supreme Court Retention,3,Patricia J. DeVaney - No,,22
+Tripp,Witten Consolidated,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,60
+Tripp,Witten Consolidated,Supreme Court Retention,3,Patricia J. DeVaney - No,,13
+Tripp,Clearfield Consolidated,Supreme Court Retention,2,Mark E. Salter - Yes,,87
+Tripp,Clearfield Consolidated,Supreme Court Retention,2,Mark E. Salter - No,,17
+Tripp,Colome Consolidated,Supreme Court Retention,2,Mark E. Salter - Yes,,253
+Tripp,Colome Consolidated,Supreme Court Retention,2,Mark E. Salter - No,,47
+Tripp,Hamill Consolidated,Supreme Court Retention,2,Mark E. Salter - Yes,,55
+Tripp,Hamill Consolidated,Supreme Court Retention,2,Mark E. Salter - No,,17
+Tripp,Ideal Consolidated,Supreme Court Retention,2,Mark E. Salter - Yes,,46
+Tripp,Ideal Consolidated,Supreme Court Retention,2,Mark E. Salter - No,,11
+Tripp,Lake Consolidated,Supreme Court Retention,2,Mark E. Salter - Yes,,96
+Tripp,Lake Consolidated,Supreme Court Retention,2,Mark E. Salter - No,,24
+Tripp,Lamro Consolidated,Supreme Court Retention,2,Mark E. Salter - Yes,,224
+Tripp,Lamro Consolidated,Supreme Court Retention,2,Mark E. Salter - No,,41
+Tripp,Sully Consolidated,Supreme Court Retention,2,Mark E. Salter - Yes,,70
+Tripp,Sully Consolidated,Supreme Court Retention,2,Mark E. Salter - No,,13
+Tripp,?,Supreme Court Retention,2,Mark E. Salter - Yes,,78
+Tripp,?,Supreme Court Retention,2,Mark E. Salter - No,,15
+Tripp,?,Supreme Court Retention,2,Mark E. Salter - Yes,,173
+Tripp,?,Supreme Court Retention,2,Mark E. Salter - No,,27
+Tripp,?,Supreme Court Retention,2,Mark E. Salter - Yes,,191
+Tripp,?,Supreme Court Retention,2,Mark E. Salter - No,,39
+Tripp,?,Supreme Court Retention,2,Mark E. Salter - Yes,,188
+Tripp,?,Supreme Court Retention,2,Mark E. Salter - No,,41
+Tripp,?,Supreme Court Retention,2,Mark E. Salter - Yes,,118
+Tripp,?,Supreme Court Retention,2,Mark E. Salter - No,,27
+Tripp,Witten Consolidated,Supreme Court Retention,2,Mark E. Salter - Yes,,59
+Tripp,Witten Consolidated,Supreme Court Retention,2,Mark E. Salter - No,,13
+Tripp,Clearfield Consolidated,Constitutional Amendment D,,Yes,,51
+Tripp,Clearfield Consolidated,Constitutional Amendment D,,No,,87
+Tripp,Colome Consolidated,Constitutional Amendment D,,Yes,,162
+Tripp,Colome Consolidated,Constitutional Amendment D,,No,,171
+Tripp,Hamill Consolidated,Constitutional Amendment D,,Yes,,38
+Tripp,Hamill Consolidated,Constitutional Amendment D,,No,,42
+Tripp,Ideal Consolidated,Constitutional Amendment D,,Yes,,21
+Tripp,Ideal Consolidated,Constitutional Amendment D,,No,,41
+Tripp,Lake Consolidated,Constitutional Amendment D,,Yes,,59
+Tripp,Lake Consolidated,Constitutional Amendment D,,No,,79
+Tripp,Lamro Consolidated,Constitutional Amendment D,,Yes,,118
+Tripp,Lamro Consolidated,Constitutional Amendment D,,No,,175
+Tripp,Sully Consolidated,Constitutional Amendment D,,Yes,,45
+Tripp,Sully Consolidated,Constitutional Amendment D,,No,,42
+Tripp,?,Constitutional Amendment D,,Yes,,40
+Tripp,?,Constitutional Amendment D,,No,,67
+Tripp,?,Constitutional Amendment D,,Yes,,117
+Tripp,?,Constitutional Amendment D,,No,,113
+Tripp,?,Constitutional Amendment D,,Yes,,118
+Tripp,?,Constitutional Amendment D,,No,,117
+Tripp,?,Constitutional Amendment D,,Yes,,114
+Tripp,?,Constitutional Amendment D,,No,,147
+Tripp,?,Constitutional Amendment D,,Yes,,85
+Tripp,?,Constitutional Amendment D,,No,,67
+Tripp,Witten Consolidated,Constitutional Amendment D,,Yes,,44
+Tripp,Witten Consolidated,Constitutional Amendment D,,No,,47
+Tripp,Clearfield Consolidated,Initiated Measure 27,,Yes,,36
+Tripp,Clearfield Consolidated,Initiated Measure 27,,No,,102
+Tripp,Colome Consolidated,Initiated Measure 27,,Yes,,78
+Tripp,Colome Consolidated,Initiated Measure 27,,No,,263
+Tripp,Hamill Consolidated,Initiated Measure 27,,Yes,,16
+Tripp,Hamill Consolidated,Initiated Measure 27,,No,,64
+Tripp,Ideal Consolidated,Initiated Measure 27,,Yes,,17
+Tripp,Ideal Consolidated,Initiated Measure 27,,No,,44
+Tripp,Lake Consolidated,Initiated Measure 27,,Yes,,28
+Tripp,Lake Consolidated,Initiated Measure 27,,No,,114
+Tripp,Lamro Consolidated,Initiated Measure 27,,Yes,,69
+Tripp,Lamro Consolidated,Initiated Measure 27,,No,,227
+Tripp,Sully Consolidated,Initiated Measure 27,,Yes,,21
+Tripp,Sully Consolidated,Initiated Measure 27,,No,,66
+Tripp,?,Initiated Measure 27,,Yes,,28
+Tripp,?,Initiated Measure 27,,No,,81
+Tripp,?,Initiated Measure 27,,Yes,,72
+Tripp,?,Initiated Measure 27,,No,,159
+Tripp,?,Initiated Measure 27,,Yes,,67
+Tripp,?,Initiated Measure 27,,No,,169
+Tripp,?,Initiated Measure 27,,Yes,,77
+Tripp,?,Initiated Measure 27,,No,,189
+Tripp,?,Initiated Measure 27,,Yes,,51
+Tripp,?,Initiated Measure 27,,No,,103
+Tripp,Witten Consolidated,Initiated Measure 27,,Yes,,33
+Tripp,Witten Consolidated,Initiated Measure 27,,No,,59

--- a/2022/counties/20221108__sd__general__turner__precinct.csv
+++ b/2022/counties/20221108__sd__general__turner__precinct.csv
@@ -1,0 +1,319 @@
+county,precinct,office,district,candidate,party,votes
+Turner,01,U.S. Senate,,Brian L. Bengs,DEM,104
+Turner,01,U.S. Senate,,Tamara J Lesnar,LIB,42
+Turner,01,U.S. Senate,,John R. Thune,REP,584
+Turner,02,U.S. Senate,,Brian L. Bengs,DEM,112
+Turner,02,U.S. Senate,,Tamara J Lesnar,LIB,33
+Turner,02,U.S. Senate,,John R. Thune,REP,557
+Turner,03,U.S. Senate,,Brian L. Bengs,DEM,75
+Turner,03,U.S. Senate,,Tamara J Lesnar,LIB,21
+Turner,03,U.S. Senate,,John R. Thune,REP,378
+Turner,04,U.S. Senate,,Brian L. Bengs,DEM,47
+Turner,04,U.S. Senate,,Tamara J Lesnar,LIB,10
+Turner,04,U.S. Senate,,John R. Thune,REP,242
+Turner,05,U.S. Senate,,Brian L. Bengs,DEM,72
+Turner,05,U.S. Senate,,Tamara J Lesnar,LIB,15
+Turner,05,U.S. Senate,,John R. Thune,REP,346
+Turner,06,U.S. Senate,,Brian L. Bengs,DEM,80
+Turner,06,U.S. Senate,,Tamara J Lesnar,LIB,18
+Turner,06,U.S. Senate,,John R. Thune,REP,414
+Turner,07,U.S. Senate,,Brian L. Bengs,DEM,35
+Turner,07,U.S. Senate,,Tamara J Lesnar,LIB,11
+Turner,07,U.S. Senate,,John R. Thune,REP,120
+Turner,08,U.S. Senate,,Brian L. Bengs,DEM,77
+Turner,08,U.S. Senate,,Tamara J Lesnar,LIB,18
+Turner,08,U.S. Senate,,John R. Thune,REP,437
+Turner,01,U.S. House,1,Collin Duprel,LIB,105
+Turner,01,U.S. House,1,Dusty Johnson,REP,594
+Turner,02,U.S. House,1,Collin Duprel,LIB,119
+Turner,02,U.S. House,1,Dusty Johnson,REP,573
+Turner,03,U.S. House,1,Collin Duprel,LIB,75
+Turner,03,U.S. House,1,Dusty Johnson,REP,391
+Turner,04,U.S. House,1,Collin Duprel,LIB,39
+Turner,04,U.S. House,1,Dusty Johnson,REP,253
+Turner,05,U.S. House,1,Collin Duprel,LIB,57
+Turner,05,U.S. House,1,Dusty Johnson,REP,360
+Turner,06,U.S. House,1,Collin Duprel,LIB,65
+Turner,06,U.S. House,1,Dusty Johnson,REP,432
+Turner,07,U.S. House,1,Collin Duprel,LIB,29
+Turner,07,U.S. House,1,Dusty Johnson,REP,125
+Turner,08,U.S. House,1,Collin Duprel,LIB,72
+Turner,08,U.S. House,1,Dusty Johnson,REP,446
+Turner,01,Governor,,Jamie Smith and Jennifer Keintz,DEM,160
+Turner,01,Governor,,Tracey Quint and Ashley Strand,LIB,30
+Turner,01,Governor,,Kristi Noem and Larry Rhoden,REP,547
+Turner,02,Governor,,Jamie Smith and Jennifer Keintz,DEM,184
+Turner,02,Governor,,Tracey Quint and Ashley Strand,LIB,16
+Turner,02,Governor,,Kristi Noem and Larry Rhoden,REP,507
+Turner,03,Governor,,Jamie Smith and Jennifer Keintz,DEM,113
+Turner,03,Governor,,Tracey Quint and Ashley Strand,LIB,11
+Turner,03,Governor,,Kristi Noem and Larry Rhoden,REP,351
+Turner,04,Governor,,Jamie Smith and Jennifer Keintz,DEM,65
+Turner,04,Governor,,Tracey Quint and Ashley Strand,LIB,9
+Turner,04,Governor,,Kristi Noem and Larry Rhoden,REP,228
+Turner,05,Governor,,Jamie Smith and Jennifer Keintz,DEM,106
+Turner,05,Governor,,Tracey Quint and Ashley Strand,LIB,9
+Turner,05,Governor,,Kristi Noem and Larry Rhoden,REP,320
+Turner,06,Governor,,Jamie Smith and Jennifer Keintz,DEM,117
+Turner,06,Governor,,Tracey Quint and Ashley Strand,LIB,11
+Turner,06,Governor,,Kristi Noem and Larry Rhoden,REP,384
+Turner,07,Governor,,Jamie Smith and Jennifer Keintz,DEM,51
+Turner,07,Governor,,Tracey Quint and Ashley Strand,LIB,9
+Turner,07,Governor,,Kristi Noem and Larry Rhoden,REP,106
+Turner,08,Governor,,Jamie Smith and Jennifer Keintz,DEM,123
+Turner,08,Governor,,Tracey Quint and Ashley Strand,LIB,17
+Turner,08,Governor,,Kristi Noem and Larry Rhoden,REP,391
+Turner,01,Secretary of State,,Thomas A Cool,DEM,162
+Turner,01,Secretary of State,,Monae Johnson,REP,542
+Turner,02,Secretary of State,,Thomas A Cool,DEM,188
+Turner,02,Secretary of State,,Monae Johnson,REP,492
+Turner,03,Secretary of State,,Thomas A Cool,DEM,113
+Turner,03,Secretary of State,,Monae Johnson,REP,347
+Turner,04,Secretary of State,,Thomas A Cool,DEM,73
+Turner,04,Secretary of State,,Monae Johnson,REP,211
+Turner,05,Secretary of State,,Thomas A Cool,DEM,115
+Turner,05,Secretary of State,,Monae Johnson,REP,291
+Turner,06,Secretary of State,,Thomas A Cool,DEM,127
+Turner,06,Secretary of State,,Monae Johnson,REP,365
+Turner,07,Secretary of State,,Thomas A Cool,DEM,59
+Turner,07,Secretary of State,,Monae Johnson,REP,99
+Turner,08,Secretary of State,,Thomas A Cool,DEM,129
+Turner,08,Secretary of State,,Monae Johnson,REP,384
+Turner,01,Attorney General,,Marty J. Jackley,REP,576
+Turner,02,Attorney General,,Marty J. Jackley,REP,572
+Turner,03,Attorney General,,Marty J. Jackley,REP,389
+Turner,04,Attorney General,,Marty J. Jackley,REP,237
+Turner,05,Attorney General,,Marty J. Jackley,REP,350
+Turner,06,Attorney General,,Marty J. Jackley,REP,428
+Turner,07,Attorney General,,Marty J. Jackley,REP,121
+Turner,08,Attorney General,,Marty J. Jackley,REP,448
+Turner,01,State Auditor,,Stephanie Marty,DEM,137
+Turner,01,State Auditor,,Rene Meyer,LIB,42
+Turner,01,State Auditor,,Richard Sattgast,REP,518
+Turner,02,State Auditor,,Stephanie Marty,DEM,153
+Turner,02,State Auditor,,Rene Meyer,LIB,41
+Turner,02,State Auditor,,Richard Sattgast,REP,480
+Turner,03,State Auditor,,Stephanie Marty,DEM,95
+Turner,03,State Auditor,,Rene Meyer,LIB,28
+Turner,03,State Auditor,,Richard Sattgast,REP,326
+Turner,04,State Auditor,,Stephanie Marty,DEM,65
+Turner,04,State Auditor,,Rene Meyer,LIB,17
+Turner,04,State Auditor,,Richard Sattgast,REP,201
+Turner,05,State Auditor,,Stephanie Marty,DEM,91
+Turner,05,State Auditor,,Rene Meyer,LIB,23
+Turner,05,State Auditor,,Richard Sattgast,REP,290
+Turner,06,State Auditor,,Stephanie Marty,DEM,101
+Turner,06,State Auditor,,Rene Meyer,LIB,17
+Turner,06,State Auditor,,Richard Sattgast,REP,372
+Turner,07,State Auditor,,Stephanie Marty,DEM,46
+Turner,07,State Auditor,,Rene Meyer,LIB,13
+Turner,07,State Auditor,,Richard Sattgast,REP,96
+Turner,08,State Auditor,,Stephanie Marty,DEM,111
+Turner,08,State Auditor,,Rene Meyer,LIB,31
+Turner,08,State Auditor,,Richard Sattgast,REP,364
+Turner,01,State Treasurer,,John Cunningham,DEM,141
+Turner,01,State Treasurer,,Josh Haeder,REP,554
+Turner,02,State Treasurer,,John Cunningham,DEM,166
+Turner,02,State Treasurer,,Josh Haeder,REP,501
+Turner,03,State Treasurer,,John Cunningham,DEM,100
+Turner,03,State Treasurer,,Josh Haeder,REP,348
+Turner,04,State Treasurer,,John Cunningham,DEM,67
+Turner,04,State Treasurer,,Josh Haeder,REP,213
+Turner,05,State Treasurer,,John Cunningham,DEM,98
+Turner,05,State Treasurer,,Josh Haeder,REP,309
+Turner,06,State Treasurer,,John Cunningham,DEM,114
+Turner,06,State Treasurer,,Josh Haeder,REP,372
+Turner,07,State Treasurer,,John Cunningham,DEM,54
+Turner,07,State Treasurer,,Josh Haeder,REP,101
+Turner,08,State Treasurer,,John Cunningham,DEM,121
+Turner,08,State Treasurer,,Josh Haeder,REP,384
+Turner,01,Commissioner of School and Public Lands,,Timothy Azure,DEM,136
+Turner,01,Commissioner of School and Public Lands,,Brock Greenfield,REP,541
+Turner,02,Commissioner of School and Public Lands,,Timothy Azure,DEM,158
+Turner,02,Commissioner of School and Public Lands,,Brock Greenfield,REP,497
+Turner,03,Commissioner of School and Public Lands,,Timothy Azure,DEM,94
+Turner,03,Commissioner of School and Public Lands,,Brock Greenfield,REP,343
+Turner,04,Commissioner of School and Public Lands,,Timothy Azure,DEM,59
+Turner,04,Commissioner of School and Public Lands,,Brock Greenfield,REP,214
+Turner,05,Commissioner of School and Public Lands,,Timothy Azure,DEM,92
+Turner,05,Commissioner of School and Public Lands,,Brock Greenfield,REP,311
+Turner,06,Commissioner of School and Public Lands,,Timothy Azure,DEM,99
+Turner,06,Commissioner of School and Public Lands,,Brock Greenfield,REP,382
+Turner,07,Commissioner of School and Public Lands,,Timothy Azure,DEM,45
+Turner,07,Commissioner of School and Public Lands,,Brock Greenfield,REP,109
+Turner,08,Commissioner of School and Public Lands,,Timothy Azure,DEM,123
+Turner,08,Commissioner of School and Public Lands,,Brock Greenfield,REP,374
+Turner,01,Public Utilities Commissioner,,Jeffrey Barth,DEM,129
+Turner,01,Public Utilities Commissioner,,Chris Nelson,REP,570
+Turner,02,Public Utilities Commissioner,,Jeffrey Barth,DEM,157
+Turner,02,Public Utilities Commissioner,,Chris Nelson,REP,531
+Turner,03,Public Utilities Commissioner,,Jeffrey Barth,DEM,101
+Turner,03,Public Utilities Commissioner,,Chris Nelson,REP,353
+Turner,04,Public Utilities Commissioner,,Jeffrey Barth,DEM,52
+Turner,04,Public Utilities Commissioner,,Chris Nelson,REP,238
+Turner,05,Public Utilities Commissioner,,Jeffrey Barth,DEM,88
+Turner,05,Public Utilities Commissioner,,Chris Nelson,REP,329
+Turner,06,Public Utilities Commissioner,,Jeffrey Barth,DEM,95
+Turner,06,Public Utilities Commissioner,,Chris Nelson,REP,398
+Turner,07,Public Utilities Commissioner,,Jeffrey Barth,DEM,36
+Turner,07,Public Utilities Commissioner,,Chris Nelson,REP,122
+Turner,08,Public Utilities Commissioner,,Jeffrey Barth,DEM,98
+Turner,08,Public Utilities Commissioner,,Chris Nelson,REP,417
+Turner,01,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,312
+Turner,02,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,308
+Turner,03,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,186
+Turner,04,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,102
+Turner,05,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,187
+Turner,06,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,220
+Turner,07,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,79
+Turner,08,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,240
+Turner,01,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,298
+Turner,02,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,295
+Turner,03,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,175
+Turner,04,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,99
+Turner,05,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,180
+Turner,06,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,217
+Turner,07,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,79
+Turner,08,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,232
+Turner,01,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,301
+Turner,02,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,288
+Turner,03,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,183
+Turner,04,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,101
+Turner,05,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,183
+Turner,06,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,214
+Turner,07,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,76
+Turner,08,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,231
+Turner,01,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,323
+Turner,02,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,289
+Turner,03,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,182
+Turner,04,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,150
+Turner,05,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,185
+Turner,06,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,224
+Turner,07,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,76
+Turner,08,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,230
+Turner,01,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,297
+Turner,02,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,286
+Turner,03,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,175
+Turner,04,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,100
+Turner,05,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,181
+Turner,06,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,209
+Turner,07,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,75
+Turner,08,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,229
+Turner,01,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,301
+Turner,02,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,289
+Turner,03,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,178
+Turner,04,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,100
+Turner,05,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,185
+Turner,06,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,208
+Turner,07,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,77
+Turner,08,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,234
+Turner,01,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,480
+Turner,01,Supreme Court Retention,3,Patricia J. DeVaney - No,,125
+Turner,02,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,510
+Turner,02,Supreme Court Retention,3,Patricia J. DeVaney - No,,102
+Turner,03,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,338
+Turner,03,Supreme Court Retention,3,Patricia J. DeVaney - No,,59
+Turner,04,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,188
+Turner,04,Supreme Court Retention,3,Patricia J. DeVaney - No,,40
+Turner,05,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,306
+Turner,05,Supreme Court Retention,3,Patricia J. DeVaney - No,,60
+Turner,06,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,365
+Turner,06,Supreme Court Retention,3,Patricia J. DeVaney - No,,67
+Turner,07,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,116
+Turner,07,Supreme Court Retention,3,Patricia J. DeVaney - No,,20
+Turner,08,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,384
+Turner,08,Supreme Court Retention,3,Patricia J. DeVaney - No,,85
+Turner,01,Supreme Court Retention,2,Mark E. Salter - Yes,,483
+Turner,01,Supreme Court Retention,2,Mark E. Salter - No,,122
+Turner,02,Supreme Court Retention,2,Mark E. Salter - Yes,,541
+Turner,02,Supreme Court Retention,2,Mark E. Salter - No,,84
+Turner,03,Supreme Court Retention,2,Mark E. Salter - Yes,,348
+Turner,03,Supreme Court Retention,2,Mark E. Salter - No,,55
+Turner,04,Supreme Court Retention,2,Mark E. Salter - Yes,,192
+Turner,04,Supreme Court Retention,2,Mark E. Salter - No,,37
+Turner,05,Supreme Court Retention,2,Mark E. Salter - Yes,,309
+Turner,05,Supreme Court Retention,2,Mark E. Salter - No,,54
+Turner,06,Supreme Court Retention,2,Mark E. Salter - Yes,,370
+Turner,06,Supreme Court Retention,2,Mark E. Salter - No,,63
+Turner,07,Supreme Court Retention,2,Mark E. Salter - Yes,,113
+Turner,07,Supreme Court Retention,2,Mark E. Salter - No,,21
+Turner,08,Supreme Court Retention,2,Mark E. Salter - Yes,,391
+Turner,08,Supreme Court Retention,2,Mark E. Salter - No,,78
+Turner,01,Constitutional Amendment D,,Yes,,329
+Turner,01,Constitutional Amendment D,,No,,388
+Turner,02,Constitutional Amendment D,,Yes,,335
+Turner,02,Constitutional Amendment D,,No,,351
+Turner,03,Constitutional Amendment D,,Yes,,229
+Turner,03,Constitutional Amendment D,,No,,234
+Turner,04,Constitutional Amendment D,,Yes,,140
+Turner,04,Constitutional Amendment D,,No,,148
+Turner,05,Constitutional Amendment D,,Yes,,233
+Turner,05,Constitutional Amendment D,,No,,190
+Turner,06,Constitutional Amendment D,,Yes,,252
+Turner,06,Constitutional Amendment D,,No,,233
+Turner,07,Constitutional Amendment D,,Yes,,98
+Turner,07,Constitutional Amendment D,,No,,67
+Turner,08,Constitutional Amendment D,,Yes,,239
+Turner,08,Constitutional Amendment D,,No,,276
+Turner,01,Initiated Measure 27,,Yes,,288
+Turner,01,Initiated Measure 27,,No,,437
+Turner,02,Initiated Measure 27,,Yes,,277
+Turner,02,Initiated Measure 27,,No,,421
+Turner,03,Initiated Measure 27,,Yes,,160
+Turner,03,Initiated Measure 27,,No,,306
+Turner,04,Initiated Measure 27,,Yes,,93
+Turner,04,Initiated Measure 27,,No,,200
+Turner,05,Initiated Measure 27,,Yes,,155
+Turner,05,Initiated Measure 27,,No,,269
+Turner,06,Initiated Measure 27,,Yes,,174
+Turner,06,Initiated Measure 27,,No,,322
+Turner,07,Initiated Measure 27,,Yes,,77
+Turner,07,Initiated Measure 27,,No,,86
+Turner,08,Initiated Measure 27,,Yes,,185
+Turner,08,Initiated Measure 27,,No,,335
+Turner,01,State Senate,16,Donn Larson,DEM,110
+Turner,01,State Senate,16,Jim Bolin,REP,387
+Turner,01,State Senate,16,Brian J. Burge,IND,219
+Turner,02,State Senate,16,Donn Larson,DEM,150
+Turner,02,State Senate,16,Jim Bolin,REP,459
+Turner,02,State Senate,16,Brian J. Burge,IND,71
+Turner,03,State Senate,16,Donn Larson,DEM,88
+Turner,03,State Senate,16,Jim Bolin,REP,335
+Turner,03,State Senate,16,Brian J. Burge,IND,26
+Turner,04,State Senate,19,Russell Graeff,DEM,56
+Turner,04,State Senate,19,Kyle Schoenfish,REP,223
+Turner,05,State Senate,16,Donn Larson,DEM,110
+Turner,05,State Senate,16,Jim Bolin,REP,282
+Turner,05,State Senate,16,Brian J. Burge,IND,25
+Turner,06,State Senate,16,Donn Larson,DEM,113
+Turner,06,State Senate,16,Jim Bolin,REP,343
+Turner,06,State Senate,16,Brian J. Burge,IND,38
+Turner,07,State Senate,16,Donn Larson,DEM,53
+Turner,07,State Senate,16,Jim Bolin,REP,92
+Turner,07,State Senate,16,Brian J. Burge,IND,11
+Turner,08 10 of 22,State Senate,16,Donn Larson,DEM,159
+Turner,08 10 of 22,State Senate,16,Jim Bolin,REP,332
+Turner,08 10 of 22,State Senate,16,Brian J. Burge,IND,27
+Turner,01,State House,16,Matt Ness,DEM,148
+Turner,01,State House,16,Kevin D. Jensen,REP,408
+Turner,01,State House,16,Karla J. Lems,REP,487
+Turner,02,State House,16,Matt Ness,DEM,165
+Turner,02,State House,16,Kevin D. Jensen,REP,377
+Turner,02,State House,16,Karla J. Lems,REP,392
+Turner,03,State House,16,Matt Ness,DEM,104
+Turner,03,State House,16,Kevin D. Jensen,REP,250
+Turner,03,State House,16,Karla J. Lems,REP,277
+Turner,04,State House,19,Jessica Bahmuller,REP,137
+Turner,04,State House,19,Drew Peterson,REP,191
+Turner,05,State House,16,Matt Ness,DEM,105
+Turner,05,State House,16,Kevin D. Jensen,REP,227
+Turner,05,State House,16,Karla J. Lems,REP,268
+Turner,06,State House,16,Matt Ness,DEM,111
+Turner,06,State House,16,Kevin D. Jensen,REP,291
+Turner,06,State House,16,Karla J. Lems,REP,290
+Turner,07,State House,16,Matt Ness,DEM,52
+Turner,07,State House,16,Kevin D. Jensen,REP,92
+Turner,07,State House,16,Karla J. Lems,REP,67
+Turner,08 11 of 22,State House,16,Matt Ness,DEM,122
+Turner,08 11 of 22,State House,16,Kevin D. Jensen,REP,308
+Turner,08 11 of 22,State House,16,Karla J. Lems,REP,307

--- a/2022/counties/20221108__sd__general__union__precinct.csv
+++ b/2022/counties/20221108__sd__general__union__precinct.csv
@@ -1,0 +1,471 @@
+county,precinct,office,district,candidate,party,votes
+Union,01,U.S. Senate,,Brian L. Bengs,DEM,66
+Union,01,U.S. Senate,,Tamara J Lesnar,LIB,15
+Union,01,U.S. Senate,,John R. Thune,REP,285
+Union,02,U.S. Senate,,Brian L. Bengs,DEM,87
+Union,02,U.S. Senate,,Tamara J Lesnar,LIB,14
+Union,02,U.S. Senate,,John R. Thune,REP,241
+Union,03,U.S. Senate,,Brian L. Bengs,DEM,202
+Union,03,U.S. Senate,,Tamara J Lesnar,LIB,25
+Union,03,U.S. Senate,,John R. Thune,REP,654
+Union,04,U.S. Senate,,Brian L. Bengs,DEM,93
+Union,04,U.S. Senate,,Tamara J Lesnar,LIB,19
+Union,04,U.S. Senate,,John R. Thune,REP,334
+Union,05,U.S. Senate,,Brian L. Bengs,DEM,129
+Union,05,U.S. Senate,,Tamara J Lesnar,LIB,19
+Union,05,U.S. Senate,,John R. Thune,REP,434
+Union,06,U.S. Senate,,Brian L. Bengs,DEM,116
+Union,06,U.S. Senate,,Tamara J Lesnar,LIB,13
+Union,06,U.S. Senate,,John R. Thune,REP,513
+Union,07,U.S. Senate,,Brian L. Bengs,DEM,86
+Union,07,U.S. Senate,,Tamara J Lesnar,LIB,7
+Union,07,U.S. Senate,,John R. Thune,REP,184
+Union,08,U.S. Senate,,Brian L. Bengs,DEM,97
+Union,08,U.S. Senate,,Tamara J Lesnar,LIB,14
+Union,08,U.S. Senate,,John R. Thune,REP,250
+Union,09,U.S. Senate,,Brian L. Bengs,DEM,151
+Union,09,U.S. Senate,,Tamara J Lesnar,LIB,33
+Union,09,U.S. Senate,,John R. Thune,REP,406
+Union,10,U.S. Senate,,Brian L. Bengs,DEM,133
+Union,10,U.S. Senate,,Tamara J Lesnar,LIB,24
+Union,10,U.S. Senate,,John R. Thune,REP,376
+Union,11,U.S. Senate,,Brian L. Bengs,DEM,112
+Union,11,U.S. Senate,,Tamara J Lesnar,LIB,17
+Union,11,U.S. Senate,,John R. Thune,REP,541
+Union,12,U.S. Senate,,Brian L. Bengs,DEM,225
+Union,12,U.S. Senate,,Tamara J Lesnar,LIB,29
+Union,12,U.S. Senate,,John R. Thune,REP,773
+Union,01,U.S. House,1,Collin Duprel,LIB,60
+Union,01,U.S. House,1,Dusty Johnson,REP,294
+Union,02,U.S. House,1,Collin Duprel,LIB,68
+Union,02,U.S. House,1,Dusty Johnson,REP,255
+Union,03,U.S. House,1,Collin Duprel,LIB,151
+Union,03,U.S. House,1,Dusty Johnson,REP,681
+Union,04,U.S. House,1,Collin Duprel,LIB,84
+Union,04,U.S. House,1,Dusty Johnson,REP,344
+Union,05,U.S. House,1,Collin Duprel,LIB,98
+Union,05,U.S. House,1,Dusty Johnson,REP,453
+Union,06,U.S. House,1,Collin Duprel,LIB,79
+Union,06,U.S. House,1,Dusty Johnson,REP,529
+Union,07,U.S. House,1,Collin Duprel,LIB,52
+Union,07,U.S. House,1,Dusty Johnson,REP,200
+Union,08,U.S. House,1,Collin Duprel,LIB,73
+Union,08,U.S. House,1,Dusty Johnson,REP,259
+Union,09,U.S. House,1,Collin Duprel,LIB,120
+Union,09,U.S. House,1,Dusty Johnson,REP,419
+Union,10,U.S. House,1,Collin Duprel,LIB,119
+Union,10,U.S. House,1,Dusty Johnson,REP,386
+Union,11,U.S. House,1,Collin Duprel,LIB,85
+Union,11,U.S. House,1,Dusty Johnson,REP,557
+Union,12,U.S. House,1,Collin Duprel,LIB,150
+Union,12,U.S. House,1,Dusty Johnson,REP,803
+Union,01,Governor,,Jamie Smith and Jennifer Keintz,DEM,84
+Union,01,Governor,,Tracey Quint and Ashley Strand,LIB,8
+Union,01,Governor,,Kristi Noem and Larry Rhoden,REP,277
+Union,02,Governor,,Jamie Smith and Jennifer Keintz,DEM,117
+Union,02,Governor,,Tracey Quint and Ashley Strand,LIB,12
+Union,02,Governor,,Kristi Noem and Larry Rhoden,REP,209
+Union,03,Governor,,Jamie Smith and Jennifer Keintz,DEM,252
+Union,03,Governor,,Tracey Quint and Ashley Strand,LIB,22
+Union,03,Governor,,Kristi Noem and Larry Rhoden,REP,608
+Union,04,Governor,,Jamie Smith and Jennifer Keintz,DEM,124
+Union,04,Governor,,Tracey Quint and Ashley Strand,LIB,14
+Union,04,Governor,,Kristi Noem and Larry Rhoden,REP,317
+Union,05,Governor,,Jamie Smith and Jennifer Keintz,DEM,193
+Union,05,Governor,,Tracey Quint and Ashley Strand,LIB,18
+Union,05,Governor,,Kristi Noem and Larry Rhoden,REP,371
+Union,06,Governor,,Jamie Smith and Jennifer Keintz,DEM,145
+Union,06,Governor,,Tracey Quint and Ashley Strand,LIB,13
+Union,06,Governor,,Kristi Noem and Larry Rhoden,REP,486
+Union,07,Governor,,Jamie Smith and Jennifer Keintz,DEM,100
+Union,07,Governor,,Tracey Quint and Ashley Strand,LIB,4
+Union,07,Governor,,Kristi Noem and Larry Rhoden,REP,172
+Union,08,Governor,,Jamie Smith and Jennifer Keintz,DEM,108
+Union,08,Governor,,Tracey Quint and Ashley Strand,LIB,11
+Union,08,Governor,,Kristi Noem and Larry Rhoden,REP,239
+Union,09,Governor,,Jamie Smith and Jennifer Keintz,DEM,176
+Union,09,Governor,,Tracey Quint and Ashley Strand,LIB,22
+Union,09,Governor,,Kristi Noem and Larry Rhoden,REP,395
+Union,10,Governor,,Jamie Smith and Jennifer Keintz,DEM,155
+Union,10,Governor,,Tracey Quint and Ashley Strand,LIB,17
+Union,10,Governor,,Kristi Noem and Larry Rhoden,REP,364
+Union,11,Governor,,Jamie Smith and Jennifer Keintz,DEM,141
+Union,11,Governor,,Tracey Quint and Ashley Strand,LIB,17
+Union,11,Governor,,Kristi Noem and Larry Rhoden,REP,518
+Union,12,Governor,,Jamie Smith and Jennifer Keintz,DEM,253
+Union,12,Governor,,Tracey Quint and Ashley Strand,LIB,11
+Union,12,Governor,,Kristi Noem and Larry Rhoden,REP,767
+Union,01,Secretary of State,,Thomas A Cool,DEM,88
+Union,01,Secretary of State,,Monae Johnson,REP,267
+Union,02,Secretary of State,,Thomas A Cool,DEM,123
+Union,02,Secretary of State,,Monae Johnson,REP,202
+Union,03,Secretary of State,,Thomas A Cool,DEM,259
+Union,03,Secretary of State,,Monae Johnson,REP,595
+Union,04,Secretary of State,,Thomas A Cool,DEM,119
+Union,04,Secretary of State,,Monae Johnson,REP,318
+Union,05,Secretary of State,,Thomas A Cool,DEM,186
+Union,05,Secretary of State,,Monae Johnson,REP,364
+Union,06,Secretary of State,,Thomas A Cool,DEM,140
+Union,06,Secretary of State,,Monae Johnson,REP,485
+Union,07,Secretary of State,,Thomas A Cool,DEM,98
+Union,07,Secretary of State,,Monae Johnson,REP,174
+Union,08,Secretary of State,,Thomas A Cool,DEM,116
+Union,08,Secretary of State,,Monae Johnson,REP,229
+Union,09,Secretary of State,,Thomas A Cool,DEM,183
+Union,09,Secretary of State,,Monae Johnson,REP,380
+Union,10,Secretary of State,,Thomas A Cool,DEM,155
+Union,10,Secretary of State,,Monae Johnson,REP,354
+Union,11,Secretary of State,,Thomas A Cool,DEM,138
+Union,11,Secretary of State,,Monae Johnson,REP,521
+Union,12,Secretary of State,,Thomas A Cool,DEM,246
+Union,12,Secretary of State,,Monae Johnson,REP,764
+Union,01,Attorney General,,Marty J. Jackley,REP,281
+Union,02,Attorney General,,Marty J. Jackley,REP,253
+Union,03,Attorney General,,Marty J. Jackley,REP,677
+Union,04,Attorney General,,Marty J. Jackley,REP,334
+Union,05,Attorney General,,Marty J. Jackley,REP,453
+Union,06,Attorney General,,Marty J. Jackley,REP,514
+Union,07,Attorney General,,Marty J. Jackley,REP,195
+Union,08,Attorney General,,Marty J. Jackley,REP,262
+Union,09,Attorney General,,Marty J. Jackley,REP,415
+Union,10,Attorney General,,Marty J. Jackley,REP,381
+Union,11,Attorney General,,Marty J. Jackley,REP,560
+Union,12,Attorney General,,Marty J. Jackley,REP,796
+Union,01,State Auditor,,Stephanie Marty,DEM,84
+Union,01,State Auditor,,Rene Meyer,LIB,21
+Union,01,State Auditor,,Richard Sattgast,REP,252
+Union,02,State Auditor,,Stephanie Marty,DEM,115
+Union,02,State Auditor,,Rene Meyer,LIB,17
+Union,02,State Auditor,,Richard Sattgast,REP,192
+Union,03,State Auditor,,Stephanie Marty,DEM,247
+Union,03,State Auditor,,Rene Meyer,LIB,36
+Union,03,State Auditor,,Richard Sattgast,REP,571
+Union,04,State Auditor,,Stephanie Marty,DEM,112
+Union,04,State Auditor,,Rene Meyer,LIB,31
+Union,04,State Auditor,,Richard Sattgast,REP,297
+Union,05,State Auditor,,Stephanie Marty,DEM,162
+Union,05,State Auditor,,Rene Meyer,LIB,22
+Union,05,State Auditor,,Richard Sattgast,REP,364
+Union,06,State Auditor,,Stephanie Marty,DEM,136
+Union,06,State Auditor,,Rene Meyer,LIB,24
+Union,06,State Auditor,,Richard Sattgast,REP,464
+Union,07,State Auditor,,Stephanie Marty,DEM,92
+Union,07,State Auditor,,Rene Meyer,LIB,11
+Union,07,State Auditor,,Richard Sattgast,REP,168
+Union,08,State Auditor,,Stephanie Marty,DEM,107
+Union,08,State Auditor,,Rene Meyer,LIB,18
+Union,08,State Auditor,,Richard Sattgast,REP,222
+Union,09,State Auditor,,Stephanie Marty,DEM,172
+Union,09,State Auditor,,Rene Meyer,LIB,35
+Union,09,State Auditor,,Richard Sattgast,REP,361
+Union,10,State Auditor,,Stephanie Marty,DEM,144
+Union,10,State Auditor,,Rene Meyer,LIB,36
+Union,10,State Auditor,,Richard Sattgast,REP,328
+Union,11,State Auditor,,Stephanie Marty,DEM,127
+Union,11,State Auditor,,Rene Meyer,LIB,23
+Union,11,State Auditor,,Richard Sattgast,REP,505
+Union,12,State Auditor,,Stephanie Marty,DEM,231
+Union,12,State Auditor,,Rene Meyer,LIB,38
+Union,12,State Auditor,,Richard Sattgast,REP,733
+Union,01,State Treasurer,,John Cunningham,DEM,80
+Union,01,State Treasurer,,Josh Haeder,REP,272
+Union,02,State Treasurer,,John Cunningham,DEM,110
+Union,02,State Treasurer,,Josh Haeder,REP,213
+Union,03,State Treasurer,,John Cunningham,DEM,250
+Union,03,State Treasurer,,Josh Haeder,REP,596
+Union,04,State Treasurer,,John Cunningham,DEM,112
+Union,04,State Treasurer,,Josh Haeder,REP,323
+Union,05,State Treasurer,,John Cunningham,DEM,169
+Union,05,State Treasurer,,Josh Haeder,REP,374
+Union,06,State Treasurer,,John Cunningham,DEM,141
+Union,06,State Treasurer,,Josh Haeder,REP,483
+Union,07,State Treasurer,,John Cunningham,DEM,95
+Union,07,State Treasurer,,Josh Haeder,REP,171
+Union,08,State Treasurer,,John Cunningham,DEM,118
+Union,08,State Treasurer,,Josh Haeder,REP,229
+Union,09,State Treasurer,,John Cunningham,DEM,174
+Union,09,State Treasurer,,Josh Haeder,REP,394
+Union,10,State Treasurer,,John Cunningham,DEM,147
+Union,10,State Treasurer,,Josh Haeder,REP,358
+Union,11,State Treasurer,,John Cunningham,DEM,132
+Union,11,State Treasurer,,Josh Haeder,REP,526
+Union,12,State Treasurer,,John Cunningham,DEM,240
+Union,12,State Treasurer,,Josh Haeder,REP,762
+Union,01,Commissioner of School and Public Lands,,Timothy Azure,DEM,84
+Union,01,Commissioner of School and Public Lands,,Brock Greenfield,REP,268
+Union,02,Commissioner of School and Public Lands,,Timothy Azure,DEM,112
+Union,02,Commissioner of School and Public Lands,,Brock Greenfield,REP,201
+Union,03,Commissioner of School and Public Lands,,Timothy Azure,DEM,242
+Union,03,Commissioner of School and Public Lands,,Brock Greenfield,REP,594
+Union,04,Commissioner of School and Public Lands,,Timothy Azure,DEM,98
+Union,04,Commissioner of School and Public Lands,,Brock Greenfield,REP,331
+Union,05,Commissioner of School and Public Lands,,Timothy Azure,DEM,166
+Union,05,Commissioner of School and Public Lands,,Brock Greenfield,REP,370
+Union,06,Commissioner of School and Public Lands,,Timothy Azure,DEM,134
+Union,06,Commissioner of School and Public Lands,,Brock Greenfield,REP,487
+Union,07,Commissioner of School and Public Lands,,Timothy Azure,DEM,92
+Union,07,Commissioner of School and Public Lands,,Brock Greenfield,REP,170
+Union,08,Commissioner of School and Public Lands,,Timothy Azure,DEM,110
+Union,08,Commissioner of School and Public Lands,,Brock Greenfield,REP,234
+Union,09,Commissioner of School and Public Lands,,Timothy Azure,DEM,174
+Union,09,Commissioner of School and Public Lands,,Brock Greenfield,REP,390
+Union,10,Commissioner of School and Public Lands,,Timothy Azure,DEM,151
+Union,10,Commissioner of School and Public Lands,,Brock Greenfield,REP,352
+Union,11,Commissioner of School and Public Lands,,Timothy Azure,DEM,135
+Union,11,Commissioner of School and Public Lands,,Brock Greenfield,REP,515
+Union,12,Commissioner of School and Public Lands,,Timothy Azure,DEM,239
+Union,12,Commissioner of School and Public Lands,,Brock Greenfield,REP,757
+Union,01,Public Utilities Commissioner,,Jeffrey Barth,DEM,79
+Union,01,Public Utilities Commissioner,,Chris Nelson,REP,280
+Union,02,Public Utilities Commissioner,,Jeffrey Barth,DEM,106
+Union,02,Public Utilities Commissioner,,Chris Nelson,REP,217
+Union,03,Public Utilities Commissioner,,Jeffrey Barth,DEM,220
+Union,03,Public Utilities Commissioner,,Chris Nelson,REP,631
+Union,04,Public Utilities Commissioner,,Jeffrey Barth,DEM,99
+Union,04,Public Utilities Commissioner,,Chris Nelson,REP,335
+Union,05,Public Utilities Commissioner,,Jeffrey Barth,DEM,153
+Union,05,Public Utilities Commissioner,,Chris Nelson,REP,399
+Union,06,Public Utilities Commissioner,,Jeffrey Barth,DEM,126
+Union,06,Public Utilities Commissioner,,Chris Nelson,REP,494
+Union,07,Public Utilities Commissioner,,Jeffrey Barth,DEM,85
+Union,07,Public Utilities Commissioner,,Chris Nelson,REP,181
+Union,08,Public Utilities Commissioner,,Jeffrey Barth,DEM,96
+Union,08,Public Utilities Commissioner,,Chris Nelson,REP,245
+Union,09,Public Utilities Commissioner,,Jeffrey Barth,DEM,159
+Union,09,Public Utilities Commissioner,,Chris Nelson,REP,399
+Union,10,Public Utilities Commissioner,,Jeffrey Barth,DEM,141
+Union,10,Public Utilities Commissioner,,Chris Nelson,REP,361
+Union,11,Public Utilities Commissioner,,Jeffrey Barth,DEM,121
+Union,11,Public Utilities Commissioner,,Chris Nelson,REP,529
+Union,12,Public Utilities Commissioner,,Jeffrey Barth,DEM,235
+Union,12,Public Utilities Commissioner,,Chris Nelson,REP,760
+Union,01,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,162
+Union,02,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,162
+Union,03,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,423
+Union,04,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,189
+Union,05,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,267
+Union,06,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,266
+Union,07,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,112
+Union,08,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,163
+Union,09,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,216
+Union,10,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,221
+Union,11,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,315
+Union,12,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,492
+Union,01,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,159
+Union,02,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,149
+Union,03,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,409
+Union,04,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,181
+Union,05,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,258
+Union,06,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,255
+Union,07,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,108
+Union,08,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,144
+Union,09,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,202
+Union,10,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,214
+Union,11,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,304
+Union,12,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,474
+Union,01,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,158
+Union,02,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,154
+Union,03,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,406
+Union,04,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,183
+Union,05,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,259
+Union,06,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,245
+Union,07,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,106
+Union,08,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,148
+Union,09,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,195
+Union,10,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,213
+Union,11,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,299
+Union,12,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,468
+Union,01,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,157
+Union,02,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,156
+Union,03,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,414
+Union,04,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,178
+Union,05,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,261
+Union,06,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,249
+Union,07,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,113
+Union,08,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,147
+Union,09,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,202
+Union,10,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,212
+Union,11,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,299
+Union,12,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,470
+Union,01,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,158
+Union,02,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,147
+Union,03,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,400
+Union,04,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,177
+Union,05,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,253
+Union,06,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,243
+Union,07,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,108
+Union,08,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,144
+Union,09,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,192
+Union,10,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,209
+Union,11,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,297
+Union,12,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,473
+Union,01,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,176
+Union,02,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,176
+Union,03,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,414
+Union,04,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,195
+Union,05,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,285
+Union,06,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,245
+Union,07,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,115
+Union,08,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,147
+Union,09,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,205
+Union,10,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,204
+Union,11,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,302
+Union,12,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,473
+Union,01,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,256
+Union,01,Supreme Court Retention,3,Patricia J. DeVaney - No,,46
+Union,02,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,235
+Union,02,Supreme Court Retention,3,Patricia J. DeVaney - No,,57
+Union,03,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,619
+Union,03,Supreme Court Retention,3,Patricia J. DeVaney - No,,129
+Union,04,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,285
+Union,04,Supreme Court Retention,3,Patricia J. DeVaney - No,,70
+Union,05,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,411
+Union,05,Supreme Court Retention,3,Patricia J. DeVaney - No,,74
+Union,06,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,398
+Union,06,Supreme Court Retention,3,Patricia J. DeVaney - No,,109
+Union,07,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,193
+Union,07,Supreme Court Retention,3,Patricia J. DeVaney - No,,41
+Union,08,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,237
+Union,08,Supreme Court Retention,3,Patricia J. DeVaney - No,,72
+Union,09,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,331
+Union,09,Supreme Court Retention,3,Patricia J. DeVaney - No,,110
+Union,10,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,332
+Union,10,Supreme Court Retention,3,Patricia J. DeVaney - No,,98
+Union,11,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,470
+Union,11,Supreme Court Retention,3,Patricia J. DeVaney - No,,83
+Union,12,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,715
+Union,12,Supreme Court Retention,3,Patricia J. DeVaney - No,,140
+Union,01,Supreme Court Retention,2,Mark E. Salter - Yes,,255
+Union,01,Supreme Court Retention,2,Mark E. Salter - No,,47
+Union,02,Supreme Court Retention,2,Mark E. Salter - Yes,,230
+Union,02,Supreme Court Retention,2,Mark E. Salter - No,,59
+Union,03,Supreme Court Retention,2,Mark E. Salter - Yes,,617
+Union,03,Supreme Court Retention,2,Mark E. Salter - No,,130
+Union,04,Supreme Court Retention,2,Mark E. Salter - Yes,,277
+Union,04,Supreme Court Retention,2,Mark E. Salter - No,,76
+Union,05,Supreme Court Retention,2,Mark E. Salter - Yes,,417
+Union,05,Supreme Court Retention,2,Mark E. Salter - No,,73
+Union,06,Supreme Court Retention,2,Mark E. Salter - Yes,,401
+Union,06,Supreme Court Retention,2,Mark E. Salter - No,,97
+Union,07,Supreme Court Retention,2,Mark E. Salter - Yes,,188
+Union,07,Supreme Court Retention,2,Mark E. Salter - No,,40
+Union,08,Supreme Court Retention,2,Mark E. Salter - Yes,,229
+Union,08,Supreme Court Retention,2,Mark E. Salter - No,,79
+Union,09,Supreme Court Retention,2,Mark E. Salter - Yes,,335
+Union,09,Supreme Court Retention,2,Mark E. Salter - No,,103
+Union,10,Supreme Court Retention,2,Mark E. Salter - Yes,,328
+Union,10,Supreme Court Retention,2,Mark E. Salter - No,,98
+Union,11,Supreme Court Retention,2,Mark E. Salter - Yes,,479
+Union,11,Supreme Court Retention,2,Mark E. Salter - No,,72
+Union,12,Supreme Court Retention,2,Mark E. Salter - Yes,,698
+Union,12,Supreme Court Retention,2,Mark E. Salter - No,,146
+Union,01,Constitutional Amendment D,,Yes,,170
+Union,01,Constitutional Amendment D,,No,,190
+Union,02,Constitutional Amendment D,,Yes,,208
+Union,02,Constitutional Amendment D,,No,,120
+Union,03,Constitutional Amendment D,,Yes,,509
+Union,03,Constitutional Amendment D,,No,,362
+Union,04,Constitutional Amendment D,,Yes,,245
+Union,04,Constitutional Amendment D,,No,,195
+Union,05,Constitutional Amendment D,,Yes,,318
+Union,05,Constitutional Amendment D,,No,,262
+Union,06,Constitutional Amendment D,,Yes,,305
+Union,06,Constitutional Amendment D,,No,,317
+Union,07,Constitutional Amendment D,,Yes,,142
+Union,07,Constitutional Amendment D,,No,,135
+Union,08,Constitutional Amendment D,,Yes,,195
+Union,08,Constitutional Amendment D,,No,,158
+Union,09,Constitutional Amendment D,,Yes,,326
+Union,09,Constitutional Amendment D,,No,,233
+Union,10,Constitutional Amendment D,,Yes,,295
+Union,10,Constitutional Amendment D,,No,,224
+Union,11,Constitutional Amendment D,,Yes,,300
+Union,11,Constitutional Amendment D,,No,,353
+Union,12,Constitutional Amendment D,,Yes,,525
+Union,12,Constitutional Amendment D,,No,,476
+Union,01,Initiated Measure 27,,Yes,,134
+Union,01,Initiated Measure 27,,No,,228
+Union,02,Initiated Measure 27,,Yes,,172
+Union,02,Initiated Measure 27,,No,,159
+Union,03,Initiated Measure 27,,Yes,,465
+Union,03,Initiated Measure 27,,No,,418
+Union,04,Initiated Measure 27,,Yes,,194
+Union,04,Initiated Measure 27,,No,,249
+Union,05,Initiated Measure 27,,Yes,,271
+Union,05,Initiated Measure 27,,No,,315
+Union,06,Initiated Measure 27,,Yes,,335
+Union,06,Initiated Measure 27,,No,,305
+Union,07,Initiated Measure 27,,Yes,,126
+Union,07,Initiated Measure 27,,No,,155
+Union,08,Initiated Measure 27,,Yes,,211
+Union,08,Initiated Measure 27,,No,,152
+Union,09,Initiated Measure 27,,Yes,,300
+Union,09,Initiated Measure 27,,No,,268
+Union,10,Initiated Measure 27,,Yes,,291
+Union,10,Initiated Measure 27,,No,,242
+Union,11,Initiated Measure 27,,Yes,,289
+Union,11,Initiated Measure 27,,No,,377
+Union,12,Initiated Measure 27,,Yes,,523
+Union,12,Initiated Measure 27,,No,,494
+Union,01,State Senate,16,Donn Larson,DEM,93
+Union,01,State Senate,16,Jim Bolin,REP,248
+Union,01,State Senate,16,Brian J. Burge,IND,20
+Union,02,State Senate,16,Donn Larson,DEM,126
+Union,02,State Senate,16,Jim Bolin,REP,193
+Union,02,State Senate,16,Brian J. Burge,IND,18
+Union,03,State Senate,17,Sydney Davis,REP,643
+Union,04,State Senate,16,Donn Larson,DEM,115
+Union,04,State Senate,16,Jim Bolin,REP,298
+Union,04,State Senate,16,Brian J. Burge,IND,29
+Union,05,State Senate,16,Donn Larson,DEM,158
+Union,05,State Senate,16,Jim Bolin,REP,378
+Union,05,State Senate,16,Brian J. Burge,IND,33
+Union,06,State Senate,17,Sydney Davis,REP,494
+Union,07,State Senate,16,Donn Larson,DEM,65
+Union,07,State Senate,16,Jim Bolin,REP,134
+Union,07,State Senate,16,Brian J. Burge,IND,13
+Union,07,State Senate,17,Sydney Davis,REP,47
+Union,08,State Senate,17,Sydney Davis,REP,241
+Union,09,State Senate,17,Sydney Davis,REP,394
+Union,10,State Senate,17,Sydney Davis,REP,375
+Union,11,State Senate,17,Sydney Davis,REP,536
+Union,12 10 of 21,State Senate,17,Sydney Davis,REP,769
+Union,DEM Precinct-01,State House,16,Matt Ness,DEM,82
+Union,DEM Precinct-01,State House,16,Kevin D. Jensen,REP,218
+Union,DEM Precinct-01,State House,16,Karla J. Lems,REP,206
+Union,02,State House,16,Matt Ness,DEM,105
+Union,02,State House,16,Kevin D. Jensen,REP,178
+Union,02,State House,16,Karla J. Lems,REP,173
+Union,03,State House,17,"Rebecca ""Bekki"" Engquist-Schroeder",DEM,253
+Union,03,State House,17,"William ""Bill"" Shorma",REP,418
+Union,03,State House,17,Chris Kassin,REP,553
+Union,04,State House,16,Matt Ness,DEM,114
+Union,04,State House,16,Kevin D. Jensen,REP,280
+Union,04,State House,16,Karla J. Lems,REP,231
+Union,05,State House,16,Matt Ness,DEM,180
+Union,05,State House,16,Kevin D. Jensen,REP,329
+Union,05,State House,16,Karla J. Lems,REP,301
+Union,06,State House,17,"Rebecca ""Bekki"" Engquist-Schroeder",DEM,139
+Union,06,State House,17,"William ""Bill"" Shorma",REP,411
+Union,06,State House,17,Chris Kassin,REP,360
+Union,07,State House,16,Matt Ness,DEM,73
+Union,07,State House,16,Kevin D. Jensen,REP,125
+Union,07,State House,16,Karla J. Lems,REP,96
+Union,07,State House,17,"Rebecca ""Bekki"" Engquist-Schroeder",DEM,23
+Union,07,State House,17,"William ""Bill"" Shorma",REP,29
+Union,07,State House,17,Chris Kassin,REP,35
+Union,08,State House,17,"Rebecca ""Bekki"" Engquist-Schroeder",DEM,120
+Union,08,State House,17,"William ""Bill"" Shorma",REP,186
+Union,08,State House,17,Chris Kassin,REP,203
+Union,09,State House,17,"Rebecca ""Bekki"" Engquist-Schroeder",DEM,167
+Union,09,State House,17,"William ""Bill"" Shorma",REP,274
+Union,09,State House,17,Chris Kassin,REP,328
+Union,10,State House,17,"Rebecca ""Bekki"" Engquist-Schroeder",DEM,156
+Union,10,State House,17,"William ""Bill"" Shorma",REP,241
+Union,10,State House,17,Chris Kassin,REP,307
+Union,11,State House,17,"Rebecca ""Bekki"" Engquist-Schroeder",DEM,132
+Union,11,State House,17,"William ""Bill"" Shorma",REP,423
+Union,11,State House,17,Chris Kassin,REP,438
+Union,12 11 of 21,State House,17,"Rebecca ""Bekki"" Engquist-Schroeder",DEM,229
+Union,12 11 of 21,State House,17,"William ""Bill"" Shorma",REP,640
+Union,12 11 of 21,State House,17,Chris Kassin,REP,540

--- a/2022/counties/20221108__sd__general__walworth__precinct.csv
+++ b/2022/counties/20221108__sd__general__walworth__precinct.csv
@@ -1,0 +1,351 @@
+county,precinct,office,district,candidate,party,votes
+Walworth,01,U.S. Senate,,Brian L. Bengs,DEM,8
+Walworth,01,U.S. Senate,,Tamara J Lesnar,LIB,11
+Walworth,01,U.S. Senate,,John R. Thune,REP,102
+Walworth,02,U.S. Senate,,Brian L. Bengs,DEM,17
+Walworth,02,U.S. Senate,,Tamara J Lesnar,LIB,8
+Walworth,02,U.S. Senate,,John R. Thune,REP,107
+Walworth,03,U.S. Senate,,Brian L. Bengs,DEM,26
+Walworth,03,U.S. Senate,,Tamara J Lesnar,LIB,15
+Walworth,03,U.S. Senate,,John R. Thune,REP,306
+Walworth,04,U.S. Senate,,Brian L. Bengs,DEM,28
+Walworth,04,U.S. Senate,,Tamara J Lesnar,LIB,6
+Walworth,04,U.S. Senate,,John R. Thune,REP,100
+Walworth,05,U.S. Senate,,Brian L. Bengs,DEM,52
+Walworth,05,U.S. Senate,,Tamara J Lesnar,LIB,14
+Walworth,05,U.S. Senate,,John R. Thune,REP,191
+Walworth,06,U.S. Senate,,Brian L. Bengs,DEM,88
+Walworth,06,U.S. Senate,,Tamara J Lesnar,LIB,13
+Walworth,06,U.S. Senate,,John R. Thune,REP,283
+Walworth,07,U.S. Senate,,Brian L. Bengs,DEM,61
+Walworth,07,U.S. Senate,,Tamara J Lesnar,LIB,10
+Walworth,07,U.S. Senate,,John R. Thune,REP,316
+Walworth,08,U.S. Senate,,Brian L. Bengs,DEM,3
+Walworth,08,U.S. Senate,,Tamara J Lesnar,LIB,5
+Walworth,08,U.S. Senate,,John R. Thune,REP,62
+Walworth,09,U.S. Senate,,Brian L. Bengs,DEM,10
+Walworth,09,U.S. Senate,,Tamara J Lesnar,LIB,4
+Walworth,09,U.S. Senate,,John R. Thune,REP,54
+Walworth,10,U.S. Senate,,Brian L. Bengs,DEM,8
+Walworth,10,U.S. Senate,,Tamara J Lesnar,LIB,6
+Walworth,10,U.S. Senate,,John R. Thune,REP,124
+Walworth,01,U.S. House,1,Collin Duprel,LIB,21
+Walworth,01,U.S. House,1,Dusty Johnson,REP,102
+Walworth,02,U.S. House,1,Collin Duprel,LIB,18
+Walworth,02,U.S. House,1,Dusty Johnson,REP,112
+Walworth,03,U.S. House,1,Collin Duprel,LIB,31
+Walworth,03,U.S. House,1,Dusty Johnson,REP,308
+Walworth,04,U.S. House,1,Collin Duprel,LIB,22
+Walworth,04,U.S. House,1,Dusty Johnson,REP,108
+Walworth,05,U.S. House,1,Collin Duprel,LIB,44
+Walworth,05,U.S. House,1,Dusty Johnson,REP,200
+Walworth,06,U.S. House,1,Collin Duprel,LIB,57
+Walworth,06,U.S. House,1,Dusty Johnson,REP,304
+Walworth,07,U.S. House,1,Collin Duprel,LIB,41
+Walworth,07,U.S. House,1,Dusty Johnson,REP,327
+Walworth,08,U.S. House,1,Collin Duprel,LIB,7
+Walworth,08,U.S. House,1,Dusty Johnson,REP,60
+Walworth,09,U.S. House,1,Collin Duprel,LIB,14
+Walworth,09,U.S. House,1,Dusty Johnson,REP,48
+Walworth,10,U.S. House,1,Collin Duprel,LIB,16
+Walworth,10,U.S. House,1,Dusty Johnson,REP,122
+Walworth,01,Governor,,Jamie Smith and Jennifer Keintz,DEM,8
+Walworth,01,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Walworth,01,Governor,,Kristi Noem and Larry Rhoden,REP,110
+Walworth,02,Governor,,Jamie Smith and Jennifer Keintz,DEM,25
+Walworth,02,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Walworth,02,Governor,,Kristi Noem and Larry Rhoden,REP,104
+Walworth,03,Governor,,Jamie Smith and Jennifer Keintz,DEM,46
+Walworth,03,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Walworth,03,Governor,,Kristi Noem and Larry Rhoden,REP,296
+Walworth,04,Governor,,Jamie Smith and Jennifer Keintz,DEM,38
+Walworth,04,Governor,,Tracey Quint and Ashley Strand,LIB,3
+Walworth,04,Governor,,Kristi Noem and Larry Rhoden,REP,95
+Walworth,05,Governor,,Jamie Smith and Jennifer Keintz,DEM,68
+Walworth,05,Governor,,Tracey Quint and Ashley Strand,LIB,11
+Walworth,05,Governor,,Kristi Noem and Larry Rhoden,REP,178
+Walworth,06,Governor,,Jamie Smith and Jennifer Keintz,DEM,116
+Walworth,06,Governor,,Tracey Quint and Ashley Strand,LIB,10
+Walworth,06,Governor,,Kristi Noem and Larry Rhoden,REP,263
+Walworth,07,Governor,,Jamie Smith and Jennifer Keintz,DEM,92
+Walworth,07,Governor,,Tracey Quint and Ashley Strand,LIB,6
+Walworth,07,Governor,,Kristi Noem and Larry Rhoden,REP,289
+Walworth,08,Governor,,Jamie Smith and Jennifer Keintz,DEM,5
+Walworth,08,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Walworth,08,Governor,,Kristi Noem and Larry Rhoden,REP,64
+Walworth,09,Governor,,Jamie Smith and Jennifer Keintz,DEM,17
+Walworth,09,Governor,,Tracey Quint and Ashley Strand,LIB,0
+Walworth,09,Governor,,Kristi Noem and Larry Rhoden,REP,51
+Walworth,10,Governor,,Jamie Smith and Jennifer Keintz,DEM,15
+Walworth,10,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Walworth,10,Governor,,Kristi Noem and Larry Rhoden,REP,123
+Walworth,01,Secretary of State,,Thomas A Cool,DEM,15
+Walworth,01,Secretary of State,,Monae Johnson,REP,102
+Walworth,02,Secretary of State,,Thomas A Cool,DEM,29
+Walworth,02,Secretary of State,,Monae Johnson,REP,102
+Walworth,03,Secretary of State,,Thomas A Cool,DEM,58
+Walworth,03,Secretary of State,,Monae Johnson,REP,274
+Walworth,04,Secretary of State,,Thomas A Cool,DEM,31
+Walworth,04,Secretary of State,,Monae Johnson,REP,99
+Walworth,05,Secretary of State,,Thomas A Cool,DEM,73
+Walworth,05,Secretary of State,,Monae Johnson,REP,175
+Walworth,06,Secretary of State,,Thomas A Cool,DEM,120
+Walworth,06,Secretary of State,,Monae Johnson,REP,251
+Walworth,07,Secretary of State,,Thomas A Cool,DEM,77
+Walworth,07,Secretary of State,,Monae Johnson,REP,287
+Walworth,08,Secretary of State,,Thomas A Cool,DEM,7
+Walworth,08,Secretary of State,,Monae Johnson,REP,59
+Walworth,09,Secretary of State,,Thomas A Cool,DEM,12
+Walworth,09,Secretary of State,,Monae Johnson,REP,47
+Walworth,10,Secretary of State,,Thomas A Cool,DEM,14
+Walworth,10,Secretary of State,,Monae Johnson,REP,124
+Walworth,01,Attorney General,,Marty J. Jackley,REP,98
+Walworth,02,Attorney General,,Marty J. Jackley,REP,114
+Walworth,03,Attorney General,,Marty J. Jackley,REP,303
+Walworth,04,Attorney General,,Marty J. Jackley,REP,110
+Walworth,05,Attorney General,,Marty J. Jackley,REP,201
+Walworth,06,Attorney General,,Marty J. Jackley,REP,299
+Walworth,07,Attorney General,,Marty J. Jackley,REP,316
+Walworth,08,Attorney General,,Marty J. Jackley,REP,63
+Walworth,09,Attorney General,,Marty J. Jackley,REP,53
+Walworth,10,Attorney General,,Marty J. Jackley,REP,134
+Walworth,01,State Auditor,,Stephanie Marty,DEM,12
+Walworth,01,State Auditor,,Rene Meyer,LIB,7
+Walworth,01,State Auditor,,Richard Sattgast,REP,100
+Walworth,02,State Auditor,,Stephanie Marty,DEM,18
+Walworth,02,State Auditor,,Rene Meyer,LIB,7
+Walworth,02,State Auditor,,Richard Sattgast,REP,105
+Walworth,03,State Auditor,,Stephanie Marty,DEM,39
+Walworth,03,State Auditor,,Rene Meyer,LIB,13
+Walworth,03,State Auditor,,Richard Sattgast,REP,279
+Walworth,04,State Auditor,,Stephanie Marty,DEM,31
+Walworth,04,State Auditor,,Rene Meyer,LIB,9
+Walworth,04,State Auditor,,Richard Sattgast,REP,89
+Walworth,05,State Auditor,,Stephanie Marty,DEM,68
+Walworth,05,State Auditor,,Rene Meyer,LIB,12
+Walworth,05,State Auditor,,Richard Sattgast,REP,167
+Walworth,06,State Auditor,,Stephanie Marty,DEM,117
+Walworth,06,State Auditor,,Rene Meyer,LIB,14
+Walworth,06,State Auditor,,Richard Sattgast,REP,246
+Walworth,07,State Auditor,,Stephanie Marty,DEM,83
+Walworth,07,State Auditor,,Rene Meyer,LIB,11
+Walworth,07,State Auditor,,Richard Sattgast,REP,269
+Walworth,08,State Auditor,,Stephanie Marty,DEM,7
+Walworth,08,State Auditor,,Rene Meyer,LIB,0
+Walworth,08,State Auditor,,Richard Sattgast,REP,54
+Walworth,09,State Auditor,,Stephanie Marty,DEM,12
+Walworth,09,State Auditor,,Rene Meyer,LIB,1
+Walworth,09,State Auditor,,Richard Sattgast,REP,46
+Walworth,10,State Auditor,,Stephanie Marty,DEM,14
+Walworth,10,State Auditor,,Rene Meyer,LIB,2
+Walworth,10,State Auditor,,Richard Sattgast,REP,119
+Walworth,01,State Treasurer,,John Cunningham,DEM,12
+Walworth,01,State Treasurer,,Josh Haeder,REP,105
+Walworth,02,State Treasurer,,John Cunningham,DEM,20
+Walworth,02,State Treasurer,,Josh Haeder,REP,112
+Walworth,03,State Treasurer,,John Cunningham,DEM,36
+Walworth,03,State Treasurer,,Josh Haeder,REP,296
+Walworth,04,State Treasurer,,John Cunningham,DEM,31
+Walworth,04,State Treasurer,,Josh Haeder,REP,98
+Walworth,05,State Treasurer,,John Cunningham,DEM,69
+Walworth,05,State Treasurer,,Josh Haeder,REP,178
+Walworth,06,State Treasurer,,John Cunningham,DEM,113
+Walworth,06,State Treasurer,,Josh Haeder,REP,262
+Walworth,07,State Treasurer,,John Cunningham,DEM,70
+Walworth,07,State Treasurer,,Josh Haeder,REP,289
+Walworth,08,State Treasurer,,John Cunningham,DEM,5
+Walworth,08,State Treasurer,,Josh Haeder,REP,59
+Walworth,09,State Treasurer,,John Cunningham,DEM,9
+Walworth,09,State Treasurer,,Josh Haeder,REP,49
+Walworth,10,State Treasurer,,John Cunningham,DEM,12
+Walworth,10,State Treasurer,,Josh Haeder,REP,122
+Walworth,01,Commissioner of School and Public Lands,,Timothy Azure,DEM,13
+Walworth,01,Commissioner of School and Public Lands,,Brock Greenfield,REP,104
+Walworth,02,Commissioner of School and Public Lands,,Timothy Azure,DEM,18
+Walworth,02,Commissioner of School and Public Lands,,Brock Greenfield,REP,112
+Walworth,03,Commissioner of School and Public Lands,,Timothy Azure,DEM,34
+Walworth,03,Commissioner of School and Public Lands,,Brock Greenfield,REP,293
+Walworth,04,Commissioner of School and Public Lands,,Timothy Azure,DEM,29
+Walworth,04,Commissioner of School and Public Lands,,Brock Greenfield,REP,97
+Walworth,05,Commissioner of School and Public Lands,,Timothy Azure,DEM,70
+Walworth,05,Commissioner of School and Public Lands,,Brock Greenfield,REP,175
+Walworth,06,Commissioner of School and Public Lands,,Timothy Azure,DEM,111
+Walworth,06,Commissioner of School and Public Lands,,Brock Greenfield,REP,253
+Walworth,07,Commissioner of School and Public Lands,,Timothy Azure,DEM,77
+Walworth,07,Commissioner of School and Public Lands,,Brock Greenfield,REP,282
+Walworth,08,Commissioner of School and Public Lands,,Timothy Azure,DEM,6
+Walworth,08,Commissioner of School and Public Lands,,Brock Greenfield,REP,60
+Walworth,09,Commissioner of School and Public Lands,,Timothy Azure,DEM,11
+Walworth,09,Commissioner of School and Public Lands,,Brock Greenfield,REP,46
+Walworth,10,Commissioner of School and Public Lands,,Timothy Azure,DEM,14
+Walworth,10,Commissioner of School and Public Lands,,Brock Greenfield,REP,118
+Walworth,01,Public Utilities Commissioner,,Jeffrey Barth,DEM,7
+Walworth,01,Public Utilities Commissioner,,Chris Nelson,REP,115
+Walworth,02,Public Utilities Commissioner,,Jeffrey Barth,DEM,17
+Walworth,02,Public Utilities Commissioner,,Chris Nelson,REP,115
+Walworth,03,Public Utilities Commissioner,,Jeffrey Barth,DEM,38
+Walworth,03,Public Utilities Commissioner,,Chris Nelson,REP,300
+Walworth,04,Public Utilities Commissioner,,Jeffrey Barth,DEM,30
+Walworth,04,Public Utilities Commissioner,,Chris Nelson,REP,99
+Walworth,05,Public Utilities Commissioner,,Jeffrey Barth,DEM,67
+Walworth,05,Public Utilities Commissioner,,Chris Nelson,REP,178
+Walworth,06,Public Utilities Commissioner,,Jeffrey Barth,DEM,93
+Walworth,06,Public Utilities Commissioner,,Chris Nelson,REP,279
+Walworth,07,Public Utilities Commissioner,,Jeffrey Barth,DEM,68
+Walworth,07,Public Utilities Commissioner,,Chris Nelson,REP,300
+Walworth,08,Public Utilities Commissioner,,Jeffrey Barth,DEM,6
+Walworth,08,Public Utilities Commissioner,,Chris Nelson,REP,62
+Walworth,09,Public Utilities Commissioner,,Jeffrey Barth,DEM,9
+Walworth,09,Public Utilities Commissioner,,Chris Nelson,REP,48
+Walworth,10,Public Utilities Commissioner,,Jeffrey Barth,DEM,9
+Walworth,10,Public Utilities Commissioner,,Chris Nelson,REP,127
+Walworth,01,State Senate,23,Bryan J. Breitling,REP,98
+Walworth,02,State Senate,23,Bryan J. Breitling,REP,108
+Walworth,03,State Senate,23,Bryan J. Breitling,REP,299
+Walworth,04,State Senate,23,Bryan J. Breitling,REP,102
+Walworth,05,State Senate,23,Bryan J. Breitling,REP,192
+Walworth,06,State Senate,23,Bryan J. Breitling,REP,285
+Walworth,07,State Senate,23,Bryan J. Breitling,REP,295
+Walworth,08,State Senate,23,Bryan J. Breitling,REP,54
+Walworth,09,State Senate,23,Bryan J. Breitling,REP,47
+Walworth,10,State Senate,23,Bryan J. Breitling,REP,125
+Walworth,01,State House,23,James D. Wangsness,REP,67
+Walworth,01,State House,23,Scott Moore,REP,95
+Walworth,02,State House,23,James D. Wangsness,REP,59
+Walworth,02,State House,23,Scott Moore,REP,95
+Walworth,03,State House,23,James D. Wangsness,REP,163
+Walworth,03,State House,23,Scott Moore,REP,249
+Walworth,04,State House,23,James D. Wangsness,REP,56
+Walworth,04,State House,23,Scott Moore,REP,89
+Walworth,05,State House,23,James D. Wangsness,REP,118
+Walworth,05,State House,23,Scott Moore,REP,165
+Walworth,06,State House,23,James D. Wangsness,REP,158
+Walworth,06,State House,23,Scott Moore,REP,247
+Walworth,07,State House,23,James D. Wangsness,REP,160
+Walworth,07,State House,23,Scott Moore,REP,255
+Walworth,08,State House,23,James D. Wangsness,REP,34
+Walworth,08,State House,23,Scott Moore,REP,53
+Walworth,09,State House,23,James D. Wangsness,REP,26
+Walworth,09,State House,23,Scott Moore,REP,40
+Walworth,10,State House,23,James D. Wangsness,REP,68
+Walworth,10,State House,23,Scott Moore,REP,108
+Walworth,01,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,64
+Walworth,02,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,73
+Walworth,03,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,189
+Walworth,04,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,65
+Walworth,05,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,131
+Walworth,06,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,182
+Walworth,07,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,182
+Walworth,08,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,41
+Walworth,09,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,31
+Walworth,10,Judge of the Circuit Court,Position A Fifth Circuit,Marshall C. Lovrien,NON,70
+Walworth,01,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,59
+Walworth,02,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,67
+Walworth,03,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,176
+Walworth,04,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,65
+Walworth,05,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,126
+Walworth,06,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,180
+Walworth,07,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,182
+Walworth,08,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,32
+Walworth,09,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,33
+Walworth,10,Judge of the Circuit Court,Position B Fifth Circuit,Tony L. Portra,NON,71
+Walworth,01,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,58
+Walworth,02,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,68
+Walworth,03,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,180
+Walworth,04,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,64
+Walworth,05,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,123
+Walworth,06,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,171
+Walworth,07,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,176
+Walworth,08,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,31
+Walworth,09,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,30
+Walworth,10,Judge of the Circuit Court,Position C Fifth Circuit,Gregory C. Magera,NON,69
+Walworth,01,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,60
+Walworth,02,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,68
+Walworth,03,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,173
+Walworth,04,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,61
+Walworth,05,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,127
+Walworth,06,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,178
+Walworth,07,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,179
+Walworth,08,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,32
+Walworth,09,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,31
+Walworth,10,Judge of the Circuit Court,Position D Fifth Circuit,Richard A. Sommers,NON,72
+Walworth,01,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,83
+Walworth,01,Supreme Court Retention,3,Patricia J. DeVaney - No,,25
+Walworth,02,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,86
+Walworth,02,Supreme Court Retention,3,Patricia J. DeVaney - No,,32
+Walworth,03,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,253
+Walworth,03,Supreme Court Retention,3,Patricia J. DeVaney - No,,48
+Walworth,04,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,93
+Walworth,04,Supreme Court Retention,3,Patricia J. DeVaney - No,,24
+Walworth,05,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,185
+Walworth,05,Supreme Court Retention,3,Patricia J. DeVaney - No,,32
+Walworth,06,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,271
+Walworth,06,Supreme Court Retention,3,Patricia J. DeVaney - No,,66
+Walworth,07,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,256
+Walworth,07,Supreme Court Retention,3,Patricia J. DeVaney - No,,62
+Walworth,08,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,46
+Walworth,08,Supreme Court Retention,3,Patricia J. DeVaney - No,,8
+Walworth,09,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,43
+Walworth,09,Supreme Court Retention,3,Patricia J. DeVaney - No,,9
+Walworth,10,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,105
+Walworth,10,Supreme Court Retention,3,Patricia J. DeVaney - No,,16
+Walworth,01,Supreme Court Retention,2,Mark E. Salter - Yes,,82
+Walworth,01,Supreme Court Retention,2,Mark E. Salter - No,,23
+Walworth,02,Supreme Court Retention,2,Mark E. Salter - Yes,,89
+Walworth,02,Supreme Court Retention,2,Mark E. Salter - No,,28
+Walworth,03,Supreme Court Retention,2,Mark E. Salter - Yes,,252
+Walworth,03,Supreme Court Retention,2,Mark E. Salter - No,,48
+Walworth,04,Supreme Court Retention,2,Mark E. Salter - Yes,,92
+Walworth,04,Supreme Court Retention,2,Mark E. Salter - No,,25
+Walworth,05,Supreme Court Retention,2,Mark E. Salter - Yes,,179
+Walworth,05,Supreme Court Retention,2,Mark E. Salter - No,,36
+Walworth,06,Supreme Court Retention,2,Mark E. Salter - Yes,,270
+Walworth,06,Supreme Court Retention,2,Mark E. Salter - No,,68
+Walworth,07,Supreme Court Retention,2,Mark E. Salter - Yes,,259
+Walworth,07,Supreme Court Retention,2,Mark E. Salter - No,,60
+Walworth,08,Supreme Court Retention,2,Mark E. Salter - Yes,,44
+Walworth,08,Supreme Court Retention,2,Mark E. Salter - No,,8
+Walworth,09,Supreme Court Retention,2,Mark E. Salter - Yes,,42
+Walworth,09,Supreme Court Retention,2,Mark E. Salter - No,,10
+Walworth,10,Supreme Court Retention,2,Mark E. Salter - Yes,,107
+Walworth,10,Supreme Court Retention,2,Mark E. Salter - No,,15
+Walworth,01,Constitutional Amendment D,,Yes,,38
+Walworth,01,Constitutional Amendment D,,No,,82
+Walworth,02,Constitutional Amendment D,,Yes,,69
+Walworth,02,Constitutional Amendment D,,No,,63
+Walworth,03,Constitutional Amendment D,,Yes,,160
+Walworth,03,Constitutional Amendment D,,No,,169
+Walworth,04,Constitutional Amendment D,,Yes,,58
+Walworth,04,Constitutional Amendment D,,No,,70
+Walworth,05,Constitutional Amendment D,,Yes,,142
+Walworth,05,Constitutional Amendment D,,No,,112
+Walworth,06,Constitutional Amendment D,,Yes,,201
+Walworth,06,Constitutional Amendment D,,No,,180
+Walworth,07,Constitutional Amendment D,,Yes,,166
+Walworth,07,Constitutional Amendment D,,No,,206
+Walworth,08,Constitutional Amendment D,,Yes,,26
+Walworth,08,Constitutional Amendment D,,No,,39
+Walworth,09,Constitutional Amendment D,,Yes,,27
+Walworth,09,Constitutional Amendment D,,No,,35
+Walworth,10,Constitutional Amendment D,,Yes,,50
+Walworth,10,Constitutional Amendment D,,No,,85
+Walworth,01,Initiated Measure 27,,Yes,,29
+Walworth,01,Initiated Measure 27,,No,,89
+Walworth,02,Initiated Measure 27,,Yes,,38
+Walworth,02,Initiated Measure 27,,No,,95
+Walworth,03,Initiated Measure 27,,Yes,,115
+Walworth,03,Initiated Measure 27,,No,,217
+Walworth,04,Initiated Measure 27,,Yes,,44
+Walworth,04,Initiated Measure 27,,No,,83
+Walworth,05,Initiated Measure 27,,Yes,,124
+Walworth,05,Initiated Measure 27,,No,,136
+Walworth,06,Initiated Measure 27,,Yes,,190
+Walworth,06,Initiated Measure 27,,No,,198
+Walworth,07,Initiated Measure 27,,Yes,,113
+Walworth,07,Initiated Measure 27,,No,,267
+Walworth,08,Initiated Measure 27,,Yes,,22
+Walworth,08,Initiated Measure 27,,No,,45
+Walworth,09,Initiated Measure 27,,Yes,,28
+Walworth,09,Initiated Measure 27,,No,,38
+Walworth,10,Initiated Measure 27,,Yes,,27
+Walworth,10,Initiated Measure 27,,No,,111

--- a/2022/counties/20221108__sd__general__yankton__precinct.csv
+++ b/2022/counties/20221108__sd__general__yankton__precinct.csv
@@ -1,0 +1,330 @@
+county,precinct,office,district,candidate,party,votes
+Yankton,Absentee Precinct,Attorney General,,Marty J. Jackley,REP,2655
+Yankton,Gayville Community Center,Attorney General,,Marty J. Jackley,REP,229
+Yankton,Lesterville Fire Hall,Attorney General,,Marty J. Jackley,REP,201
+Yankton,Lewis and Clark Recreation Area,Attorney General,,Marty J. Jackley,REP,375
+Yankton,Mayfield Store,Attorney General,,Marty J. Jackley,REP,173
+Yankton,Yankton City Hall,Attorney General,,Marty J. Jackley,REP,1155
+Yankton,Yankton Fire Station #2,Attorney General,,Marty J. Jackley,REP,1559
+Yankton,Absentee Precinct,Commissioner of School and Public Lands,,Brock Greenfield,REP,2069
+Yankton,Absentee Precinct,Commissioner of School and Public Lands,,Timothy Azure,DEM,1475
+Yankton,Gayville Community Center,Commissioner of School and Public Lands,,Brock Greenfield,REP,198
+Yankton,Gayville Community Center,Commissioner of School and Public Lands,,Timothy Azure,DEM,69
+Yankton,Lesterville Fire Hall,Commissioner of School and Public Lands,,Brock Greenfield,REP,195
+Yankton,Lesterville Fire Hall,Commissioner of School and Public Lands,,Timothy Azure,DEM,41
+Yankton,Lewis and Clark Recreation Area,Commissioner of School and Public Lands,,Brock Greenfield,REP,328
+Yankton,Lewis and Clark Recreation Area,Commissioner of School and Public Lands,,Timothy Azure,DEM,90
+Yankton,Mayfield Store,Commissioner of School and Public Lands,,Brock Greenfield,REP,158
+Yankton,Mayfield Store,Commissioner of School and Public Lands,,Timothy Azure,DEM,63
+Yankton,Yankton City Hall,Commissioner of School and Public Lands,,Brock Greenfield,REP,917
+Yankton,Yankton City Hall,Commissioner of School and Public Lands,,Timothy Azure,DEM,544
+Yankton,Yankton Fire Station #2,Commissioner of School and Public Lands,,Brock Greenfield,REP,1304
+Yankton,Yankton Fire Station #2,Commissioner of School and Public Lands,,Timothy Azure,DEM,536
+Yankton,Absentee Precinct,Constitutional Amendment D,,No,,1573
+Yankton,Absentee Precinct,Constitutional Amendment D,,Yes,,2254
+Yankton,Gayville Community Center,Constitutional Amendment D,,No,,139
+Yankton,Gayville Community Center,Constitutional Amendment D,,Yes,,169
+Yankton,Lesterville Fire Hall,Constitutional Amendment D,,No,,176
+Yankton,Lesterville Fire Hall,Constitutional Amendment D,,Yes,,90
+Yankton,Lewis and Clark Recreation Area,Constitutional Amendment D,,No,,239
+Yankton,Lewis and Clark Recreation Area,Constitutional Amendment D,,Yes,,217
+Yankton,Mayfield Store,Constitutional Amendment D,,No,,143
+Yankton,Mayfield Store,Constitutional Amendment D,,Yes,,96
+Yankton,Yankton City Hall,Constitutional Amendment D,,No,,609
+Yankton,Yankton City Hall,Constitutional Amendment D,,Yes,,1029
+Yankton,Yankton Fire Station #2,Constitutional Amendment D,,No,,910
+Yankton,Yankton Fire Station #2,Constitutional Amendment D,,Yes,,1108
+Yankton,Absentee Precinct,County Commissioner At Large,,Cheri Loest,IND,1814
+Yankton,Absentee Precinct,County Commissioner At Large,,Dan Klimisch,REP,2371
+Yankton,Absentee Precinct,County Commissioner At Large,,John R. Marquardt,REP,1611
+Yankton,Absentee Precinct,County Commissioner At Large,,Matt Evans,IND,1428
+Yankton,Absentee Precinct,County Commissioner At Large,,Ryan Heine,REP,1816
+Yankton,Gayville Community Center,County Commissioner At Large,,Cheri Loest,IND,113
+Yankton,Gayville Community Center,County Commissioner At Large,,Dan Klimisch,REP,143
+Yankton,Gayville Community Center,County Commissioner At Large,,John R. Marquardt,REP,164
+Yankton,Gayville Community Center,County Commissioner At Large,,Matt Evans,IND,111
+Yankton,Gayville Community Center,County Commissioner At Large,,Ryan Heine,REP,170
+Yankton,Lesterville Fire Hall,County Commissioner At Large,,Cheri Loest,IND,125
+Yankton,Lesterville Fire Hall,County Commissioner At Large,,Dan Klimisch,REP,145
+Yankton,Lesterville Fire Hall,County Commissioner At Large,,John R. Marquardt,REP,139
+Yankton,Lesterville Fire Hall,County Commissioner At Large,,Matt Evans,IND,70
+Yankton,Lesterville Fire Hall,County Commissioner At Large,,Ryan Heine,REP,165
+Yankton,Lewis and Clark Recreation Area,County Commissioner At Large,,Cheri Loest,IND,156
+Yankton,Lewis and Clark Recreation Area,County Commissioner At Large,,Dan Klimisch,REP,293
+Yankton,Lewis and Clark Recreation Area,County Commissioner At Large,,John R. Marquardt,REP,252
+Yankton,Lewis and Clark Recreation Area,County Commissioner At Large,,Matt Evans,IND,126
+Yankton,Lewis and Clark Recreation Area,County Commissioner At Large,,Ryan Heine,REP,265
+Yankton,Mayfield Store,County Commissioner At Large,,Cheri Loest,IND,117
+Yankton,Mayfield Store,County Commissioner At Large,,Dan Klimisch,REP,95
+Yankton,Mayfield Store,County Commissioner At Large,,John R. Marquardt,REP,113
+Yankton,Mayfield Store,County Commissioner At Large,,Matt Evans,IND,80
+Yankton,Mayfield Store,County Commissioner At Large,,Ryan Heine,REP,146
+Yankton,Yankton City Hall,County Commissioner At Large,,Cheri Loest,IND,692
+Yankton,Yankton City Hall,County Commissioner At Large,,Dan Klimisch,REP,910
+Yankton,Yankton City Hall,County Commissioner At Large,,John R. Marquardt,REP,656
+Yankton,Yankton City Hall,County Commissioner At Large,,Matt Evans,IND,646
+Yankton,Yankton City Hall,County Commissioner At Large,,Ryan Heine,REP,751
+Yankton,Yankton Fire Station #2,County Commissioner At Large,,Cheri Loest,IND,763
+Yankton,Yankton Fire Station #2,County Commissioner At Large,,Dan Klimisch,REP,1218
+Yankton,Yankton Fire Station #2,County Commissioner At Large,,John R. Marquardt,REP,957
+Yankton,Yankton Fire Station #2,County Commissioner At Large,,Matt Evans,IND,694
+Yankton,Yankton Fire Station #2,County Commissioner At Large,,Ryan Heine,REP,1071
+Yankton,Absentee Precinct,Governor,,Jamie Smith and Jennifer Keintz,DEM,1741
+Yankton,Absentee Precinct,Governor,,Kristi Noem and Larry Rhoden,REP,2054
+Yankton,Absentee Precinct,Governor,,Tracey Quint and Ashley Strand,LIB,108
+Yankton,Gayville Community Center,Governor,,Jamie Smith and Jennifer Keintz,DEM,85
+Yankton,Gayville Community Center,Governor,,Kristi Noem and Larry Rhoden,REP,210
+Yankton,Gayville Community Center,Governor,,Tracey Quint and Ashley Strand,LIB,20
+Yankton,Lesterville Fire Hall,Governor,,Jamie Smith and Jennifer Keintz,DEM,41
+Yankton,Lesterville Fire Hall,Governor,,Kristi Noem and Larry Rhoden,REP,224
+Yankton,Lesterville Fire Hall,Governor,,Tracey Quint and Ashley Strand,LIB,8
+Yankton,Lewis and Clark Recreation Area,Governor,,Jamie Smith and Jennifer Keintz,DEM,105
+Yankton,Lewis and Clark Recreation Area,Governor,,Kristi Noem and Larry Rhoden,REP,349
+Yankton,Lewis and Clark Recreation Area,Governor,,Tracey Quint and Ashley Strand,LIB,9
+Yankton,Mayfield Store,Governor,,Jamie Smith and Jennifer Keintz,DEM,63
+Yankton,Mayfield Store,Governor,,Kristi Noem and Larry Rhoden,REP,175
+Yankton,Mayfield Store,Governor,,Tracey Quint and Ashley Strand,LIB,14
+Yankton,Yankton City Hall,Governor,,Jamie Smith and Jennifer Keintz,DEM,656
+Yankton,Yankton City Hall,Governor,,Kristi Noem and Larry Rhoden,REP,926
+Yankton,Yankton City Hall,Governor,,Tracey Quint and Ashley Strand,LIB,69
+Yankton,Yankton Fire Station #2,Governor,,Jamie Smith and Jennifer Keintz,DEM,659
+Yankton,Yankton Fire Station #2,Governor,,Kristi Noem and Larry Rhoden,REP,1309
+Yankton,Yankton Fire Station #2,Governor,,Tracey Quint and Ashley Strand,LIB,85
+Yankton,Absentee Precinct,Initiated Measure 27,,No,,2054
+Yankton,Absentee Precinct,Initiated Measure 27,,Yes,,1823
+Yankton,Gayville Community Center,Initiated Measure 27,,No,,146
+Yankton,Gayville Community Center,Initiated Measure 27,,Yes,,166
+Yankton,Lesterville Fire Hall,Initiated Measure 27,,No,,209
+Yankton,Lesterville Fire Hall,Initiated Measure 27,,Yes,,61
+Yankton,Lewis and Clark Recreation Area,Initiated Measure 27,,No,,274
+Yankton,Lewis and Clark Recreation Area,Initiated Measure 27,,Yes,,186
+Yankton,Mayfield Store,Initiated Measure 27,,No,,182
+Yankton,Mayfield Store,Initiated Measure 27,,Yes,,69
+Yankton,Yankton City Hall,Initiated Measure 27,,No,,702
+Yankton,Yankton City Hall,Initiated Measure 27,,Yes,,953
+Yankton,Yankton Fire Station #2,Initiated Measure 27,,No,,1102
+Yankton,Yankton Fire Station #2,Initiated Measure 27,,Yes,,938
+Yankton,Absentee Precinct,James River Water Development District,,Dan Klimisch,NON,730
+Yankton,Absentee Precinct,James River Water Development District,,Sandy Williams,NON,384
+Yankton,Gayville Community Center,James River Water Development District,,Dan Klimisch,NON,149
+Yankton,Gayville Community Center,James River Water Development District,,Sandy Williams,NON,100
+Yankton,Lesterville Fire Hall,James River Water Development District,,Dan Klimisch,NON,126
+Yankton,Lesterville Fire Hall,James River Water Development District,,Sandy Williams,NON,92
+Yankton,Lewis and Clark Recreation Area,James River Water Development District,,Dan Klimisch,NON,213
+Yankton,Lewis and Clark Recreation Area,James River Water Development District,,Sandy Williams,NON,99
+Yankton,Mayfield Store,James River Water Development District,,Dan Klimisch,NON,74
+Yankton,Mayfield Store,James River Water Development District,,Sandy Williams,NON,122
+Yankton,Yankton City Hall,James River Water Development District,,Dan Klimisch,NON,194
+Yankton,Yankton City Hall,James River Water Development District,,Sandy Williams,NON,94
+Yankton,Yankton Fire Station #2,James River Water Development District,,Dan Klimisch,NON,273
+Yankton,Yankton Fire Station #2,James River Water Development District,,Sandy Williams,NON,105
+Yankton,Absentee Precinct,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,1598
+Yankton,Gayville Community Center,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,138
+Yankton,Lesterville Fire Hall,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,91
+Yankton,Lewis and Clark Recreation Area,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,167
+Yankton,Mayfield Store,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,88
+Yankton,Yankton City Hall,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,735
+Yankton,Yankton Fire Station #2,Judge of the Circuit Court,Position A First Circuit,Chris S. Giles,NON,889
+Yankton,Absentee Precinct,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,1970
+Yankton,Gayville Community Center,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,142
+Yankton,Lesterville Fire Hall,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,99
+Yankton,Lewis and Clark Recreation Area,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,200
+Yankton,Mayfield Store,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,101
+Yankton,Yankton City Hall,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,827
+Yankton,Yankton Fire Station #2,Judge of the Circuit Court,Position B First Circuit,David Knoff,NON,1033
+Yankton,Absentee Precinct,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,1589
+Yankton,Gayville Community Center,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,138
+Yankton,Lesterville Fire Hall,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,89
+Yankton,Lewis and Clark Recreation Area,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,165
+Yankton,Mayfield Store,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,93
+Yankton,Yankton City Hall,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,719
+Yankton,Yankton Fire Station #2,Judge of the Circuit Court,Position C First Circuit,Bruce V. Anderson,NON,903
+Yankton,Absentee Precinct,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,1762
+Yankton,Gayville Community Center,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,141
+Yankton,Lesterville Fire Hall,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,104
+Yankton,Lewis and Clark Recreation Area,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,179
+Yankton,Mayfield Store,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,105
+Yankton,Yankton City Hall,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,778
+Yankton,Yankton Fire Station #2,Judge of the Circuit Court,Position D First Circuit,Cheryle W. Gering,NON,939
+Yankton,Absentee Precinct,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,1554
+Yankton,Gayville Community Center,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,126
+Yankton,Lesterville Fire Hall,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,85
+Yankton,Lewis and Clark Recreation Area,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,166
+Yankton,Mayfield Store,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,89
+Yankton,Yankton City Hall,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,708
+Yankton,Yankton Fire Station #2,Judge of the Circuit Court,Position E First Circuit,Patrick T. Smith,NON,862
+Yankton,Absentee Precinct,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,1623
+Yankton,Gayville Community Center,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,141
+Yankton,Lesterville Fire Hall,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,88
+Yankton,Lewis and Clark Recreation Area,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,164
+Yankton,Mayfield Store,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,89
+Yankton,Yankton City Hall,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,735
+Yankton,Yankton Fire Station #2,Judge of the Circuit Court,Position F First Circuit,Tami A. Bern,NON,889
+Yankton,Absentee Precinct,Public Utilities Commissioner,,Chris Nelson,REP,2306
+Yankton,Absentee Precinct,Public Utilities Commissioner,,Jeffrey Barth,DEM,1364
+Yankton,Gayville Community Center,Public Utilities Commissioner,,Chris Nelson,REP,220
+Yankton,Gayville Community Center,Public Utilities Commissioner,,Jeffrey Barth,DEM,67
+Yankton,Lesterville Fire Hall,Public Utilities Commissioner,,Chris Nelson,REP,207
+Yankton,Lesterville Fire Hall,Public Utilities Commissioner,,Jeffrey Barth,DEM,49
+Yankton,Lewis and Clark Recreation Area,Public Utilities Commissioner,,Chris Nelson,REP,354
+Yankton,Lewis and Clark Recreation Area,Public Utilities Commissioner,,Jeffrey Barth,DEM,81
+Yankton,Mayfield Store,Public Utilities Commissioner,,Chris Nelson,REP,179
+Yankton,Mayfield Store,Public Utilities Commissioner,,Jeffrey Barth,DEM,54
+Yankton,Yankton City Hall,Public Utilities Commissioner,,Chris Nelson,REP,996
+Yankton,Yankton City Hall,Public Utilities Commissioner,,Jeffrey Barth,DEM,507
+Yankton,Yankton Fire Station #2,Public Utilities Commissioner,,Chris Nelson,REP,1425
+Yankton,Yankton Fire Station #2,Public Utilities Commissioner,,Jeffrey Barth,DEM,470
+Yankton,Absentee Precinct,Secretary of State,,Monae Johnson,REP,2054
+Yankton,Absentee Precinct,Secretary of State,,Thomas A Cool,DEM,1598
+Yankton,Gayville Community Center,Secretary of State,,Monae Johnson,REP,201
+Yankton,Gayville Community Center,Secretary of State,,Thomas A Cool,DEM,97
+Yankton,Lesterville Fire Hall,Secretary of State,,Monae Johnson,REP,204
+Yankton,Lesterville Fire Hall,Secretary of State,,Thomas A Cool,DEM,40
+Yankton,Lewis and Clark Recreation Area,Secretary of State,,Monae Johnson,REP,328
+Yankton,Lewis and Clark Recreation Area,Secretary of State,,Thomas A Cool,DEM,113
+Yankton,Mayfield Store,Secretary of State,,Monae Johnson,REP,165
+Yankton,Mayfield Store,Secretary of State,,Thomas A Cool,DEM,70
+Yankton,Yankton City Hall,Secretary of State,,Monae Johnson,REP,901
+Yankton,Yankton City Hall,Secretary of State,,Thomas A Cool,DEM,637
+Yankton,Yankton Fire Station #2,Secretary of State,,Monae Johnson,REP,1289
+Yankton,Yankton Fire Station #2,Secretary of State,,Thomas A Cool,DEM,627
+Yankton,Absentee Precinct,State Auditor,,Rene Meyer,LIB,147
+Yankton,Absentee Precinct,State Auditor,,Richard Sattgast,REP,2014
+Yankton,Absentee Precinct,State Auditor,,Stephanie Marty,DEM,1485
+Yankton,Gayville Community Center,State Auditor,,Rene Meyer,LIB,22
+Yankton,Gayville Community Center,State Auditor,,Richard Sattgast,REP,184
+Yankton,Gayville Community Center,State Auditor,,Stephanie Marty,DEM,75
+Yankton,Lesterville Fire Hall,State Auditor,,Rene Meyer,LIB,14
+Yankton,Lesterville Fire Hall,State Auditor,,Richard Sattgast,REP,192
+Yankton,Lesterville Fire Hall,State Auditor,,Stephanie Marty,DEM,33
+Yankton,Lewis and Clark Recreation Area,State Auditor,,Rene Meyer,LIB,27
+Yankton,Lewis and Clark Recreation Area,State Auditor,,Richard Sattgast,REP,305
+Yankton,Lewis and Clark Recreation Area,State Auditor,,Stephanie Marty,DEM,90
+Yankton,Mayfield Store,State Auditor,,Rene Meyer,LIB,22
+Yankton,Mayfield Store,State Auditor,,Richard Sattgast,REP,146
+Yankton,Mayfield Store,State Auditor,,Stephanie Marty,DEM,62
+Yankton,Yankton City Hall,State Auditor,,Rene Meyer,LIB,114
+Yankton,Yankton City Hall,State Auditor,,Richard Sattgast,REP,843
+Yankton,Yankton City Hall,State Auditor,,Stephanie Marty,DEM,549
+Yankton,Yankton Fire Station #2,State Auditor,,Rene Meyer,LIB,119
+Yankton,Yankton Fire Station #2,State Auditor,,Richard Sattgast,REP,1237
+Yankton,Yankton Fire Station #2,State Auditor,,Stephanie Marty,DEM,518
+Yankton,Absentee Precinct,State House,18,Jay Williams,DEM,997
+Yankton,Absentee Precinct,State House,18,Julie Auch,REP,1778
+Yankton,Absentee Precinct,State House,18,Mike Stevens,REP,2151
+Yankton,Absentee Precinct,State House,18,Ryan D. Cwach,DEM,2111
+Yankton,Gayville Community Center,State House,18,Jay Williams,DEM,57
+Yankton,Gayville Community Center,State House,18,Julie Auch,REP,192
+Yankton,Gayville Community Center,State House,18,Mike Stevens,REP,171
+Yankton,Gayville Community Center,State House,18,Ryan D. Cwach,DEM,126
+Yankton,Lesterville Fire Hall,State House,18,Jay Williams,DEM,20
+Yankton,Lesterville Fire Hall,State House,18,Julie Auch,REP,204
+Yankton,Lesterville Fire Hall,State House,18,Mike Stevens,REP,157
+Yankton,Lesterville Fire Hall,State House,18,Ryan D. Cwach,DEM,82
+Yankton,Lewis and Clark Recreation Area,State House,18,Jay Williams,DEM,47
+Yankton,Lewis and Clark Recreation Area,State House,18,Julie Auch,REP,290
+Yankton,Lewis and Clark Recreation Area,State House,18,Mike Stevens,REP,318
+Yankton,Lewis and Clark Recreation Area,State House,18,Ryan D. Cwach,DEM,167
+Yankton,Mayfield Store,State House,18,Jay Williams,DEM,41
+Yankton,Mayfield Store,State House,18,Julie Auch,REP,168
+Yankton,Mayfield Store,State House,18,Mike Stevens,REP,127
+Yankton,Mayfield Store,State House,18,Ryan D. Cwach,DEM,89
+Yankton,Yankton City Hall,State House,18,Jay Williams,DEM,363
+Yankton,Yankton City Hall,State House,18,Julie Auch,REP,742
+Yankton,Yankton City Hall,State House,18,Mike Stevens,REP,915
+Yankton,Yankton City Hall,State House,18,Ryan D. Cwach,DEM,855
+Yankton,Yankton Fire Station #2,State House,18,Jay Williams,DEM,310
+Yankton,Yankton Fire Station #2,State House,18,Julie Auch,REP,1116
+Yankton,Yankton Fire Station #2,State House,18,Mike Stevens,REP,1229
+Yankton,Yankton Fire Station #2,State House,18,Ryan D. Cwach,DEM,954
+Yankton,Absentee Precinct,State Senate,18,Fredrick Bender,DEM,1495
+Yankton,Absentee Precinct,State Senate,18,Jean M. Hunhoff,REP,2281
+Yankton,Gayville Community Center,State Senate,18,Fredrick Bender,DEM,89
+Yankton,Gayville Community Center,State Senate,18,Jean M. Hunhoff,REP,208
+Yankton,Lesterville Fire Hall,State Senate,18,Fredrick Bender,DEM,54
+Yankton,Lesterville Fire Hall,State Senate,18,Jean M. Hunhoff,REP,203
+Yankton,Lewis and Clark Recreation Area,State Senate,18,Fredrick Bender,DEM,87
+Yankton,Lewis and Clark Recreation Area,State Senate,18,Jean M. Hunhoff,REP,355
+Yankton,Mayfield Store,State Senate,18,Fredrick Bender,DEM,65
+Yankton,Mayfield Store,State Senate,18,Jean M. Hunhoff,REP,174
+Yankton,Yankton City Hall,State Senate,18,Fredrick Bender,DEM,609
+Yankton,Yankton City Hall,State Senate,18,Jean M. Hunhoff,REP,967
+Yankton,Yankton Fire Station #2,State Senate,18,Fredrick Bender,DEM,608
+Yankton,Yankton Fire Station #2,State Senate,18,Jean M. Hunhoff,REP,1347
+Yankton,Absentee Precinct,State Treasurer,,John Cunningham,DEM,1546
+Yankton,Absentee Precinct,State Treasurer,,Josh Haeder,REP,2069
+Yankton,Gayville Community Center,State Treasurer,,John Cunningham,DEM,76
+Yankton,Gayville Community Center,State Treasurer,,Josh Haeder,REP,203
+Yankton,Lesterville Fire Hall,State Treasurer,,John Cunningham,DEM,39
+Yankton,Lesterville Fire Hall,State Treasurer,,Josh Haeder,REP,196
+Yankton,Lewis and Clark Recreation Area,State Treasurer,,John Cunningham,DEM,99
+Yankton,Lewis and Clark Recreation Area,State Treasurer,,Josh Haeder,REP,331
+Yankton,Mayfield Store,State Treasurer,,John Cunningham,DEM,68
+Yankton,Mayfield Store,State Treasurer,,Josh Haeder,REP,161
+Yankton,Yankton City Hall,State Treasurer,,John Cunningham,DEM,574
+Yankton,Yankton City Hall,State Treasurer,,Josh Haeder,REP,922
+Yankton,Yankton Fire Station #2,State Treasurer,,John Cunningham,DEM,544
+Yankton,Yankton Fire Station #2,State Treasurer,,Josh Haeder,REP,1323
+Yankton,Absentee Precinct,Supreme Court Retention,2,No,,647
+Yankton,Absentee Precinct,Supreme Court Retention,2,Yes,,2507
+Yankton,Gayville Community Center,Supreme Court Retention,2,No,,58
+Yankton,Gayville Community Center,Supreme Court Retention,2,Yes,,193
+Yankton,Lesterville Fire Hall,Supreme Court Retention,2,No,,45
+Yankton,Lesterville Fire Hall,Supreme Court Retention,2,Yes,,159
+Yankton,Lewis and Clark Recreation Area,Supreme Court Retention,2,No,,72
+Yankton,Lewis and Clark Recreation Area,Supreme Court Retention,2,Yes,,303
+Yankton,Mayfield Store,Supreme Court Retention,2,No,,46
+Yankton,Mayfield Store,Supreme Court Retention,2,Yes,,149
+Yankton,Yankton City Hall,Supreme Court Retention,2,No,,280
+Yankton,Yankton City Hall,Supreme Court Retention,2,Yes,,1065
+Yankton,Yankton Fire Station #2,Supreme Court Retention,2,No,,310
+Yankton,Yankton Fire Station #2,Supreme Court Retention,2,Yes,,1334
+Yankton,Absentee Precinct,Supreme Court Retention,3,No,,648
+Yankton,Absentee Precinct,Supreme Court Retention,3,Yes,,2523
+Yankton,Gayville Community Center,Supreme Court Retention,3,No,,53
+Yankton,Gayville Community Center,Supreme Court Retention,3,Yes,,200
+Yankton,Lesterville Fire Hall,Supreme Court Retention,3,No,,48
+Yankton,Lesterville Fire Hall,Supreme Court Retention,3,Yes,,159
+Yankton,Lewis and Clark Recreation Area,Supreme Court Retention,3,No,,76
+Yankton,Lewis and Clark Recreation Area,Supreme Court Retention,3,Yes,,300
+Yankton,Mayfield Store,Supreme Court Retention,3,No,,45
+Yankton,Mayfield Store,Supreme Court Retention,3,Yes,,155
+Yankton,Yankton City Hall,Supreme Court Retention,3,No,,274
+Yankton,Yankton City Hall,Supreme Court Retention,3,Yes,,1072
+Yankton,Yankton Fire Station #2,Supreme Court Retention,3,No,,307
+Yankton,Yankton Fire Station #2,Supreme Court Retention,3,Yes,,1349
+Yankton,Absentee Precinct,U.S. House,1,Collin Duprel,LIB,856
+Yankton,Absentee Precinct,U.S. House,1,Dusty Johnson,REP,2693
+Yankton,Gayville Community Center,U.S. House,1,Collin Duprel,LIB,65
+Yankton,Gayville Community Center,U.S. House,1,Dusty Johnson,REP,231
+Yankton,Lesterville Fire Hall,U.S. House,1,Collin Duprel,LIB,41
+Yankton,Lesterville Fire Hall,U.S. House,1,Dusty Johnson,REP,221
+Yankton,Lewis and Clark Recreation Area,U.S. House,1,Collin Duprel,LIB,73
+Yankton,Lewis and Clark Recreation Area,U.S. House,1,Dusty Johnson,REP,372
+Yankton,Mayfield Store,U.S. House,1,Collin Duprel,LIB,52
+Yankton,Mayfield Store,U.S. House,1,Dusty Johnson,REP,195
+Yankton,Yankton City Hall,U.S. House,1,Collin Duprel,LIB,381
+Yankton,Yankton City Hall,U.S. House,1,Dusty Johnson,REP,1169
+Yankton,Yankton Fire Station #2,U.S. House,1,Collin Duprel,LIB,336
+Yankton,Yankton Fire Station #2,U.S. House,1,Dusty Johnson,REP,1618
+Yankton,Absentee Precinct,U.S. Senate,,Brian L. Bengs,DEM,1365
+Yankton,Absentee Precinct,U.S. Senate,,John R. Thune,REP,2408
+Yankton,Absentee Precinct,U.S. Senate,,Tamara J Lesnar,LIB,106
+Yankton,Gayville Community Center,U.S. Senate,,Brian L. Bengs,DEM,58
+Yankton,Gayville Community Center,U.S. Senate,,John R. Thune,REP,237
+Yankton,Gayville Community Center,U.S. Senate,,Tamara J Lesnar,LIB,18
+Yankton,Lesterville Fire Hall,U.S. Senate,,Brian L. Bengs,DEM,24
+Yankton,Lesterville Fire Hall,U.S. Senate,,John R. Thune,REP,229
+Yankton,Lesterville Fire Hall,U.S. Senate,,Tamara J Lesnar,LIB,19
+Yankton,Lewis and Clark Recreation Area,U.S. Senate,,Brian L. Bengs,DEM,64
+Yankton,Lewis and Clark Recreation Area,U.S. Senate,,John R. Thune,REP,373
+Yankton,Lewis and Clark Recreation Area,U.S. Senate,,Tamara J Lesnar,LIB,25
+Yankton,Mayfield Store,U.S. Senate,,Brian L. Bengs,DEM,50
+Yankton,Mayfield Store,U.S. Senate,,John R. Thune,REP,183
+Yankton,Mayfield Store,U.S. Senate,,Tamara J Lesnar,LIB,18
+Yankton,Yankton City Hall,U.S. Senate,,Brian L. Bengs,DEM,477
+Yankton,Yankton City Hall,U.S. Senate,,John R. Thune,REP,1078
+Yankton,Yankton City Hall,U.S. Senate,,Tamara J Lesnar,LIB,84
+Yankton,Yankton Fire Station #2,U.S. Senate,,Brian L. Bengs,DEM,424
+Yankton,Yankton Fire Station #2,U.S. Senate,,John R. Thune,REP,1543
+Yankton,Yankton Fire Station #2,U.S. Senate,,Tamara J Lesnar,LIB,70

--- a/2022/counties/20221108__sd__general__ziebach__precinct.csv
+++ b/2022/counties/20221108__sd__general__ziebach__precinct.csv
@@ -1,0 +1,235 @@
+county,precinct,office,district,candidate,party,votes
+Ziebach,1 Bridger,U.S. Senate,,Brian L. Bengs,DEM,14
+Ziebach,1 Bridger,U.S. Senate,,Tamara J Lesnar,LIB,0
+Ziebach,1 Bridger,U.S. Senate,,John R. Thune,REP,15
+Ziebach,2 Cherry Creek,U.S. Senate,,Brian L. Bengs,DEM,40
+Ziebach,2 Cherry Creek,U.S. Senate,,Tamara J Lesnar,LIB,10
+Ziebach,2 Cherry Creek,U.S. Senate,,John R. Thune,REP,16
+Ziebach,3 Davis,U.S. Senate,,Brian L. Bengs,DEM,64
+Ziebach,3 Davis,U.S. Senate,,Tamara J Lesnar,LIB,17
+Ziebach,3 Davis,U.S. Senate,,John R. Thune,REP,79
+Ziebach,4 Glad Valley,U.S. Senate,,Brian L. Bengs,DEM,4
+Ziebach,4 Glad Valley,U.S. Senate,,Tamara J Lesnar,LIB,0
+Ziebach,4 Glad Valley,U.S. Senate,,John R. Thune,REP,52
+Ziebach,"-5 North Dupree, Precinct-8",U.S. Senate,,Brian L. Bengs,DEM,100
+Ziebach,"-5 North Dupree, Precinct-8",U.S. Senate,,Tamara J Lesnar,LIB,17
+Ziebach,"-5 North Dupree, Precinct-8",U.S. Senate,,John R. Thune,REP,211
+Ziebach,7 Red Scaffold,U.S. Senate,,Brian L. Bengs,DEM,20
+Ziebach,7 Red Scaffold,U.S. Senate,,Tamara J Lesnar,LIB,3
+Ziebach,7 Red Scaffold,U.S. Senate,,John R. Thune,REP,16
+Ziebach,1 Bridger,U.S. House,1,Collin Duprel,LIB,9
+Ziebach,1 Bridger,U.S. House,1,Dusty Johnson,REP,11
+Ziebach,2 Cherry Creek,U.S. House,1,Collin Duprel,LIB,35
+Ziebach,2 Cherry Creek,U.S. House,1,Dusty Johnson,REP,18
+Ziebach,3 Davis,U.S. House,1,Collin Duprel,LIB,68
+Ziebach,3 Davis,U.S. House,1,Dusty Johnson,REP,83
+Ziebach,4 Glad Valley,U.S. House,1,Collin Duprel,LIB,12
+Ziebach,4 Glad Valley,U.S. House,1,Dusty Johnson,REP,43
+Ziebach,"-5 North Dupree, Precinct-8",U.S. House,1,Collin Duprel,LIB,89
+Ziebach,"-5 North Dupree, Precinct-8",U.S. House,1,Dusty Johnson,REP,215
+Ziebach,7 Red Scaffold,U.S. House,1,Collin Duprel,LIB,15
+Ziebach,7 Red Scaffold,U.S. House,1,Dusty Johnson,REP,19
+Ziebach,1 Bridger,Governor,,Jamie Smith and Jennifer Keintz,DEM,15
+Ziebach,1 Bridger,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Ziebach,1 Bridger,Governor,,Kristi Noem and Larry Rhoden,REP,12
+Ziebach,2 Cherry Creek,Governor,,Jamie Smith and Jennifer Keintz,DEM,47
+Ziebach,2 Cherry Creek,Governor,,Tracey Quint and Ashley Strand,LIB,5
+Ziebach,2 Cherry Creek,Governor,,Kristi Noem and Larry Rhoden,REP,14
+Ziebach,3 Davis,Governor,,Jamie Smith and Jennifer Keintz,DEM,90
+Ziebach,3 Davis,Governor,,Tracey Quint and Ashley Strand,LIB,7
+Ziebach,3 Davis,Governor,,Kristi Noem and Larry Rhoden,REP,67
+Ziebach,4 Glad Valley,Governor,,Jamie Smith and Jennifer Keintz,DEM,10
+Ziebach,4 Glad Valley,Governor,,Tracey Quint and Ashley Strand,LIB,2
+Ziebach,4 Glad Valley,Governor,,Kristi Noem and Larry Rhoden,REP,45
+Ziebach,"-5 North Dupree, Precinct-8",Governor,,Jamie Smith and Jennifer Keintz,DEM,115
+Ziebach,"-5 North Dupree, Precinct-8",Governor,,Tracey Quint and Ashley Strand,LIB,17
+Ziebach,"-5 North Dupree, Precinct-8",Governor,,Kristi Noem and Larry Rhoden,REP,197
+Ziebach,7 Red Scaffold,Governor,,Jamie Smith and Jennifer Keintz,DEM,27
+Ziebach,7 Red Scaffold,Governor,,Tracey Quint and Ashley Strand,LIB,1
+Ziebach,7 Red Scaffold,Governor,,Kristi Noem and Larry Rhoden,REP,10
+Ziebach,1 Bridger,Secretary of State,,Thomas A Cool,DEM,17
+Ziebach,1 Bridger,Secretary of State,,Monae Johnson,REP,11
+Ziebach,2 Cherry Creek,Secretary of State,,Thomas A Cool,DEM,50
+Ziebach,2 Cherry Creek,Secretary of State,,Monae Johnson,REP,13
+Ziebach,3 Davis,Secretary of State,,Thomas A Cool,DEM,92
+Ziebach,3 Davis,Secretary of State,,Monae Johnson,REP,58
+Ziebach,4 Glad Valley,Secretary of State,,Thomas A Cool,DEM,11
+Ziebach,4 Glad Valley,Secretary of State,,Monae Johnson,REP,41
+Ziebach,"-5 North Dupree, Precinct-8",Secretary of State,,Thomas A Cool,DEM,127
+Ziebach,"-5 North Dupree, Precinct-8",Secretary of State,,Monae Johnson,REP,185
+Ziebach,7 Red Scaffold,Secretary of State,,Thomas A Cool,DEM,24
+Ziebach,7 Red Scaffold,Secretary of State,,Monae Johnson,REP,11
+Ziebach,1 Bridger,Attorney General,,Marty J. Jackley,REP,14
+Ziebach,2 Cherry Creek,Attorney General,,Marty J. Jackley,REP,22
+Ziebach,3 Davis,Attorney General,,Marty J. Jackley,REP,77
+Ziebach,4 Glad Valley,Attorney General,,Marty J. Jackley,REP,45
+Ziebach,"-5 North Dupree, Precinct-8",Attorney General,,Marty J. Jackley,REP,226
+Ziebach,7 Red Scaffold,Attorney General,,Marty J. Jackley,REP,16
+Ziebach,1 Bridger,State Auditor,,Stephanie Marty,DEM,14
+Ziebach,1 Bridger,State Auditor,,Rene Meyer,LIB,4
+Ziebach,1 Bridger,State Auditor,,Richard Sattgast,REP,11
+Ziebach,2 Cherry Creek,State Auditor,,Stephanie Marty,DEM,49
+Ziebach,2 Cherry Creek,State Auditor,,Rene Meyer,LIB,8
+Ziebach,2 Cherry Creek,State Auditor,,Richard Sattgast,REP,6
+Ziebach,3 Davis,State Auditor,,Stephanie Marty,DEM,73
+Ziebach,3 Davis,State Auditor,,Rene Meyer,LIB,19
+Ziebach,3 Davis,State Auditor,,Richard Sattgast,REP,54
+Ziebach,4 Glad Valley,State Auditor,,Stephanie Marty,DEM,12
+Ziebach,4 Glad Valley,State Auditor,,Rene Meyer,LIB,5
+Ziebach,4 Glad Valley,State Auditor,,Richard Sattgast,REP,34
+Ziebach,"-5 North Dupree, Precinct-8",State Auditor,,Stephanie Marty,DEM,117
+Ziebach,"-5 North Dupree, Precinct-8",State Auditor,,Rene Meyer,LIB,23
+Ziebach,"-5 North Dupree, Precinct-8",State Auditor,,Richard Sattgast,REP,176
+Ziebach,7 Red Scaffold,State Auditor,,Stephanie Marty,DEM,25
+Ziebach,7 Red Scaffold,State Auditor,,Rene Meyer,LIB,3
+Ziebach,7 Red Scaffold,State Auditor,,Richard Sattgast,REP,9
+Ziebach,1 Bridger,State Treasurer,,John Cunningham,DEM,16
+Ziebach,1 Bridger,State Treasurer,,Josh Haeder,REP,12
+Ziebach,2 Cherry Creek,State Treasurer,,John Cunningham,DEM,47
+Ziebach,2 Cherry Creek,State Treasurer,,Josh Haeder,REP,15
+Ziebach,3 Davis,State Treasurer,,John Cunningham,DEM,84
+Ziebach,3 Davis,State Treasurer,,Josh Haeder,REP,58
+Ziebach,4 Glad Valley,State Treasurer,,John Cunningham,DEM,13
+Ziebach,4 Glad Valley,State Treasurer,,Josh Haeder,REP,38
+Ziebach,"-5 North Dupree, Precinct-8",State Treasurer,,John Cunningham,DEM,127
+Ziebach,"-5 North Dupree, Precinct-8",State Treasurer,,Josh Haeder,REP,185
+Ziebach,7 Red Scaffold,State Treasurer,,John Cunningham,DEM,24
+Ziebach,7 Red Scaffold,State Treasurer,,Josh Haeder,REP,10
+Ziebach,1 Bridger,Commissioner of School and Public Lands,,Timothy Azure,DEM,16
+Ziebach,1 Bridger,Commissioner of School and Public Lands,,Brock Greenfield,REP,11
+Ziebach,2 Cherry Creek,Commissioner of School and Public Lands,,Timothy Azure,DEM,53
+Ziebach,2 Cherry Creek,Commissioner of School and Public Lands,,Brock Greenfield,REP,10
+Ziebach,3 Davis,Commissioner of School and Public Lands,,Timothy Azure,DEM,92
+Ziebach,3 Davis,Commissioner of School and Public Lands,,Brock Greenfield,REP,52
+Ziebach,4 Glad Valley,Commissioner of School and Public Lands,,Timothy Azure,DEM,10
+Ziebach,4 Glad Valley,Commissioner of School and Public Lands,,Brock Greenfield,REP,39
+Ziebach,"-5 North Dupree, Precinct-8",Commissioner of School and Public Lands,,Timothy Azure,DEM,128
+Ziebach,"-5 North Dupree, Precinct-8",Commissioner of School and Public Lands,,Brock Greenfield,REP,182
+Ziebach,7 Red Scaffold,Commissioner of School and Public Lands,,Timothy Azure,DEM,23
+Ziebach,7 Red Scaffold,Commissioner of School and Public Lands,,Brock Greenfield,REP,10
+Ziebach,1 Bridger,Public Utilities Commissioner,,Jeffrey Barth,DEM,14
+Ziebach,1 Bridger,Public Utilities Commissioner,,Chris Nelson,REP,13
+Ziebach,2 Cherry Creek,Public Utilities Commissioner,,Jeffrey Barth,DEM,46
+Ziebach,2 Cherry Creek,Public Utilities Commissioner,,Chris Nelson,REP,17
+Ziebach,3 Davis,Public Utilities Commissioner,,Jeffrey Barth,DEM,88
+Ziebach,3 Davis,Public Utilities Commissioner,,Chris Nelson,REP,57
+Ziebach,4 Glad Valley,Public Utilities Commissioner,,Jeffrey Barth,DEM,7
+Ziebach,4 Glad Valley,Public Utilities Commissioner,,Chris Nelson,REP,45
+Ziebach,"-5 North Dupree, Precinct-8",Public Utilities Commissioner,,Jeffrey Barth,DEM,117
+Ziebach,"-5 North Dupree, Precinct-8",Public Utilities Commissioner,,Chris Nelson,REP,203
+Ziebach,7 Red Scaffold,Public Utilities Commissioner,,Jeffrey Barth,DEM,20
+Ziebach,7 Red Scaffold,Public Utilities Commissioner,,Chris Nelson,REP,13
+Ziebach,1 Bridger,State Senate,28,Ryan M. Maher,REP,16
+Ziebach,2 Cherry Creek,State Senate,28,Ryan M. Maher,REP,33
+Ziebach,3 Davis,State Senate,28,Ryan M. Maher,REP,88
+Ziebach,4 Glad Valley,State Senate,28,Ryan M. Maher,REP,47
+Ziebach,"-5 North Dupree, Precinct-8",State Senate,28,Ryan M. Maher,REP,240
+Ziebach,7 Red Scaffold,State Senate,28,Ryan M. Maher,REP,20
+Ziebach,1 Bridger,State House,28A,Oren L Lesmeister,DEM,17
+Ziebach,1 Bridger,State House,28A,Ralph Lyon,REP,11
+Ziebach,2 Cherry Creek,State House,28A,Oren L Lesmeister,DEM,56
+Ziebach,2 Cherry Creek,State House,28A,Ralph Lyon,REP,11
+Ziebach,3 Davis,State House,28A,Oren L Lesmeister,DEM,112
+Ziebach,3 Davis,State House,28A,Ralph Lyon,REP,47
+Ziebach,4 Glad Valley,State House,28A,Oren L Lesmeister,DEM,18
+Ziebach,4 Glad Valley,State House,28A,Ralph Lyon,REP,39
+Ziebach,"-5 North Dupree, Precinct-8",State House,28A,Oren L Lesmeister,DEM,150
+Ziebach,"-5 North Dupree, Precinct-8",State House,28A,Ralph Lyon,REP,175
+Ziebach,7 Red Scaffold,State House,28A,Oren L Lesmeister,DEM,23
+Ziebach,7 Red Scaffold,State House,28A,Ralph Lyon,REP,14
+Ziebach,1 Bridger,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,9
+Ziebach,2 Cherry Creek,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,18
+Ziebach,3 Davis,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,46
+Ziebach,4 Glad Valley,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,23
+Ziebach,"-5 North Dupree, Precinct-8",Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,122
+Ziebach,7 Red Scaffold,Judge of the Circuit Court,Position A Fourth Circuit,Eric J. Strawn,NON,10
+Ziebach,1 Bridger,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,11
+Ziebach,2 Cherry Creek,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,18
+Ziebach,3 Davis,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,47
+Ziebach,4 Glad Valley,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,19
+Ziebach,"-5 North Dupree, Precinct-8",Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,131
+Ziebach,7 Red Scaffold,Judge of the Circuit Court,Position B Fourth Circuit,Michael W. Day,NON,11
+Ziebach,1 Bridger,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,8
+Ziebach,2 Cherry Creek,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,19
+Ziebach,3 Davis,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,45
+Ziebach,4 Glad Valley,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,21
+Ziebach,"-5 North Dupree, Precinct-8",Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,119
+Ziebach,7 Red Scaffold,Judge of the Circuit Court,Position C Fourth Circuit,Michelle Palmer Comer,NON,11
+Ziebach,1 Bridger,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,4
+Ziebach,1 Bridger,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,0
+Ziebach,1 Bridger,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,6
+Ziebach,1 Bridger,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,5
+Ziebach,1 Bridger,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,3
+Ziebach,2 Cherry Creek,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,11
+Ziebach,2 Cherry Creek,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,9
+Ziebach,2 Cherry Creek,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,10
+Ziebach,2 Cherry Creek,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,7
+Ziebach,2 Cherry Creek,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,7
+Ziebach,3 Davis,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,12
+Ziebach,3 Davis,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,7
+Ziebach,3 Davis,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,30
+Ziebach,3 Davis,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,15
+Ziebach,3 Davis,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,4
+Ziebach,4 Glad Valley,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,2
+Ziebach,4 Glad Valley,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,6
+Ziebach,4 Glad Valley,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,10
+Ziebach,4 Glad Valley,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,5
+Ziebach,4 Glad Valley,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,11
+Ziebach,"-5 North Dupree, Precinct-8",Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,19
+Ziebach,"-5 North Dupree, Precinct-8",Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,38
+Ziebach,"-5 North Dupree, Precinct-8",Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,69
+Ziebach,"-5 North Dupree, Precinct-8",Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,29
+Ziebach,"-5 North Dupree, Precinct-8",Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,22
+Ziebach,7 Red Scaffold,Judge of the Circuit Court,Position D Fourth Circuit,Tina M. Hogue,NON,4
+Ziebach,7 Red Scaffold,Judge of the Circuit Court,Position D Fourth Circuit,Chad R. Callahan,NON,4
+Ziebach,7 Red Scaffold,Judge of the Circuit Court,Position D Fourth Circuit,Jennifer Tomac,NON,3
+Ziebach,7 Red Scaffold,Judge of the Circuit Court,Position D Fourth Circuit,John H. Fitzgerald,NON,4
+Ziebach,7 Red Scaffold,Judge of the Circuit Court,Position D Fourth Circuit,David V. Natvig,NON,6
+Ziebach,1 Bridger,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,19
+Ziebach,1 Bridger,Supreme Court Retention,3,Patricia J. DeVaney - No,,6
+Ziebach,2 Cherry Creek,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,34
+Ziebach,2 Cherry Creek,Supreme Court Retention,3,Patricia J. DeVaney - No,,27
+Ziebach,3 Davis,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,93
+Ziebach,3 Davis,Supreme Court Retention,3,Patricia J. DeVaney - No,,45
+Ziebach,4 Glad Valley,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,32
+Ziebach,4 Glad Valley,Supreme Court Retention,3,Patricia J. DeVaney - No,,13
+Ziebach,"-5 North Dupree, Precinct-8",Supreme Court Retention,3,Patricia J. DeVaney - Yes,,200
+Ziebach,"-5 North Dupree, Precinct-8",Supreme Court Retention,3,Patricia J. DeVaney - No,,83
+Ziebach,7 Red Scaffold,Supreme Court Retention,3,Patricia J. DeVaney - Yes,,19
+Ziebach,7 Red Scaffold,Supreme Court Retention,3,Patricia J. DeVaney - No,,16
+Ziebach,1 Bridger,Supreme Court Retention,2,Mark E. Salter - Yes,,17
+Ziebach,1 Bridger,Supreme Court Retention,2,Mark E. Salter - No,,8
+Ziebach,2 Cherry Creek,Supreme Court Retention,2,Mark E. Salter - Yes,,33
+Ziebach,2 Cherry Creek,Supreme Court Retention,2,Mark E. Salter - No,,25
+Ziebach,3 Davis,Supreme Court Retention,2,Mark E. Salter - Yes,,89
+Ziebach,3 Davis,Supreme Court Retention,2,Mark E. Salter - No,,47
+Ziebach,4 Glad Valley,Supreme Court Retention,2,Mark E. Salter - Yes,,30
+Ziebach,4 Glad Valley,Supreme Court Retention,2,Mark E. Salter - No,,14
+Ziebach,"-5 North Dupree, Precinct-8",Supreme Court Retention,2,Mark E. Salter - Yes,,190
+Ziebach,"-5 North Dupree, Precinct-8",Supreme Court Retention,2,Mark E. Salter - No,,87
+Ziebach,7 Red Scaffold,Supreme Court Retention,2,Mark E. Salter - Yes,,20
+Ziebach,7 Red Scaffold,Supreme Court Retention,2,Mark E. Salter - No,,14
+Ziebach,1 Bridger,Constitutional Amendment D,,Yes,,24
+Ziebach,1 Bridger,Constitutional Amendment D,,No,,4
+Ziebach,2 Cherry Creek,Constitutional Amendment D,,Yes,,52
+Ziebach,2 Cherry Creek,Constitutional Amendment D,,No,,12
+Ziebach,3 Davis,Constitutional Amendment D,,Yes,,131
+Ziebach,3 Davis,Constitutional Amendment D,,No,,29
+Ziebach,4 Glad Valley,Constitutional Amendment D,,Yes,,25
+Ziebach,4 Glad Valley,Constitutional Amendment D,,No,,32
+Ziebach,"-5 North Dupree, Precinct-8",Constitutional Amendment D,,Yes,,188
+Ziebach,"-5 North Dupree, Precinct-8",Constitutional Amendment D,,No,,134
+Ziebach,7 Red Scaffold,Constitutional Amendment D,,Yes,,31
+Ziebach,7 Red Scaffold,Constitutional Amendment D,,No,,6
+Ziebach,1 Bridger,Initiated Measure 27,,Yes,,15
+Ziebach,1 Bridger,Initiated Measure 27,,No,,13
+Ziebach,2 Cherry Creek,Initiated Measure 27,,Yes,,51
+Ziebach,2 Cherry Creek,Initiated Measure 27,,No,,14
+Ziebach,3 Davis,Initiated Measure 27,,Yes,,115
+Ziebach,3 Davis,Initiated Measure 27,,No,,47
+Ziebach,4 Glad Valley,Initiated Measure 27,,Yes,,6
+Ziebach,4 Glad Valley,Initiated Measure 27,,No,,51
+Ziebach,"-5 North Dupree, Precinct-8",Initiated Measure 27,,Yes,,142
+Ziebach,"-5 North Dupree, Precinct-8",Initiated Measure 27,,No,,185
+Ziebach,7 Red Scaffold,Initiated Measure 27,,Yes,,23
+Ziebach,7 Red Scaffold,Initiated Measure 27,,No,,16

--- a/2024/20240604__sd__primary__county.csv
+++ b/2024/20240604__sd__primary__county.csv
@@ -171,14 +171,14 @@ Marshall,President,,DEM,Marianne Williamson,14
 Marshall,President,,DEM,Joseph R Biden Jr,97
 Marshall,President,,DEM,Dean Phillips,19
 Marshall,President,,DEM,Armando Perez-Serrato,6
-Mccook,President,,DEM,Marianne Williamson,9
-Mccook,President,,DEM,Joseph R Biden Jr,65
-Mccook,President,,DEM,Dean Phillips,16
-Mccook,President,,DEM,Armando Perez-Serrato,4
-Mcpherson,President,,DEM,Marianne Williamson,5
-Mcpherson,President,,DEM,Joseph R Biden Jr,25
-Mcpherson,President,,DEM,Dean Phillips,5
-Mcpherson,President,,DEM,Armando Perez-Serrato,3
+McCook,President,,DEM,Marianne Williamson,9
+McCook,President,,DEM,Joseph R Biden Jr,65
+McCook,President,,DEM,Dean Phillips,16
+McCook,President,,DEM,Armando Perez-Serrato,4
+McPherson,President,,DEM,Marianne Williamson,5
+McPherson,President,,DEM,Joseph R Biden Jr,25
+McPherson,President,,DEM,Dean Phillips,5
+McPherson,President,,DEM,Armando Perez-Serrato,3
 Meade,President,,DEM,Marianne Williamson,72
 Meade,President,,DEM,Joseph R Biden Jr,353
 Meade,President,,DEM,Dean Phillips,51
@@ -321,8 +321,8 @@ Faulk,State Senate,23,REP,Steven Ray Roseland,393
 Faulk,State Senate,23,REP,Mark Lapka,155
 Hand,State Senate,23,REP,Steven Ray Roseland,271
 Hand,State Senate,23,REP,Mark Lapka,243
-Mcpherson,State Senate,23,REP,Steven Ray Roseland,84
-Mcpherson,State Senate,23,REP,Mark Lapka,553
+McPherson,State Senate,23,REP,Steven Ray Roseland,84
+McPherson,State Senate,23,REP,Mark Lapka,553
 Potter,State Senate,23,REP,Steven Ray Roseland,372
 Potter,State Senate,23,REP,Mark Lapka,143
 Walworth,State Senate,23,REP,Steven Ray Roseland,302
@@ -496,9 +496,9 @@ Hanson,State House,19,REP,Jessica Bahmuller,444
 Hutchinson,State House,19,REP,Drew Peterson,451
 Hutchinson,State House,19,REP,Steven Mettler,509
 Hutchinson,State House,19,REP,Jessica Bahmuller,708
-Mccook,State House,19,REP,Drew Peterson,367
-Mccook,State House,19,REP,Steven Mettler,252
-Mccook,State House,19,REP,Jessica Bahmuller,478
+McCook,State House,19,REP,Drew Peterson,367
+McCook,State House,19,REP,Steven Mettler,252
+McCook,State House,19,REP,Jessica Bahmuller,478
 Turner,State House,19,REP,Drew Peterson,26
 Turner,State House,19,REP,Steven Mettler,34
 Turner,State House,19,REP,Jessica Bahmuller,35
@@ -541,9 +541,9 @@ Faulk,State House,23,REP,James D. Wangsness,236
 Hand,State House,23,REP,Spencer Gosch,289
 Hand,State House,23,REP,Scott Moore,411
 Hand,State House,23,REP,James D. Wangsness,235
-Mcpherson,State House,23,REP,Spencer Gosch,500
-Mcpherson,State House,23,REP,Scott Moore,538
-Mcpherson,State House,23,REP,James D. Wangsness,110
+McPherson,State House,23,REP,Spencer Gosch,500
+McPherson,State House,23,REP,Scott Moore,538
+McPherson,State House,23,REP,James D. Wangsness,110
 Potter,State House,23,REP,Spencer Gosch,247
 Potter,State House,23,REP,Scott Moore,313
 Potter,State House,23,REP,James D. Wangsness,271

--- a/scripts/parse_2022_county.py
+++ b/scripts/parse_2022_county.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Parse the SD 2022 general election statewide canvass (clean digital PDF text layer)
+into an OpenElections county-level CSV."""
+import os, re, csv, sys
+from pathlib import Path
+from natural_pdf import PDF
+
+# Repo root (this file lives in <repo>/scripts/). The source-PDF repo is expected as a
+# sibling checkout; override with SD_SOURCES if it lives elsewhere.
+REPO = Path(__file__).resolve().parents[1]
+SOURCES = Path(os.environ.get("SD_SOURCES", REPO.parent / "openelections-sources-sd"))
+
+PDF_PATH = sys.argv[1] if len(sys.argv) > 1 else \
+    str(SOURCES / "2022/general/2022Generalcanvassreport.pdf")
+OUT = sys.argv[2] if len(sys.argv) > 2 else \
+    str(REPO / "2022/20221108__sd__general__county.csv")
+
+COUNTIES = {c.lower(): c for c in [
+ "Aurora","Beadle","Bennett","Bon Homme","Brookings","Brown","Brule","Buffalo","Butte",
+ "Campbell","Charles Mix","Clark","Clay","Codington","Corson","Custer","Davison","Day",
+ "Deuel","Dewey","Douglas","Edmunds","Fall River","Faulk","Grant","Gregory","Haakon",
+ "Hamlin","Hand","Hanson","Harding","Hughes","Hutchinson","Hyde","Jackson","Jerauld",
+ "Jones","Kingsbury","Lake","Lawrence","Lincoln","Lyman","Marshall","McCook","McPherson",
+ "Meade","Mellette","Miner","Minnehaha","Moody","Oglala Lakota","Pennington","Perkins",
+ "Potter","Roberts","Sanborn","Spink","Stanley","Sully","Todd","Tripp","Turner","Union",
+ "Walworth","Yankton","Ziebach"]}
+
+PARTY = r'(DEM|REP|LIB|IND|NON|CON|NPA|UNF)'
+PARTY_SPLIT = re.compile(r'\s-\s' + PARTY + r'\b')
+HAS_PARTY = re.compile(r'\s-\s' + PARTY + r'\b')
+INT_RE = re.compile(r'^[\d,]+$')
+ORD = {"First":"1","Second":"2","Third":"3","Fourth":"4","Fifth":"5","Sixth":"6",
+       "Seventh":"7","Eighth":"8","Ninth":"9"}
+
+def split_row(line):
+    toks = line.split()
+    nums=[]; i=len(toks)
+    while i>0 and INT_RE.match(toks[i-1]):
+        nums.append(int(toks[i-1].replace(",",""))); i-=1
+    if not nums: return None
+    nums.reverse()
+    return " ".join(toks[:i]), nums
+
+def parse_candidates(line):
+    toks = PARTY_SPLIT.split(line)
+    cands=[]
+    for j in range(0,len(toks)-1,2):
+        name=toks[j].strip(); party=toks[j+1]
+        if name: cands.append((name,party))
+    return cands
+
+def normalize_office(text):
+    """Return (office, district, justice_or_None)."""
+    t = re.sub(r'\s+',' ',text).strip()
+    if t.startswith("United States Senator"): return "U.S. Senate","",None
+    if t.startswith("United States Representative"): return "U.S. House","1",None
+    if t.startswith("Governor"): return "Governor","",None
+    if t.startswith("Secretary of State"): return "Secretary of State","",None
+    if t.startswith("Attorney General"): return "Attorney General","",None
+    if t.startswith("State Auditor"): return "State Auditor","",None
+    if t.startswith("State Treasurer"): return "State Treasurer","",None
+    if t.startswith("Commissioner of School and Public Lands"):
+        return "Commissioner of School and Public Lands","",None
+    if t.startswith("Public Utilities Commissioner"): return "Public Utilities Commissioner","",None
+    m=re.match(r'State Senator District (\w+)',t)
+    if m: return "State Senate",m.group(1),None
+    m=re.match(r'State Representative District (\w+)',t)
+    if m: return "State House",m.group(1),None
+    m=re.match(r'Judge of the Circuit Court,\s*(.+)',t)
+    if m: return "Judge of the Circuit Court",m.group(1).strip(),None
+    if t.startswith("Supreme Court Justice Retention"):
+        jm=re.search(r'Shall Justice (.+?) representing',t)
+        dm=re.search(r'the (\w+) Supreme Court District',t)
+        justice=jm.group(1).strip() if jm else ""
+        dist=ORD.get(dm.group(1),"") if dm else ""
+        return "Supreme Court Retention",dist,justice
+    m=re.match(r'(Constitutional Amendment [A-Z]\b)',t)
+    if m: return m.group(1),"",None
+    m=re.match(r'(Initiated Measure \d+)\b',t)
+    if m: return m.group(1),"",None
+    m=re.match(r'(Referred Law \d+)\b',t)
+    if m: return m.group(1),"",None
+    if "James River Water Development District" in t:
+        return "James River Water Development District","",None
+    return t,"",None  # fallback (flag later)
+
+pdf = PDF(PDF_PATH)
+contests=[]  # dict office,district,justice,cands,rows,total
+cur=None
+office_buf=[]
+
+def finalize_header(cands, is_yesno=False):
+    global cur, office_buf
+    office_text=" ".join(office_buf).strip()
+    office,district,justice = normalize_office(office_text)
+    cur={"office":office,"district":district,"justice":justice,
+         "cands":cands,"rows":{}, "total":None,"raw":office_text}
+    contests.append(cur)
+    office_buf=[]
+
+for pi in range(1,len(pdf.pages)):
+    for raw in (pdf.pages[pi].extract_text() or "").splitlines():
+        line=raw.strip()
+        if not line: continue
+        if line=="County": continue
+        # measure/retention header
+        if line in ("County Yes No","Yes No"):
+            finalize_header([("Yes",""),("No","")], is_yesno=True); continue
+        # candidate header (Name - PARTY ...)
+        if HAS_PARTY.search(line) and not line.startswith("County "):
+            finalize_header(parse_candidates(line)); continue
+        # 'County <office>' continuation OR 'County <office>' that is candidate header
+        if line.startswith("County "):
+            rest=line[len("County "):].strip()
+            if HAS_PARTY.search(rest):
+                # e.g. 'County James River...': actually office; but if it parses as cands? keep as office
+                office_buf=[rest]; continue
+            office_buf=[rest]; continue
+        # data / total row
+        row=split_row(line)
+        if row:
+            name,nums=row
+            low=name.strip().lower()
+            if low=="total" and cur is not None:
+                cur["total"]=nums; continue
+            if low in COUNTIES and cur is not None:
+                cur["rows"][COUNTIES[low]]=nums; continue
+            # unknown leading text w/ trailing ints -> office description (rare); fall through
+        office_buf.append(line)
+
+# ---- Merge contest fragments that share the same (office, district, justice, candidate set) ----
+merged={}
+for c in contests:
+    key=(c["office"],c["district"],c["justice"],tuple(n for n,_ in c["cands"]))
+    if key not in merged:
+        merged[key]={"office":c["office"],"district":c["district"],"justice":c["justice"],
+                     "cands":c["cands"],"rows":{}, "total":None}
+    m=merged[key]
+    m["rows"].update(c["rows"])
+    if c["total"] is not None: m["total"]=c["total"]  # grand total appears on last fragment
+
+# ---- Build output rows + validate merged ----
+out=[]
+problems=[]
+for c in merged.values():
+    office,district,justice,cands=c["office"],c["district"],c["justice"],c["cands"]
+    ncol=len(cands)
+    colsum=[0]*ncol
+    for cty,nums in c["rows"].items():
+        if len(nums)!=ncol:
+            problems.append(f"COLCOUNT {office} d{district} {cty}: {len(nums)} vs {ncol}"); continue
+        for k in range(ncol): colsum[k]+=nums[k]
+    if c["total"] and colsum!=c["total"]:
+        problems.append(f"TOTAL {office} d{district}: sum {colsum} != pdf {c['total']}")
+    if c["total"] is None:
+        problems.append(f"NOTOTAL {office} d{district}: no Total row found ({len(c['rows'])} counties)")
+    for cty,nums in c["rows"].items():
+        if len(nums)!=ncol: continue
+        for (name,party),v in zip(cands,nums):
+            cand=name
+            if office=="Supreme Court Retention" and justice:
+                cand=f"{justice} - {name}"
+            out.append([cty,office,district,party,cand,v])
+
+with open(OUT,"w",newline="") as f:
+    w=csv.writer(f); w.writerow(["county","office","district","party","candidate","votes"]); w.writerows(out)
+
+# summary
+from collections import Counter
+print(f"contests parsed: {len(contests)}   output rows: {len(out)}")
+oc=Counter((r[1],r[2]) for r in out)
+print("offices:")
+for (o,d),n in sorted(oc.items()):
+    print(f"   {n:5d}  {o}{' d'+d if d else ''}")
+print(f"\nVALIDATION problems: {len(problems)}")
+for p in problems[:40]: print("  ",p)

--- a/scripts/parse_2022_mz.py
+++ b/scripts/parse_2022_mz.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Vision-LLM extraction of specific pages from the scanned MarshallZiebachgen22.pdf
+(2022 SD general). Layout: precincts as ROWS, candidates as COLUMNS, 'Name - PARTY'
+headers; some pages show several legislative districts side by side. Caches per page."""
+import re, json, sys, os
+from pathlib import Path
+import llm
+from json_repair import repair_json
+from natural_pdf import PDF
+
+REPO = Path(__file__).resolve().parents[1]
+SOURCES = Path(os.environ.get("SD_SOURCES", REPO.parent / "openelections-sources-sd"))
+SRC=str(SOURCES / "2022/general/MarshallZiebachgen22.pdf")
+CACHE=Path(os.environ.get("SD_CACHE", Path.home()/"sd_cache")); CACHE.mkdir(exist_ok=True)
+RENDER_DPI=200
+
+PROMPT="""This is one page from the South Dakota 2022 GENERAL ELECTION precinct canvass.
+The COUNTY name is in the page header (e.g. "Yankton County", "Minnehaha County").
+The table has PRECINCTS as ROWS (leftmost column, e.g. "Absentee Precinct", "Precinct-0104")
+and CANDIDATES as COLUMNS. Each column header gives a candidate and party as "Name - PARTY"
+(parties: DEM, REP, LIB, IND, NON). For ballot measures the columns are "Yes" and "No".
+
+Some pages show SEVERAL contests side by side - e.g. multiple "State Senator District NN"
+or "State Representative District NN" groups, each with its own candidate columns. On those
+pages each precinct has numbers only under the columns of the district it belongs to; other
+cells are blank.
+
+Return a JSON array. One element per (precinct, candidate) cell that has a vote number:
+- "precinct": precinct name/number exactly as printed (string)
+- "office": contest name (e.g. "United States Senator", "Governor and Lieutenant Governor",
+  "State Senator District 09", "State Representative District 14", "Attorney General",
+  "Constitutional Amendment D", "Initiated Measure 27", "Judge of the Circuit Court, Position A First Circuit")
+- "candidate": candidate full name as printed (for measures use "Yes"/"No")
+- "party": DEM/REP/LIB/IND/NON, or "" for measures
+- "votes": integer (no commas)
+
+Rules:
+- SKIP the "Total" / "Totals" row and the page footer ("N of M").
+- Only output a row for a cell that actually has a number (skip blank cells).
+- Read digits carefully; commas are thousands separators (1,546 -> 1546).
+- Return ONLY the JSON array, no prose, no markdown fences."""
+
+def extract_json(text):
+    text=text.strip()
+    if text.startswith("```"):
+        text=re.sub(r"^```[a-z]*\n?","",text); text=re.sub(r"\n?```$","",text).strip()
+    if not text.startswith("["):
+        s=text.find("["); e=text.rfind("]")
+        if s!=-1 and e!=-1: text=text[s:e+1]
+    return json.loads(repair_json(text))
+
+def process(pages, model_name, county):
+    model=llm.get_model(model_name)
+    slug=re.sub(r"[^A-Za-z0-9]+","-",model_name).strip("-")
+    pdf=PDF(SRC)
+    allrows=[]
+    for i in pages:
+        cache=CACHE/f"mz_{slug}_page{i}.json"
+        if cache.exists():
+            recs=json.load(open(cache)); print(f"  p{i} (cached) {len(recs)} rows")
+        else:
+            img=CACHE/f"mz_page{i}.png"
+            if not img.exists():
+                pdf.pages[i].render(resolution=RENDER_DPI).save(str(img))
+            print(f"  p{i} -> {model_name} ...", flush=True)
+            resp=model.prompt(PROMPT, attachments=[llm.Attachment(path=str(img))])
+            try: recs=extract_json(resp.text())
+            except Exception as e:
+                print("    JSON FAIL", e); recs=[]
+            json.dump(recs, open(cache,"w"), indent=1)
+            print(f"    {len(recs)} rows")
+        for r in recs: r["county"]=county
+        allrows+=recs
+    return allrows
+
+if __name__=="__main__":
+    target=sys.argv[1]   # 'yankton' or 'minnehaha'
+    model=sys.argv[2] if len(sys.argv)>2 else "qwen3.5:397b-cloud"
+    if target=="yankton":
+        rows=process(range(442,465),model,"Yankton")
+    else:
+        rows=process([int(x) for x in sys.argv[3].split(",")],model,"Minnehaha")
+    json.dump(rows, open(CACHE/f"mz_{target}_rows.json","w"), indent=1)
+    print(f"TOTAL {len(rows)} raw rows -> mz_{target}_rows.json")

--- a/scripts/parse_2022_mz_reconcile.py
+++ b/scripts/parse_2022_mz_reconcile.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Normalize MZ vision-LLM rows, reconcile against county totals, write/merge precinct CSV."""
+import os, re, json, csv, sys
+from collections import defaultdict
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+CACHE=Path(os.environ.get("SD_CACHE", Path.home()/"sd_cache"))
+COUNTY_CSV=str(REPO / "2022/20221108__sd__general__county.csv")
+ORD={"First":"1","Second":"2","Third":"3","Fourth":"4","Fifth":"5","Sixth":"6",
+     "Seventh":"7","Eighth":"8","Ninth":"9"}
+
+def normalize_office(text):
+    t=re.sub(r'\s+',' ',text).strip()
+    if re.search(r'United States Senator|U\.?S\.? Senate',t,re.I): return "U.S. Senate",""
+    if re.search(r'United States Representative|U\.?S\.? House',t,re.I): return "U.S. House","1"
+    if re.search(r'Governor',t,re.I): return "Governor",""
+    if re.search(r'Secretary of State',t,re.I): return "Secretary of State",""
+    if re.search(r'Attorney General',t,re.I): return "Attorney General",""
+    if re.search(r'State Auditor',t,re.I): return "State Auditor",""
+    if re.search(r'State Treasurer',t,re.I): return "State Treasurer",""
+    if re.search(r'Commissioner of School',t,re.I): return "Commissioner of School and Public Lands",""
+    if re.search(r'Public Utilities',t,re.I): return "Public Utilities Commissioner",""
+    m=re.search(r'Senator.*?District (\d+\w?)',t,re.I) or re.search(r'State Senate.*?(\d+\w?)',t,re.I)
+    if m and re.search(r'senat',t,re.I): return "State Senate",m.group(1)
+    m=re.search(r'Represent\w*.*?District (\d+\w?)',t,re.I)
+    if m: return "State House",m.group(1)
+    m=re.search(r'Judge of the Circuit Court,?\s*(Position \w+ \w+ Circuit)',t,re.I)
+    if m: return "Judge of the Circuit Court",m.group(1)
+    if re.search(r'Supreme Court.*Retention|Retention.*Justice',t,re.I):
+        dm=re.search(r'(\w+) Supreme Court District',t)
+        return "Supreme Court Retention",(ORD.get(dm.group(1),"") if dm else "")
+    m=re.search(r'Constitutional Amendment ([A-Z])\b',t,re.I)
+    if m: return f"Constitutional Amendment {m.group(1).upper()}",""
+    m=re.search(r'Initiated Measure (\d+)',t,re.I)
+    if m: return f"Initiated Measure {m.group(1)}",""
+    if re.search(r'James River Water',t,re.I): return "James River Water Development District",""
+    return t,""
+
+def nprec(p):
+    p=re.sub(r'^Precinct[\s\-_]+','',str(p),flags=re.I).strip()
+    return p or "?"
+
+# county totals
+cf=defaultdict(list)
+for r in csv.DictReader(open(COUNTY_CSV)):
+    cf[(r['county'],r['office'],r['district'])].append((r['candidate'],r['party'],int(r['votes'])))
+
+target=sys.argv[1]
+county=target.capitalize()
+rows=json.load(open(CACHE/f"mz_{target}_rows.json"))
+# normalize + dedupe
+norm=[]
+seen=set()
+for r in rows:
+    office,district=normalize_office(r.get('office',''))
+    key=(county,nprec(r.get('precinct','')),office,district,
+         str(r.get('candidate','')).strip(),str(r.get('party','')).strip().upper())
+    if key in seen: continue
+    seen.add(key)
+    try: v=int(str(r.get('votes',0)).replace(',','').strip() or 0)
+    except: v=0
+    norm.append([county,nprec(r.get('precinct','')),office,district,
+                 str(r.get('candidate','')).strip(),str(r.get('party','')).strip().upper(),v])
+
+# reconcile by contest-total (county,office,district)
+psum=defaultdict(int)
+for c,p,o,d,cand,pty,v in norm: psum[(c,o,d)]+=v
+print(f"{target}: {len(norm)} rows, {len(set((o,d) for _,_,o,d,_,_,_ in norm))} contests")
+ok=0; bad=[]
+contests=set((o,d) for _,_,o,d,_,_,_ in norm)
+for (o,d) in sorted(contests):
+    ct=sum(t for _,_,t in cf.get((county,o,d),[]))
+    ps=psum[(county,o,d)]
+    if cf.get((county,o,d)) and ct==ps: ok+=1
+    else: bad.append((o,d,ct,ps))
+print(f"  contest-total reconciled: {ok}/{len(contests)}")
+for o,d,ct,ps in bad[:40]:
+    print(f"   MISMATCH {o} d{d}: county {ct} vs precinct {ps} (Δ{ps-ct:+d})")
+# save normalized
+json.dump(norm, open(CACHE/f"mz_{target}_norm.json","w"))

--- a/scripts/parse_2022_precinct.py
+++ b/scripts/parse_2022_precinct.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Parse the SD 2022 general precinct canvass (clean digital PDF, one contest per page,
+contests may span consecutive pages). Candidate identity per column is recovered by
+matching the page's column totals to the already-parsed county-level totals -- this both
+labels the columns and reconciles precinct<->county automatically. Local races not present
+in the county file are collected separately for a header-parse fallback."""
+import os, re, csv, sys
+from pathlib import Path
+from collections import defaultdict
+from natural_pdf import PDF
+
+# Repo root (this file lives in <repo>/scripts/). The source-PDF repo is expected as a
+# sibling checkout; override with SD_SOURCES if it lives elsewhere.
+REPO = Path(__file__).resolve().parents[1]
+SOURCES = Path(os.environ.get("SD_SOURCES", REPO.parent / "openelections-sources-sd"))
+
+PREC_PDF = str(SOURCES / "2022/general/2022PrecintCanvass.pdf")
+COUNTY_CSV = str(REPO / "2022/20221108__sd__general__county.csv")
+# Output goes to a staging dir, NOT the committed 2022/counties: re-running this digital
+# parse would otherwise clobber Yankton (absent here) and the 8 Minnehaha legislative
+# contests that were filled in from the scanned regional PDF (see parse_2022_mz.py).
+OUTDIR = os.environ.get("SD_PRECINCT_OUT", "/tmp/sd_2022_precinct_staging")
+
+COUNTIES = {c.lower(): c for c in [
+ "Aurora","Beadle","Bennett","Bon Homme","Brookings","Brown","Brule","Buffalo","Butte",
+ "Campbell","Charles Mix","Clark","Clay","Codington","Corson","Custer","Davison","Day",
+ "Deuel","Dewey","Douglas","Edmunds","Fall River","Faulk","Grant","Gregory","Haakon",
+ "Hamlin","Hand","Hanson","Harding","Hughes","Hutchinson","Hyde","Jackson","Jerauld",
+ "Jones","Kingsbury","Lake","Lawrence","Lincoln","Lyman","Marshall","McCook","McPherson",
+ "Meade","Mellette","Miner","Minnehaha","Moody","Oglala Lakota","Pennington","Perkins",
+ "Potter","Roberts","Sanborn","Spink","Stanley","Sully","Todd","Tripp","Turner","Union",
+ "Walworth","Yankton","Ziebach"]}
+
+INT_RE = re.compile(r'^[\d,]+$')
+ORD = {"First":"1","Second":"2","Third":"3","Fourth":"4","Fifth":"5","Sixth":"6",
+       "Seventh":"7","Eighth":"8","Ninth":"9"}
+
+def split_row(line):
+    toks=line.split(); nums=[]; i=len(toks)
+    while i>0 and INT_RE.match(toks[i-1]):
+        nums.append(int(toks[i-1].replace(",",""))); i-=1
+    if not nums: return None
+    nums.reverse(); return " ".join(toks[:i]), nums
+
+def normalize_office(text):
+    t=re.sub(r'\s+',' ',text).strip()
+    if re.search(r'United States Senator',t): return "U.S. Senate",""
+    if re.search(r'United States Representative',t): return "U.S. House","1"
+    if re.search(r'Governor and Lieutenant Governor',t): return "Governor",""
+    if re.search(r'Secretary of State',t): return "Secretary of State",""
+    if re.search(r'Attorney General',t): return "Attorney General",""
+    if re.search(r'State Auditor',t): return "State Auditor",""
+    if re.search(r'State Treasurer',t): return "State Treasurer",""
+    if re.search(r'Commissioner of School and Public Lands',t):
+        return "Commissioner of School and Public Lands",""
+    if re.search(r'Public Utilities Commissioner',t): return "Public Utilities Commissioner",""
+    m=re.search(r'State Senator District (\w+)',t)
+    if m: return "State Senate",m.group(1)
+    m=re.search(r'State Representative District (\w+)',t)
+    if m: return "State House",m.group(1)
+    m=re.search(r'Judge of the Circuit Court,\s*(Position \w+ \w+ Circuit)',t)
+    if m: return "Judge of the Circuit Court",m.group(1)
+    if re.search(r'Supreme Court Justice Retention',t):
+        dm=re.search(r'the (\w+) Supreme Court District',t)
+        return "Supreme Court Retention",(ORD.get(dm.group(1),"") if dm else "")
+    m=re.search(r'Constitutional Amendment ([A-Z])\b',t)
+    if m: return f"Constitutional Amendment {m.group(1)}",""
+    m=re.search(r'Initiated Measure (\d+)\b',t)
+    if m: return f"Initiated Measure {m.group(1)}",""
+    m=re.search(r'Referred Law (\d+)\b',t)
+    if m: return f"Referred Law {m.group(1)}",""
+    if re.search(r'James River Water Development District',t):
+        return "James River Water Development District",""
+    # tolerant fallback for headers wrapped mid-word ('State Representati ve District 26B')
+    flat=re.sub(r'\s+','',t)
+    m=re.search(r'StateSenatorDistrict(\d+[AB]?)', flat)
+    if m: return "State Senate", m.group(1)
+    m=re.search(r'StateRepresentativeDistrict(\d+[AB]?)', flat)
+    if m: return "State House", m.group(1)
+    return None  # unknown / local
+
+def normalize_precinct(p):
+    p=re.sub(r'^Precinct[\s\-_]+','',p,flags=re.I).strip()
+    return p or "?"
+
+# ---- load county totals: (office,district,county) -> [(candidate,party,total)] ----
+cf=defaultdict(list)
+with open(COUNTY_CSV) as f:
+    for r in csv.DictReader(f):
+        cf[(r['office'],r['district'],r['county'])].append(
+            (r['candidate'],r['party'],int(r['votes'])))
+
+def trailing_int_count(line):
+    return len(split_row(line)[1]) if split_row(line) else 0
+
+def split_row_n(line, ncol):
+    """Take exactly ncol trailing integer tokens as votes; the rest is the precinct name."""
+    toks=line.split()
+    if len(toks)<ncol: return None
+    vt=toks[-ncol:]
+    if not all(INT_RE.match(t) for t in vt): return None
+    name=" ".join(toks[:-ncol]).strip()
+    return name, [int(t.replace(",","")) for t in vt]
+
+def cluster(values, gap=8):
+    """Cluster sorted scalar values; return list of cluster center floats."""
+    vs=sorted(values); clusters=[]; cur=[vs[0]]
+    for v in vs[1:]:
+        if v-cur[-1]<=gap: cur.append(v)
+        else: clusters.append(cur); cur=[v]
+    clusters.append(cur)
+    return [sum(c)/len(c) for c in clusters]
+
+def extract_matrix(page):
+    """Return (dlabels, rows). dlabels=[(x0,x1,district)] from header band.
+    rows=[(name, [(x_center,value)])] with wrapped-name fragments merged by proximity."""
+    words=list(page.words)
+    dlabels=[]
+    for w in words:
+        if w.top<112:
+            m=re.search(r'District (\d+\w?)', w.text)
+            if m: dlabels.append((w.x0,w.x1,m.group(1))); continue
+            # lettered districts (26A/26B/28A/28B) often split from their 'District' word
+            m2=re.fullmatch(r'(\d+[AB])', w.text.strip())
+            if m2: dlabels.append((w.x0,w.x1,m2.group(1)))
+    pname_top=min((w.top for w in words if w.text.startswith('Precinct Name')), default=112)
+    byrow={}
+    for w in words:
+        if w.top>pname_top: byrow.setdefault(round(w.top), []).append(w)
+    valrows=[]; labrows=[]
+    for top in sorted(byrow):
+        ws=sorted(byrow[top], key=lambda w:w.x0)
+        vals=[((w.x0+w.x1)/2,int(w.text.replace(',',''))) for w in ws if INT_RE.match(w.text)]
+        lab=" ".join(w.text for w in ws if not INT_RE.match(w.text)).strip()
+        if lab.lower()=='total': continue
+        if vals: valrows.append([top,lab,vals])
+        elif lab: labrows.append((top,lab))
+    if not valrows: return dlabels, []
+    # attach each orphan label row to the nearest value row (handles names above & below)
+    name_frags={id(vr):[(vr[0],vr[1])] for vr in valrows}
+    for ltop,lab in labrows:
+        vr=min(valrows, key=lambda v:abs(v[0]-ltop))
+        name_frags[id(vr)].append((ltop,lab))
+    rows=[]
+    for vr in valrows:
+        frags=sorted(name_frags[id(vr)])
+        nm=" ".join(f for _,f in frags if f).strip()
+        rows.append((nm, vr[2]))
+    return dlabels, rows
+
+def resolve_matrix_page(county, office_base, dlabels, rows):
+    """Order districts left-to-right by header label, then consume value columns
+    left-to-right, giving each district its county-file candidate count. Returns (out, ok)."""
+    if not rows or not dlabels: return [],False
+    all_xc=[xc for _,vals in rows for xc,_ in vals]
+    centers=sorted(cluster(all_xc, gap=10))
+    # district order = label x0 (dedup, keep leftmost occurrence)
+    seen={}
+    for x0,x1,d in sorted(dlabels):
+        if d not in seen: seen[d]=x0
+    dorder=sorted(seen, key=lambda d:seen[d])
+    colmap={}; idx=0
+    for d in dorder:
+        cands=cf.get((office_base,d,county))
+        if not cands: return [],False
+        for (cn,cp,ct) in cands:
+            if idx>=len(centers): return [],False
+            colmap[centers[idx]]=(cn,cp,d); idx+=1
+    if idx!=len(centers): return [],False   # column count must match total candidates
+    col_of=lambda xc: min(centers,key=lambda c:abs(c-xc))
+    out=[]
+    for prec,vals in rows:
+        for xc,v in vals:
+            cn,cp,d=colmap[col_of(xc)]
+            out.append((normalize_precinct(prec),office_base,d,cn,cp,v))
+    return out,True
+
+pdf=PDF(PREC_PDF)
+# ---- parse each page (defer int splitting until ncol is known) ----
+pages=[]
+matrix_pages=[]
+for i,p in enumerate(pdf.pages):
+    lines=[l.strip() for l in (p.extract_text() or '').splitlines() if l.strip()]
+    county=None; office_text_lines=[]; rawrows=[]; total=None
+    for l in lines:
+        if l.endswith(' County'):
+            cand=l[:-len(' County')].strip()
+            if cand.lower() in COUNTIES: county=COUNTIES[cand.lower()]
+            break
+    seen_county=False
+    for l in lines:
+        if l.startswith('General Election'): continue
+        if l.endswith(' County') and not seen_county: seen_county=True; continue
+        if not seen_county: continue
+        if l.startswith('Precinct Name'): continue
+        if re.match(r'\d+ of \d+$', l): continue            # page footer
+        r=split_row(l)
+        if r:
+            name,nums=r
+            # office headers can end in a number ('State Senator District 21'); don't
+            # mistake them for precinct data rows.
+            if name.strip().lower()=='total': total=nums    # Total row -> reliable ncol
+            elif re.search(r'District$', name.strip()): office_text_lines.append(l)
+            else: rawrows.append(l)                          # candidate data row (split later)
+        else:
+            office_text_lines.append(l)
+    office_join=' '.join(office_text_lines)
+    # detect district labels from header geometry (top<112) -- robust to text-flow quirks
+    hdr=" ".join(w.text for w in p.words if w.top<112)
+    districts_here=set(re.findall(r'District (\d+\w?)', hdr))
+    office_base=None
+    if 'State Senator' in hdr: office_base='State Senate'
+    elif 'State Representative' in hdr: office_base='State House'
+    # matrix page: legislative with 2+ districts side by side -> resolve per page (geometry)
+    if county and office_base and len(districts_here)>=2:
+        dlabels,mrows=extract_matrix(p)
+        matrix_pages.append({'i':i,'county':county,'office_base':office_base,
+                             'districts':sorted(districts_here),'dlabels':dlabels,'rows':mrows})
+        continue
+    office=normalize_office(office_join) if office_text_lines else None
+    pages.append({'i':i,'county':county,'office':office,
+                  'raw_office':office_join,'rawrows':rawrows,'total':total})
+
+# ---- merge consecutive pages with same (county, office) ----
+merged={}  # (county,office,district) -> {'rawrows':[...], 'total':...}
+order=[]
+for pg in pages:
+    if pg['county'] is None or pg['office'] is None:
+        continue
+    office,district=pg['office']
+    key=(pg['county'],office,district)
+    if key not in merged:
+        merged[key]={'rawrows':[], 'total':None}; order.append(key)
+    merged[key]['rawrows'].extend(pg['rawrows'])
+    if pg['total'] is not None: merged[key]['total']=pg['total']
+
+# ---- assign candidates via county-total matching, build output ----
+out_by_county=defaultdict(list)
+unmatched=[]; recon_fail=[]; rowparse_fail=[]
+for key in order:
+    county,office,district=key
+    m=merged[key]; total=m['total']
+    cands=cf.get((office,district,county))
+    # determine column count: prefer Total row, else county-file candidate count
+    if total is not None: ncol=len(total)
+    elif cands: ncol=len(cands)
+    else:
+        from collections import Counter as _C
+        ncol=_C(trailing_int_count(l) for l in m['rawrows']).most_common(1)[0][0]
+    rows=[]
+    for l in m['rawrows']:
+        rn=split_row_n(l,ncol)
+        if rn is None: rowparse_fail.append((key,l)); continue
+        rows.append(rn)
+    if not rows: continue
+    if not cands or len(cands)!=ncol:
+        unmatched.append((key,ncol,len(cands) if cands else 0)); continue
+    # match columns to candidates by total value
+    colsum=[0]*ncol
+    okcols=True
+    for prec,nums in rows:
+        if len(nums)!=ncol: okcols=False; continue
+        for k in range(ncol): colsum[k]+=nums[k]
+    # map each column index -> candidate by matching colsum to cand total (greedy unique)
+    used=[False]*len(cands); mapping=[None]*ncol
+    for k in range(ncol):
+        for ci,(cn,cp,ct) in enumerate(cands):
+            if not used[ci] and ct==colsum[k]:
+                mapping[k]=(cn,cp); used[ci]=True; break
+    if any(mp is None for mp in mapping):
+        # fallback: assign by order
+        mapping=[(c[0],c[1]) for c in cands]
+        recon_fail.append((key,colsum,[c[2] for c in cands]))
+    for prec,nums in rows:
+        if len(nums)!=ncol: continue
+        for k,(cn,cp) in enumerate(mapping):
+            out_by_county[county].append([county,normalize_precinct(prec),office,district,cn,cp,nums[k]])
+
+# ---- resolve matrix pages per page (geometry); emit every resolved page ----
+matrix_ok=0; matrix_pagefail=[]
+for mp in matrix_pages:
+    res,ok=resolve_matrix_page(mp['county'],mp['office_base'],mp['dlabels'],mp['rows'])
+    if ok:
+        matrix_ok+=1
+        for prec,office,district,cn,cp,v in res:
+            out_by_county[mp['county']].append([mp['county'],prec,office,district,cn,cp,v])
+    else:
+        matrix_pagefail.append((mp['i'],mp['county'],mp['office_base'],mp['districts']))
+
+# ---- final validation: drop any (county,office,district) whose precinct sums don't match
+# the county totals (keeps output 100% reconciled; partially-parsed matrix contests removed)
+psum=defaultdict(int)
+for county,rows in out_by_county.items():
+    for r in rows:
+        psum[(r[0],r[2],r[3],r[4],r[5])]+=r[6]   # county,office,district,candidate,party
+drop=set()  # (county,office,district)
+contests_seen=set((r[0],r[2],r[3]) for rows in out_by_county.values() for r in rows)
+for (county,office,district) in contests_seen:
+    expected=cf.get((office,district,county))
+    if not expected: continue
+    ok=all(psum.get((county,office,district,cn,cp))==ct for cn,cp,ct in expected)
+    if not ok: drop.add((county,office,district))
+dropped_rows=0
+for county in list(out_by_county):
+    kept=[r for r in out_by_county[county] if (r[0],r[2],r[3]) not in drop]
+    dropped_rows+=len(out_by_county[county])-len(kept)
+    out_by_county[county]=kept
+
+# ---- write per-county CSVs ----
+import os
+os.makedirs(OUTDIR,exist_ok=True)
+def slug(c): return c.lower().replace(' ','_')
+for county,rows in out_by_county.items():
+    with open(f"{OUTDIR}/20221108__sd__general__{slug(county)}__precinct.csv","w",newline="") as f:
+        w=csv.writer(f); w.writerow(["county","precinct","office","district","candidate","party","votes"]); w.writerows(rows)
+
+print(f"pages: {len(pages)}   merged contests: {len(merged)}   counties out: {len(out_by_county)}")
+print(f"output rows: {sum(len(v) for v in out_by_county.values())}")
+print(f"matrix pages OK: {matrix_ok}   page-fail: {len(matrix_pagefail)}   dropped (unreconciled) contests: {len(drop)} ({dropped_rows} rows)")
+for x in sorted(drop)[:30]: print("   DROP",x)
+print(f"\nUNMATCHED (not in county file / col mismatch): {len(unmatched)}")
+from collections import Counter
+uc=Counter()
+for (key,nc,have) in unmatched:
+    uc[key[1]]+=1
+for o,n in uc.most_common(): print(f"   {n:4d}  {o}")
+print(f"\nRECON FAIL (col totals != county cand totals): {len(recon_fail)}")
+for key,colsum,ctot in recon_fail[:20]: print("  ",key,"colsum",colsum,"cand",ctot)


### PR DESCRIPTION
This pull request adds a new file containing detailed precinct-level election results for South Dakota counties from the 2022 general election. The file includes vote counts for various federal, state, and judicial offices, as well as ballot measures.

**New election results data:**

* Added precinct-level results for:
  * Federal races (U.S. Senate, U.S. House)
  * State executive offices (Governor, Secretary of State, Attorney General, State Auditor, State Treasurer, Commissioner of School and Public Lands, Public Utilities Commissioner)
  * State legislative offices (State Senate, State House)
  * Judicial offices (Judge of the Circuit Court, Supreme Court Retention)
  * Ballot measures (Constitutional Amendment D, Initiated Measure 27)